### PR TITLE
docs: add CSS padding instructions for Waybar theme compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` /
 
 `signal: 13` lets the scroll-cycle commands refresh the bar instantly (via `SIGRTMIN+13`) instead of waiting for the next 300s interval.
 
+If your Waybar theme puts a tray expander immediately after `custom/aibar`, such as Omarchy's `group/tray-expander` with `custom/expand-icon`, the usage text can sit very close to the expand icon. Add right padding for the module in your Waybar CSS if you want extra spacing:
+
+```css
+#custom-aibar {
+    padding-right: 18px;
+}
+```
+
 ### Per-vendor modules
 
 If you'd rather see them all at once:


### PR DESCRIPTION
# docs: add Waybar CSS spacing note for `custom/aibar`

Adds a README note explaining how to customize Waybar CSS spacing for `custom/aibar` when it is placed next to a tray expander icon.

This helps users avoid the AI usage text appearing too close to the `custom/expand-icon` module when `custom/aibar` is the first item in `modules-right`.

## Changes

Documented an optional Waybar CSS rule:

```css
#custom-aibar {
    padding-right: 18px;
}
```

Also added context for configurations using:

```json
"group/tray-expander"
"custom/expand-icon"
```

where the expander icon may appear visually attached to the AI usage text due to missing spacing between adjacent modules.

## Before

<img width="279" height="24" alt="image" src="https://github.com/user-attachments/assets/76a0057c-ab4c-42fe-acf0-0bfc88a55403" />

## After

<img width="286" height="28" alt="image" src="https://github.com/user-attachments/assets/137247b1-8465-4101-a514-446537f99221" />

## Testing

Documentation-only change.

No code changes or automated tests were required.
