### PR TITLE
feat: GNOME Shell extension — 5h + weekly usage bars in the top panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ packaging/aur/pkg/
 packaging/aur/src/
 packaging/aur/*.pkg.tar.*
 packaging/aur/*.tar.gz
+
+# GNOME extension - compiled schema (build artifact)
+gnome-extension/schemas/gschemas.compiled

--- a/gnome-extension/README.md
+++ b/gnome-extension/README.md
@@ -1,0 +1,74 @@
+# AI Usage Bar — GNOME Shell extension
+
+A native GNOME top-panel indicator for [`ai-usagebar`](../README.md). It puts
+the **5-hour session** and **weekly** usage bars next to the clock/network,
+and shows the full bordered tooltip in a click dropdown.
+
+This is the GNOME counterpart to the project's Waybar widget: Waybar is
+Wayland-only (Sway/Hyprland) and can't dock into the GNOME top bar, so this
+extension bridges the gap by shelling out to the same `ai-usagebar` binary and
+drawing the bars with native `St` widgets.
+
+![panel: `5h 2% ███░░░░░  7d 77% ██████░░`](../screenshot.png)
+
+## Requirements
+
+- GNOME Shell **45–48** (ESM extensions).
+- The `ai-usagebar` binary on `PATH` (or `~/.cargo/bin`, or set an explicit
+  path in preferences). Install it with `cargo install ai-usagebar` or from
+  the AUR — see the [main README](../README.md).
+- For the colored bars to be even, the panel uses a monospace font. For the
+  dropdown's Nerd Font glyphs to render, set a Nerd Font as your monospace
+  font; without one the icons show as tofu but the bars/numbers are fine.
+
+## Install (dev)
+
+```bash
+./install.sh
+# then reload the shell:
+#   X11      → Alt+F2, type 'r', Enter
+#   Wayland  → log out / in
+gnome-extensions enable ai-usagebar@akitaonrails.github.io
+```
+
+Manual equivalent:
+
+```bash
+UUID=ai-usagebar@akitaonrails.github.io
+DEST=~/.local/share/gnome-shell/extensions/$UUID
+glib-compile-schemas schemas/
+mkdir -p "$DEST" && cp -r * "$DEST"/      # or: ln -s "$PWD" "$DEST"
+```
+
+## Preferences
+
+`gnome-extensions prefs ai-usagebar@akitaonrails.github.io`
+
+| Setting | Default | Notes |
+|---|---|---|
+| Show 5h / weekly bar | on / on | toggle either window |
+| Show percentage | on | numeric `%` next to each bar |
+| Bar width | 8 | cells per bar (4–20) |
+| Refresh interval | 30 s | 5–3600 |
+| Vendor | `anthropic` | only Anthropic has the 5h + weekly windows |
+| Binary path | auto | empty = `PATH` then `~/.cargo/bin` |
+| Panel area | `right` | `right` = next to network/clock; also `center`/`left` |
+| Panel index | 0 | order within the area (0 = leftmost) |
+
+## How it renders
+
+It runs:
+
+```
+ai-usagebar --vendor <vendor> --format '{session_pct};;{weekly_pct}'
+```
+
+parses the Waybar JSON (`{text, tooltip, class}`), and draws two bars from the
+percentages. Colors mirror the binary's default One Dark theme and
+`severity_for()` thresholds (≥90 red · ≥75 orange · ≥50 yellow · else green),
+so it matches the Waybar widget. The dropdown shows the binary's own
+`tooltip` markup verbatim.
+
+The subprocess is spawned **asynchronously** (`Gio.Subprocess` +
+`communicate_utf8_async`) so it never blocks the shell, and all timers /
+signal handlers are torn down in `disable()`.

--- a/gnome-extension/README.md
+++ b/gnome-extension/README.md
@@ -2,7 +2,7 @@
 
 A native GNOME top-panel indicator for [`ai-usagebar`](../README.md). It puts
 the **5-hour session** and **weekly** usage bars next to the clock/network,
-and shows the full bordered tooltip in a click dropdown.
+with optional Sonnet-only and extra-usage rows in a native click dropdown.
 
 This is the GNOME counterpart to the project's Waybar widget: Waybar is
 Wayland-only (Sway/Hyprland) and can't dock into the GNOME top bar, so this
@@ -60,14 +60,15 @@ mkdir -p "$DEST" && cp -r * "$DEST"/      # or: ln -s "$PWD" "$DEST"
 It runs:
 
 ```
-ai-usagebar --vendor <vendor> --format '{session_pct};;{weekly_pct}'
+ai-usagebar --vendor <vendor> --format '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit}'
 ```
 
-parses the Waybar JSON (`{text, tooltip, class}`), and draws two bars from the
-percentages. Colors mirror the binary's default One Dark theme and
-`severity_for()` thresholds (≥90 red · ≥75 orange · ≥50 yellow · else green),
-so it matches the Waybar widget. The dropdown shows the binary's own
-`tooltip` markup verbatim.
+parses the Waybar JSON (`{text, tooltip, class}`), extracts the formatted
+fields from `text`, and draws the plan, session, weekly, optional Sonnet-only,
+and optional extra-usage values with native `St` widgets. Colors mirror the
+binary's default One Dark theme and `severity_for()` thresholds (≥90 red · ≥75
+orange · ≥50 yellow · else green), so it matches the Waybar widget. The
+dropdown is a native aligned menu, not the tooltip markup rendered verbatim.
 
 The subprocess is spawned **asynchronously** (`Gio.Subprocess` +
 `communicate_utf8_async`) so it never blocks the shell, and all timers /

--- a/gnome-extension/extension.js
+++ b/gnome-extension/extension.js
@@ -28,6 +28,7 @@ const RED = '#e06c75';
 // All ten fields we pull from the binary, joined by ';;'.
 const FORMAT = '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;' +
     '{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit}';
+const REFRESH_TIMEOUT_SECS = 60;
 
 // severity_for(pct) from src/pango.rs: >=90 critical, >=75 high, >=50 mid, else low.
 function colorForPct(pct, colors) {
@@ -78,7 +79,10 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         this._data = null;          // parsed snapshot for redraws
         this._busy = false;
         this._timer = 0;
-        this._cancellable = new Gio.Cancellable();
+        this._refreshTimeoutId = 0;
+        this._refreshCancellable = null;
+        this._refreshProc = null;
+        this._refreshToken = 0;
         this._rows = {};
 
         // Panel: one markup label holds tags + percentages + bars.
@@ -197,10 +201,13 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         if (this._busy)
             return;
         this._busy = true;
+        const token = ++this._refreshToken;
 
         const bin = resolveBinary(this._settings);
         const vendor = this._settings.get_string('vendor') || 'anthropic';
         const argv = [bin, '--vendor', vendor, '--format', FORMAT];
+        const cancellable = new Gio.Cancellable();
+        this._refreshCancellable = cancellable;
 
         let proc;
         try {
@@ -208,25 +215,60 @@ class AiUsageBarIndicator extends PanelMenu.Button {
                 argv,
                 flags: Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE,
             });
-            proc.init(this._cancellable);
+            proc.init(cancellable);
         } catch (e) {
             this._busy = false;
+            this._refreshCancellable = null;
             this._setError(`não consegui executar "${bin}"`, String(e));
             return;
         }
+        this._refreshProc = proc;
 
-        proc.communicate_utf8_async(null, this._cancellable, (p, res) => {
-            this._busy = false;
+        let timedOut = false;
+        const timeoutId = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, REFRESH_TIMEOUT_SECS, () => {
+            timedOut = true;
+            if (this._refreshTimeoutId === timeoutId)
+                this._refreshTimeoutId = 0;
+            try {
+                proc.force_exit();
+            } catch (e) {}
+            cancellable.cancel();
+            if (this._refreshToken === token) {
+                this._busy = false;
+                this._setError('ai-usagebar demorou demais', `timeout após ${REFRESH_TIMEOUT_SECS}s`);
+            }
+            return GLib.SOURCE_REMOVE;
+        });
+        this._refreshTimeoutId = timeoutId;
+
+        const cleanup = () => {
+            if (this._refreshTimeoutId === timeoutId) {
+                GLib.source_remove(timeoutId);
+                this._refreshTimeoutId = 0;
+            }
+            if (this._refreshCancellable === cancellable)
+                this._refreshCancellable = null;
+            if (this._refreshProc === proc)
+                this._refreshProc = null;
+        };
+
+        proc.communicate_utf8_async(null, cancellable, (p, res) => {
+            if (this._refreshToken === token)
+                this._busy = false;
             try {
                 const [, out, err] = p.communicate_utf8_finish(res);
+                cleanup();
+                if (timedOut)
+                    return;
                 if ((!out || !out.trim()) && !p.get_successful()) {
                     this._setError('ai-usagebar falhou', err || '');
                     return;
                 }
                 this._consume(out || '');
             } catch (e) {
+                cleanup();
                 if (!(e instanceof GLib.Error &&
-                      e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)))
+                      e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) && !timedOut)
                     this._setError('erro ao ler a saída', String(e));
             }
         });
@@ -248,16 +290,24 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             this._label.clutter_text.set_markup(`<span foreground="${FG}">${esc(raw) || '…'}</span>`);
             return;
         }
+        const isPlaceholder = s => /^\{[^}]+\}$/.test(String(s).trim());
+        const field = s => {
+            const t = String(s ?? '').trim();
+            return t && !isPlaceholder(t) ? t : '';
+        };
         const num = s => {
-            const n = parseInt(s, 10);
+            const t = field(s);
+            if (!t)
+                return null;
+            const n = parseInt(t, 10);
             return Number.isFinite(n) ? n : null;
         };
         this._data = {
-            plan: f[0].trim(),
-            session: {pct: num(f[1]) ?? 0, reset: f[2].trim()},
-            weekly: {pct: num(f[3]) ?? 0, reset: f[4].trim()},
-            sonnet: {pct: num(f[5]), reset: f[6].trim()},
-            extra: {pct: num(f[7]) ?? 0, spent: f[8].trim(), limit: f[9].trim()},
+            plan: field(f[0]),
+            session: {pct: num(f[1]) ?? 0, reset: field(f[2])},
+            weekly: {pct: num(f[3]) ?? 0, reset: field(f[4])},
+            sonnet: {pct: num(f[5]), reset: field(f[6])},
+            extra: {pct: num(f[7]), spent: field(f[8]), limit: field(f[9])},
         };
         this._render();
     }
@@ -293,7 +343,8 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             parts.push(seg('5h', d.session.pct, `${d.session.pct}%`));
         if (this._settings.get_boolean('show-weekly'))
             parts.push(seg('7d', d.weekly.pct, `${d.weekly.pct}%`));
-        if (this._settings.get_boolean('show-extra') && d.extra.spent)
+        if (this._settings.get_boolean('show-extra') &&
+            d.extra.pct != null && d.extra.spent && d.extra.limit)
             parts.push(seg('ex', d.extra.pct, d.extra.spent));
 
         const gap = `<span foreground="${DIM}">   </span>`;
@@ -321,7 +372,8 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         upd('session', d.session.pct, `${d.session.pct}%`, d.session.reset, true);
         upd('weekly', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.reset, true);
         upd('sonnet', d.sonnet.pct, `${d.sonnet.pct ?? 0}%`, d.sonnet.reset, d.sonnet.pct != null);
-        upd('extra', d.extra.pct, `${d.extra.spent} / ${d.extra.limit}`, null, !!d.extra.spent);
+        upd('extra', d.extra.pct, `${d.extra.spent} / ${d.extra.limit}`, null,
+            d.extra.pct != null && !!d.extra.spent && !!d.extra.limit);
     }
 
     _setError(short, detail) {
@@ -359,7 +411,18 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             GLib.source_remove(this._timer);
             this._timer = 0;
         }
-        this._cancellable.cancel();
+        if (this._refreshTimeoutId) {
+            GLib.source_remove(this._refreshTimeoutId);
+            this._refreshTimeoutId = 0;
+        }
+        if (this._refreshCancellable)
+            this._refreshCancellable.cancel();
+        if (this._refreshProc) {
+            try {
+                this._refreshProc.force_exit();
+            } catch (e) {}
+            this._refreshProc = null;
+        }
         for (const id of this._viewIds ?? [])
             this._settings.disconnect(id);
         for (const id of this._sourceIds ?? [])

--- a/gnome-extension/extension.js
+++ b/gnome-extension/extension.js
@@ -1,0 +1,408 @@
+// AI Usage Bar — GNOME Shell indicator that renders ai-usagebar's
+// 5-hour (session), weekly, and (optionally) extra-usage bars in the top
+// panel next to the clock/network, with a native, aligned dropdown.
+//
+// It shells out to the `ai-usagebar` binary (always exits 0, emits Waybar
+// JSON `{text, tooltip, class}`) and draws everything with native St
+// widgets. Bar colors and thresholds default to the binary's One Dark
+// theme but are user-configurable.
+
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+import Clutter from 'gi://Clutter';
+import GLib from 'gi://GLib';
+import Gio from 'gi://Gio';
+
+import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+const ROLE = 'ai-usagebar';
+
+// Fixed accent colors (tags / dim text). Bar colors are user-configurable.
+const DIM = '#5c6370';
+const FG = '#abb2bf';
+const RED = '#e06c75';
+
+// All ten fields we pull from the binary, joined by ';;'.
+const FORMAT = '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;' +
+    '{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit}';
+
+// severity_for(pct) from src/pango.rs: >=90 critical, >=75 high, >=50 mid, else low.
+function colorForPct(pct, colors) {
+    if (pct >= 90)
+        return colors.critical;
+    if (pct >= 75)
+        return colors.high;
+    if (pct >= 50)
+        return colors.mid;
+    return colors.low;
+}
+
+function esc(s) {
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+// Two-segment block bar as Pango markup, `width` cells wide.
+function barMarkup(pct, width, colors) {
+    const p = Math.max(0, Math.min(100, Math.round(pct)));
+    const filled = Math.round((p * width) / 100);
+    return `<span foreground="${colorForPct(p, colors)}">${'█'.repeat(filled)}</span>` +
+        `<span foreground="${colors.empty}">${'░'.repeat(width - filled)}</span>`;
+}
+
+function resolveBinary(settings) {
+    const configured = settings.get_string('binary-path');
+    if (configured && GLib.file_test(configured, GLib.FileTest.IS_EXECUTABLE))
+        return configured;
+    const onPath = GLib.find_program_in_path('ai-usagebar');
+    if (onPath)
+        return onPath;
+    const cargo = `${GLib.get_home_dir()}/.cargo/bin/ai-usagebar`;
+    if (GLib.file_test(cargo, GLib.FileTest.IS_EXECUTABLE))
+        return cargo;
+    return 'ai-usagebar';
+}
+
+const Indicator = GObject.registerClass(
+class AiUsageBarIndicator extends PanelMenu.Button {
+    _init(settings, openPrefs) {
+        super._init(0.0, 'AI Usage Bar', false);
+
+        this._settings = settings;
+        this._openPrefs = openPrefs;
+        this._data = null;          // parsed snapshot for redraws
+        this._busy = false;
+        this._timer = 0;
+        this._cancellable = new Gio.Cancellable();
+        this._rows = {};
+
+        // Panel: one markup label holds tags + percentages + bars.
+        this._label = new St.Label({
+            text: '5h …',
+            y_align: Clutter.ActorAlign.CENTER,
+            style_class: 'aiub-label',
+        });
+        this.add_child(this._label);
+
+        this._buildMenu();
+
+        // Re-render cached data when any display setting changes (no refetch).
+        const viewKeys = [
+            'bar-width', 'show-percent', 'show-bars', 'show-session',
+            'show-weekly', 'show-extra', 'color-low', 'color-mid',
+            'color-high', 'color-critical', 'color-empty',
+        ];
+        this._viewIds = viewKeys.map(k =>
+            this._settings.connect(`changed::${k}`, () => this._render()));
+
+        this._intervalId = this._settings.connect('changed::refresh-interval',
+            () => this._restartTimer());
+        this._sourceIds = [
+            this._settings.connect('changed::vendor', () => this._refresh()),
+            this._settings.connect('changed::binary-path', () => this._refresh()),
+        ];
+
+        this.menu.connect('open-state-changed', (_m, open) => {
+            if (open)
+                this._refresh();
+        });
+
+        this._refresh();
+        this._restartTimer();
+    }
+
+    _buildMenu() {
+        // Header (plan name).
+        const header = new PopupMenu.PopupBaseMenuItem({reactive: false, can_focus: false});
+        this._planLabel = new St.Label({text: 'AI Usage', x_expand: true, style_class: 'aiub-header'});
+        header.add_child(this._planLabel);
+        this.menu.addMenuItem(header);
+
+        this._addRow('session', 'Session');
+        this._addRow('weekly', 'Weekly');
+        this._addRow('sonnet', 'Sonnet only');
+        this._addRow('extra', 'Extra usage');
+
+        this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
+        const refreshItem = new PopupMenu.PopupMenuItem('Atualizar agora');
+        refreshItem.connect('activate', () => this._refresh());
+        this.menu.addMenuItem(refreshItem);
+
+        const tuiItem = new PopupMenu.PopupMenuItem('Abrir TUI');
+        tuiItem.connect('activate', () => this._openTui());
+        this.menu.addMenuItem(tuiItem);
+
+        const prefsItem = new PopupMenu.PopupMenuItem('Configurações');
+        prefsItem.connect('activate', () => this._openPrefs());
+        this.menu.addMenuItem(prefsItem);
+    }
+
+    // A native, font-independent row: [name ........ value] / bar / reset.
+    _addRow(key, name) {
+        const item = new PopupMenu.PopupBaseMenuItem({reactive: false, can_focus: false});
+        const vbox = new St.BoxLayout({
+            orientation: Clutter.Orientation.VERTICAL,
+            x_expand: true,
+            style_class: 'aiub-row',
+        });
+
+        const head = new St.BoxLayout({x_expand: true});
+        const nameL = new St.Label({text: name, x_expand: true, style_class: 'aiub-row-name'});
+        const valL = new St.Label({style_class: 'aiub-row-val'});
+        head.add_child(nameL);
+        head.add_child(valL);
+
+        const barL = new St.Label({style_class: 'aiub-row-bar'});
+        const resetL = new St.Label({style_class: 'aiub-row-reset'});
+
+        vbox.add_child(head);
+        vbox.add_child(barL);
+        vbox.add_child(resetL);
+        item.add_child(vbox);
+        this.menu.addMenuItem(item);
+
+        this._rows[key] = {item, valL, barL, resetL};
+    }
+
+    _colors() {
+        const g = k => this._settings.get_string(k);
+        return {
+            low: g('color-low'),
+            mid: g('color-mid'),
+            high: g('color-high'),
+            critical: g('color-critical'),
+            empty: g('color-empty'),
+        };
+    }
+
+    _restartTimer() {
+        if (this._timer) {
+            GLib.source_remove(this._timer);
+            this._timer = 0;
+        }
+        const secs = Math.max(5, this._settings.get_int('refresh-interval'));
+        this._timer = GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, secs, () => {
+            this._refresh();
+            return GLib.SOURCE_CONTINUE;
+        });
+    }
+
+    _refresh() {
+        if (this._busy)
+            return;
+        this._busy = true;
+
+        const bin = resolveBinary(this._settings);
+        const vendor = this._settings.get_string('vendor') || 'anthropic';
+        const argv = [bin, '--vendor', vendor, '--format', FORMAT];
+
+        let proc;
+        try {
+            proc = new Gio.Subprocess({
+                argv,
+                flags: Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_PIPE,
+            });
+            proc.init(this._cancellable);
+        } catch (e) {
+            this._busy = false;
+            this._setError(`não consegui executar "${bin}"`, String(e));
+            return;
+        }
+
+        proc.communicate_utf8_async(null, this._cancellable, (p, res) => {
+            this._busy = false;
+            try {
+                const [, out, err] = p.communicate_utf8_finish(res);
+                if ((!out || !out.trim()) && !p.get_successful()) {
+                    this._setError('ai-usagebar falhou', err || '');
+                    return;
+                }
+                this._consume(out || '');
+            } catch (e) {
+                if (!(e instanceof GLib.Error &&
+                      e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)))
+                    this._setError('erro ao ler a saída', String(e));
+            }
+        });
+    }
+
+    _consume(stdout) {
+        let data;
+        try {
+            data = JSON.parse(stdout);
+        } catch (e) {
+            this._setError('saída inválida', stdout);
+            return;
+        }
+        const raw = (data.text ?? '').toString().replace(/<[^>]*>/g, '');
+        const f = raw.split(';;');
+        if (f.length < 10) {
+            // Loading… / ⚠ — show the binary's own text.
+            this._data = null;
+            this._label.clutter_text.set_markup(`<span foreground="${FG}">${esc(raw) || '…'}</span>`);
+            return;
+        }
+        const num = s => {
+            const n = parseInt(s, 10);
+            return Number.isFinite(n) ? n : null;
+        };
+        this._data = {
+            plan: f[0].trim(),
+            session: {pct: num(f[1]) ?? 0, reset: f[2].trim()},
+            weekly: {pct: num(f[3]) ?? 0, reset: f[4].trim()},
+            sonnet: {pct: num(f[5]), reset: f[6].trim()},
+            extra: {pct: num(f[7]) ?? 0, spent: f[8].trim(), limit: f[9].trim()},
+        };
+        this._render();
+    }
+
+    // Redraw both the panel and the dropdown from cached data + settings.
+    _render() {
+        const d = this._data;
+        if (!d)
+            return;
+        const colors = this._colors();
+        this._renderPanel(d, colors);
+        this._renderDropdown(d, colors);
+    }
+
+    _renderPanel(d, colors) {
+        const w = Math.max(4, Math.min(20, this._settings.get_int('bar-width')));
+        const showPct = this._settings.get_boolean('show-percent');
+        const showBars = this._settings.get_boolean('show-bars');
+
+        const seg = (tag, pct, valueText) => {
+            const toks = [`<span foreground="${DIM}">${tag}</span>`];
+            if (showPct)
+                toks.push(`<span foreground="${colorForPct(pct, colors)}">${esc(valueText)}</span>`);
+            if (showBars)
+                toks.push(barMarkup(pct, w, colors));
+            if (!showPct && !showBars) // never render an empty segment
+                toks.push(`<span foreground="${colorForPct(pct, colors)}">${esc(valueText)}</span>`);
+            return toks.join(' ');
+        };
+
+        const parts = [];
+        if (this._settings.get_boolean('show-session'))
+            parts.push(seg('5h', d.session.pct, `${d.session.pct}%`));
+        if (this._settings.get_boolean('show-weekly'))
+            parts.push(seg('7d', d.weekly.pct, `${d.weekly.pct}%`));
+        if (this._settings.get_boolean('show-extra') && d.extra.spent)
+            parts.push(seg('ex', d.extra.pct, d.extra.spent));
+
+        const gap = `<span foreground="${DIM}">   </span>`;
+        this._label.clutter_text.set_markup(parts.join(gap) || ' ');
+    }
+
+    _renderDropdown(d, colors) {
+        this._planLabel.text = d.plan || 'AI Usage';
+
+        const upd = (key, pct, valueText, reset, visible) => {
+            const r = this._rows[key];
+            r.item.visible = visible;
+            if (!visible)
+                return;
+            r.valL.text = valueText;
+            r.barL.clutter_text.set_markup(barMarkup(pct ?? 0, 18, colors));
+            if (reset) {
+                r.resetL.text = `↺ resets in ${reset}`;
+                r.resetL.visible = true;
+            } else {
+                r.resetL.visible = false;
+            }
+        };
+
+        upd('session', d.session.pct, `${d.session.pct}%`, d.session.reset, true);
+        upd('weekly', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.reset, true);
+        upd('sonnet', d.sonnet.pct, `${d.sonnet.pct ?? 0}%`, d.sonnet.reset, d.sonnet.pct != null);
+        upd('extra', d.extra.pct, `${d.extra.spent} / ${d.extra.limit}`, null, !!d.extra.spent);
+    }
+
+    _setError(short, detail) {
+        this._data = null;
+        this._label.clutter_text.set_markup(`<span foreground="${RED}">⚠ ai</span>`);
+        const msg = detail ? `${short}\n${esc(detail).slice(0, 300)}` : short;
+        this._planLabel.clutter_text.set_markup(`<span foreground="${FG}">${esc(msg)}</span>`);
+        for (const r of Object.values(this._rows))
+            r.item.visible = false;
+    }
+
+    _openTui() {
+        const tui = GLib.find_program_in_path('ai-usagebar-tui') ||
+            `${GLib.get_home_dir()}/.cargo/bin/ai-usagebar-tui`;
+        const candidates = [
+            ['kgx', '--', tui],
+            ['gnome-terminal', '--', tui],
+            ['xterm', '-e', tui],
+        ];
+        for (const argv of candidates) {
+            if (!GLib.find_program_in_path(argv[0]))
+                continue;
+            try {
+                Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
+                return;
+            } catch (e) {
+                // try the next terminal
+            }
+        }
+        Main.notify('AI Usage Bar', 'Nenhum terminal encontrado (kgx / gnome-terminal / xterm).');
+    }
+
+    destroy() {
+        if (this._timer) {
+            GLib.source_remove(this._timer);
+            this._timer = 0;
+        }
+        this._cancellable.cancel();
+        for (const id of this._viewIds ?? [])
+            this._settings.disconnect(id);
+        for (const id of this._sourceIds ?? [])
+            this._settings.disconnect(id);
+        if (this._intervalId)
+            this._settings.disconnect(this._intervalId);
+        this._viewIds = this._sourceIds = null;
+        this._intervalId = 0;
+        super.destroy();
+    }
+});
+
+export default class AiUsageBarExtension extends Extension {
+    enable() {
+        this._settings = this.getSettings();
+        this._place();
+        this._placeIds = [
+            this._settings.connect('changed::panel-box', () => this._place()),
+            this._settings.connect('changed::panel-index', () => this._place()),
+        ];
+    }
+
+    _place() {
+        const existing = Main.panel.statusArea[ROLE];
+        if (existing) {
+            existing.destroy();
+            delete Main.panel.statusArea[ROLE];
+        }
+        this._indicator = new Indicator(this._settings, () => this.openPreferences());
+        const box = this._settings.get_string('panel-box') || 'right';
+        const index = Math.max(0, this._settings.get_int('panel-index'));
+        Main.panel.addToStatusArea(ROLE, this._indicator, index, box);
+    }
+
+    disable() {
+        for (const id of this._placeIds ?? [])
+            this._settings.disconnect(id);
+        this._placeIds = null;
+        if (this._indicator) {
+            this._indicator.destroy();
+            this._indicator = null;
+        }
+        delete Main.panel.statusArea[ROLE];
+        this._settings = null;
+    }
+}

--- a/gnome-extension/install.sh
+++ b/gnome-extension/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Dev install for the AI Usage Bar GNOME Shell extension.
+# Symlinks this folder into ~/.local/share/gnome-shell/extensions and
+# compiles the GSettings schema. Run, then reload the shell.
+set -euo pipefail
+
+UUID="ai-usagebar@akitaonrails.github.io"
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEST="$HOME/.local/share/gnome-shell/extensions/$UUID"
+
+echo "› Compiling schema…"
+glib-compile-schemas "$SRC/schemas"
+
+echo "› Linking $DEST → $SRC"
+mkdir -p "$(dirname "$DEST")"
+rm -rf "$DEST"
+ln -s "$SRC" "$DEST"
+
+echo
+echo "✓ Installed (dev symlink)."
+echo
+echo "Next:"
+echo "  1. Reload GNOME Shell:"
+echo "       • X11  → Alt+F2, type 'r', Enter"
+echo "       • Wayland → log out and back in"
+echo "  2. Enable it:"
+echo "       gnome-extensions enable $UUID"
+echo "  3. Settings (interval, bars, position):"
+echo "       gnome-extensions prefs $UUID"
+echo
+echo "Logs:  journalctl -f -o cat /usr/bin/gnome-shell"

--- a/gnome-extension/metadata.json
+++ b/gnome-extension/metadata.json
@@ -1,0 +1,11 @@
+{
+  "uuid": "ai-usagebar@akitaonrails.github.io",
+  "name": "AI Usage Bar",
+  "description": "Anthropic Claude (and other vendors') plan usage in the GNOME top panel, next to the clock/network: the 5-hour session bar and the weekly bar, with the full bordered tooltip in a dropdown. Backed by the `ai-usagebar` binary (https://github.com/akitaonrails/ai-usagebar).",
+  "version": 1,
+  "version-name": "0.1.0",
+  "shell-version": ["45", "46", "47", "48"],
+  "url": "https://github.com/akitaonrails/ai-usagebar",
+  "settings-schema": "org.gnome.shell.extensions.ai-usagebar",
+  "gettext-domain": "ai-usagebar"
+}

--- a/gnome-extension/prefs.js
+++ b/gnome-extension/prefs.js
@@ -1,0 +1,325 @@
+// Preferences (libadwaita) for AI Usage Bar.
+
+import Adw from 'gi://Adw';
+import Gtk from 'gi://Gtk';
+import Gdk from 'gi://Gdk';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+
+import {ExtensionPreferences, gettext as _} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+// ── Vendor login / config ────────────────────────────────────────────────
+const VENDOR_AUTH = [
+    {id: 'anthropic', name: 'Anthropic (Claude)', kind: 'oauth', cli: 'claude', login: 'claude', pkg: '@anthropic-ai/claude-code'},
+    {id: 'openai', name: 'OpenAI (Codex)', kind: 'oauth', cli: 'codex', login: 'codex login', pkg: '@openai/codex'},
+    {id: 'zai', name: 'Z.AI (GLM)', kind: 'apikey', env: 'ZAI_API_KEY'},
+    {id: 'openrouter', name: 'OpenRouter', kind: 'apikey', env: 'OPENROUTER_API_KEY'},
+    {id: 'deepseek', name: 'DeepSeek', kind: 'apikey', env: 'DEEPSEEK_API_KEY'},
+];
+
+// Does ~/.config/ai-usagebar/config.toml have an uncommented api_key in [section]?
+function configHasApiKey(section) {
+    const path = `${GLib.get_home_dir()}/.config/ai-usagebar/config.toml`;
+    if (!GLib.file_test(path, GLib.FileTest.EXISTS))
+        return false;
+    try {
+        const [ok, bytes] = GLib.file_get_contents(path);
+        if (!ok)
+            return false;
+        let inSection = false;
+        for (const raw of new TextDecoder().decode(bytes).split('\n')) {
+            const t = raw.trim();
+            if (t.startsWith('['))
+                inSection = t === `[${section}]`;
+            else if (inSection && !t.startsWith('#') && /^api_key\s*=\s*["']\S/.test(t))
+                return true;
+        }
+    } catch (e) {}
+    return false;
+}
+
+function vendorConfigured(v) {
+    const home = GLib.get_home_dir();
+    if (v.id === 'anthropic')
+        return GLib.file_test(`${home}/.claude/.credentials.json`, GLib.FileTest.EXISTS);
+    if (v.id === 'openai')
+        return GLib.file_test(`${home}/.codex/auth.json`, GLib.FileTest.EXISTS);
+    return (GLib.getenv(v.env) || '').length > 0 || configHasApiKey(v.id);
+}
+
+// Open the user's terminal running `command` (login shell, so claude/codex are on PATH).
+function spawnInTerminal(command) {
+    for (const argv of [
+        ['kgx', '--', 'bash', '-lc', command],
+        ['gnome-terminal', '--', 'bash', '-lc', command],
+        ['xterm', '-e', 'bash', '-lc', command],
+    ]) {
+        if (!GLib.find_program_in_path(argv[0]))
+            continue;
+        try {
+            Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
+            return true;
+        } catch (e) {}
+    }
+    return false;
+}
+
+// Is `cli` on the login-shell PATH? (npm-global / nvm bins often aren't on the
+// prefs process PATH, so we ask a login shell.)
+function checkCliInstalled(cli, callback) {
+    try {
+        const p = Gio.Subprocess.new(
+            ['bash', '-lc', `command -v ${cli}`],
+            Gio.SubprocessFlags.STDOUT_PIPE | Gio.SubprocessFlags.STDERR_SILENCE);
+        p.communicate_utf8_async(null, null, (proc, res) => {
+            try {
+                const [, out] = proc.communicate_utf8_finish(res);
+                callback((out || '').trim().length > 0);
+            } catch (e) {
+                callback(false);
+            }
+        });
+    } catch (e) {
+        callback(false);
+    }
+}
+
+// Terminal script: if the CLI is missing, offer to npm-install it (with
+// consent), then run the login. Runs in a login shell so PATH is complete.
+function oauthCommand(v) {
+    // Installs to ~/.local (already on PATH) so no sudo is needed even when the
+    // system npm prefix is root-owned (/usr/lib/node_modules).
+    return [
+        `export PATH="$HOME/.local/bin:$PATH";`,
+        `if command -v ${v.cli} >/dev/null 2>&1; then ${v.login};`,
+        `else echo "⚠ ${v.cli} nao encontrado.";`,
+        `echo "Instalo em ~/.local sem sudo (npm --prefix). Pacote: ${v.pkg}"; echo;`,
+        `read -p "Instalar agora? [y/N] " a;`,
+        `if [ "$a" = y ] || [ "$a" = Y ]; then npm i -g --prefix "$HOME/.local" ${v.pkg} && hash -r && ${v.login}; fi;`,
+        `fi;`,
+        `echo; read -p "Enter para fechar..."`,
+    ].join(' ');
+}
+
+// Bind an Adw.ComboRow (index-based) to a string GSetting via a value table.
+function bindCombo(settings, key, comboRow, values) {
+    const sync = () => {
+        const idx = values.indexOf(settings.get_string(key));
+        comboRow.selected = idx < 0 ? 0 : idx;
+    };
+    sync();
+    comboRow.connect('notify::selected', () => {
+        const v = values[comboRow.selected];
+        if (v !== undefined && v !== settings.get_string(key))
+            settings.set_string(key, v);
+    });
+    const id = settings.connect(`changed::${key}`, sync);
+    comboRow.connect('destroy', () => settings.disconnect(id));
+}
+
+function rgbaToHex(rgba) {
+    const h = v => Math.round(Math.max(0, Math.min(1, v)) * 255).toString(16).padStart(2, '0');
+    return `#${h(rgba.red)}${h(rgba.green)}${h(rgba.blue)}`;
+}
+
+// A row with a GTK color picker bound to a hex-string GSetting.
+function colorRow(settings, key, title) {
+    const row = new Adw.ActionRow({title});
+    const btn = new Gtk.ColorDialogButton({
+        dialog: new Gtk.ColorDialog({with_alpha: false}),
+        valign: Gtk.Align.CENTER,
+    });
+    let updating = false;
+    const load = () => {
+        const rgba = new Gdk.RGBA();
+        if (rgba.parse(settings.get_string(key))) {
+            updating = true;
+            btn.set_rgba(rgba);
+            updating = false;
+        }
+    };
+    load();
+    btn.connect('notify::rgba', () => {
+        if (!updating)
+            settings.set_string(key, rgbaToHex(btn.get_rgba()));
+    });
+    const id = settings.connect(`changed::${key}`, load);
+    row.connect('destroy', () => settings.disconnect(id));
+    row.add_suffix(btn);
+    row.activatable_widget = btn;
+    return row;
+}
+
+export default class AiUsageBarPrefs extends ExtensionPreferences {
+    fillPreferencesWindow(window) {
+        const settings = this.getSettings();
+        const page = new Adw.PreferencesPage();
+        window.add(page);
+
+        // ── Display ──────────────────────────────────────────────────────
+        const display = new Adw.PreferencesGroup({title: _('Exibição')});
+        page.add(display);
+
+        const showSession = new Adw.SwitchRow({title: _('Mostrar barra de 5h (sessão)')});
+        settings.bind('show-session', showSession, 'active', Gio.SettingsBindFlags.DEFAULT);
+        display.add(showSession);
+
+        const showWeekly = new Adw.SwitchRow({title: _('Mostrar barra semanal')});
+        settings.bind('show-weekly', showWeekly, 'active', Gio.SettingsBindFlags.DEFAULT);
+        display.add(showWeekly);
+
+        const showExtra = new Adw.SwitchRow({
+            title: _('Mostrar barra de uso extra (3ª)'),
+            subtitle: _('o custo extra ($) como terceira barra'),
+        });
+        settings.bind('show-extra', showExtra, 'active', Gio.SettingsBindFlags.DEFAULT);
+        display.add(showExtra);
+
+        const showPercent = new Adw.SwitchRow({title: _('Mostrar porcentagem/valor')});
+        settings.bind('show-percent', showPercent, 'active', Gio.SettingsBindFlags.DEFAULT);
+        display.add(showPercent);
+
+        const showBars = new Adw.SwitchRow({
+            title: _('Mostrar barras'),
+            subtitle: _('desligado = só os números, sem as barras'),
+        });
+        settings.bind('show-bars', showBars, 'active', Gio.SettingsBindFlags.DEFAULT);
+        display.add(showBars);
+
+        const barWidth = new Adw.SpinRow({
+            title: _('Largura de cada barra (células)'),
+            adjustment: new Gtk.Adjustment({lower: 4, upper: 20, step_increment: 1, page_increment: 2}),
+        });
+        settings.bind('bar-width', barWidth, 'value', Gio.SettingsBindFlags.DEFAULT);
+        display.add(barWidth);
+
+        // ── Cores ────────────────────────────────────────────────────────
+        const colors = new Adw.PreferencesGroup({
+            title: _('Cores'),
+            description: _('Cor da barra por faixa de uso (One Dark por padrão).'),
+        });
+        page.add(colors);
+        colors.add(colorRow(settings, 'color-low', _('Baixo (<50%)')));
+        colors.add(colorRow(settings, 'color-mid', _('Médio (50–74%)')));
+        colors.add(colorRow(settings, 'color-high', _('Alto (75–89%)')));
+        colors.add(colorRow(settings, 'color-critical', _('Crítico (≥90%)')));
+        colors.add(colorRow(settings, 'color-empty', _('Vazio (fundo da barra)')));
+
+        // ── Dados ────────────────────────────────────────────────────────
+        const data = new Adw.PreferencesGroup({title: _('Dados')});
+        page.add(data);
+
+        const interval = new Adw.SpinRow({
+            title: _('Intervalo de atualização (s)'),
+            adjustment: new Gtk.Adjustment({lower: 5, upper: 3600, step_increment: 5, page_increment: 30}),
+        });
+        settings.bind('refresh-interval', interval, 'value', Gio.SettingsBindFlags.DEFAULT);
+        data.add(interval);
+
+        const vendor = new Adw.ComboRow({
+            title: _('Vendor'),
+            subtitle: _('anthropic expõe as janelas de 5h + semanal'),
+            model: Gtk.StringList.new(['anthropic', 'openai', 'zai', 'openrouter', 'deepseek']),
+        });
+        bindCombo(settings, 'vendor', vendor, ['anthropic', 'openai', 'zai', 'openrouter', 'deepseek']);
+        data.add(vendor);
+
+        const binPath = new Adw.EntryRow({title: _('Caminho do binário (vazio = auto)')});
+        settings.bind('binary-path', binPath, 'text', Gio.SettingsBindFlags.DEFAULT);
+        data.add(binPath);
+
+        // ── Position ─────────────────────────────────────────────────────
+        const pos = new Adw.PreferencesGroup({
+            title: _('Posição no painel'),
+            description: _('Mudanças aplicam na hora.'),
+        });
+        page.add(pos);
+
+        const box = new Adw.ComboRow({
+            title: _('Área'),
+            subtitle: _('right = ao lado da rede/relógio'),
+            model: Gtk.StringList.new(['left', 'center', 'right']),
+        });
+        bindCombo(settings, 'panel-box', box, ['left', 'center', 'right']);
+        pos.add(box);
+
+        const index = new Adw.SpinRow({
+            title: _('Índice na área'),
+            subtitle: _('0 = mais à esquerda da área escolhida'),
+            adjustment: new Gtk.Adjustment({lower: 0, upper: 20, step_increment: 1, page_increment: 1}),
+        });
+        settings.bind('panel-index', index, 'value', Gio.SettingsBindFlags.DEFAULT);
+        pos.add(index);
+
+        this._buildVendorsPage(window);
+    }
+
+    // A "Vendors" tab: per-vendor credential status + a login/config button.
+    _buildVendorsPage(window) {
+        const page = new Adw.PreferencesPage({
+            title: _('Vendors'),
+            icon_name: 'dialog-password-symbolic',
+        });
+        window.add(page);
+
+        const group = new Adw.PreferencesGroup({
+            title: _('Login / configuração por vendor'),
+            description: _('OAuth abre um terminal com o comando de login; vendors de API key são configurados no TUI. Reabra esta janela para reavaliar o status.'),
+        });
+        page.add(group);
+
+        const updates = [];
+        for (const v of VENDOR_AUTH) {
+            const row = new Adw.ActionRow({title: v.name});
+            const btn = new Gtk.Button({valign: Gtk.Align.CENTER});
+            btn.add_css_class('flat');
+            row.add_suffix(btn);
+
+            const update = () => {
+                if (v.kind !== 'oauth') {
+                    const ok = vendorConfigured(v);
+                    row.subtitle = ok ? _('✓ Configurado') : `⚠ ${_('Sem API key')} — ${v.env}`;
+                    btn.label = _('Configurar (TUI)');
+                    return;
+                }
+                if (vendorConfigured(v)) {
+                    row.subtitle = _('✓ Configurado');
+                    btn.label = _('Re-logar');
+                    return;
+                }
+                row.subtitle = _('verificando…');
+                checkCliInstalled(v.cli, (installed) => {
+                    row.subtitle = installed
+                        ? `⚠ ${_('Não logado')} — \`${v.login}\``
+                        : `⚠ ${v.cli} ${_('não instalado')} (instala em ~/.local, sem sudo)`;
+                    btn.label = installed ? _('Logar') : _('Instalar + logar');
+                });
+            };
+            update();
+            updates.push(update);
+
+            btn.connect('clicked', () => {
+                if (v.kind === 'oauth') {
+                    spawnInTerminal(oauthCommand(v));
+                } else {
+                    const tui = GLib.find_program_in_path('ai-usagebar-tui') ||
+                        `${GLib.get_home_dir()}/.cargo/bin/ai-usagebar-tui`;
+                    spawnInTerminal(`"${tui}"`);
+                }
+                GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 4, () => {
+                    update();
+                    return GLib.SOURCE_REMOVE;
+                });
+            });
+
+            group.add(row);
+        }
+
+        // Re-check when the window regains focus (e.g., after logging in via
+        // the terminal) — fixes the "still shows não logado" loop.
+        window.connect('notify::is-active', () => {
+            if (window.is_active)
+                updates.forEach(u => u());
+        });
+    }
+}

--- a/gnome-extension/prefs.js
+++ b/gnome-extension/prefs.js
@@ -64,6 +64,22 @@ function spawnInTerminal(command) {
     return false;
 }
 
+function spawnArgvInTerminal(commandArgv) {
+    for (const argv of [
+        ['kgx', '--', ...commandArgv],
+        ['gnome-terminal', '--', ...commandArgv],
+        ['xterm', '-e', ...commandArgv],
+    ]) {
+        if (!GLib.find_program_in_path(argv[0]))
+            continue;
+        try {
+            Gio.Subprocess.new(argv, Gio.SubprocessFlags.NONE);
+            return true;
+        } catch (e) {}
+    }
+    return false;
+}
+
 // Is `cli` on the login-shell PATH? (npm-global / nvm bins often aren't on the
 // prefs process PATH, so we ask a login shell.)
 function checkCliInstalled(cli, callback) {
@@ -113,8 +129,7 @@ function bindCombo(settings, key, comboRow, values) {
         if (v !== undefined && v !== settings.get_string(key))
             settings.set_string(key, v);
     });
-    const id = settings.connect(`changed::${key}`, sync);
-    comboRow.connect('destroy', () => settings.disconnect(id));
+    settings.connect(`changed::${key}`, sync);
 }
 
 function rgbaToHex(rgba) {
@@ -143,8 +158,7 @@ function colorRow(settings, key, title) {
         if (!updating)
             settings.set_string(key, rgbaToHex(btn.get_rgba()));
     });
-    const id = settings.connect(`changed::${key}`, load);
-    row.connect('destroy', () => settings.disconnect(id));
+    settings.connect(`changed::${key}`, load);
     row.add_suffix(btn);
     row.activatable_widget = btn;
     return row;
@@ -304,7 +318,7 @@ export default class AiUsageBarPrefs extends ExtensionPreferences {
                 } else {
                     const tui = GLib.find_program_in_path('ai-usagebar-tui') ||
                         `${GLib.get_home_dir()}/.cargo/bin/ai-usagebar-tui`;
-                    spawnInTerminal(`"${tui}"`);
+                    spawnArgvInTerminal([tui]);
                 }
                 GLib.timeout_add_seconds(GLib.PRIORITY_DEFAULT, 4, () => {
                     update();

--- a/gnome-extension/schemas/org.gnome.shell.extensions.ai-usagebar.gschema.xml
+++ b/gnome-extension/schemas/org.gnome.shell.extensions.ai-usagebar.gschema.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schemalist>
+  <schema id="org.gnome.shell.extensions.ai-usagebar"
+          path="/org/gnome/shell/extensions/ai-usagebar/">
+
+    <key name="refresh-interval" type="i">
+      <default>30</default>
+      <range min="5" max="3600"/>
+      <summary>Refresh interval in seconds</summary>
+    </key>
+
+    <key name="vendor" type="s">
+      <default>'anthropic'</default>
+      <summary>Vendor to display (anthropic shows the 5h + weekly windows)</summary>
+    </key>
+
+    <key name="binary-path" type="s">
+      <default>''</default>
+      <summary>Absolute path to the ai-usagebar binary (empty = auto-detect on PATH / ~/.cargo/bin)</summary>
+    </key>
+
+    <key name="bar-width" type="i">
+      <default>8</default>
+      <range min="4" max="20"/>
+      <summary>Width of each bar in cells</summary>
+    </key>
+
+    <key name="show-percent" type="b">
+      <default>true</default>
+      <summary>Show the numeric percentage next to each bar</summary>
+    </key>
+
+    <key name="show-session" type="b">
+      <default>true</default>
+      <summary>Show the 5-hour session bar</summary>
+    </key>
+
+    <key name="show-weekly" type="b">
+      <default>true</default>
+      <summary>Show the weekly bar</summary>
+    </key>
+
+    <key name="panel-box" type="s">
+      <choices>
+        <choice value="left"/>
+        <choice value="center"/>
+        <choice value="right"/>
+      </choices>
+      <default>'right'</default>
+      <summary>Which panel area to live in (right = next to network/clock)</summary>
+    </key>
+
+    <key name="panel-index" type="i">
+      <default>0</default>
+      <range min="0" max="20"/>
+      <summary>Position index within the chosen panel area</summary>
+    </key>
+
+    <key name="show-extra" type="b">
+      <default>false</default>
+      <summary>Show the extra-usage (cost) bar as a third bar</summary>
+    </key>
+
+    <key name="show-bars" type="b">
+      <default>true</default>
+      <summary>Draw the bars; when off, show only the percentages</summary>
+    </key>
+
+    <key name="color-low" type="s">
+      <default>'#98c379'</default>
+      <summary>Bar color for &lt;50% usage</summary>
+    </key>
+
+    <key name="color-mid" type="s">
+      <default>'#e5c07b'</default>
+      <summary>Bar color for 50-74% usage</summary>
+    </key>
+
+    <key name="color-high" type="s">
+      <default>'#d19a66'</default>
+      <summary>Bar color for 75-89% usage</summary>
+    </key>
+
+    <key name="color-critical" type="s">
+      <default>'#e06c75'</default>
+      <summary>Bar color for 90%+ usage</summary>
+    </key>
+
+    <key name="color-empty" type="s">
+      <default>'#3e4451'</default>
+      <summary>Color of the empty part of the bar</summary>
+    </key>
+
+  </schema>
+</schemalist>

--- a/gnome-extension/stylesheet.css
+++ b/gnome-extension/stylesheet.css
@@ -1,0 +1,31 @@
+/* Panel label: monospace so the █/░ bar cells line up evenly. */
+.aiub-label {
+    font-family: monospace;
+    font-feature-settings: "tnum";
+    padding: 0 4px;
+}
+
+/* Dropdown rows — native St layout, font-independent alignment. */
+.aiub-header {
+    font-weight: bold;
+    padding: 4px 12px 2px 12px;
+}
+
+.aiub-row {
+    spacing: 2px;
+    padding: 3px 12px;
+    min-width: 240px;
+}
+
+.aiub-row-name {
+    font-weight: bold;
+}
+
+.aiub-row-bar {
+    font-family: monospace;
+}
+
+.aiub-row-reset {
+    font-size: 0.85em;
+    color: #888888;
+}


