### PR TITLE
Add DeepSeek vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **DeepSeek vendor** (`--vendor deepseek`): fetches credit balance from
+  `GET /user/balance`, preferring USD over CNY when both currencies are
+  present. Severity thresholds are scaled per currency (CNY ≈ 7× USD).
+  API key is read from `DEEPSEEK_API_KEY` env var or `[deepseek] api_key`
+  in config. Disabled by default (requires explicit opt-in).
+- DeepSeek API key field added to the TUI Settings overlay (`s` key),
+  consistent with Z.AI and OpenRouter.
 
 ## [0.4.5] — 2026-05-28
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-usagebar
 
-Waybar widget and tabbed TUI for AI plan usage across **Anthropic Claude**, **OpenAI Codex/ChatGPT**, **Z.AI (GLM)**, and **OpenRouter**.
+Waybar widget and tabbed TUI for AI plan usage across **Anthropic Claude**, **OpenAI Codex/ChatGPT**, **Z.AI (GLM)**, **OpenRouter**, and **DeepSeek**.
 
 This started as a Rust port of [`claudebar`](https://github.com/mryll/claudebar) and stays drop-in compatible with it. It keeps the minimalist Pango-bordered tooltip, Omarchy theme auto-detection, and flock-protected OAuth refresh, then adds three more vendors and a proper testable codebase instead of one long shell script.
 
@@ -60,6 +60,7 @@ Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth c
 | OpenAI | OAuth, read from `~/.codex/auth.json` | Run `codex login` once. Token auto-refreshes. |
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
 | OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. |
+| DeepSeek | API key (`DEEPSEEK_API_KEY` env or `[deepseek] api_key` in config) | Set either. Disabled by default — add `[deepseek] enabled = true` to config. |
 
 ### Credential resolution order (for API-key vendors)
 
@@ -77,13 +78,13 @@ For each API-key vendor, ai-usagebar checks in this order:
 
 ## Configuration
 
-`~/.config/ai-usagebar/config.toml` (optional — defaults enable all four vendors). Full example:
+`~/.config/ai-usagebar/config.toml` (optional — defaults enable all four OAuth/env-key vendors). Full example:
 
 ```toml
 [ui]
 # Which vendor the widget shows when --vendor is omitted, AND which tab
 # is selected when the TUI opens. Defaults to anthropic when not set.
-# primary = "anthropic"   # anthropic | openai | zai | openrouter
+# primary = "anthropic"   # anthropic | openai | zai | openrouter | deepseek
 
 [anthropic]
 enabled = true
@@ -103,6 +104,11 @@ api_key_env = "ZAI_API_KEY"
 enabled = true
 api_key_env = "OPENROUTER_API_KEY"
 # api_key = "sk-or-v1-..."
+
+[deepseek]
+enabled = true             # disabled by default; enable once you add an API key
+api_key_env = "DEEPSEEK_API_KEY"
+# api_key = "sk-..."       # used if DEEPSEEK_API_KEY is unset; chmod 600 the file!
 ```
 
 ## Quick start
@@ -113,6 +119,7 @@ ai-usagebar                        # uses [ui] primary (defaults to anthropic)
 ai-usagebar --vendor openai
 ai-usagebar --vendor zai
 ai-usagebar --vendor openrouter
+ai-usagebar --vendor deepseek
 
 # Force Waybar JSON (e.g. piping into jq).
 ai-usagebar --json

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,7 +8,7 @@
 [ui]
 # Which vendor the widget shows when `--vendor` is omitted, AND which tab
 # is selected when the TUI opens. Comment out to default to Anthropic.
-# Valid: anthropic | openai | zai | openrouter
+# Valid: anthropic | openai | zai | openrouter | deepseek
 # primary = "anthropic"
 
 [anthropic]
@@ -38,3 +38,9 @@ api_key_env = "ZAI_API_KEY"      # checked first; if set + non-empty, used
 enabled = true
 api_key_env = "OPENROUTER_API_KEY"
 # api_key = "sk-or-v1-..."
+
+[deepseek]
+# Disabled by default — enable once you've set a key (env var or inline).
+enabled = false
+api_key_env = "DEEPSEEK_API_KEY"  # checked first; if set + non-empty, used
+# api_key = "sk-..."              # fallback; chmod 600 the file if you use it

--- a/src/active.rs
+++ b/src/active.rs
@@ -58,6 +58,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "openai" => Some(VendorId::Openai),
         "zai" => Some(VendorId::Zai),
         "openrouter" => Some(VendorId::Openrouter),
+        "deepseek" => Some(VendorId::Deepseek),
         _ => None,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub openai: OpenAiConfig,
     pub zai: ZaiConfig,
     pub openrouter: OpenRouterConfig,
+    pub deepseek: DeepseekConfig,
 }
 
 /// UI / dispatch preferences. Currently just `primary` — which vendor the
@@ -118,6 +119,24 @@ impl Default for OpenRouterConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct DeepseekConfig {
+    pub enabled: bool,
+    pub api_key_env: String,
+    pub api_key: Option<String>,
+}
+
+impl Default for DeepseekConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            api_key_env: "DEEPSEEK_API_KEY".to_string(),
+            api_key: None,
+        }
+    }
+}
+
 /// Resolve an API key for a vendor: env var wins, then inline config, then
 /// a clear error naming both fields. Used by Z.AI and OpenRouter vendors.
 pub fn resolve_api_key(
@@ -168,6 +187,7 @@ impl Config {
             VendorId::Openai => self.openai.enabled,
             VendorId::Zai => self.zai.enabled,
             VendorId::Openrouter => self.openrouter.enabled,
+            VendorId::Deepseek => self.deepseek.enabled,
         }
     }
 
