### PR TITLE
ci: enrich GitHub release body with CHANGELOG section + full diff link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout source (for CHANGELOG + previous tag)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
       - uses: actions/download-artifact@v5
         with:
           path: artifacts
@@ -93,7 +99,24 @@ jobs:
         env:
           TAG: ${{ inputs.ref || github.ref_name }}
         run: |
+          VERSION="${TAG#v}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -1)
+
+          # Extract matching section from CHANGELOG.md (between "## [VERSION]"
+          # and the next "## [" header). Empty file if no match.
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\["ver"\\]" {flag=1; next}
+            flag && /^## \[/ {exit}
+            flag {print}
+          ' CHANGELOG.md > changelog_section.md
+
           {
+            if [ -s changelog_section.md ]; then
+              echo "## What's changed"
+              echo
+              cat changelog_section.md
+            fi
+
             echo "## Install"
             echo
             echo "### Arch (AUR)"
@@ -106,13 +129,18 @@ jobs:
             echo "### Manual"
             echo
             echo '```bash'
-            echo "curl -fsSL https://github.com/akitaonrails/ai-usagebar/releases/download/${TAG}/ai-usagebar-linux-x86_64.tar.gz | tar xz -C ~/.local/bin ai-usagebar ai-usagebar-tui"
+            echo "curl -fsSL https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}/ai-usagebar-linux-x86_64.tar.gz | tar xz -C ~/.local/bin ai-usagebar ai-usagebar-tui"
             echo '```'
             echo
             echo "## Checksums (SHA256)"
             echo '```'
             cat artifacts/*.sha256
             echo '```'
+
+            if [ -n "$PREV_TAG" ]; then
+              echo
+              echo "**Full diff**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_TAG}...${TAG}"
+            fi
           } > body.md
 
       - name: Create / update GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- **Release notes** — `release.yml` now extracts the matching
+  `CHANGELOG.md` section into the GitHub Release body and appends a
+  `Full diff` compare link against the previous tag. Replaces the
+  prior install-and-checksums-only body.
 
 ## [0.4.1] — 2026-05-26
 


### PR DESCRIPTION
## Summary

The Release workflow currently publishes release bodies that contain
only the install instructions and SHA256 checksums. This PR enriches
the body so a casual reader landing on the release page can see what
actually changed without leaving GitHub.

The body is now assembled from:

- The matching `## [X.Y.Z]` section extracted from `CHANGELOG.md`
  (already maintained per Keep-A-Changelog).
- The existing Install (AUR + manual curl) block.
- The existing SHA256 checksums block.
- A **Full diff** compare link against the previous tag (derived from
  `git tag --sort=-v:refname`).

The download URL also switches from a hardcoded `akitaonrails/ai-usagebar`
path to `${GITHUB_REPOSITORY}`, so the workflow renders correct links
when run on forks. This is what enabled end-to-end testing of this
change without polluting upstream tags.

## Mock release for review

The exact workflow in this PR was test-published on a fork:

https://github.com/sombraSoft/ai-usagebar/releases/tag/v0.0.0-rc1

(The `[Unreleased]` section in this PR's `CHANGELOG.md` edit is what
gets surfaced when the next real tag is cut.)

## Test plan

- [x] Mock release published successfully on fork (CI green, both
      x86_64 and aarch64 tarballs built).
- [x] CHANGELOG section extraction verified against existing 0.4.1
      heading layout.
- [x] Workflow still falls back gracefully when CHANGELOG has no
      matching section (body just skips the "What's changed" block).
- [x] Workflow still falls back gracefully when there's no previous
      tag (body skips the "Full diff" link).
- [ ] Confirm against next real upstream tag after merge.