### PR TITLE
feat(anthropic): config-driven multiple accounts via --account (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **Config-driven multiple Anthropic accounts** (#14). Declare extra
+  subscriptions once under `[[anthropic.accounts]]` (`label` +
+  `credentials_path`) and select one on the CLI with `--account <label>`,
+  instead of repeating `--creds-path`/`--cache-dir` on every widget module.
+  Each named account gets an isolated cache at
+  `~/.cache/ai-usagebar/anthropic/<label>/`. Anthropic-only; `--account`
+  conflicts with `--creds-path`. Fully back-compatible: the singular
+  `[anthropic] credentials_path` stays the default account, `--vendor
+  anthropic` with no `--account` is byte-identical to before, and configs
+  with zero or one account keep the unchanged `~/.cache/ai-usagebar/anthropic/`
+  cache path (no migration). Per-account TUI tabs remain a follow-up.
 
 ## [0.9.0] — 2026-07-04
 

--- a/README.md
+++ b/README.md
@@ -281,11 +281,50 @@ credentials file and its own cache directory:
   API-key vendors (Z.AI, OpenRouter, DeepSeek) point each module at a
   different key via a wrapper script that sets the env var, plus its own
   `--cache-dir`.
-- The TUI shows one tab per vendor (not per account); first-class
-  multi-account is tracked in
+- The TUI still shows one tab per vendor (not per account); per-account TUI
+  tabs are tracked in
   [#14](https://github.com/akitaonrails/ai-usagebar/issues/14).
 - On macOS, the login Keychain can hold only one Claude credential per OS
   user, so additional accounts must be file-based as shown above.
+
+#### Config-driven accounts (`--account`)
+
+Instead of repeating `--creds-path`/`--cache-dir` on every module, name your
+extra Anthropic accounts once in config and select them with `--account
+<label>`:
+
+```toml
+[anthropic]
+# The default account. `--vendor anthropic` with no `--account` uses this,
+# exactly as before. Optional — falls back to ~/.claude/.credentials.json.
+# credentials_path = "~/.claude/.credentials.json"
+
+[[anthropic.accounts]]
+label = "work"
+credentials_path = "~/.config/ai-usagebar/accounts/work.json"
+
+[[anthropic.accounts]]
+label = "personal"
+credentials_path = "~/.config/ai-usagebar/accounts/personal.json"
+```
+
+```jsonc
+"custom/claude-work": {
+    "exec": "ai-usagebar --vendor anthropic --account work --format 'w {session_pct}% · {session_reset}'",
+    "return-type": "json",
+    "interval": 300,
+    "tooltip": true
+}
+```
+
+- The **default account** is the singular `[anthropic] credentials_path` (or the
+  platform default file). `--vendor anthropic` without `--account` uses it, with
+  the same output and the same `~/.cache/ai-usagebar/anthropic/` cache as today.
+- Each `--account <label>` gets an isolated cache at
+  `~/.cache/ai-usagebar/anthropic/<label>/` automatically — no `--cache-dir`
+  needed. Only *extra* accounts get a subdir; the default never moves.
+- `--account` is Anthropic-only and can't be combined with `--creds-path` (both
+  name a credentials file). A typo'd label fails loudly, listing the known ones.
 
 ## Hyprland: float the TUI window
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -42,6 +42,18 @@ impl Cache {
         Ok(Self { dir: base })
     }
 
+    /// Cache for a specific named account of a vendor, rooted at
+    /// `~/.cache/ai-usagebar/<vendor>/<label>`. Only *extra* accounts use
+    /// this; the default account keeps [`Cache::for_vendor`] so its path never
+    /// moves (issue #14, back-compat rule 2).
+    pub fn for_vendor_account(vendor: &str, label: &str) -> Result<Self> {
+        let base = xdg_cache_dir()?
+            .join("ai-usagebar")
+            .join(vendor)
+            .join(label);
+        Ok(Self { dir: base })
+    }
+
     /// Cache rooted at an arbitrary directory — for tests.
     pub fn at(path: PathBuf) -> Self {
         Self { dir: path }

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,12 @@ pub struct UiConfig {
 pub struct AnthropicConfig {
     pub enabled: bool,
     /// Override the credentials file path (defaults to `~/.claude/.credentials.json`).
+    /// This is the *default* account; extra subscriptions go in `accounts`.
     pub credentials_path: Option<PathBuf>,
+    /// Extra Anthropic accounts beyond the default, each selected on the CLI
+    /// with `--account <label>` (issue #14). Empty by default, so existing
+    /// single-account configs are byte-for-byte unchanged.
+    pub accounts: Vec<AnthropicAccount>,
 }
 
 impl Default for AnthropicConfig {
@@ -53,7 +58,45 @@ impl Default for AnthropicConfig {
         Self {
             enabled: true,
             credentials_path: None,
+            accounts: Vec::new(),
         }
+    }
+}
+
+/// One extra Anthropic account beyond the default (issue #14). The default
+/// account stays the singular `[anthropic] credentials_path`; each entry here
+/// is an additional subscription selected on the CLI with `--account <label>`.
+///
+/// ```toml
+/// [[anthropic.accounts]]
+/// label = "work"
+/// credentials_path = "~/.config/ai-usagebar/accounts/work.json"
+/// ```
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AnthropicAccount {
+    /// Stable name used on the CLI (`--account <label>`) and as the cache
+    /// subdir (`~/.cache/ai-usagebar/anthropic/<label>`).
+    pub label: String,
+    /// OAuth credentials file for this account (same JSON shape Claude Code
+    /// writes). Token refreshes are written back here, so each account keeps
+    /// itself alive independently.
+    pub credentials_path: PathBuf,
+}
+
+impl AnthropicConfig {
+    /// Find a configured extra account by label, or error listing the known
+    /// labels so a typo fails loudly instead of silently hitting the default.
+    pub fn account(&self, label: &str) -> Result<&AnthropicAccount> {
+        self.accounts
+            .iter()
+            .find(|a| a.label == label)
+            .ok_or_else(|| {
+                let known: Vec<&str> = self.accounts.iter().map(|a| a.label.as_str()).collect();
+                AppError::Credentials(format!(
+                    "anthropic account {label:?} not found in [[anthropic.accounts]]; \
+                     known labels: {known:?}"
+                ))
+            })
     }
 }
 
@@ -411,5 +454,37 @@ enabled = false
         assert!(c.is_enabled(VendorId::Deepseek));
         assert!(c.enabled_vendors().contains(&VendorId::Deepseek));
         assert_eq!(c.deepseek.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn parses_anthropic_accounts_and_looks_them_up() {
+        let f = write_toml(
+            r#"
+            [anthropic]
+            enabled = true
+
+            [[anthropic.accounts]]
+            label = "personal"
+            credentials_path = "/creds/personal.json"
+
+            [[anthropic.accounts]]
+            label = "work"
+            credentials_path = "/creds/work.json"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        assert_eq!(c.anthropic.accounts.len(), 2);
+        let work = c.anthropic.account("work").unwrap();
+        assert_eq!(work.credentials_path, PathBuf::from("/creds/work.json"));
+        // A typo names the offending label and lists the known ones.
+        let err = format!("{:?}", c.anthropic.account("missing").unwrap_err());
+        assert!(err.contains("missing") && err.contains("work"), "{err}");
+    }
+
+    #[test]
+    fn anthropic_accounts_default_to_empty() {
+        // No [[anthropic.accounts]] → the single default account, empty list,
+        // nothing to migrate (issue #14, back-compat rule 1).
+        assert!(Config::default().anthropic.accounts.is_empty());
     }
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -112,6 +112,14 @@ pub struct Cli {
     /// accounts" in the README.
     #[arg(long, value_name = "FILE")]
     pub creds_path: Option<std::path::PathBuf>,
+
+    /// Select a named Anthropic account from `[[anthropic.accounts]]` in
+    /// config (issue #14). Without it, `--vendor anthropic` uses the default
+    /// account — the singular `[anthropic] credentials_path` — with unchanged
+    /// output and cache path. Anthropic only; conflicts with the lower-level
+    /// `--creds-path` (they both name a credentials file).
+    #[arg(long, value_name = "LABEL", conflicts_with = "creds_path")]
+    pub account: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -3,6 +3,7 @@
 //! into a fallback `⚠` JSON / pretty line so Waybar never hides the module.
 
 use std::io::Write;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -244,14 +245,7 @@ async fn deepseek_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
 
 async fn anthropic_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     let client = http_client()?;
-    let cache = vendor_cache(cli, "anthropic")?;
-    let creds_path = match cli.creds_path.as_deref() {
-        Some(p) => p.to_path_buf(),
-        None => match config.anthropic.credentials_path.as_deref() {
-            Some(p) => p.to_path_buf(),
-            None => anthropic::creds::default_path()?,
-        },
-    };
+    let (creds_path, cache) = anthropic_target(cli, config)?;
     let endpoints = anthropic::fetch::Endpoints::default();
     let outcome = match anthropic::fetch_snapshot(
         &client,
@@ -306,6 +300,46 @@ fn vendor_cache(cli: &Cli, vendor: &str) -> Result<Cache> {
         Some(p) => Ok(Cache::at(p.join(vendor))),
         None => Cache::for_vendor(vendor),
     }
+}
+
+/// Resolve the Anthropic credentials file + cache for this run, honoring
+/// `--account` (issue #14). `--cache-dir` still overrides the cache location;
+/// `--account <label>` selects a configured extra account (its credentials
+/// file and an `anthropic/<label>` cache subdir); with neither, the default
+/// account behaves byte-identically to before.
+fn anthropic_target(cli: &Cli, config: &Config) -> Result<(PathBuf, Cache)> {
+    match cli.account.as_deref() {
+        Some(label) => named_account_target(cli, config, label),
+        None => Ok((
+            anthropic_default_creds(cli, config)?,
+            vendor_cache(cli, "anthropic")?,
+        )),
+    }
+}
+
+/// A configured extra account (`--account <label>`): its own credentials file
+/// and an isolated `anthropic/<label>` cache. `--account` conflicts with
+/// `--creds-path`, so the account's file is the only credentials source here.
+fn named_account_target(cli: &Cli, config: &Config, label: &str) -> Result<(PathBuf, Cache)> {
+    let account = config.anthropic.account(label)?;
+    let cache = match cli.cache_dir.as_deref() {
+        Some(p) => Cache::at(p.join("anthropic").join(label)),
+        None => Cache::for_vendor_account("anthropic", label)?,
+    };
+    Ok((account.credentials_path.clone(), cache))
+}
+
+/// Default-account credentials: `--creds-path` wins, then the singular
+/// `[anthropic] credentials_path`, then the platform default file. This is the
+/// pre-#14 resolution, kept intact so default output never changes.
+fn anthropic_default_creds(cli: &Cli, config: &Config) -> Result<PathBuf> {
+    if let Some(p) = cli.creds_path.as_deref() {
+        return Ok(p.to_path_buf());
+    }
+    if let Some(p) = config.anthropic.credentials_path.as_deref() {
+        return Ok(p.to_path_buf());
+    }
+    anthropic::creds::default_path()
 }
 
 fn theme_from_cli(cli: &Cli) -> Theme {
@@ -391,5 +425,68 @@ mod tests {
         let out = fallback(&err, &cli_default());
         assert_eq!(out.text, "⚠");
         assert!(out.tooltip.contains("missing token"));
+    }
+
+    // --- issue #14: multi-account Anthropic target resolution ---------------
+    // All hermetic: paths are only *resolved*, never opened, and every cache
+    // uses an explicit --cache-dir (Cache::at) so no test touches real XDG.
+
+    fn cli_with(account: Option<&str>, creds: Option<&str>, cache: Option<&str>) -> Cli {
+        let mut c = cli_default();
+        c.account = account.map(str::to_string);
+        c.creds_path = creds.map(PathBuf::from);
+        c.cache_dir = cache.map(PathBuf::from);
+        c
+    }
+
+    fn config_with_account(label: &str, creds: &str) -> Config {
+        let mut config = Config::default();
+        config
+            .anthropic
+            .accounts
+            .push(crate::config::AnthropicAccount {
+                label: label.into(),
+                credentials_path: creds.into(),
+            });
+        config
+    }
+
+    #[test]
+    fn default_account_target_is_unchanged() {
+        // No --account: creds come from --creds-path and the cache stays at the
+        // vendor root (…/anthropic) — byte-identical to the pre-#14 path.
+        let cli = cli_with(None, Some("/tmp/creds.json"), Some("/tmp/cache"));
+        let (creds, cache) = anthropic_target(&cli, &Config::default()).unwrap();
+        assert_eq!(creds, PathBuf::from("/tmp/creds.json"));
+        assert_eq!(cache.dir(), std::path::Path::new("/tmp/cache/anthropic"));
+    }
+
+    #[test]
+    fn named_account_uses_its_creds_and_label_subdir() {
+        let config = config_with_account("work", "/creds/work.json");
+        let cli = cli_with(Some("work"), None, Some("/tmp/cache"));
+        let (creds, cache) = anthropic_target(&cli, &config).unwrap();
+        assert_eq!(creds, PathBuf::from("/creds/work.json"));
+        assert_eq!(
+            cache.dir(),
+            std::path::Path::new("/tmp/cache/anthropic/work")
+        );
+    }
+
+    #[test]
+    fn unknown_account_errors_listing_known_labels() {
+        let config = config_with_account("work", "/creds/work.json");
+        let cli = cli_with(Some("nope"), None, Some("/tmp/cache"));
+        let err = anthropic_target(&cli, &config).unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(msg.contains("nope"), "names the bad label: {msg}");
+        assert!(msg.contains("work"), "lists known labels: {msg}");
+    }
+
+    #[test]
+    fn account_conflicts_with_creds_path() {
+        use clap::Parser;
+        let res = Cli::try_parse_from(["ai-usagebar", "--account", "work", "--creds-path", "/x"]);
+        assert!(res.is_err(), "--account and --creds-path must conflict");
     }
 }


### PR DESCRIPTION
Draft for #14 — first pass at first-class multiple accounts, scoped to the config + widget/CLI layer as we discussed. TUI tabs left for a follow-up.

### What's here

- `[[anthropic.accounts]]` in config (`label` + `credentials_path` — your sketch as-is).
- `--account <label>` on the CLI to pick one. Anthropic-only, and it conflicts with `--creds-path` since both name a credentials file.
- Named accounts get an isolated cache at `~/.cache/ai-usagebar/anthropic/<label>/` automatically — no `--cache-dir` needed.

### Sticking to the four back-compat rules

1. Singular `[anthropic] credentials_path` stays the default account, valid forever.
2. 0–1 accounts keep `~/.cache/ai-usagebar/anthropic/` — only *extra* accounts get a `<label>` subdir, no migration.
3. `--vendor anthropic` with no `--account` resolves to the default → byte-identical output.
4. TUI multi-tab is a follow-up; the widget + config layer here is complete.

### Tests / docs

Cover config parse + lookup (including the typo error that lists known labels), target resolution for default vs named vs unknown account, and the `--account`/`--creds-path` conflict. `cargo test` green (247), `clippy -D warnings` clean, `fmt` clean. README's "Multiple accounts" section gets a config-driven subsection; CHANGELOG under `[Unreleased]`.

Left as **draft** so you can sanity-check the config/CLI shape before I touch the TUI.

---

One unrelated heads-up while I was here: `cargo clippy` on macOS trips `collapsible_if` in `anthropic/creds.rs::write_back` (the Keychain-gated branch). CI doesn't catch it because that block is `#[cfg(target_os = "macos")]` and CI runs on Linux. Not touching it in this PR — happy to send a one-liner separately if you want it.