@@ -205,6 +225,8 @@ mod tests {
         assert!(c.is_enabled(VendorId::Openai));
         assert!(c.is_enabled(VendorId::Zai));
         assert!(c.is_enabled(VendorId::Openrouter));
+        // DeepSeek requires an explicit API key, so it defaults to disabled.
+        assert!(!c.is_enabled(VendorId::Deepseek));
         assert_eq!(c.enabled_vendors().len(), 4);
     }
 
@@ -345,6 +367,8 @@ enabled = false
 
     #[test]
     fn enabled_vendors_preserves_canonical_order() {
+        // DeepSeek is disabled by default (requires explicit API key config),
+        // so it is absent from the enabled list unless the user enables it.
         let c = Config::default();
         assert_eq!(
             c.enabled_vendors(),
@@ -352,8 +376,23 @@ enabled = false
                 VendorId::Anthropic,
                 VendorId::Openai,
                 VendorId::Zai,
-                VendorId::Openrouter
+                VendorId::Openrouter,
             ]
         );
+    }
+
+    #[test]
+    fn deepseek_appears_when_enabled() {
+        let f = write_toml(
+            r#"
+            [deepseek]
+            enabled = true
+            api_key = "sk-test"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        assert!(c.is_enabled(VendorId::Deepseek));
+        assert!(c.enabled_vendors().contains(&VendorId::Deepseek));
+        assert_eq!(c.deepseek.api_key.as_deref(), Some("sk-test"));
     }
 }

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -1,0 +1,240 @@
+//! Fetch DeepSeek usage from `/user/balance`.
+
+use std::time::Duration;
+
+use crate::cache::{Cache, acquire_lock};
+use crate::error::{AppError, Result};
+use crate::usage::DeepseekSnapshot;
+
+use super::types::BalanceResponse;
+
+pub const BASE_URL: &str = "https://api.deepseek.com";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub balance: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            balance: format!("{BASE_URL}/user/balance"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchOutcome {
+    pub snapshot: DeepseekSnapshot,
+    pub stale: bool,
+    pub last_error: Option<(u16, String)>,
+    pub cache_age: Option<Duration>,
+}
+
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    api_key: &str,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
+        return Ok(reuse_cache(bytes, cache, false));
+    }
+
+    match fetch_live(client, &endpoints.balance, api_key).await {
+        Ok(snap) => {
+            let bytes = serde_json::to_vec(&snap_to_json(&snap)).unwrap_or_default();
+            cache.write_payload(&bytes)?;
+            Ok(FetchOutcome {
+                snapshot: snap,
+                stale: false,
+                last_error: None,
+                cache_age: Some(Duration::ZERO),
+            })
+        }
+        Err(e) if e.is_transient() => fallback_silent(cache),
+        Err(AppError::Http { status, body }) => {
+            cache.mark_stale();
+            cache.write_last_error(status, &body);
+            fallback_with_error(cache, Some((status, body)))
+        }
+        Err(e) => {
+            cache.mark_stale();
+            cache.write_last_error(0, &e.to_string());
+            fallback_with_error(cache, Some((0, e.to_string())))
+        }
+    }
+}
+
+fn fallback_silent(cache: &Cache) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.maybe_payload()? else {
+        return Err(AppError::Transport(
+            "deepseek: no cache and network unreachable".into(),
+        ));
+    };
+    Ok(reuse_cache(bytes, cache, true))
+}
+
+fn fallback_with_error(cache: &Cache, last_error: Option<(u16, String)>) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.maybe_payload()? else {
+        return Err(AppError::Other("deepseek: no usable cache".into()));
+    };
+    let mut outcome = reuse_cache(bytes, cache, true);
+    outcome.last_error = last_error;
+    Ok(outcome)
+}
+
+fn reuse_cache(bytes: Vec<u8>, cache: &Cache, stale: bool) -> FetchOutcome {
+    let snap = parse_cache(&bytes).unwrap_or_default();
+    FetchOutcome {
+        snapshot: snap,
+        stale,
+        last_error: cache.read_last_error(),
+        cache_age: cache.payload_age(),
+    }
+}
+
+fn parse_cache(bytes: &[u8]) -> Result<DeepseekSnapshot> {
+    let v: serde_json::Value = serde_json::from_slice(bytes)?;
+    Ok(DeepseekSnapshot {
+        is_available: v["is_available"].as_bool().unwrap_or(false),
+        balance: v["balance"].as_f64().unwrap_or(0.0),
+        granted: v["granted"].as_f64().unwrap_or(0.0),
+        topped_up: v["topped_up"].as_f64().unwrap_or(0.0),
+        currency: v["currency"].as_str().unwrap_or("").to_string(),
+    })
+}
+
+fn snap_to_json(snap: &DeepseekSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "is_available": snap.is_available,
+        "balance": snap.balance,
+        "granted": snap.granted,
+        "topped_up": snap.topped_up,
+        "currency": snap.currency,
+    })
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+) -> Result<DeepseekSnapshot> {
+    let resp = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Accept", "application/json")
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport(format!("deepseek timeout: {url}")))??;
+
+    let status = resp.status();
+    let bytes = resp.bytes().await?;
+
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&bytes).chars().take(200).collect();
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let r: BalanceResponse = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Schema(format!("deepseek balance response: {e}")))?;
+    Ok(r.into_snapshot())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cache_fixture() -> (TempDir, Cache) {
+        let td = TempDir::new().unwrap();
+        let cache = Cache::at(td.path().join("deepseek"));
+        cache.ensure_dir().unwrap();
+        (td, cache)
+    }
+
+    #[tokio::test]
+    async fn live_200_returns_snapshot() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/user/balance")
+            .with_status(200)
+            .with_body(r#"{
+                "is_available": true,
+                "balance_infos": [
+                    {"currency": "USD", "total_balance": "5.00", "granted_balance": "5.00", "topped_up_balance": "0.00"}
+                ]
+            }"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            balance: format!("{}/user/balance", server.url()),
+        };
+        let out = fetch_snapshot(
+            &client,
+            "sk-test",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        assert!(out.snapshot.is_available);
+        assert!((out.snapshot.balance - 5.0).abs() < 1e-9);
+        assert_eq!(out.snapshot.currency, "USD");
+        assert!(!out.stale);
+    }
+
+    #[tokio::test]
+    async fn http_401_falls_back_to_cache() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/user/balance")
+            .with_status(401)
+            .with_body(r#"{"error": "invalid api key"}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let seed = serde_json::json!({
+            "is_available": true,
+            "balance": 3.0,
+            "granted": 3.0,
+            "topped_up": 0.0,
+            "currency": "USD"
+        });
+        cache.write_payload(seed.to_string().as_bytes()).unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            balance: format!("{}/user/balance", server.url()),
+        };
+        let out = fetch_snapshot(
+            &client,
+            "bad-key",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        assert!(out.stale);
+        assert!((out.snapshot.balance - 3.0).abs() < 1e-9);
+        assert_eq!(out.last_error.as_ref().map(|(c, _)| *c), Some(401));
+    }
+}

