### PR TITLE
Honor [anthropic] credentials_path in the waybar widget

### DIFF
--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -102,7 +102,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         )));
     }
     match vendor {
-        Vendor::Anthropic => anthropic_output(cli).await,
+        Vendor::Anthropic => anthropic_output(cli, &config).await,
         Vendor::Openrouter => openrouter_output(cli, &config).await,
         Vendor::Openai => openai_output(cli, &config).await,
         Vendor::Zai => zai_output(cli, &config).await,
@@ -241,12 +241,15 @@ async fn deepseek_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     ))
 }
 
-async fn anthropic_output(cli: &Cli) -> Result<WaybarOutput> {
+async fn anthropic_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     let client = http_client()?;
     let cache = vendor_cache(cli, "anthropic")?;
     let creds_path = match cli.creds_path.as_deref() {
         Some(p) => p.to_path_buf(),
-        None => anthropic::creds::default_path()?,
+        None => match config.anthropic.credentials_path.as_deref() {
+            Some(p) => p.to_path_buf(),
+            None => anthropic::creds::default_path()?,
+        },
     };
     let endpoints = anthropic::fetch::Endpoints::default();
     let outcome = match anthropic::fetch_snapshot(


### PR DESCRIPTION
## Problem

The waybar widget errors with an I/O error on the default credentials path even when a custom `credentials_path` is set under `[anthropic]` in `config.toml`. The TUI works fine with the same config.

## Cause

`widget/run.rs::anthropic_output()` only consulted the `--creds-path` CLI flag before falling back to the hardcoded `~/.claude/.credentials.json`. It never received or read `config.anthropic.credentials_path`, so that key was silently ignored. The TUI behaves correctly because `tui/app.rs` already reads the config value.

## Fix

Pass `&Config` into `anthropic_output()` and resolve the path as:

`--creds-path` flag → `config.anthropic.credentials_path` → default `~/.claude/.credentials.json`

This mirrors the existing `openai_output()` behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)