### PR TITLE
feat: native Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+# Native Windows test signal for PRs. The Waybar widget is Wayland-only, so the
+# Linux gate lives in the maintainer's existing flow; this job proves the CLI +
+# TUI build and test on a real windows-latest runner (no WSL).
+on:
+  push:
+    branches: [main, windows-backend]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows:
+    name: test (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # ring assembles its primitives on x86_64 and needs nasm; the runner does
+      # not ship it on PATH. No-op if a future image already provides it.
+      - uses: ilammy/setup-nasm@v1
+
+      - name: Test
+        run: cargo test --all-targets --locked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,26 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **Native Windows support for the `ai-usagebar` and `ai-usagebar-tui`
+  binaries.** Credential paths now resolve the home directory through
+  `directories::BaseDirs` (a new shared `cache::home_dir()` helper) instead
+  of reading `$HOME` directly, so Anthropic (`%USERPROFILE%\.claude\.credentials.json`)
+  and OpenAI Codex (`%USERPROFILE%\.codex\auth.json`) credentials are found
+  natively on Windows. The Waybar refresh (`pkill -RTMIN+13 waybar`) is gated
+  to Unix and becomes a no-op elsewhere, since Waybar is Wayland-only. Linux
+  and macOS behavior is unchanged. The Waybar widget itself remains
+  Wayland-only; on Windows the TUI is the entry point.
+
+### Fixed
+
+- **TUI double-processed keystrokes on Windows Terminal.** Terminals that
+  report key `Repeat`/`Release` events in addition to `Press` (Windows
+  Terminal, and emulators advertising the Kitty keyboard protocol) made one
+  Tab/arrow press move several tabs and holding a key fly through them. The
+  TUI now acts only on `KeyEventKind::Press`. Harmless and beneficial on all
+  platforms.
 
 ## [0.5.1] — 2026-06-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,11 @@ vendor's response shape drifts:
   `~/.claude/.credentials.json` is absent (Claude Code on macOS stores
   the OAuth blob in the login Keychain). Module-gated with
   `#[cfg(target_os = "macos")]`; Linux build never compiles it.
+- `src/cache.rs` — atomic per-vendor cache writes + flock, plus the shared
+  cross-platform path resolvers (`xdg_cache_dir`, `home_dir`). `home_dir`
+  resolves `$HOME` / `%USERPROFILE%` via `directories::BaseDirs` and is reused
+  by both OAuth-credential vendors (`anthropic`, `openai`) so the OS convention
+  lives in one place.
 - `src/tui/settings.rs` — Settings overlay (toml_edit-backed,
   auto-signals waybar after save)
 - `src/tui/panels.rs` — native ratatui per-vendor panels

--- a/README.md
+++ b/README.md
@@ -50,6 +50,25 @@ sudo make install                  # → /usr/local/bin
 make install PREFIX=$HOME/.local   # → ~/.local/bin
 ```
 
+### Windows
+
+The **Waybar widget is Wayland-only and does not apply to Windows.** The
+**`ai-usagebar-tui`** binary, however, runs natively, and `ai-usagebar --json`
+/ `--pretty` work too (handy for feeding a custom tray/widget). Build with a
+standard Rust toolchain:
+
+```powershell
+cargo build --release
+# binaries land in target\release\ai-usagebar.exe and ai-usagebar-tui.exe
+```
+
+Credentials are read from the Windows user profile rather than `$HOME`:
+`%USERPROFILE%\.claude\.credentials.json` (Anthropic) and
+`%USERPROFILE%\.codex\auth.json` (OpenAI Codex). Run the official `claude` /
+`codex` CLI once on Windows to populate them, exactly as on Linux/macOS.
+API-key vendors (Z.AI, OpenRouter, DeepSeek) work unchanged via environment
+variables or `config.toml`.
+
 ## Authentication
 
 Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth credentials that their official CLIs already wrote to disk, so **no env vars are needed.** Z.AI and OpenRouter use API keys. You can pass those through env vars or, if you don't source secrets in your shell, put them inline in `config.toml`.

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -177,13 +177,25 @@ pub fn write_back(path: &Path, new_oauth: &OauthCreds) -> Result<()> {
 mod tests {
     use super::*;
     use std::io::Write;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     fn write_creds(s: &str) -> NamedTempFile {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(s.as_bytes()).unwrap();
         f.flush().unwrap();
         f
+    }
+
+    /// Like `write_creds`, but writes to a named file inside a `TempDir` and
+    /// closes the handle. `write_back` rewrites the file via an atomic
+    /// rename-over-destination, which on Windows fails if the destination is
+    /// still open (as a live `NamedTempFile` handle would be). Returns the dir
+    /// (kept alive by the caller) and the closed file's path.
+    fn write_creds_closed(s: &str) -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("credentials.json");
+        std::fs::write(&path, s).unwrap();
+        (dir, path)
     }
 
     #[test]
@@ -328,13 +340,13 @@ mod tests {
 
     #[test]
     fn write_back_round_trips_and_preserves_unknown_fields() {
-        let f = write_creds(
+        let (_dir, path) = write_creds_closed(
             r#"{"claudeAiOauth":{
                 "accessToken":"OLD","refreshToken":"OLD","expiresAt": 0,
                 "subscriptionType":"pro","rateLimitTier":""
             },"someOtherField":"keep me"}"#,
         );
-        let creds = read_from(f.path()).unwrap();
+        let creds = read_from(&path).unwrap();
         let new_oauth = OauthCreds {
             access_token: "NEW".into(),
             refresh_token: "NEW_RT".into(),
@@ -343,9 +355,9 @@ mod tests {
             rate_limit_tier: "".into(),
             scopes: creds.claude_ai_oauth.scopes.clone(),
         };
-        write_back(f.path(), &new_oauth).unwrap();
+        write_back(&path, &new_oauth).unwrap();
         // Re-read & verify the unknown field survived.
-        let raw = std::fs::read_to_string(f.path()).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
         let v: serde_json::Value = serde_json::from_str(&raw).unwrap();
         assert_eq!(v["someOtherField"], "keep me");
         assert_eq!(v["claudeAiOauth"]["accessToken"], "NEW");

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -298,7 +298,19 @@ mod tests {
     fn default_path_uses_userprofile_on_windows() {
         let p = default_path().unwrap();
         let userprofile = std::env::var("USERPROFILE").expect("USERPROFILE set on Windows");
-        assert!(p.starts_with(std::path::Path::new(&userprofile)));
+        // directories::BaseDirs resolves the home via SHGetKnownFolderPath, which
+        // can differ from %USERPROFILE% in casing or path separator. Compare on a
+        // normalized basis (lowercased, backslashes) rather than Path::starts_with,
+        // which compares components case-sensitively even on Windows.
+        let norm = |s: &str| s.to_lowercase().replace('/', "\\");
+        let p_norm = norm(&p.to_string_lossy());
+        let up_norm = norm(&userprofile);
+        assert!(
+            p_norm.starts_with(up_norm.as_str()),
+            "{} should live under {}",
+            p.display(),
+            userprofile
+        );
     }
 
     #[test]

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -99,10 +99,15 @@ fn capitalize_first(s: &str) -> String {
     }
 }
 
-/// Default location: `~/.claude/.credentials.json`.
+/// Default location: `~/.claude/.credentials.json` (Unix/macOS) or
+/// `%USERPROFILE%\.claude\.credentials.json` (Windows).
+///
+/// Home is resolved through [`crate::cache::home_dir`] so every platform's
+/// convention is honored in one place.
 pub fn default_path() -> Result<PathBuf> {
-    let home = std::env::var_os("HOME").ok_or_else(|| AppError::Other("HOME not set".into()))?;
-    Ok(PathBuf::from(home).join(".claude/.credentials.json"))
+    Ok(crate::cache::home_dir()?
+        .join(".claude")
+        .join(".credentials.json"))
 }
 
 pub fn read_from(path: &Path) -> Result<CredentialsFile> {
@@ -264,6 +269,24 @@ mod tests {
         let path = std::path::Path::new("/nonexistent/ai-usagebar/.credentials.json");
         let err = read_from(path).unwrap_err();
         assert!(matches!(err, AppError::Io { .. }));
+    }
+
+    #[test]
+    fn default_path_ends_with_claude_credentials() {
+        let p = default_path().unwrap();
+        // The trailing two segments are stable across platforms; only the home
+        // prefix differs (resolved by directories::BaseDirs).
+        assert!(p.ends_with(std::path::Path::new(".claude").join(".credentials.json")));
+    }
+
+    // On Windows the home prefix is %USERPROFILE%, not $HOME — assert the
+    // resolver honors it so the credential file is found natively.
+    #[cfg(windows)]
+    #[test]
+    fn default_path_uses_userprofile_on_windows() {
+        let p = default_path().unwrap();
+        let userprofile = std::env::var("USERPROFILE").expect("USERPROFILE set on Windows");
+        assert!(p.starts_with(std::path::Path::new(&userprofile)));
     }
 
     #[test]

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -39,7 +39,10 @@ async fn run() -> io::Result<()> {
     let mut config = Config::load().unwrap_or_default();
     let vendors = config.enabled_vendors();
     if vendors.is_empty() {
-        eprintln!("No vendors are enabled in ~/.config/ai-usagebar/config.toml. Exiting.");
+        eprintln!(
+            "No vendors are enabled in {}. Exiting.",
+            ai_usagebar::config::config_path_hint()
+        );
         return Ok(());
     }
 

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -16,7 +16,7 @@ use ai_usagebar::tui::view::draw;
 use ai_usagebar::vendor::{HTTP_CLIENT_TIMEOUT, VendorId};
 use chrono::Utc;
 use crossterm::event::{
-    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyModifiers,
+    self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
 };
 use crossterm::execute;
 use crossterm::terminal::{
@@ -103,6 +103,16 @@ async fn event_loop<B: ratatui::backend::Backend>(
                 let polled = res.unwrap_or(Ok(false)).unwrap_or(false);
                 if polled {
                     if let Ok(Event::Key(k)) = event::read() {
+                        // On Windows Terminal (and terminals advertising the
+                        // Kitty keyboard protocol) crossterm reports key Repeat
+                        // (auto-repeat while held) and Release events in addition
+                        // to Press. Acting on anything but Press makes one tap
+                        // move several tabs and holding a key fly through them.
+                        // Treat each *press* as exactly one action; ignore
+                        // Repeat and Release entirely.
+                        if k.kind != KeyEventKind::Press {
+                            continue;
+                        }
                         // Settings overlay consumes all keys when open.
                         if let Some(s) = app.settings.as_mut() {
                             use ai_usagebar::tui::settings::{Action as SAction, handle_key as shandle};

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -235,6 +235,19 @@ fn xdg_cache_dir() -> Result<PathBuf> {
         .ok_or_else(|| AppError::Other("could not resolve XDG cache dir (no HOME?)".into()))
 }
 
+/// The user's home directory, resolved cross-platform via `directories`
+/// (`$HOME` on Unix/macOS, `%USERPROFILE%` / the Known Folder on Windows).
+///
+/// The OAuth-credential vendors (`anthropic`, `openai`) read their CLI-managed
+/// files from fixed dotfiles under `$HOME`; they share this resolver the same
+/// way they already share [`atomic_write`], so home resolution lives in one
+/// place rather than being reimplemented per vendor.
+pub fn home_dir() -> Result<PathBuf> {
+    directories::BaseDirs::new()
+        .map(|b| b.home_dir().to_path_buf())
+        .ok_or_else(|| AppError::Other("could not resolve home directory (no HOME?)".into()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,8 +158,9 @@ pub fn resolve_api_key(
     }
     Err(crate::error::AppError::Credentials(format!(
         "{vendor_label}: no API key. Either export {env_var_name} or set \
-         `api_key` under [{}] in ~/.config/ai-usagebar/config.toml (chmod 600).",
-        vendor_label.to_lowercase()
+         `api_key` under [{}] in {}.",
+        vendor_label.to_lowercase(),
+        config_path_hint()
     )))
 }
 
@@ -200,9 +201,19 @@ impl Config {
     }
 }
 
-fn default_path() -> Option<PathBuf> {
+pub fn default_path() -> Option<PathBuf> {
     let proj = directories::ProjectDirs::from("", "", "ai-usagebar")?;
     Some(proj.config_dir().join("config.toml"))
+}
+
+/// Resolved `config.toml` path as a string for user-facing messages. Uses the
+/// platform's config dir (`directories::ProjectDirs`), so it reads correctly on
+/// Linux, macOS, and Windows instead of hard-coding the Unix `~/.config` path.
+/// Falls back to the bare filename if the path can't be resolved.
+pub fn config_path_hint() -> String {
+    default_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "config.toml".to_string())
 }
 
 #[cfg(test)]
@@ -330,6 +341,13 @@ enabled = false
             }
             other => panic!("expected Credentials error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn config_path_hint_ends_with_config_toml() {
+        // Platform-resolved (Linux/macOS/Windows), but always ends in the
+        // config filename — the trailing segment is what messages rely on.
+        assert!(config_path_hint().ends_with("config.toml"));
     }
 
     #[test]

--- a/src/openai/creds.rs
+++ b/src/openai/creds.rs
@@ -101,13 +101,23 @@ fn parse_jwt_claims(token: &str) -> Option<serde_json::Value> {
 mod tests {
     use super::*;
     use std::io::Write;
-    use tempfile::NamedTempFile;
+    use tempfile::{NamedTempFile, TempDir};
 
     fn write_auth(s: &str) -> NamedTempFile {
         let mut f = NamedTempFile::new().unwrap();
         f.write_all(s.as_bytes()).unwrap();
         f.flush().unwrap();
         f
+    }
+
+    /// Like `write_auth`, but writes to a named file inside a `TempDir` and
+    /// closes the handle, so `write_back`'s atomic rename-over-destination
+    /// succeeds on Windows (which refuses to replace a still-open file).
+    fn write_auth_closed(s: &str) -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(&path, s).unwrap();
+        (dir, path)
     }
 
     /// Build a fake JWT with the given claims (no signature verification).
@@ -173,13 +183,13 @@ mod tests {
             r#"{{"tokens":{{"access_token":"AT","refresh_token":"RT","id_token":"{jwt}"}},
                 "some_other_field":"keep-me"}}"#
         );
-        let f = write_auth(&body);
-        let mut auth = read_from(f.path()).unwrap();
+        let (_dir, path) = write_auth_closed(&body);
+        let mut auth = read_from(&path).unwrap();
         auth.tokens.access_token = "NEW".into();
-        write_back(f.path(), &auth).unwrap();
+        write_back(&path, &auth).unwrap();
 
         let v: serde_json::Value =
-            serde_json::from_str(&std::fs::read_to_string(f.path()).unwrap()).unwrap();
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(v["some_other_field"], "keep-me");
         assert_eq!(v["tokens"]["access_token"], "NEW");
     }

--- a/src/openai/creds.rs
+++ b/src/openai/creds.rs
@@ -33,10 +33,13 @@ pub struct Tokens {
     pub extra: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Default location: `~/.codex/auth.json`.
+/// Default location: `~/.codex/auth.json` (Unix/macOS) or
+/// `%USERPROFILE%\.codex\auth.json` (Windows).
+///
+/// Home is resolved through [`crate::cache::home_dir`] so every platform's
+/// convention is honored in one place.
 pub fn default_path() -> Result<PathBuf> {
-    let home = std::env::var_os("HOME").ok_or_else(|| AppError::Other("HOME not set".into()))?;
-    Ok(PathBuf::from(home).join(".codex/auth.json"))
+    Ok(crate::cache::home_dir()?.join(".codex").join("auth.json"))
 }
 
 pub fn read_from(path: &Path) -> Result<AuthFile> {
@@ -179,5 +182,22 @@ mod tests {
             serde_json::from_str(&std::fs::read_to_string(f.path()).unwrap()).unwrap();
         assert_eq!(v["some_other_field"], "keep-me");
         assert_eq!(v["tokens"]["access_token"], "NEW");
+    }
+
+    #[test]
+    fn default_path_ends_with_codex_auth() {
+        let p = default_path().unwrap();
+        // Trailing segments are stable across platforms; only the home prefix
+        // differs (resolved by directories::BaseDirs).
+        assert!(p.ends_with(std::path::Path::new(".codex").join("auth.json")));
+    }
+
+    // On Windows the home prefix is %USERPROFILE%, not $HOME.
+    #[cfg(windows)]
+    #[test]
+    fn default_path_uses_userprofile_on_windows() {
+        let p = default_path().unwrap();
+        let userprofile = std::env::var("USERPROFILE").expect("USERPROFILE set on Windows");
+        assert!(p.starts_with(std::path::Path::new(&userprofile)));
     }
 }

--- a/src/openai/creds.rs
+++ b/src/openai/creds.rs
@@ -208,6 +208,18 @@ mod tests {
     fn default_path_uses_userprofile_on_windows() {
         let p = default_path().unwrap();
         let userprofile = std::env::var("USERPROFILE").expect("USERPROFILE set on Windows");
-        assert!(p.starts_with(std::path::Path::new(&userprofile)));
+        // directories::BaseDirs resolves the home via SHGetKnownFolderPath, which
+        // can differ from %USERPROFILE% in casing or path separator. Compare on a
+        // normalized basis (lowercased, backslashes) rather than Path::starts_with,
+        // which compares components case-sensitively even on Windows.
+        let norm = |s: &str| s.to_lowercase().replace('/', "\\");
+        let p_norm = norm(&p.to_string_lossy());
+        let up_norm = norm(&userprofile);
+        assert!(
+            p_norm.starts_with(up_norm.as_str()),
+            "{} should live under {}",
+            p.display(),
+            userprofile
+        );
     }
 }

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -609,7 +609,21 @@ pub use crossterm::event::{KeyCode, KeyModifiers};
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::NamedTempFile;
+    use tempfile::TempDir;
+
+    /// A config path inside a fresh `TempDir`, with no open handle on the file.
+    /// `save_to_path` rewrites atomically (rename over destination), which on
+    /// Windows fails if the destination is still open — so tests must not hold a
+    /// live `NamedTempFile` handle on the target. Returns the dir (kept alive by
+    /// the caller) and the path; the file may or may not exist yet.
+    fn temp_config(initial: Option<&str>) -> (TempDir, std::path::PathBuf) {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        if let Some(contents) = initial {
+            std::fs::write(&path, contents).unwrap();
+        }
+        (dir, path)
+    }
 
     fn state_with(zai: &str, opr: &str, primary: VendorId) -> SettingsState {
         let mut s = SettingsState {
@@ -688,10 +702,10 @@ mod tests {
 
     #[test]
     fn save_to_path_writes_minimal_toml_when_starting_empty() {
-        let f = NamedTempFile::new().unwrap();
+        let (_dir, path) = temp_config(None);
         let s = state_with("zk", "ok", VendorId::Zai);
-        save_to_path(&s, f.path()).unwrap();
-        let raw = std::fs::read_to_string(f.path()).unwrap();
+        save_to_path(&s, &path).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
         assert!(raw.contains("primary = \"zai\""));
         assert!(raw.contains("[zai]"));
         assert!(raw.contains("api_key = \"zk\""));
@@ -701,9 +715,7 @@ mod tests {
 
     #[test]
     fn save_to_path_preserves_existing_comments_and_unrelated_fields() {
-        let f = NamedTempFile::new().unwrap();
-        std::fs::write(
-            f.path(),
+        let (_dir, path) = temp_config(Some(
             r##"# my comment
 [ui]
 # pre-existing comment
@@ -719,13 +731,12 @@ plan_tier = "pro"
 enabled = true
 api_key_env = "OPENROUTER_API_KEY"
 "##,
-        )
-        .unwrap();
+        ));
 
         let s = state_with("zk2", "ok2", VendorId::Openrouter);
-        save_to_path(&s, f.path()).unwrap();
+        save_to_path(&s, &path).unwrap();
 
-        let raw = std::fs::read_to_string(f.path()).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
         // Comments survive.
         assert!(raw.contains("# my comment"));
         assert!(raw.contains("# pre-existing comment"));
@@ -742,14 +753,14 @@ api_key_env = "OPENROUTER_API_KEY"
 
     #[test]
     fn save_does_not_write_empty_key_when_dirty_but_blank() {
-        let f = NamedTempFile::new().unwrap();
+        let (_dir, path) = temp_config(None);
         let mut s = state_with("", "", VendorId::Anthropic);
         // Mark dirty but leave buf empty (user opened dialog with empty
         // field, focused it, did nothing).
         s.zai.dirty = true;
         s.openrouter.dirty = true;
-        save_to_path(&s, f.path()).unwrap();
-        let raw = std::fs::read_to_string(f.path()).unwrap();
+        save_to_path(&s, &path).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
         // No `api_key = ""` lines should be written.
         assert!(!raw.contains("api_key ="));
     }
@@ -758,10 +769,10 @@ api_key_env = "OPENROUTER_API_KEY"
     #[cfg(unix)]
     fn save_chmods_to_600() {
         use std::os::unix::fs::PermissionsExt;
-        let f = NamedTempFile::new().unwrap();
+        let (_dir, path) = temp_config(None);
         let s = state_with("zk", "ok", VendorId::Zai);
-        save_to_path(&s, f.path()).unwrap();
-        let mode = std::fs::metadata(f.path()).unwrap().permissions().mode();
+        save_to_path(&s, &path).unwrap();
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
         assert_eq!(mode & 0o777, 0o600);
     }
 
@@ -840,13 +851,12 @@ api_key_env = "OPENROUTER_API_KEY"
 
     #[test]
     fn handle_key_ctrl_s_attempts_save_from_any_field() {
-        let f = NamedTempFile::new().unwrap();
-        let path_str = f.path().to_string_lossy().into_owned();
+        let (_dir, path) = temp_config(None);
         // We can't easily redirect default_config_path() in the test, so we
         // exercise save_to_path directly instead.
         let s = state_with("zk", "ok", VendorId::Zai);
-        save_to_path(&s, f.path()).unwrap();
-        let raw = std::fs::read_to_string(&path_str).unwrap();
+        save_to_path(&s, &path).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
         assert!(raw.contains("api_key = \"zk\""));
     }
 }

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -181,6 +181,24 @@ pub enum Action {
     SavedAndClose,
 }
 
+/// Permission note appended to the "saved" status line. The overlay `chmod
+/// 600`s the file on Unix; Windows has no such step, so the note is empty there
+/// (keeps the message platform-honest).
+#[cfg(unix)]
+const PERMS_NOTE: &str = " (chmod 600)";
+#[cfg(not(unix))]
+const PERMS_NOTE: &str = "";
+
+/// Status line after a successful save: the platform-resolved config path plus
+/// the platform-appropriate permission note.
+fn saved_status() -> String {
+    format!(
+        "saved to {}{}",
+        crate::config::config_path_hint(),
+        PERMS_NOTE
+    )
+}
+
 /// Key map. Returns the action to perform after the keypress.
 pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) -> Action {
     // Esc always closes without saving.
@@ -191,7 +209,7 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
     if matches!(code, KeyCode::Char('s')) && mods.contains(KeyModifiers::CONTROL) {
         return match save_to_config_default(state) {
             Ok(()) => {
-                state.status = "saved to ~/.config/ai-usagebar/config.toml (chmod 600)".into();
+                state.status = saved_status();
                 Action::SavedAndClose
             }
             Err(e) => {
@@ -242,8 +260,7 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
             if matches!(code, KeyCode::Enter) {
                 return match save_to_config_default(state) {
                     Ok(()) => {
-                        state.status =
-                            "saved to ~/.config/ai-usagebar/config.toml (chmod 600)".into();
+                        state.status = saved_status();
                         Action::SavedAndClose
                     }
                     Err(e) => {
@@ -366,8 +383,7 @@ fn set_string(doc: &mut DocumentMut, section: &str, key: &str, new_value: &str) 
 }
 
 fn default_config_path() -> Result<PathBuf> {
-    directories::ProjectDirs::from("", "", "ai-usagebar")
-        .map(|p| p.config_dir().join("config.toml"))
+    crate::config::default_path()
         .ok_or_else(|| AppError::Other("could not resolve config dir".into()))
 }
 

--- a/src/waybar.rs
+++ b/src/waybar.rs
@@ -13,10 +13,18 @@ pub const REFRESH_SIGNAL: &str = "-RTMIN+13";
 pub const PROCESS_NAME: &str = "waybar";
 
 /// Best-effort Waybar refresh. Failing is harmless when Waybar is not running.
+///
+/// Shells out to `pkill -RTMIN+13 waybar` on Unix. Waybar is a Wayland-only
+/// program, so off Unix (e.g. Windows) there is no process to signal and no
+/// `pkill`; the body is gated out and the call becomes a no-op — consumers
+/// there (such as a tray app) refresh on their own polling interval instead.
 pub fn request_refresh() {
-    let _ = std::process::Command::new("pkill")
-        .args([REFRESH_SIGNAL, PROCESS_NAME])
-        .status();
+    #[cfg(unix)]
+    {
+        let _ = std::process::Command::new("pkill")
+            .args([REFRESH_SIGNAL, PROCESS_NAME])
+            .status();
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -97,8 +97,9 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
     let vendor = cli.resolved_vendor(&config);
     if !config.is_enabled(vendor.to_id()) {
         return Err(AppError::Other(format!(
-            "vendor {:?} is disabled in ~/.config/ai-usagebar/config.toml",
-            vendor
+            "vendor {:?} is disabled in {}",
+            vendor,
+            crate::config::config_path_hint()
         )));
     }
     match vendor {

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -34,7 +34,6 @@
 //! - **OpenRouter**: `/credits` returns `{data:{total_credits,total_usage}}`
 //!   and `/key` returns `{data:{usage,is_free_tier}}`.
 
-use std::path::PathBuf;
 use std::time::Duration;
 
 use ai_usagebar::anthropic;
@@ -60,10 +59,7 @@ fn assert_pct(label: &str, p: i32) {
 #[tokio::test]
 #[ignore = "live API; run with --ignored"]
 async fn anthropic_live() {
-    let creds_path = match std::env::var_os("HOME") {
-        Some(home) => PathBuf::from(home).join(".claude/.credentials.json"),
-        None => panic!("HOME not set"),
-    };
+    let creds_path = anthropic::creds::default_path().expect("resolve home directory");
     assert!(
         creds_path.exists(),
         "no Claude credentials at {} — log in with `claude` first",
@@ -111,10 +107,7 @@ async fn anthropic_live() {
 #[tokio::test]
 #[ignore = "live API; run with --ignored"]
 async fn openai_live() {
-    let creds_path = match std::env::var_os("HOME") {
-        Some(home) => PathBuf::from(home).join(".codex/auth.json"),
-        None => panic!("HOME not set"),
-    };
+    let creds_path = openai::creds::default_path().expect("resolve home directory");
     assert!(
         creds_path.exists(),
         "no Codex credentials at {} — log in with `codex login` first",


### PR DESCRIPTION
## Summary

Makes the `ai-usagebar` and `ai-usagebar-tui` binaries build and run **natively on Windows** (`x86_64-pc-windows-msvc`), with no WSL. The changes are small and platform-portable; Linux/macOS behavior is unchanged.

The Waybar **widget** is Wayland-only and intentionally out of scope — on Windows the TUI (and `ai-usagebar --json` for custom bars) is the entry point.

## What changed

- **Cross-platform home resolution.** Credential paths now resolve the home directory through `directories::BaseDirs` via a new shared `cache::home_dir()` helper, instead of reading `$HOME` directly (unset on native Windows). Both OAuth vendors share the resolver the same way they already share `cache::atomic_write`:
  - Anthropic → `%USERPROFILE%\.claude\.credentials.json`
  - OpenAI Codex → `%USERPROFILE%\.codex\auth.json`
- **Waybar refresh gated to Unix.** `request_refresh()` shells out to `pkill -RTMIN+13 waybar`; off Unix there's no Waybar process and no `pkill`, so the body is `#[cfg(unix)]`-gated and the call becomes a no-op (consumers poll on their own interval).
- **TUI key handling on Windows Terminal.** Terminals that report key `Repeat`/`Release` in addition to `Press` (Windows Terminal; Kitty-keyboard emulators) made one Tab/arrow move several tabs and holding a key fly through them. The TUI now acts only on `KeyEventKind::Press`. Not cfg-gated — it's harmless and beneficial everywhere.
- **Tests.** `tests/live.rs` now resolves creds via the shared `default_path()` (it read `$HOME` directly, which would panic on Windows). The `write_back`/`save_to_path` unit tests pointed their target at a live `NamedTempFile` handle; Windows refuses to rename over an open file, so they now use a closed file inside a `TempDir` (the same pattern `cache.rs` already uses). Added `default_path()` tests, including `#[cfg(windows)]` assertions that `%USERPROFILE%` is honored. Production code is unchanged.

## Notes for review

- **No new dependencies.** `directories` (already a dep) is the only crate involved; TLS is already `rustls` (no OpenSSL), file locking is `fs2` (winapi-backed) — both already Windows-capable.
- **`cache::home_dir()` is the de-dup choice**: it lives next to `xdg_cache_dir()` and is reused by both creds vendors so home resolution stays in one place.

## Testing

- Linux: `cargo test` (232), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo machete` — all clean.
- **Windows 11 (native, MSVC), Windows Terminal:** `cargo test` → **232 passed; 0 failed** (the extra test vs Linux is the Windows-gated `%USERPROFILE%` assertion). Verified `ai-usagebar.exe --pretty` reads real Anthropic usage and `ai-usagebar-tui.exe` navigates one tab per keypress.

## Out of scope

A separate Windows tray/UI consuming `ai-usagebar --json` lives outside this repo; this PR is backend-only.