--- a/src/deepseek/mod.rs
+++ b/src/deepseek/mod.rs
@@ -1,0 +1,5 @@
+pub mod fetch;
+pub mod types;
+pub mod vendor;
+
+pub use fetch::fetch_snapshot;

--- a/src/deepseek/types.rs
+++ b/src/deepseek/types.rs
@@ -1,0 +1,92 @@
+//! Wire types for DeepSeek's `/user/balance` endpoint.
+
+use serde::Deserialize;
+
+use crate::usage::DeepseekSnapshot;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct BalanceResponse {
+    pub is_available: bool,
+    pub balance_infos: Vec<BalanceInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct BalanceInfo {
+    pub currency: String,
+    pub total_balance: String,
+    pub granted_balance: String,
+    pub topped_up_balance: String,
+}
+
+impl BalanceResponse {
+    pub fn into_snapshot(self) -> DeepseekSnapshot {
+        // Prefer USD, fall back to CNY, then whatever's first.
+        let info = self
+            .balance_infos
+            .iter()
+            .find(|b| b.currency == "USD")
+            .or_else(|| self.balance_infos.iter().find(|b| b.currency == "CNY"))
+            .or_else(|| self.balance_infos.first())
+            .cloned()
+            .unwrap_or_default();
+
+        DeepseekSnapshot {
+            is_available: self.is_available,
+            balance: parse_f64(&info.total_balance),
+            granted: parse_f64(&info.granted_balance),
+            topped_up: parse_f64(&info.topped_up_balance),
+            currency: info.currency,
+        }
+    }
+}
+
+fn parse_f64(s: &str) -> f64 {
+    s.trim().parse::<f64>().unwrap_or(0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_balance_response() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "CNY", "total_balance": "10.00", "granted_balance": "10.00", "topped_up_balance": "0.00"},
+                {"currency": "USD", "total_balance": "1.50", "granted_balance": "1.50", "topped_up_balance": "0.00"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        let snap = r.into_snapshot();
+        assert!(snap.is_available);
+        assert_eq!(snap.currency, "USD");
+        assert!((snap.balance - 1.50).abs() < 1e-9);
+    }
+
+    #[test]
+    fn fallback_to_cny_when_no_usd() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "CNY", "total_balance": "20.00", "granted_balance": "20.00", "topped_up_balance": "0.00"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        let snap = r.into_snapshot();
+        assert_eq!(snap.currency, "CNY");
+        assert!((snap.balance - 20.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn empty_balance_infos() {
+        let raw = r#"{"is_available": false, "balance_infos": []}"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        let snap = r.into_snapshot();
+        assert!(!snap.is_available);
+        assert_eq!(snap.balance, 0.0);
+        assert_eq!(snap.currency, "");
+    }
+}

--- a/src/deepseek/vendor.rs
+++ b/src/deepseek/vendor.rs
@@ -1,0 +1,272 @@
+//! DeepSeek renderer — bar text + bordered Pango tooltip.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::pacing::PaceSeverity;
+use crate::pango::{color_span, escape, severity_color};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::usage::DeepseekSnapshot;
+use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+
+pub const DEFAULT_FORMAT: &str = "{ds_balance}";
+
+pub fn build_placeholders(snap: &DeepseekSnapshot) -> HashMap<&'static str, String> {
+    let avail = if snap.is_available { "up" } else { "down" };
+    placeholders(vec![
+        ("icon", "󰧑".to_string()),
+        ("vendor_short", "dsk".to_string()),
+        // Cross-vendor aliases — no rate-limit windows for DeepSeek.
+        ("session_pct", "0".to_string()),
+        ("session_reset", "—".to_string()),
+        ("weekly_pct", "0".to_string()),
+        ("weekly_reset", "—".to_string()),
+        ("plan", "DeepSeek".to_string()),
+        ("ds_balance", format_money(snap.balance, &snap.currency)),
+        ("ds_granted", format_money(snap.granted, &snap.currency)),
+        ("ds_topped_up", format_money(snap.topped_up, &snap.currency)),
+        ("ds_available", avail.to_string()),
+        ("currency", snap.currency.clone()),
+    ])
+}
+
+fn format_money(v: f64, currency: &str) -> String {
+    match currency {
+        "USD" => format!("${v:.2}"),
+        "CNY" => format!("¥{v:.2}"),
+        _ => format!("{v:.2} {currency}"),
+    }
+}
+
+pub fn severity(snap: &DeepseekSnapshot) -> PaceSeverity {
+    if !snap.is_available {
+        return PaceSeverity::Critical;
+    }
+    // Thresholds scaled by currency. CNY ≈ 7× USD (rough parity).
+    // critical / high / mid boundaries in each currency unit.
+    let (t_critical, t_high, t_mid) = match snap.currency.as_str() {
+        "CNY" => (7.0_f64, 35.0, 140.0),
+        _ => (1.0_f64, 5.0, 20.0), // USD and unknowns treated as USD-scale
+    };
+    if snap.balance < t_critical {
+        PaceSeverity::Critical
+    } else if snap.balance < t_high {
+        PaceSeverity::High
+    } else if snap.balance < t_mid {
+        PaceSeverity::Mid
+    } else {
+        PaceSeverity::Low
+    }
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &DeepseekSnapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let class = Class::from(severity(snap));
+    let format = opts
+        .format
+        .clone()
+        .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
+    let values = build_placeholders(snap);
+
+    let mut text = substitute(&format, &values);
+    if outcome.stale {
+        text.push_str(" ⏸");
+    }
+
+    let wrapper_color = severity_color(severity(snap), theme).to_string();
+    let icon_prefix = match opts.icon.as_deref() {
+        Some(ic) if !ic.is_empty() => format!("{ic} "),
+        _ => String::new(),
+    };
+    let bar_text = color_span(&wrapper_color, &format!("{icon_prefix}{text}"));
+
+    let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
+        substitute(fmt, &values)
+    } else {
+        render_tooltip(outcome, snap, theme, now)
+    };
+
+    WaybarOutput {
+        text: bar_text,
+        tooltip,
+        class,
+    }
+}
+
+fn render_tooltip(
+    outcome: &VendorOutcome,
+    snap: &DeepseekSnapshot,
+    theme: &Theme,
+    now: DateTime<Utc>,
+) -> String {
+    let blue = &theme.blue;
+    let dim = &theme.dim;
+    let fg = &theme.fg;
+    let color = severity_color(severity(snap), theme);
+
+    let avail_label = if snap.is_available {
+        "API available"
+    } else {
+        "API unavailable"
+    };
+
+    let mut lines: Vec<TooltipLine> = Vec::new();
+    lines.push(TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{blue}'>DeepSeek</span>"
+    )));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body("".into()));
+
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{fg}'>  󰢗  Balance</span>"
+    )));
+    lines.push(TooltipLine::Body(format!(
+        "   <span font_weight='bold' foreground='{color}'>{bal}</span>",
+        bal = escape(&format_money(snap.balance, &snap.currency))
+    )));
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>     granted {granted} · topped-up {topped}</span>",
+        granted = escape(&format_money(snap.granted, &snap.currency)),
+        topped = escape(&format_money(snap.topped_up, &snap.currency))
+    )));
+
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰛴  {avail_label}</span>"
+    )));
+
+    if let Some((code, msg)) = outcome.last_error.as_ref() {
+        if *code != 0 {
+            let (icon, ecolor) = if *code >= 500 {
+                ("󰅚", theme.red.as_str())
+            } else {
+                ("󰀪", theme.orange.as_str())
+            };
+            lines.push(TooltipLine::Body("".into()));
+            lines.push(TooltipLine::Sep);
+            lines.push(TooltipLine::Body(format!(
+                " <span foreground='{ecolor}'>  {icon}  HTTP {code}</span>"
+            )));
+            lines.push(TooltipLine::Body(format!(
+                "     <span foreground='{dim}'>{}</span>",
+                escape(msg)
+            )));
+        }
+    }
+
+    let updated = updated_at_hm(now, outcome.cache_age);
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰅐  Updated {updated}</span>"
+    )));
+
+    render_bordered(&lines, theme)
+}
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(o: FetchOutcome) -> Self {
+        Self {
+            snapshot: crate::usage::VendorSnapshot::Deepseek(o.snapshot),
+            stale: o.stale,
+            last_error: o.last_error,
+            cache_age: o.cache_age,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usage::DeepseekSnapshot;
+
+    fn sample_snap() -> DeepseekSnapshot {
+        DeepseekSnapshot {
+            is_available: true,
+            balance: 5.50,
+            granted: 5.00,
+            topped_up: 0.50,
+            currency: "USD".into(),
+        }
+    }
+
+    fn sample_outcome(snap: DeepseekSnapshot) -> VendorOutcome {
+        VendorOutcome {
+            snapshot: crate::usage::VendorSnapshot::Deepseek(snap),
+            stale: false,
+            last_error: None,
+            cache_age: Some(std::time::Duration::from_secs(10)),
+        }
+    }
+
+    fn opts() -> RenderOpts {
+        RenderOpts {
+            format: None,
+            tooltip_format: None,
+            icon: None,
+            pace_tolerance: 5,
+            format_pace_color: false,
+            tooltip_pace_pts: false,
+        }
+    }
+
+    #[test]
+    fn default_render_shows_balance() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let theme = Theme::default();
+        let out = render(&outcome, &snap, &theme, &opts(), Utc::now());
+        assert!(out.text.contains("$5.50"));
+    }
+
+    #[test]
+    fn tooltip_includes_balance_and_availability() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let theme = Theme::default();
+        let out = render(&outcome, &snap, &theme, &opts(), Utc::now());
+        assert!(out.tooltip.contains("Balance"));
+        assert!(out.tooltip.contains("$5.50"));
+        assert!(out.tooltip.contains("API available"));
+    }
+
+    #[test]
+    fn unavailable_api_shows_critical_severity() {
+        let mut snap = sample_snap();
+        snap.is_available = false;
+        assert_eq!(severity(&snap), PaceSeverity::Critical);
+    }
+
+    #[test]
+    fn stale_appends_pause() {
+        let snap = sample_snap();
+        let mut outcome = sample_outcome(snap.clone());
+        outcome.stale = true;
+        let theme = Theme::default();
+        let out = render(&outcome, &snap, &theme, &opts(), Utc::now());
+        assert!(out.text.contains("⏸"));
+    }
+
+    #[test]
+    fn cny_format() {
+        let snap = DeepseekSnapshot {
+            is_available: true,
+            balance: 20.0,
+            granted: 20.0,
+            topped_up: 0.0,
+            currency: "CNY".into(),
+        };
+        assert_eq!(format_money(snap.balance, &snap.currency), "¥20.00");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod anthropic;
 pub mod cache;
 pub mod config;
 pub mod countdown;
+pub mod deepseek;
 pub mod error;
 pub mod format;
 pub mod openai;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -104,9 +104,9 @@ pub async fn refresh_one(client: &Client, config: &Config, vendor: VendorId) -> 
             // `Utc::now() - cache_age` on every draw and the displayed time would
             // tick upward in real time instead of holding at the last refresh.
             let now = Utc::now();
-            let fetched_at = outcome.cache_age.map(|age| {
-                now - chrono::Duration::from_std(age).unwrap_or_default()
-            });
+            let fetched_at = outcome
+                .cache_age
+                .map(|age| now - chrono::Duration::from_std(age).unwrap_or_default());
             TabState::Ready(Box::new(ReadyTab {
                 snapshot: outcome.snapshot,
                 stale: outcome.stale,
@@ -194,6 +194,19 @@ async fn build_outcome(
             let endpoints = crate::openai::fetch::Endpoints::default();
             let outcome =
                 crate::openai::fetch_snapshot(client, &creds_path, &cache, &endpoints, DEFAULT_TTL)
+                    .await?;
+            Ok(outcome.into())
+        }
+        VendorId::Deepseek => {
+            let api_key = crate::config::resolve_api_key(
+                "DeepSeek",
+                &config.deepseek.api_key_env,
+                config.deepseek.api_key.as_deref(),
+            )?;
+            let cache = crate::cache::Cache::for_vendor("deepseek")?;
+            let endpoints = crate::deepseek::fetch::Endpoints::default();
+            let outcome =
+                crate::deepseek::fetch_snapshot(client, &api_key, &cache, &endpoints, DEFAULT_TTL)
                     .await?;
             Ok(outcome.into())
         }

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -78,6 +78,7 @@ pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> 
                 VendorSnapshot::Openai(s) => openai_sections(s, now, pace_tolerance),
                 VendorSnapshot::Zai(s) => zai_sections(s, now),
                 VendorSnapshot::Openrouter(s) => openrouter_sections(s),
+                VendorSnapshot::Deepseek(s) => deepseek_sections(s),
             };
             // Inject the (already-absolute) fetched-at instant into the title
             // row, right-aligned. Pre-snapshotted in app::refresh_one so it
@@ -229,6 +230,43 @@ fn openrouter_sections(s: &crate::usage::OpenRouterSnapshot) -> Vec<Section> {
         } else {
             "paid tier".into()
         }],
+    });
+    v
+}
+
+fn deepseek_sections(s: &crate::usage::DeepseekSnapshot) -> Vec<Section> {
+    let currency = &s.currency;
+    let fmt = |v: f64| match currency.as_str() {
+        "USD" => format!("${v:.2}"),
+        "CNY" => format!("¥{v:.2}"),
+        _ => format!("{v:.2} {currency}"),
+    };
+    let avail = if s.is_available {
+        "available"
+    } else {
+        "unavailable"
+    };
+    let mut v = vec![Section::Title {
+        left: "DeepSeek".into(),
+        right: None,
+    }];
+    v.push(Section::Spacer);
+    v.push(Section::Text {
+        label: "Balance".into(),
+        value: fmt(s.balance),
+    });
+    v.push(Section::Block {
+        label: "Breakdown".into(),
+        body: vec![format!(
+            "granted {} · topped-up {}",
+            fmt(s.granted),
+            fmt(s.topped_up)
+        )],
+    });
+    v.push(Section::Spacer);
+    v.push(Section::Block {
+        label: "API".into(),
+        body: vec![avail.into()],
     });
     v
 }

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -26,6 +26,7 @@ pub enum Focus {
     Primary,
     ZaiKey,
     OpenrouterKey,
+    DeepseekKey,
     SaveButton,
 }
 
