### PR TITLE
fix(tui): signal Waybar after every live API fetch, not just Settings save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- The TUI now fires `SIGRTMIN+13` after every refresh that hits the live API
+  (initial load, `r`/`R`, and the 60-second auto-refresh), so a Waybar module
+  configured with `signal: 13` re-execs against the freshly written cache and
+  shows the same numbers as the TUI. Previously only the Settings overlay
+  signaled Waybar, so the bar could keep displaying usage up to `interval`
+  seconds (300s in the sample config) older than the TUI open right next to
+  it. The signaled re-exec reuses the fresh cache, so no extra API call is
+  made.
 
 ## [0.7.1] — 2026-06-08
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,8 @@ Save writes to `~/.config/ai-usagebar/config.toml` via `toml_edit` so your exist
 
 After save, the Settings overlay fires `SIGRTMIN+13` so any Waybar module configured with `signal: 13` refreshes immediately. You don't need to wait for the next 300-second interval or kick the bar by hand. The TUI's own tabs also re-fetch right away, so a freshly set API key takes effect on the spot.
 
+The TUI fires the same signal whenever one of its refreshes hits the live API (on open, on `r`/`R`, and on its 60-second auto-refresh). Since a live fetch rewrites the shared on-disk cache, the signaled bar re-execs against that fresh cache — no extra API call — and stays in sync with the TUI instead of showing a number up to `interval` seconds older.
+
 If your module doesn't use `signal: 13`, the signal is a no-op and the bar will refresh on its next normal tick (up to `interval` seconds away). To force-refresh manually: `pkill -SIGUSR2 waybar` (full reload).
 
 ## Theming

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -95,8 +95,18 @@ where
             // Snapshot results from background tasks.
             Some((idx, state)) = rx.recv() => {
                 if let Some(slot) = app.tabs.get_mut(idx) {
+                    // A live fetch just rewrote this vendor's on-disk cache,
+                    // so the bar can disagree with the TUI sitting next to it
+                    // for up to `interval` seconds. Nudge Waybar the same way
+                    // the Settings overlay does after a save: a `signal: 13`
+                    // module re-execs against the still-fresh cache (no extra
+                    // API call); without the signal it's a no-op.
+                    let fresh = matches!(&state, TabState::Ready(t) if t.fresh_fetch);
                     *slot = state;
                     app.last_refresh = Utc::now();
+                    if fresh {
+                        ai_usagebar::waybar::request_refresh();
+                    }
                 }
             }
             // Periodic auto-refresh of all tabs.

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -33,6 +33,12 @@ pub struct ReadyTab {
     /// timestamp stays stable across redraws instead of drifting with the
     /// passing wall clock.
     pub fetched_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// True when this refresh hit the live API (and therefore rewrote the
+    /// on-disk cache) rather than reusing a still-fresh cached payload.
+    /// The TUI binary uses this to nudge Waybar (`SIGRTMIN+13`) so the bar
+    /// re-execs against the just-written cache instead of showing a number
+    /// up to `interval` seconds older than the TUI sitting next to it.
+    pub fresh_fetch: bool,
 }
 
 #[derive(Debug)]
@@ -123,10 +129,19 @@ pub async fn refresh_one(client: &Client, config: &Config, vendor: VendorId) -> 
                 stale: outcome.stale,
                 last_error: outcome.last_error,
                 fetched_at,
+                fresh_fetch: is_live_fetch(outcome.cache_age),
             }))
         }
         Err(e) => TabState::Error(e.to_string()),
     }
+}
+
+/// True when `cache_age` says the bytes came from the API during this call.
+/// Every vendor's `fetch_snapshot` reports `Some(Duration::ZERO)` exactly on
+/// a successful live fetch; cache reuse reports the payload file's real
+/// (mtime-derived, nonzero) age, and fallback paths report it too.
+fn is_live_fetch(cache_age: Option<Duration>) -> bool {
+    cache_age.is_some_and(|age| age.is_zero())
 }
 
 async fn build_outcome(
@@ -250,5 +265,16 @@ mod tests {
         let mut app = App::with_theme(vec![VendorId::Anthropic], Theme::default());
         app.select_primary(Some(VendorId::Openai));
         assert_eq!(app.active_vendor(), Some(VendorId::Anthropic));
+    }
+
+    #[test]
+    fn is_live_fetch_only_on_zero_cache_age() {
+        // Live fetch — every vendor reports exactly ZERO.
+        assert!(is_live_fetch(Some(Duration::ZERO)));
+        // Cache reuse / fallback — mtime-derived, nonzero age.
+        assert!(!is_live_fetch(Some(Duration::from_millis(5))));
+        assert!(!is_live_fetch(Some(Duration::from_secs(59))));
+        // No cache age at all (e.g. payload missing).
+        assert!(!is_live_fetch(None));
     }
 }

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -531,6 +531,7 @@ mod tests {
             stale: false,
             last_error: None,
             fetched_at: Some(now() - chrono::Duration::seconds(15)),
+            fresh_fetch: false,
         }))
     }
 


### PR DESCRIPTION
## Symptom

With the sample Waybar module (`interval: 300`, `signal: 13`), the bar can sit on a stale percentage — e.g. showing `cld 4%` — while the TUI launched from `on-click` shows the real, much higher number right next to it. The bar only catches up on its next 300-second tick, so the two UIs visibly disagree for minutes at a time.

## Root cause

The TUI already refreshes the **shared** on-disk cache (`~/.cache/ai-usagebar/<vendor>/usage.json`) on open, on `r`/`R`, and on its 60-second auto-refresh — but only the Settings overlay fired `SIGRTMIN+13` (`src/tui/settings.rs`). So fresh data lands on disk and Waybar is never told about it.

## Fix

- `ReadyTab` gains a `fresh_fetch` flag, true exactly when `fetch_snapshot` reported `cache_age == Some(Duration::ZERO)` — the existing convention all five vendors use to mean "these bytes came from the API during this call" (cache reuse and stale fallbacks report the payload's real mtime-derived age).
- The TUI binary calls `waybar::request_refresh()` when such a result lands, mirroring what the Settings overlay already does after a save.

Properties preserved:

- **No extra API calls.** The signaled re-exec hits the just-written cache well inside its 60s TTL, so the README's "keep Waybar polling at 300s" rate-limit guidance is unaffected. Cache-reuse and stale-fallback results don't signal at all.
- **No-op without the signal.** Modules not configured with `signal: 13` behave exactly as before (documented in the README addition).
- **Hermetic tests.** The decision is a pure helper (`is_live_fetch`) with a unit test; the `pkill` side effect lives only in the TUI binary's event loop, matching the existing `settings.rs` placement.

## Testing

- `cargo test` — 242 passed (includes the new `is_live_fetch_only_on_zero_cache_age`)
- `cargo clippy --all-targets -- -D warnings` — clean
- Manually verified on Omarchy/Arch (waybar running, anthropic + openai enabled) with a logging shim in front of `pkill` on `PATH`:
  - caches older than the 60s TTL → opening the patched TUI logged `pkill -RTMIN+13 waybar` once per live-fetched vendor, and the running bar refreshed to the new percentage;
  - re-opening immediately (caches now fresh) → zero signals, confirming cache reuse stays silent.

CHANGELOG updated under `[Unreleased]`; README's signal section documents the new behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
