### PR TITLE
fix: use local timezone instead of UTC for displayed times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 toml = "0.8"
 toml_edit = "0.22"
 clap = { version = "4", features = ["derive", "env"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde", "clock"] }
 fs2 = "0.4"
 tempfile = "3"
 directories = "5"

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -244,7 +244,7 @@ fn render_tooltip(
     let updated = match outcome.cache_age {
         Some(age) => {
             let when = now - chrono::Duration::from_std(age).unwrap_or_default();
-            when.format("%H:%M").to_string()
+            when.with_timezone(&chrono::Local).format("%H:%M").to_string()
         }
         None => "—".to_string(),
     };

--- a/src/openrouter/vendor.rs
+++ b/src/openrouter/vendor.rs
@@ -209,7 +209,7 @@ fn render_tooltip(
     let updated = match outcome.cache_age {
         Some(age) => {
             let when = now - chrono::Duration::from_std(age).unwrap_or_default();
-            when.format("%H:%M").to_string()
+            when.with_timezone(&chrono::Local).format("%H:%M").to_string()
         }
         None => "—".to_string(),
     };

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -90,7 +90,7 @@ pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> 
             let updated = match cache_age {
                 Some(age) => {
                     let when = now - chrono::Duration::from_std(*age).unwrap_or_default();
-                    when.format("Updated %H:%M:%S").to_string()
+                    when.with_timezone(&chrono::Local).format("Updated %H:%M:%S").to_string()
                 }
                 None => "Updated —".into(),
             };

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -106,7 +106,7 @@ fn draw_footer(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         Span::styled("[q]", Style::default().fg(accent(&app.theme))),
         Span::styled(" quit", Style::default().fg(dim_color)),
         Span::styled(
-            format!("   ·   updated {}", app.last_refresh.format("%H:%M:%S")),
+            format!("   ·   updated {}", app.last_refresh.with_timezone(&chrono::Local).format("%H:%M:%S")),
             Style::default().fg(dim_color),
         ),
     ]);

--- a/src/widget/render.rs
+++ b/src/widget/render.rs
@@ -446,7 +446,7 @@ fn render_default_tooltip(input: &RenderInput) -> String {
     let updated = match input.outcome.cache_age {
         Some(age) => {
             let when = input.now - chrono::Duration::from_std(age).unwrap_or_default();
-            when.format("%H:%M").to_string()
+            when.with_timezone(&chrono::Local).format("%H:%M").to_string()
         }
         None => "—".to_string(),
     };

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -171,7 +171,7 @@ fn render_tooltip(
     let updated = match outcome.cache_age {
         Some(age) => {
             let when = now - chrono::Duration::from_std(age).unwrap_or_default();
-            when.format("%H:%M").to_string()
+            when.with_timezone(&chrono::Local).format("%H:%M").to_string()
         }
         None => "—".to_string(),
     };


### PR DESCRIPTION
All "Updated HH:MM" timestamps were formatted from `DateTime<Utc>` without converting to the system's local timezone, causing a 3-hour offset (UTC-3) for users in that timezone.

Changes:
- Apply `.with_timezone(&chrono::Local)` before `.format()` in all 6 locations where times are displayed to users (widget tooltip, TUI panels, TUI status bar, and per-vendor renderers)
- Explicitly add the `clock` feature to the `chrono` dependency in `Cargo.toml`

Files changed:
- `Cargo.toml` — add `clock` feature to chrono
- `src/widget/render.rs` — tooltip updated time
- `src/tui/panels.rs` — panel updated time
- `src/tui/view.rs` — status bar refresh time
- `src/zai/vendor.rs` — tooltip updated time
- `src/openrouter/vendor.rs` — tooltip updated time
- `src/openai/vendor.rs` — tooltip updated time