@@ -34,7 +35,8 @@ impl Focus {
         match self {
             Focus::Primary => Focus::ZaiKey,
             Focus::ZaiKey => Focus::OpenrouterKey,
-            Focus::OpenrouterKey => Focus::SaveButton,
+            Focus::OpenrouterKey => Focus::DeepseekKey,
+            Focus::DeepseekKey => Focus::SaveButton,
             Focus::SaveButton => Focus::Primary,
         }
     }
@@ -43,7 +45,8 @@ impl Focus {
             Focus::Primary => Focus::SaveButton,
             Focus::ZaiKey => Focus::Primary,
             Focus::OpenrouterKey => Focus::ZaiKey,
-            Focus::SaveButton => Focus::OpenrouterKey,
+            Focus::DeepseekKey => Focus::OpenrouterKey,
+            Focus::SaveButton => Focus::DeepseekKey,
         }
     }
 }
@@ -149,6 +152,7 @@ pub struct SettingsState {
     pub primary: VendorId,
     pub zai: KeyInput,
     pub openrouter: KeyInput,
+    pub deepseek: KeyInput,
     /// One-line status displayed in the footer ("Saved", "Error: ...", "").
     pub status: String,
 }
@@ -160,6 +164,7 @@ impl SettingsState {
             primary: cfg.ui.primary.unwrap_or(VendorId::Anthropic),
             zai: KeyInput::from_config(cfg.zai.api_key.as_deref()),
             openrouter: KeyInput::from_config(cfg.openrouter.api_key.as_deref()),
+            deepseek: KeyInput::from_config(cfg.deepseek.api_key.as_deref()),
             status: String::new(),
         }
     }