### PR DESCRIPTION
## What

Adds a native **GNOME Shell extension** under `gnome-extension/` that shows
ai-usagebar's **5-hour (session)** and **weekly** usage bars — plus an optional
**extra-usage (cost)** bar — directly in the GNOME top panel, next to the
clock/network, with the full per-window breakdown in a click-dropdown.

## Why

The project's bar UI targets **Waybar**, which is Wayland-only (Sway/Hyprland)
and can't dock into the GNOME top panel. GNOME users (X11 or Wayland) had no
in-panel option. This extension bridges that by shelling out to the same
`ai-usagebar` binary and drawing the bars with native `St` widgets — so GNOME
gets parity with Waybar without touching the Rust crate.

## How it works

- Runs `ai-usagebar --vendor <v> --format '{session_pct};;{weekly_pct};;…'`,
  parses the existing Waybar JSON (`{text, tooltip, class}`), and renders.
- Bar colors + thresholds mirror the binary's default One Dark theme and
  `severity_for()` (≥90 red · ≥75 orange · ≥50 yellow · else green), so the
  panel matches the Waybar widget. All colors are user-overridable.
- The subprocess is spawned **asynchronously** (`Gio.Subprocess` +
  `communicate_utf8_async`) — it never blocks the shell. Timers and signal
  handlers are torn down in `disable()`.

## Configurable (libadwaita prefs)

Which bars (5h / weekly / extra), percentages-only vs bars, bar width,
per-severity colors (GTK color pickers), refresh interval, vendor, binary
path, and panel position (left/center/right + index).

## Scope / safety

- **Self-contained in `gnome-extension/`** — zero changes to the Rust crate,
  packaging, or existing behavior.
- GNOME Shell **45–48** (ESM). Install via `gnome-extension/install.sh`
  (symlink + `glib-compile-schemas`) or copy into
  `~/.local/share/gnome-shell/extensions/`.
- `gnome-extension/README.md` documents setup; the compiled schema is
  git-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
