### PR TITLE
feat(anthropic): read credentials from macOS Keychain when file is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **macOS Keychain fallback for Anthropic credentials.** Recent Claude
+  Code builds on macOS store their OAuth state in the login Keychain
+  (generic-password service `Claude Code-credentials`) instead of
+  `~/.claude/.credentials.json`, so the widget failed with an I/O error
+  on a missing file. When the file is absent on macOS, ai-usagebar now
+  reads the same `{ claudeAiOauth, mcpOAuth }` JSON from the Keychain
+  via `security(1)`, and writes refreshed tokens back to that same item
+  so it keeps a single source of truth with Claude Code instead of
+  forking a stale copy. Linux behavior is unchanged.
 
 ## [0.4.5] — 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth c
 
 | Vendor | Method | Action required |
 |---|---|---|
-| Anthropic | OAuth, read from `~/.claude/.credentials.json` | Run `claude` once to log in. Token auto-refreshes. |
+| Anthropic | OAuth, read from `~/.claude/.credentials.json` (or the macOS login Keychain — see below) | Run `claude` once to log in. Token auto-refreshes. |
 | OpenAI | OAuth, read from `~/.codex/auth.json` | Run `codex login` once. Token auto-refreshes. |
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
 | OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. |
@@ -74,6 +74,10 @@ For each API-key vendor, ai-usagebar checks in this order:
 - If you put inline `api_key` values in config, `chmod 600 ~/.config/ai-usagebar/config.toml`. The default behavior reads only env vars, which is safer when your config might be world-readable.
 - Don't commit your config dir if you check it into dotfiles unless you've redacted `api_key` lines.
 - OAuth credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`) are managed by their respective CLIs and already chmod-protected.
+
+#### macOS: Anthropic credentials in the Keychain
+
+On macOS, recent Claude Code builds don't write `~/.claude/.credentials.json` — they keep the same OAuth JSON in the **login Keychain** under the generic-password service `Claude Code-credentials`. ai-usagebar detects the missing file and transparently reads (and writes refreshed tokens back to) that Keychain item via the built-in `security` tool, so no manual step is needed. If the file *does* exist it still takes precedence, matching Linux.
 
 ## Configuration
 

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -1,5 +1,9 @@
 //! Read and write `~/.claude/.credentials.json` — the OAuth state the Claude
 //! CLI maintains. Mirrors claudebar:330-333 (read) and claudebar:447-452 (write).
+//!
+//! On macOS the file often doesn't exist: recent Claude Code builds keep the
+//! same JSON in the login Keychain instead. When the file is absent we transom
+//! over to [`keychain`] so subscription usage works there too.
 
 use std::path::{Path, PathBuf};
 
@@ -7,6 +11,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::cache::atomic_write;
 use crate::error::{AppError, Result};
+
+#[cfg(target_os = "macos")]
+use super::keychain;
 
 /// Disk shape (matches claudebar's jq paths).
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -99,36 +106,64 @@ pub fn default_path() -> Result<PathBuf> {
 }
 
 pub fn read_from(path: &Path) -> Result<CredentialsFile> {
-    let raw = std::fs::read_to_string(path).map_err(|e| AppError::io_at(path, e))?;
-    serde_json::from_str(&raw).map_err(|e| {
+    match std::fs::read_to_string(path) {
+        Ok(raw) => parse(&raw, &path.display().to_string()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // No file — on macOS the credentials usually live in the Keychain.
+            #[cfg(target_os = "macos")]
+            if let Some(raw) = keychain::read_raw()? {
+                return parse(&raw, "macOS Keychain (Claude Code-credentials)");
+            }
+            Err(AppError::io_at(path, e))
+        }
+        Err(e) => Err(AppError::io_at(path, e)),
+    }
+}
+
+/// Parse a credentials JSON blob from any source (`source` only labels errors).
+fn parse(raw: &str, source: &str) -> Result<CredentialsFile> {
+    serde_json::from_str(raw).map_err(|e| {
         AppError::Credentials(format!(
-            "could not parse {}: {e}. Run `claude` to re-authenticate.",
-            path.display()
+            "could not parse {source}: {e}. Run `claude` to re-authenticate."
         ))
     })
 }
 
-/// Persist updated credentials, preserving any unknown top-level fields the
-/// Claude CLI might have added. Reads the existing file, merges our updates
-/// into the `claudeAiOauth` object, and atomically writes it back.
-pub fn write_back(path: &Path, new_oauth: &OauthCreds) -> Result<()> {
-    let mut doc: serde_json::Value = std::fs::read_to_string(path)
-        .map_err(|e| AppError::io_at(path, e))
-        .and_then(|s| serde_json::from_str(&s).map_err(AppError::Json))
-        .unwrap_or_else(|_| serde_json::json!({}));
-
-    let obj = match doc.as_object_mut() {
-        Some(o) => o,
-        None => {
-            doc = serde_json::json!({});
-            doc.as_object_mut().expect("just constructed object")
-        }
-    };
-    obj.insert(
+/// Merge a refreshed `claudeAiOauth` into an existing credentials document
+/// (or a fresh `{}`), preserving any unknown top-level fields the Claude CLI
+/// keeps there (e.g. `mcpOAuth`). Pure so the merge is unit-testable without
+/// touching disk or the Keychain.
+fn merge_oauth(existing: Option<&str>, new_oauth: &OauthCreds) -> Result<serde_json::Value> {
+    let mut doc: serde_json::Value = existing
+        .and_then(|s| serde_json::from_str(s).ok())
+        .unwrap_or_else(|| serde_json::json!({}));
+    if !doc.is_object() {
+        doc = serde_json::json!({});
+    }
+    doc.as_object_mut().expect("just ensured object").insert(
         "claudeAiOauth".into(),
         serde_json::to_value(new_oauth).map_err(AppError::Json)?,
     );
+    Ok(doc)
+}
 
+/// Persist updated credentials, preserving any unknown top-level fields the
+/// Claude CLI might have added. Writes back to wherever the creds actually
+/// live: the file if present, otherwise (macOS) the Keychain item — keeping a
+/// single shared source of truth with Claude Code instead of forking a stale
+/// copy and rotating the refresh token out from under it.
+pub fn write_back(path: &Path, new_oauth: &OauthCreds) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    if !path.exists() {
+        if let Some(existing) = keychain::read_raw()? {
+            let doc = merge_oauth(Some(&existing), new_oauth)?;
+            let json = serde_json::to_string(&doc).map_err(AppError::Json)?;
+            return keychain::write_raw(&json);
+        }
+    }
+
+    let existing = std::fs::read_to_string(path).ok();
+    let doc = merge_oauth(existing.as_deref(), new_oauth)?;
     let bytes = serde_json::to_vec_pretty(&doc).map_err(AppError::Json)?;
     atomic_write(path, &bytes)
 }
@@ -218,6 +253,54 @@ mod tests {
         let f = write_creds("not json");
         let err = read_from(f.path()).unwrap_err();
         assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    // Linux-only: a missing file with no Keychain fallback is an I/O error,
+    // not a parse error. Gated off macOS so we never read the developer's real
+    // Keychain item (which would both flake and surface a live token).
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn read_from_missing_file_is_io_error() {
+        let path = std::path::Path::new("/nonexistent/ai-usagebar/.credentials.json");
+        let err = read_from(path).unwrap_err();
+        assert!(matches!(err, AppError::Io { .. }));
+    }
+
+    #[test]
+    fn merge_oauth_preserves_unknown_top_level_fields() {
+        let existing = r#"{"claudeAiOauth":{"accessToken":"OLD"},"mcpOAuth":{"x":1}}"#;
+        let new_oauth = OauthCreds {
+            access_token: "NEW".into(),
+            refresh_token: "RT".into(),
+            expires_at_ms: 99,
+            subscription_type: "max".into(),
+            rate_limit_tier: "".into(),
+            scopes: None,
+        };
+        let doc = merge_oauth(Some(existing), &new_oauth).unwrap();
+        assert_eq!(doc["mcpOAuth"]["x"], 1);
+        assert_eq!(doc["claudeAiOauth"]["accessToken"], "NEW");
+        assert_eq!(doc["claudeAiOauth"]["expiresAt"], 99);
+    }
+
+    #[test]
+    fn merge_oauth_handles_empty_and_non_object_input() {
+        let new_oauth = OauthCreds {
+            access_token: "A".into(),
+            refresh_token: "R".into(),
+            expires_at_ms: 0,
+            subscription_type: "pro".into(),
+            rate_limit_tier: "".into(),
+            scopes: None,
+        };
+        // None → fresh object.
+        let doc = merge_oauth(None, &new_oauth).unwrap();
+        assert_eq!(doc["claudeAiOauth"]["accessToken"], "A");
+        // Garbage / non-object → discarded, fresh object.
+        let doc = merge_oauth(Some("not json"), &new_oauth).unwrap();
+        assert_eq!(doc["claudeAiOauth"]["accessToken"], "A");
+        let doc = merge_oauth(Some("[1,2,3]"), &new_oauth).unwrap();
+        assert_eq!(doc["claudeAiOauth"]["accessToken"], "A");
     }
 
     #[test]

--- a/src/anthropic/keychain.rs
+++ b/src/anthropic/keychain.rs
@@ -1,0 +1,92 @@
+//! macOS Keychain access for Claude Code OAuth credentials.
+//!
+//! On Linux the Claude CLI writes its OAuth state to
+//! `~/.claude/.credentials.json`. On macOS, recent Claude Code builds instead
+//! store the *same* `{ "claudeAiOauth": …, "mcpOAuth": … }` JSON as a generic
+//! password item in the login Keychain (service `Claude Code-credentials`), so
+//! the file never exists and a naive read fails with an I/O error.
+//!
+//! We shell out to the built-in `security(1)` tool rather than pulling in a
+//! macOS-only crate (`security-framework`) — it keeps the dependency tree and
+//! the Linux build untouched, and mirrors the project's "read what the CLI
+//! already wrote" philosophy.
+
+use std::process::Command;
+
+use crate::error::{AppError, Result};
+
+/// Generic-password *service* name Claude Code uses for the credentials blob.
+const SERVICE: &str = "Claude Code-credentials";
+
+/// The Keychain item's *account* is the macOS short username. We match on it
+/// when updating so we touch exactly the item Claude Code created.
+fn account() -> String {
+    std::env::var("USER").unwrap_or_default()
+}
+
+/// Read the raw credentials JSON from the login Keychain.
+///
+/// Returns `Ok(None)` when no such item exists (so callers can fall through to
+/// the file path / a "run `claude`" error), and `Err` only on an unexpected
+/// `security` failure.
+pub fn read_raw() -> Result<Option<String>> {
+    let mut cmd = Command::new("/usr/bin/security");
+    cmd.args(["find-generic-password", "-s", SERVICE, "-w"]);
+    let acct = account();
+    if !acct.is_empty() {
+        cmd.args(["-a", &acct]);
+    }
+
+    let out = cmd
+        .output()
+        .map_err(|e| AppError::Other(format!("could not run `security`: {e}")))?;
+
+    if !out.status.success() {
+        // `security` exits 44 (errSecItemNotFound) when the item is absent.
+        // Treat any non-success as "not in Keychain" — never a hard error,
+        // so the caller can still surface the friendlier file-missing message.
+        return Ok(None);
+    }
+
+    let value = String::from_utf8(out.stdout)
+        .map_err(|e| AppError::Other(format!("Keychain value was not UTF-8: {e}")))?;
+    let value = value.trim_end_matches('\n').to_string();
+    if value.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(value))
+    }
+}
+
+/// Persist updated credentials JSON back to the *same* Keychain item, so the
+/// widget and Claude Code keep sharing a single source of truth (mirroring how
+/// they share one file on Linux). `-U` updates the item in place if it exists.
+///
+/// Note: the JSON is passed as a `security` argument and is therefore briefly
+/// visible in this process's argv (e.g. to `ps`) on the user's own machine.
+/// `security` offers no stdin path for the password, and this runs only on the
+/// rare proactive token refresh, so we accept the local-only exposure of a
+/// secret that already lives in this user's Keychain.
+pub fn write_raw(json: &str) -> Result<()> {
+    let status = Command::new("/usr/bin/security")
+        .args([
+            "add-generic-password",
+            "-U",
+            "-s",
+            SERVICE,
+            "-a",
+            &account(),
+            "-w",
+            json,
+        ])
+        .status()
+        .map_err(|e| AppError::Other(format!("could not run `security`: {e}")))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(AppError::Other(
+            "failed to update Claude credentials in the macOS Keychain".into(),
+        ))
+    }
+}

--- a/src/anthropic/mod.rs
+++ b/src/anthropic/mod.rs
@@ -6,6 +6,8 @@
 
 pub mod creds;
 pub mod fetch;
+#[cfg(target_os = "macos")]
+pub mod keychain;
 pub mod oauth;
 pub mod types;
 


### PR DESCRIPTION
## Problem

On macOS, recent Claude Code builds **don't write** `~/.claude/.credentials.json`. Instead they store the OAuth state in the **login Keychain** as a generic-password item under the service `Claude Code-credentials` (account = the macOS short username). The JSON payload is the same `{ "claudeAiOauth": …, "mcpOAuth": … }` shape the Linux CLI writes to disk.

Because the file never exists, the Anthropic widget/TUI fails immediately with:

```
I/O error at /Users/<you>/.claude/.credentials.json
```

so subscription usage can't be shown on macOS at all.

## Fix

When the credentials file is absent **on macOS**, fall back to the Keychain:

- **Read:** `read_from()` catches `NotFound` and reads the JSON via `security find-generic-password -s "Claude Code-credentials" -w`.
- **Write:** `write_back()` writes refreshed tokens back to that **same Keychain item** (`security add-generic-password -U …`), preserving unknown top-level fields like `mcpOAuth`. This keeps a single source of truth shared with Claude Code instead of forking a stale `~/.claude/.credentials.json` and rotating the refresh token out from under it.
- If the file *does* exist, it still takes precedence — Linux behavior is **completely unchanged**.

All Keychain code lives in a new `src/anthropic/keychain.rs` gated behind `#[cfg(target_os = "macos")]` and shells out to the built-in `security(1)` tool, so there's **no new dependency** and the Linux build is untouched. The JSON merge logic is extracted into a pure, platform-independent `merge_oauth()` helper with unit tests.

### Why `security` instead of a crate

Avoids a macOS-only dependency (`security-framework`) and matches the project's existing "read what the official CLI already wrote" philosophy. The one tradeoff — the secret is briefly visible in this process's argv during the rare proactive token refresh — is documented inline; `security` offers no stdin path for the password and the value already lives in the user's own Keychain.

## Testing

- `cargo test` — **220 passed** (added 3 unit tests for `merge_oauth`; Keychain-touching paths are gated off non-macOS CI so they never read a developer's real item or surface a live token).
- `cargo clippy --all-targets -- -D warnings` — clean.
- **Manual, on macOS:** moved `~/.claude/.credentials.json` aside so only the Keychain remained, then ran the release binary:
  ```
  $ ./target/release/ai-usagebar --vendor anthropic
  6% · 4h 52m   (class: low, tooltip rendered with plan + session bars)
  ```
  Confirms the real binary reads from the Keychain end-to-end with no file present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)