@@ -200,6 +205,7 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
         match state.focus {
             Focus::ZaiKey => state.zai.toggle_reveal(),
             Focus::OpenrouterKey => state.openrouter.toggle_reveal(),
+            Focus::DeepseekKey => state.deepseek.toggle_reveal(),
             _ => {}
         }
         return Action::Continue;
@@ -231,6 +237,7 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
         Focus::Primary => handle_primary(state, code),
         Focus::ZaiKey => handle_input(&mut state.zai, code),
         Focus::OpenrouterKey => handle_input(&mut state.openrouter, code),
+        Focus::DeepseekKey => handle_input(&mut state.deepseek, code),
         Focus::SaveButton => {
             if matches!(code, KeyCode::Enter) {
                 return match save_to_config_default(state) {
@@ -313,6 +320,10 @@ pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
     if state.openrouter.dirty && !state.openrouter.buf.is_empty() {
         set_string(&mut doc, "openrouter", "api_key", &state.openrouter.buf)?;
     }
+    // [deepseek].api_key — same
+    if state.deepseek.dirty && !state.deepseek.buf.is_empty() {
+        set_string(&mut doc, "deepseek", "api_key", &state.deepseek.buf)?;
+    }
 
     let bytes = doc.to_string();
     crate::cache::atomic_write(path, bytes.as_bytes())?;
@@ -380,17 +391,19 @@ pub fn render(f: &mut Frame, area: Rect, state: &SettingsState, theme: &Theme) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(1), // primary label
-            Constraint::Length(2), // primary radio row
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // zai label
-            Constraint::Length(2), // zai input
-            Constraint::Length(1), // openrouter label
-            Constraint::Length(2), // openrouter input
-            Constraint::Length(1), // spacer
-            Constraint::Length(1), // save button
-            Constraint::Length(1), // status
-            Constraint::Min(0),    // hint
+            Constraint::Length(1), // [0] primary label
+            Constraint::Length(2), // [1] primary radio row
+            Constraint::Length(1), // [2] spacer
+            Constraint::Length(1), // [3] zai label
+            Constraint::Length(2), // [4] zai input
+            Constraint::Length(1), // [5] openrouter label
+            Constraint::Length(2), // [6] openrouter input
+            Constraint::Length(1), // [7] deepseek label
+            Constraint::Length(2), // [8] deepseek input
+            Constraint::Length(1), // [9] spacer
+            Constraint::Length(1), // [10] save button
+            Constraint::Length(1), // [11] status
+            Constraint::Min(0),    // [12] hint
         ])
         .split(inner);
 
@@ -451,6 +464,27 @@ pub fn render(f: &mut Frame, area: Rect, state: &SettingsState, theme: &Theme) {
         chunks[6],
     );
 
+    // DeepSeek key.
+    f.render_widget(
+        Paragraph::new(label(
+            "DeepSeek API key (DEEPSEEK_API_KEY env wins if set)",
+            state.focus == Focus::DeepseekKey,
+            fg,
+            accent,
+        )),
+        chunks[7],
+    );
+    f.render_widget(
+        Paragraph::new(render_input(
+            &state.deepseek,
+            state.focus == Focus::DeepseekKey,
+            fg,
+            accent,
+            dim,
+        )),
+        chunks[8],
+    );
+
     // Save button.
     let save_style = if state.focus == Focus::SaveButton {
         Style::default()
@@ -464,7 +498,7 @@ pub fn render(f: &mut Frame, area: Rect, state: &SettingsState, theme: &Theme) {
             "   [ Save (Ctrl-S) ]   ",
             save_style,
         ))),
