### PR TITLE
test: make vendor-resolution + TUI/theme tests hermetic (fix AUR source-build failure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,17 @@ patch version instead.
   the user's choice (and `chmod 600`ed by the Settings overlay), but
   **never commit** a real key. The `.gitignore` covers `.env`,
   `*.credentials.json`, and `.claude/`.
+- **Tests are hermetic.** A `#[test]`/`#[tokio::test]` must never read or
+  write a real `$HOME`/`$XDG` path (config, cache, creds, Omarchy theme)
+  or branch on an ambient env var — the AUR `check()` runs `cargo test`
+  during `makepkg`, so any test that reads a user's *customized* files
+  fails the install on their machine. Always inject the path/dependency
+  via the test seam, never the real-path resolver:
+  `Cache::at` not `for_vendor`, `active::{read_from,write_to,cycle_at}`
+  not `{read,write,cycle}`, `creds::read_from` not `default_path`,
+  `Theme::merged_with_omarchy_file` not `merged_with_omarchy`,
+  `Cli::resolve_vendor_with` not `resolved_vendor`, `App::with_theme`
+  not `new`. Live API tests stay behind `#[ignore]` (see `tests/live.rs`).
 
 ## Secret-discipline rules (learned the hard way)
 

--- a/src/active.rs
+++ b/src/active.rs
@@ -6,7 +6,7 @@
 //! at `<cache-dir>/active_vendor`.
 
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::cache::atomic_write;
 use crate::error::{AppError, Result};
@@ -25,30 +25,55 @@ fn state_path() -> Result<PathBuf> {
 /// Read the persisted active vendor, if any. `None` means "no override —
 /// callers fall back to [ui] primary or anthropic".
 pub fn read() -> Option<VendorId> {
-    let path = state_path().ok()?;
-    let raw = fs::read_to_string(&path).ok()?;
+    read_from(&state_path().ok()?)
+}
+
+/// Read the persisted active vendor from an explicit path. The real-path
+/// [`read`] is a thin wrapper over this; tests use this directly with a
+/// `TempDir`-backed path so they never touch `~/.cache/ai-usagebar`.
+pub fn read_from(path: &Path) -> Option<VendorId> {
+    let raw = fs::read_to_string(path).ok()?;
     parse_slug(raw.trim())
 }
 
 /// Persist `vendor` as the active one. Atomic.
 pub fn write(vendor: VendorId) -> Result<()> {
-    let path = state_path()?;
-    atomic_write(&path, vendor.slug().as_bytes())
+    write_to(&state_path()?, vendor)
+}
+
+/// Persist `vendor` to an explicit path. Atomic. Test-friendly counterpart
+/// to [`write`] (mirrors [`crate::cache::Cache::at`] vs `for_vendor`).
+pub fn write_to(path: &Path, vendor: VendorId) -> Result<()> {
+    atomic_write(path, vendor.slug().as_bytes())
 }
 
 /// Cycle the active vendor by `delta` positions through `enabled` (which
 /// preserves canonical order). Wraps. If no state exists, starts at `start`
 /// (usually `[ui] primary` or anthropic).
 pub fn cycle(enabled: &[VendorId], start: VendorId, delta: i32) -> Result<VendorId> {
+    cycle_at(&state_path()?, enabled, start, delta)
+}
+
+/// Cycle using an explicit state-file path. The real-path [`cycle`] is a thin
+/// wrapper over this; tests drive this with a `TempDir` path so the cycle +
+/// persistence logic is covered without reading or writing the real cache.
+pub fn cycle_at(
+    path: &Path,
+    enabled: &[VendorId],
+    start: VendorId,
+    delta: i32,
+) -> Result<VendorId> {
     if enabled.is_empty() {
         return Err(AppError::Other("no enabled vendors to cycle".into()));
     }
-    let current = read().filter(|v| enabled.contains(v)).unwrap_or(start);
+    let current = read_from(path)
+        .filter(|v| enabled.contains(v))
+        .unwrap_or(start);
     let cur_idx = enabled.iter().position(|v| *v == current).unwrap_or(0);
     let n = enabled.len() as i32;
     let next_idx = ((cur_idx as i32 + delta).rem_euclid(n)) as usize;
     let next = enabled[next_idx];
-    write(next)?;
+    write_to(path, next)?;
     Ok(next)
 }
 
@@ -66,6 +91,14 @@ fn parse_slug(s: &str) -> Option<VendorId> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    const ALL_FOUR: [VendorId; 4] = [
+        VendorId::Anthropic,
+        VendorId::Openai,
+        VendorId::Zai,
+        VendorId::Openrouter,
+    ];
 
     #[test]
     fn parse_slug_round_trip() {
@@ -81,24 +114,70 @@ mod tests {
     }
 
     #[test]
-    fn cycle_wraps_forward_and_backward() {
-        // Pure cycle math (no disk I/O — we don't call read/write here,
-        // only go through `cycle` which would touch disk). Verify the
-        // index arithmetic directly.
-        let enabled = [
-            VendorId::Anthropic,
-            VendorId::Openai,
-            VendorId::Zai,
-            VendorId::Openrouter,
-        ];
-        let step = |from: usize, delta: i32| -> VendorId {
-            enabled[((from as i32 + delta).rem_euclid(4)) as usize]
-        };
-        // forward from Anthropic → Openai
-        assert_eq!(step(0, 1), VendorId::Openai);
-        // backward from Anthropic → Openrouter (wrap)
-        assert_eq!(step(0, -1), VendorId::Openrouter);
-        // forward from Openrouter → Anthropic (wrap)
-        assert_eq!(step(3, 1), VendorId::Anthropic);
+    fn read_from_missing_or_garbage_returns_none() {
+        let td = TempDir::new().unwrap();
+        // Missing file → None.
+        assert!(read_from(&td.path().join("active_vendor")).is_none());
+        // Round-trip a real slug.
+        let path = td.path().join("active_vendor");
+        write_to(&path, VendorId::Zai).unwrap();
+        assert_eq!(read_from(&path), Some(VendorId::Zai));
+        // Garbage content → None (not a known slug).
+        fs::write(&path, "not-a-vendor").unwrap();
+        assert!(read_from(&path).is_none());
+    }
+
+    #[test]
+    fn cycle_at_persists_state_across_calls() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("active_vendor");
+
+        // No state yet → starts at `start`, steps forward to Openai.
+        let v = cycle_at(&path, &ALL_FOUR, VendorId::Anthropic, 1).unwrap();
+        assert_eq!(v, VendorId::Openai);
+        assert_eq!(read_from(&path), Some(VendorId::Openai));
+
+        // Next forward step reads the persisted Openai → Zai.
+        let v = cycle_at(&path, &ALL_FOUR, VendorId::Anthropic, 1).unwrap();
+        assert_eq!(v, VendorId::Zai);
+        assert_eq!(read_from(&path), Some(VendorId::Zai));
+    }
+
+    #[test]
+    fn cycle_at_wraps_forward_and_backward() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("active_vendor");
+        write_to(&path, VendorId::Anthropic).unwrap();
+
+        // backward from Anthropic wraps to Openrouter
+        assert_eq!(
+            cycle_at(&path, &ALL_FOUR, VendorId::Anthropic, -1).unwrap(),
+            VendorId::Openrouter
+        );
+        // forward from Openrouter wraps back to Anthropic
+        assert_eq!(
+            cycle_at(&path, &ALL_FOUR, VendorId::Anthropic, 1).unwrap(),
+            VendorId::Anthropic
+        );
+    }
+
+    #[test]
+    fn cycle_at_ignores_persisted_vendor_not_in_enabled_set() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("active_vendor");
+        // Persist a vendor that isn't in the enabled set → fall back to `start`.
+        write_to(&path, VendorId::Deepseek).unwrap();
+        let enabled = [VendorId::Anthropic, VendorId::Openai];
+        // start=Openai (idx 1), +1 wraps to idx 0 = Anthropic.
+        let v = cycle_at(&path, &enabled, VendorId::Openai, 1).unwrap();
+        assert_eq!(v, VendorId::Anthropic);
+    }
+
+    #[test]
+    fn cycle_at_errors_on_empty_enabled() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("active_vendor");
+        let res = cycle_at(&path, &[], VendorId::Anthropic, 1);
+        assert!(matches!(res, Err(AppError::Other(_))));
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -49,12 +49,23 @@ pub struct App {
 
 impl App {
     pub fn new(vendors: Vec<VendorId>) -> Self {
+        // Production: resolve the palette from the environment (Omarchy theme
+        // if present, else One Dark).
+        Self::with_theme(vendors, Theme::default().merged_with_omarchy())
+    }
+
+    /// Like [`App::new`] but with an explicit theme. Lets tests build an `App`
+    /// without reading the real Omarchy theme file
+    /// (`$HOME/.config/omarchy/current/theme/colors.toml`) — `new` resolves
+    /// that path and the `$HOME` env var via `merged_with_omarchy`, which is
+    /// not hermetic. Production code uses `new`/`new_with_primary`.
+    pub fn with_theme(vendors: Vec<VendorId>, theme: Theme) -> Self {
         let n = vendors.len();
         Self {
             vendors,
             active: 0,
             tabs: vec![TabState::Loading; n],
-            theme: Theme::default().merged_with_omarchy(),
+            theme,
             last_refresh: Utc::now(),
             quit: false,
             settings: None,
@@ -221,16 +232,20 @@ pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 mod tests {
     use super::*;
 
+    // Use `App::with_theme(.., Theme::default())` rather than `App::new`, which
+    // would read the real Omarchy theme file + `$HOME`. The tab-selection logic
+    // under test is theme-agnostic.
     #[test]
     fn select_primary_moves_to_enabled_vendor() {
-        let mut app = App::new(vec![VendorId::Anthropic, VendorId::Openrouter]);
+        let mut app =
+            App::with_theme(vec![VendorId::Anthropic, VendorId::Openrouter], Theme::default());
         app.select_primary(Some(VendorId::Openrouter));
         assert_eq!(app.active_vendor(), Some(VendorId::Openrouter));
     }
 
     #[test]
     fn select_primary_ignores_disabled_vendor() {
-        let mut app = App::new(vec![VendorId::Anthropic]);
+        let mut app = App::with_theme(vec![VendorId::Anthropic], Theme::default());
         app.select_primary(Some(VendorId::Openai));
         assert_eq!(app.active_vendor(), Some(VendorId::Anthropic));
     }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -135,11 +135,38 @@ impl Cli {
     ///   2. persisted scroll-cycle state (`~/.cache/ai-usagebar/active_vendor`)
     ///   3. `[ui] primary` from config
     ///   4. anthropic (lowest)
+    ///
+    /// This reads the persisted scroll-cycle state from disk via
+    /// [`crate::active::read`]. The pure precedence logic lives in
+    /// [`Cli::resolve_vendor_with`] so it can be unit-tested without touching
+    /// `~/.cache/ai-usagebar/active_vendor`.
     pub fn resolved_vendor(&self, config: &crate::config::Config) -> Vendor {
+        // Only consult the scroll-cycle state file when it could actually
+        // matter. An explicit `--vendor` wins outright (precedence #1), so we
+        // skip the disk read entirely in that case — preserving the original
+        // short-circuit and keeping the documented `--vendor` widget config off
+        // the `active_vendor` read path.
+        let active = if self.vendor.is_some() {
+            None
+        } else {
+            crate::active::read()
+        };
+        self.resolve_vendor_with(config, active)
+    }
+
+    /// Pure precedence resolution given an explicit scroll-cycle `active`
+    /// override (i.e. whatever [`crate::active::read`] returned). Split out
+    /// from the disk read so tests exercise the precedence rules hermetically
+    /// instead of depending on the developer's real `active_vendor` file.
+    pub fn resolve_vendor_with(
+        &self,
+        config: &crate::config::Config,
+        active: Option<crate::vendor::VendorId>,
+    ) -> Vendor {
         if let Some(v) = self.vendor {
             return v;
         }
-        if let Some(id) = crate::active::read() {
+        if let Some(id) = active {
             if config.is_enabled(id) {
                 return id_to_vendor(id);
             }
@@ -190,9 +217,12 @@ mod tests {
     fn defaults_match_claudebar() {
         let cli = Cli::parse_from(["ai-usagebar"]);
         assert_eq!(cli.vendor, None);
-        // Without explicit --vendor and with default config, resolve to anthropic.
+        // Without explicit --vendor, no scroll-cycle override, and default
+        // config, resolve to anthropic. Use `resolve_vendor_with(.., None)`
+        // rather than `resolved_vendor` so the test never reads the real
+        // ~/.cache/ai-usagebar/active_vendor file.
         let cfg = crate::config::Config::default();
-        assert_eq!(cli.resolved_vendor(&cfg), Vendor::Anthropic);
+        assert_eq!(cli.resolve_vendor_with(&cfg, None), Vendor::Anthropic);
         assert_eq!(cli.pace_tolerance, 5);
         assert!(cli.format.is_none());
         assert!(cli.tooltip_format.is_none());
@@ -206,18 +236,45 @@ mod tests {
 
     #[test]
     fn primary_from_config_wins_when_vendor_unset() {
+        // No --vendor and no scroll-cycle override → [ui] primary wins.
         let cli = Cli::parse_from(["ai-usagebar"]);
         let mut cfg = crate::config::Config::default();
         cfg.ui.primary = Some(crate::vendor::VendorId::Openrouter);
-        assert_eq!(cli.resolved_vendor(&cfg), Vendor::Openrouter);
+        assert_eq!(cli.resolve_vendor_with(&cfg, None), Vendor::Openrouter);
     }
 
     #[test]
-    fn explicit_vendor_overrides_config_primary() {
+    fn explicit_vendor_overrides_everything() {
+        // Explicit --vendor beats BOTH a persisted scroll-cycle override and
+        // [ui] primary.
         let cli = Cli::parse_from(["ai-usagebar", "--vendor", "zai"]);
         let mut cfg = crate::config::Config::default();
         cfg.ui.primary = Some(crate::vendor::VendorId::Openrouter);
-        assert_eq!(cli.resolved_vendor(&cfg), Vendor::Zai);
+        let active = Some(crate::vendor::VendorId::Openai);
+        assert_eq!(cli.resolve_vendor_with(&cfg, active), Vendor::Zai);
+    }
+
+    #[test]
+    fn active_override_wins_over_config_primary_when_enabled() {
+        // Precedence rule #2: a persisted scroll-cycle vendor beats [ui]
+        // primary, as long as it is still enabled.
+        let cli = Cli::parse_from(["ai-usagebar"]);
+        let mut cfg = crate::config::Config::default();
+        cfg.ui.primary = Some(crate::vendor::VendorId::Openrouter);
+        let active = Some(crate::vendor::VendorId::Zai);
+        assert_eq!(cli.resolve_vendor_with(&cfg, active), Vendor::Zai);
+    }
+
+    #[test]
+    fn disabled_active_override_falls_back_to_config_primary() {
+        // A persisted active vendor the user has since disabled is skipped;
+        // resolution falls through to [ui] primary.
+        let cli = Cli::parse_from(["ai-usagebar"]);
+        let mut cfg = crate::config::Config::default();
+        cfg.zai.enabled = false;
+        cfg.ui.primary = Some(crate::vendor::VendorId::Openrouter);
+        let active = Some(crate::vendor::VendorId::Zai);
+        assert_eq!(cli.resolve_vendor_with(&cfg, active), Vendor::Openrouter);
     }
 
     #[test]


### PR DESCRIPTION
## The symptom: `yay -S ai-usagebar` fails to install — but only on *your* machine

A user who already runs the widget tries to update it from the AUR **source**
package:

```console
$ yay -S ai-usagebar
...
   Compiling ai-usagebar v0.5.1 (.../ai-usagebar-0.5.1)
    Finished `release` profile [optimized] target(s) in 30.15s
     Running unittests src/lib.rs (target/release/deps/ai_usagebar-1ecc9421f0b03946)
...
test widget::cli::tests::primary_from_config_wins_when_vendor_unset ... FAILED
test widget::cli::tests::defaults_match_claudebar ... FAILED

failures:

---- widget::cli::tests::primary_from_config_wins_when_vendor_unset stdout ----
thread '...' panicked at src/widget/cli.rs:212:9:
assertion `left == right` failed
  left: Openai
 right: Openrouter

---- widget::cli::tests::defaults_match_claudebar stdout ----
thread '...' panicked at src/widget/cli.rs:195:9:
assertion `left == right` failed
  left: Openai
 right: Anthropic

failures:
    widget::cli::tests::defaults_match_claudebar
    widget::cli::tests::primary_from_config_wins_when_vendor_unset

test result: FAILED. 227 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out

error: test failed, to rerun pass `--lib`
==> ERROR: A failure occurred in check().
    Aborting...
```

<sub>*(Real output, reproduced at `v0.5.1` with `active_vendor=openai` — this is exactly what `makepkg` runs in `check()`. Build path elided.)*</sub>

The build aborts. On a teammate's fresh machine the same version installs fine.
The only difference: the affected user had **scroll-cycled the widget to a
non-default vendor** at some point, so `~/.cache/ai-usagebar/active_vendor`
holds `openai`.

This only bites **source-install** users. `packaging/aur/PKGBUILD` runs the test
suite in its `check()`:

```bash
check() {
  cd "$pkgname-$pkgver"
  cargo test --frozen --release
}
```

`makepkg` runs `check()` against the *building user's real `$HOME`*, so a
customized `active_vendor` file leaks into the tests. The `-bin` package skips
compilation and tests entirely, so `ai-usagebar-bin` users never hit it — which
is exactly why the failure looks non-reproducible.

## Root cause: tests reached real `$HOME`/`$XDG` state instead of an injected seam

Two unit tests asserted a *fixed* resolved vendor:

- `defaults_match_claudebar` → expects `Anthropic`
- `primary_from_config_wins_when_vendor_unset` → expects `Openrouter`

Both went through `Cli::resolved_vendor`, which calls `crate::active::read()` →
reads `~/.cache/ai-usagebar/active_vendor`. The widget's documented vendor
precedence is:

1. explicit `--vendor` (highest)
2. **persisted scroll-cycle state** (`active_vendor`)
3. `[ui] primary` from config
4. anthropic (lowest)

So a planted `active_vendor` at precedence level 2 overrides the value the
tests expect at levels 3–4 — and the assertion flips to the cycled vendor.

A short audit also found `App::new` reads the Omarchy theme file +
`$HOME` via `merged_with_omarchy()`. Its assertions don't depend on the palette
so it wasn't *failing*, but it's the same non-hermetic class of bug and would be
a latent flake.

### Reproduce on any clean checkout

```bash
mkdir -p ~/.cache/ai-usagebar && printf openai > ~/.cache/ai-usagebar/active_vendor
cargo test --lib widget::cli::tests   # 2 failures: left: Openai
rm -rf ~/.cache/ai-usagebar           # clean up
```

## The fix: inject the path/dependency, keep the real-path resolver as a thin wrapper

This repo already has the right pattern — `Cache::at(path)` for tests vs
`Cache::for_vendor()` for production. This PR applies the same seam to the three
offenders:

| Production (unchanged) | New test seam |
| --- | --- |
| `active::{read,write,cycle}` | `active::{read_from,write_to,cycle_at}` — take an explicit path |
| `Cli::resolved_vendor(config)` | `Cli::resolve_vendor_with(config, active)` — pure precedence, no disk |
| `App::new(vendors)` | `App::with_theme(vendors, theme)` — explicit palette, no theme-file read |

The real-path functions become one-line wrappers over the seam, so **production
behavior is unchanged**. The hermetic tests then exercise the logic
*deterministically*:

- scroll-cycle precedence is now covered on purpose (it was only ever exercised
  by accident, via whatever happened to be in the developer's real file);
- a `TempDir` round-trip covers `cycle_at`/`read_from`/`write_to`;
- the TUI/theme tests pass `Theme::default()` and never touch
  `~/.config/omarchy/...`.

`resolved_vendor` still short-circuits the `active_vendor` read when `--vendor`
is explicit (the documented multi-module Waybar config), so the disk-access
profile is identical to before — not just the output.

A **`Tests are hermetic`** invariant is added to `CLAUDE.md` so this class of
regression is caught in review rather than at install time.

## Verification

- `cargo test` → **235 lib + 3 e2e pass**, 4 live tests `#[ignore]`d; clean.
- `cargo clippy --all-targets -- -D warnings` → clean.
- Suite re-run with the **exact hostile state** that broke the install
  (`active_vendor=openai` planted in the real cache path) → **235/235 pass**.

## Scope

No `Cargo.toml` / `CHANGELOG.md` / PKGBUILD changes and no version bump — this is
a test-only + internal-seam change with no user-visible behavior difference.
Cutting a release is the maintainer's call (per the `CLAUDE.md` checklist); happy
to add a `CHANGELOG.md` "Fixed" entry if you'd like one.

---

**Diffstat:** 4 files, +197 / −35 (net +6 tests, 229 → 235).