-        chunks[8],
+        chunks[10],
     );
 
     // Status line.
@@ -474,7 +508,7 @@ pub fn render(f: &mut Frame, area: Rect, state: &SettingsState, theme: &Theme) {
                 state.status.clone(),
                 Style::default().fg(dim),
             ))),
-            chunks[9],
+            chunks[11],
         );
     }
 
@@ -483,7 +517,7 @@ pub fn render(f: &mut Frame, area: Rect, state: &SettingsState, theme: &Theme) {
         "  Tab/↑↓ move · ←→ pick vendor · Ctrl-V reveal · Ctrl-S save · Esc cancel",
         Style::default().fg(dim),
     )]);
-    f.render_widget(Paragraph::new(hint), chunks[10]);
+    f.render_widget(Paragraph::new(hint), chunks[12]);
 }
 
 fn label(text: &str, focused: bool, fg: Color, accent: Color) -> Line<'static> {
@@ -518,6 +552,7 @@ fn vendor_label(v: VendorId) -> &'static str {
         VendorId::Openai => "OpenAI",
         VendorId::Zai => "Z.AI",
         VendorId::Openrouter => "OpenRouter",
+        VendorId::Deepseek => "DeepSeek",
     }
 }
 
@@ -582,6 +617,7 @@ mod tests {
             primary,
             zai: KeyInput::from_config(Some(zai)),
             openrouter: KeyInput::from_config(Some(opr)),
+            deepseek: KeyInput::default(),
             status: String::new(),
         };
         // Mark dirty so save writes them.
@@ -596,11 +632,13 @@ mod tests {
             Focus::Primary,
             Focus::ZaiKey,
             Focus::OpenrouterKey,
+            Focus::DeepseekKey,
             Focus::SaveButton,
         ];
+        let n = order.len();
         for (i, f) in order.iter().enumerate() {
-            assert_eq!(f.next(), order[(i + 1) % 4]);
-            assert_eq!(f.prev(), order[(i + 3) % 4]);
+            assert_eq!(f.next(), order[(i + 1) % n]);
+            assert_eq!(f.prev(), order[(i + n - 1) % n]);
         }
     }
 
@@ -734,6 +772,7 @@ api_key_env = "OPENROUTER_API_KEY"
             primary: VendorId::Anthropic,
             zai: KeyInput::default(),
             openrouter: KeyInput::default(),
+            deepseek: KeyInput::default(),
             status: String::new(),
         };
         assert_eq!(
@@ -755,6 +794,7 @@ api_key_env = "OPENROUTER_API_KEY"
             primary: VendorId::Anthropic,
             zai: KeyInput::default(),
             openrouter: KeyInput::default(),
+            deepseek: KeyInput::default(),
             status: String::new(),
         };
         assert_eq!(
@@ -770,6 +810,7 @@ api_key_env = "OPENROUTER_API_KEY"
             primary: VendorId::Anthropic,
             zai: KeyInput::default(),
             openrouter: KeyInput::default(),
+            deepseek: KeyInput::default(),
             status: String::new(),
         };
         handle_key(&mut s, KeyCode::Right, KeyModifiers::NONE);
@@ -787,6 +828,7 @@ api_key_env = "OPENROUTER_API_KEY"
             primary: VendorId::Anthropic,
             zai: KeyInput::from_config(Some("secret")),
             openrouter: KeyInput::default(),
+            deepseek: KeyInput::default(),
             status: String::new(),
         };
         assert!(!s.zai.revealed);

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -36,6 +36,7 @@ fn vendor_label(id: VendorId) -> &'static str {
         VendorId::Openai => "OpenAI",
         VendorId::Zai => "GLM (Z.AI)",
         VendorId::Openrouter => "OpenRouter",
+        VendorId::Deepseek => "DeepSeek",
     }
 }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -77,6 +77,34 @@ impl ExtraUsage {
     }
 }
 
+/// DeepSeek — credit balance from `/user/balance`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DeepseekSnapshot {
+    pub is_available: bool,
+    /// Current balance (prefer USD, fallback to CNY).
+    pub balance: f64,
+    /// Free-granted credits component.
+    pub granted: f64,
+    /// Topped-up (purchased) credits component.
+    pub topped_up: f64,
+    /// The currency of the above amounts ("USD", "CNY", etc.).
+    pub currency: String,
+}
+
+impl Eq for DeepseekSnapshot {}
+
+impl Default for DeepseekSnapshot {
+    fn default() -> Self {
+        Self {
+            is_available: false,
+            balance: 0.0,
+            granted: 0.0,
+            topped_up: 0.0,
+            currency: String::new(),
+        }
+    }
+}
+
 /// Discriminated union of vendor-specific snapshots. The widget and TUI match
 /// on this to pick a renderer.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,6 +113,7 @@ pub enum VendorSnapshot {
     Openai(OpenAiSnapshot),
     Zai(ZaiSnapshot),
     Openrouter(OpenRouterSnapshot),
+    Deepseek(DeepseekSnapshot),
 }
 
 /// OpenAI Codex OAuth — mirrors Anthropic's two-window + extras pattern.

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -24,6 +24,7 @@ pub enum VendorId {
     Openai,
     Zai,
     Openrouter,
+    Deepseek,
 }
 
 impl VendorId {
@@ -33,6 +34,7 @@ impl VendorId {
             VendorId::Openai => "openai",
             VendorId::Zai => "zai",
             VendorId::Openrouter => "openrouter",
+            VendorId::Deepseek => "deepseek",
         }
     }
 
@@ -42,6 +44,7 @@ impl VendorId {
             VendorId::Openai,
             VendorId::Zai,
             VendorId::Openrouter,
+            VendorId::Deepseek,
         ]
     }
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -114,6 +114,7 @@ pub enum Vendor {
     Openai,
     Zai,
     Openrouter,
+    Deepseek,
 }
 
 impl Vendor {
@@ -123,6 +124,7 @@ impl Vendor {
             Vendor::Openai => crate::vendor::VendorId::Openai,
             Vendor::Zai => crate::vendor::VendorId::Zai,
             Vendor::Openrouter => crate::vendor::VendorId::Openrouter,
+            Vendor::Deepseek => crate::vendor::VendorId::Deepseek,
         }
     }
 }
@@ -155,6 +157,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::Openai => Vendor::Openai,
         crate::vendor::VendorId::Zai => Vendor::Zai,
         crate::vendor::VendorId::Openrouter => Vendor::Openrouter,
+        crate::vendor::VendorId::Deepseek => Vendor::Deepseek,
     }
 }
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -11,6 +11,7 @@ use reqwest::Client;
 use crate::anthropic::{self, fetch::FetchOutcome};
 use crate::cache::{Cache, DEFAULT_TTL};
 use crate::config::Config;
+use crate::deepseek;
 use crate::error::{AppError, Result};
 use crate::openai;
 use crate::openrouter;
@@ -105,6 +106,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::Openrouter => openrouter_output(cli, &config).await,
         Vendor::Openai => openai_output(cli, &config).await,
         Vendor::Zai => zai_output(cli, &config).await,
+        Vendor::Deepseek => deepseek_output(cli, &config).await,
     }
 }
 
@@ -202,6 +204,35 @@ async fn openrouter_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     let vendor_outcome: VendorOutcome = outcome.into();
     let opts = RenderOpts::from_cli(cli);
     Ok(openrouter::vendor::render(
+        &vendor_outcome,
+        &snap,
+        &theme,
+        &opts,
+        chrono::Utc::now(),
+    ))
+}
+
+async fn deepseek_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let api_key = crate::config::resolve_api_key(
+        "DeepSeek",
+        &config.deepseek.api_key_env,
+        config.deepseek.api_key.as_deref(),
+    )?;
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "deepseek")?;
+    let endpoints = deepseek::fetch::Endpoints::default();
+    let outcome =
+        match deepseek::fetch_snapshot(&client, &api_key, &cache, &endpoints, DEFAULT_TTL).await {
+            Ok(o) => o,
+            Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
+            Err(e) => return Err(e),
+        };
+
+    let theme = theme_from_cli(cli);
+    let snap = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    let opts = RenderOpts::from_cli(cli);
+    Ok(deepseek::vendor::render(
         &vendor_outcome,
         &snap,
         &theme,


### PR DESCRIPTION
## Add DeepSeek vendor

This adds **DeepSeek** as a vendor alongside Anthropic, OpenAI, Z.AI, and OpenRouter, so the widget/TUI can show your DeepSeek credit balance.

### What it does
- Fetches credit balance from `GET /user/balance`, preferring **USD** over **CNY** when the account exposes both.
- Severity thresholds are scaled per currency (CNY ≈ 7× USD), so CNY accounts aren't incorrectly flagged as low.
- Reads the API key from `DEEPSEEK_API_KEY` (env) or `[deepseek] api_key` (config), using the existing `resolve_api_key` order.
- **Disabled by default** — requires explicit `[deepseek] enabled = true` + a key.
- Adds a DeepSeek key field to the TUI Settings overlay, consistent with Z.AI / OpenRouter.

### Design notes
I followed the **OpenRouter** module as the template since it's the most similar existing vendor (single API-key, balance-style endpoint): same `mod/types/fetch/vendor` split, same cache/`flock`/stale-fallback patterns, same "widget always exits 0" fallback path.

### Testing
- `cargo test` → 229 passing, 0 regressions (added unit tests for the balance parser, USD/CNY preference, fallback-to-cache on HTTP 401, severity, and rendering).
- `cargo clippy --all-targets -- -D warnings` → clean.
- README, CHANGELOG (`[Unreleased]`), and `config.example.toml` updated.

Happy to adjust naming, thresholds, or anything else to match your preferences. Thanks for the project! 🙏
