### PR TITLE
feat(tui): per-account Anthropic tabs (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **Per-account tabs in the TUI** (#17, follow-up to #14). `ai-usagebar-tui`
+  now shows the default Claude tab plus one tab per `[[anthropic.accounts]]`
+  entry, each fetching with its own credentials file and `anthropic/<label>`
+  cache (the same resolution the widget's `--account` uses, extracted into a
+  shared `AnthropicConfig::account_target`). Anthropic-only; other vendors are
+  still one tab each. With no extra accounts configured the tab set and order
+  are unchanged.
 
 ## [0.10.0] — 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -281,9 +281,9 @@ credentials file and its own cache directory:
   API-key vendors (Z.AI, OpenRouter, DeepSeek) point each module at a
   different key via a wrapper script that sets the env var, plus its own
   `--cache-dir`.
-- The TUI still shows one tab per vendor (not per account); per-account TUI
-  tabs are tracked in
-  [#14](https://github.com/akitaonrails/ai-usagebar/issues/14).
+- The TUI shows the default Claude tab plus one tab per configured
+  `[[anthropic.accounts]]` entry (see the config example below); Tab / `h` / `l`
+  cycle through them like any other tab.
 - On macOS, the login Keychain can hold only one Claude credential per OS
   user, so additional accounts must be file-based as shown above.
 
@@ -325,6 +325,9 @@ credentials_path = "~/.config/ai-usagebar/accounts/personal.json"
   needed. Only *extra* accounts get a subdir; the default never moves.
 - `--account` is Anthropic-only and can't be combined with `--creds-path` (both
   name a credentials file). A typo'd label fails loudly, listing the known ones.
+- **`ai-usagebar-tui`** reads the same `[[anthropic.accounts]]` and shows one
+  tab per account (after the default Claude tab), so the config above wires up
+  the widget and the TUI at once.
 
 ## Hyprland: float the TUI window
 

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -1,4 +1,5 @@
-//! Interactive TUI — one tab per enabled vendor.
+//! Interactive TUI — one tab per enabled vendor, plus one extra tab per
+//! configured Anthropic account (`[[anthropic.accounts]]`, issues #14/#17).
 //!
 //! Controls:
 //!   Tab / l / →   next tab
@@ -11,9 +12,11 @@ use std::io;
 use std::time::Duration;
 
 use ai_usagebar::config::Config;
-use ai_usagebar::tui::app::{App, REFRESH_INTERVAL, TabState, refresh_one};
+use ai_usagebar::tui::app::{
+    App, REFRESH_INTERVAL, TabId, TabState, refresh_one, tabs_from_config,
+};
 use ai_usagebar::tui::view::draw;
-use ai_usagebar::vendor::{HTTP_CLIENT_TIMEOUT, VendorId};
+use ai_usagebar::vendor::HTTP_CLIENT_TIMEOUT;
 use chrono::Utc;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -37,8 +40,8 @@ async fn main() {
 
 async fn run() -> io::Result<()> {
     let mut config = Config::load().unwrap_or_default();
-    let vendors = config.enabled_vendors();
-    if vendors.is_empty() {
+    let tabs = tabs_from_config(&config);
+    if tabs.is_empty() {
         eprintln!(
             "No vendors are enabled in {}. Exiting.",
             ai_usagebar::config::config_path_hint()
@@ -51,7 +54,7 @@ async fn run() -> io::Result<()> {
         .build()
         .map_err(io::Error::other)?;
 
-    let mut app = App::new_with_primary(vendors, config.ui.primary);
+    let mut app = App::new_with_primary(tabs, config.ui.primary);
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -151,10 +154,10 @@ where
                     }
                     // Refresh-on-key handling.
                     if matches!(k.code, KeyCode::Char('r'))
-                        && let Some(v) = app.active_vendor()
+                        && let Some(tab) = app.active_tab_id().cloned()
                     {
                         let idx = app.active;
-                        spawn_one(app, idx, v, client, config, &tx);
+                        spawn_one(app, idx, tab, client, config, &tx);
                     }
                     if matches!(k.code, KeyCode::Char('R')) {
                         spawn_all(app, client, config, &tx);
@@ -175,15 +178,15 @@ fn spawn_all(
     config: &Config,
     tx: &mpsc::UnboundedSender<(usize, TabState)>,
 ) {
-    for (i, v) in app.vendors.clone().into_iter().enumerate() {
-        spawn_one(app, i, v, client, config, tx);
+    for (i, tab) in app.tabs_meta.clone().into_iter().enumerate() {
+        spawn_one(app, i, tab, client, config, tx);
     }
 }
 
 fn spawn_one(
     app: &mut App,
     idx: usize,
-    vendor: VendorId,
+    tab: TabId,
     client: &Client,
     config: &Config,
     tx: &mpsc::UnboundedSender<(usize, TabState)>,
@@ -193,7 +196,7 @@ fn spawn_one(
     let cfg = config.clone();
     app.tabs[idx] = TabState::Loading;
     tokio::spawn(async move {
-        let state = refresh_one(&client, &cfg, vendor).await;
+        let state = refresh_one(&client, &cfg, &tab).await;
         let _ = tx.send((idx, state));
     });
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::anthropic::creds::CredsTarget;
+use crate::cache::Cache;
 use crate::error::{AppError, Result};
 use crate::vendor::VendorId;
 
@@ -98,6 +100,20 @@ impl AnthropicConfig {
                      known labels: {known:?}"
                 ))
             })
+    }
+
+    /// Resolve a named account to the credentials target + isolated cache it
+    /// fetches through: a strict [`CredsTarget::Explicit`] on the account's file
+    /// (never the Keychain — issue #15) and an `anthropic/<label>` cache subdir.
+    /// Shared by the widget (`--account`) and the TUI's per-account tab (#14,
+    /// #17) so both resolve accounts identically; the widget layers its
+    /// `--cache-dir` override on top of the cache returned here.
+    pub fn account_target(&self, label: &str) -> Result<(CredsTarget, Cache)> {
+        let account = self.account(label)?;
+        Ok((
+            CredsTarget::Explicit(account.credentials_path.clone()),
+            Cache::for_vendor_account("anthropic", label)?,
+        ))
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -35,9 +35,54 @@ pub struct ReadyTab {
     pub fetched_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Identity of one TUI tab. Usually a whole vendor; for Anthropic it can also
+/// name a specific configured account (issues #14 / #17). `account: None` is a
+/// plain vendor tab — the default Claude account, or any non-Anthropic vendor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TabId {
+    pub vendor: VendorId,
+    pub account: Option<String>,
+}
+
+impl TabId {
+    /// A plain vendor tab (default account for Anthropic).
+    pub fn vendor(vendor: VendorId) -> Self {
+        Self {
+            vendor,
+            account: None,
+        }
+    }
+
+    /// A named Anthropic account tab (`[[anthropic.accounts]]` label).
+    pub fn account(label: impl Into<String>) -> Self {
+        Self {
+            vendor: VendorId::Anthropic,
+            account: Some(label.into()),
+        }
+    }
+}
+
+/// Expand enabled vendors into the tab list. Anthropic yields its default
+/// account tab followed by one tab per `[[anthropic.accounts]]` entry, in
+/// config order; every other vendor is a single tab. With no extra accounts
+/// configured the result equals `config.enabled_vendors()` — identical tab set
+/// and order to before (issue #14/#17 back-compat).
+pub fn tabs_from_config(config: &Config) -> Vec<TabId> {
+    let mut tabs = Vec::new();
+    for vendor in config.enabled_vendors() {
+        tabs.push(TabId::vendor(vendor));
+        if vendor == VendorId::Anthropic {
+            for acct in &config.anthropic.accounts {
+                tabs.push(TabId::account(acct.label.clone()));
+            }
+        }
+    }
+    tabs
+}
+
 #[derive(Debug)]
 pub struct App {
-    pub vendors: Vec<VendorId>,
+    pub tabs_meta: Vec<TabId>,
     pub active: usize,
     pub tabs: Vec<TabState>,
     pub theme: Theme,
@@ -48,10 +93,10 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(vendors: Vec<VendorId>) -> Self {
+    pub fn new(tabs_meta: Vec<TabId>) -> Self {
         // Production: resolve the palette from the environment (Omarchy theme
         // if present, else One Dark).
-        Self::with_theme(vendors, Theme::default().merged_with_omarchy())
+        Self::with_theme(tabs_meta, Theme::default().merged_with_omarchy())
     }
 
     /// Like [`App::new`] but with an explicit theme. Lets tests build an `App`
@@ -59,10 +104,10 @@ impl App {
     /// (`$HOME/.config/omarchy/current/theme/colors.toml`) — `new` resolves
     /// that path and the `$HOME` env var via `merged_with_omarchy`, which is
     /// not hermetic. Production code uses `new`/`new_with_primary`.
-    pub fn with_theme(vendors: Vec<VendorId>, theme: Theme) -> Self {
-        let n = vendors.len();
+    pub fn with_theme(tabs_meta: Vec<TabId>, theme: Theme) -> Self {
+        let n = tabs_meta.len();
         Self {
-            vendors,
+            tabs_meta,
             active: 0,
             tabs: vec![TabState::Loading; n],
             theme,
@@ -74,41 +119,47 @@ impl App {
 
     /// Construct with an initial active tab — usually `[ui] primary` from
     /// config. Silently falls through to index 0 if the requested vendor
-    /// isn't in `vendors` (e.g. it was disabled).
-    pub fn new_with_primary(vendors: Vec<VendorId>, primary: Option<VendorId>) -> Self {
-        let mut app = Self::new(vendors);
+    /// isn't present (e.g. it was disabled).
+    pub fn new_with_primary(tabs_meta: Vec<TabId>, primary: Option<VendorId>) -> Self {
+        let mut app = Self::new(tabs_meta);
         app.select_primary(primary);
         app
     }
 
-    pub fn active_vendor(&self) -> Option<VendorId> {
-        self.vendors.get(self.active).copied()
+    pub fn active_tab_id(&self) -> Option<&TabId> {
+        self.tabs_meta.get(self.active)
     }
 
+    pub fn active_vendor(&self) -> Option<VendorId> {
+        self.tabs_meta.get(self.active).map(|t| t.vendor)
+    }
+
+    /// Move to the first tab of `primary`'s vendor (the default account tab,
+    /// since it precedes any of that vendor's account tabs).
     pub fn select_primary(&mut self, primary: Option<VendorId>) {
         if let Some(p) = primary
-            && let Some(idx) = self.vendors.iter().position(|v| *v == p)
+            && let Some(idx) = self.tabs_meta.iter().position(|t| t.vendor == p)
         {
             self.active = idx;
         }
     }
 
     pub fn next_tab(&mut self) {
-        if !self.vendors.is_empty() {
-            self.active = (self.active + 1) % self.vendors.len();
+        if !self.tabs_meta.is_empty() {
+            self.active = (self.active + 1) % self.tabs_meta.len();
         }
     }
 
     pub fn prev_tab(&mut self) {
-        if !self.vendors.is_empty() {
-            self.active = (self.active + self.vendors.len() - 1) % self.vendors.len();
+        if !self.tabs_meta.is_empty() {
+            self.active = (self.active + self.tabs_meta.len() - 1) % self.tabs_meta.len();
         }
     }
 }
 
-/// Fetch and render one vendor — returns a `TabState`.
-pub async fn refresh_one(client: &Client, config: &Config, vendor: VendorId) -> TabState {
-    match build_outcome(client, config, vendor).await {
+/// Fetch and render one tab — returns a `TabState`.
+pub async fn refresh_one(client: &Client, config: &Config, tab: &TabId) -> TabState {
+    match build_outcome(client, config, tab).await {
         Ok(outcome) => {
             // Resolve the cache age (a duration from "now" at fetch time) into an
             // absolute instant ONCE. Without this, sections_for would recompute
@@ -129,21 +180,25 @@ pub async fn refresh_one(client: &Client, config: &Config, vendor: VendorId) -> 
     }
 }
 
-async fn build_outcome(
-    client: &Client,
-    config: &Config,
-    vendor: VendorId,
-) -> Result<VendorOutcome> {
-    match vendor {
+async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<VendorOutcome> {
+    match tab.vendor {
         VendorId::Anthropic => {
-            let cache = crate::cache::Cache::for_vendor("anthropic")?;
-            // Config credentials_path is an explicit choice (strict read);
-            // only the platform default gets the macOS Keychain fallback.
-            let creds_target = match config.anthropic.credentials_path.clone() {
-                Some(p) => crate::anthropic::creds::CredsTarget::Explicit(p),
-                None => crate::anthropic::creds::CredsTarget::Default(
-                    crate::anthropic::creds::default_path().unwrap_or_default(),
-                ),
+            // A named account resolves to its own file + `anthropic/<label>`
+            // cache, shared with the widget via `account_target` (#14/#17).
+            // The default tab keeps the pre-existing resolution: config
+            // `credentials_path` is an explicit strict read, and only the
+            // platform default gets the macOS Keychain fallback.
+            let (creds_target, cache) = match tab.account.as_deref() {
+                Some(label) => config.anthropic.account_target(label)?,
+                None => {
+                    let target = match config.anthropic.credentials_path.clone() {
+                        Some(p) => crate::anthropic::creds::CredsTarget::Explicit(p),
+                        None => crate::anthropic::creds::CredsTarget::Default(
+                            crate::anthropic::creds::default_path().unwrap_or_default(),
+                        ),
+                    };
+                    (target, crate::cache::Cache::for_vendor("anthropic")?)
+                }
             };
             let endpoints = crate::anthropic::fetch::Endpoints::default();
             let outcome = crate::anthropic::fetch_snapshot(
@@ -241,7 +296,10 @@ mod tests {
     #[test]
     fn select_primary_moves_to_enabled_vendor() {
         let mut app = App::with_theme(
-            vec![VendorId::Anthropic, VendorId::Openrouter],
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::vendor(VendorId::Openrouter),
+            ],
             Theme::default(),
         );
         app.select_primary(Some(VendorId::Openrouter));
@@ -250,8 +308,66 @@ mod tests {
 
     #[test]
     fn select_primary_ignores_disabled_vendor() {
-        let mut app = App::with_theme(vec![VendorId::Anthropic], Theme::default());
+        let mut app = App::with_theme(vec![TabId::vendor(VendorId::Anthropic)], Theme::default());
         app.select_primary(Some(VendorId::Openai));
         assert_eq!(app.active_vendor(), Some(VendorId::Anthropic));
+    }
+
+    fn config_with_accounts(labels: &[&str]) -> Config {
+        let mut config = Config::default();
+        // Keep only Anthropic enabled so the test asserts on account expansion,
+        // not on the full default vendor set.
+        config.openai.enabled = false;
+        config.zai.enabled = false;
+        config.openrouter.enabled = false;
+        config.anthropic.accounts = labels
+            .iter()
+            .map(|l| crate::config::AnthropicAccount {
+                label: (*l).to_string(),
+                credentials_path: format!("/creds/{l}.json").into(),
+            })
+            .collect();
+        config
+    }
+
+    #[test]
+    fn tabs_expand_anthropic_accounts_after_default() {
+        // Default Claude tab first, then each account in config order.
+        let tabs = tabs_from_config(&config_with_accounts(&["work", "personal"]));
+        assert_eq!(
+            tabs,
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::account("work"),
+                TabId::account("personal"),
+            ]
+        );
+    }
+
+    #[test]
+    fn tabs_without_accounts_are_just_enabled_vendors() {
+        // No [[anthropic.accounts]] → one tab per enabled vendor, unchanged.
+        let config = Config::default();
+        let tabs = tabs_from_config(&config);
+        let vendors: Vec<VendorId> = tabs.iter().map(|t| t.vendor).collect();
+        assert_eq!(vendors, config.enabled_vendors());
+        assert!(tabs.iter().all(|t| t.account.is_none()));
+    }
+
+    #[test]
+    fn select_primary_lands_on_default_account_tab() {
+        // With account tabs present, `primary = anthropic` selects the default
+        // Claude tab (index 0), not one of its account tabs.
+        let app = {
+            let tabs = tabs_from_config(&config_with_accounts(&["work"]));
+            let mut a = App::with_theme(tabs, Theme::default());
+            a.select_primary(Some(VendorId::Anthropic));
+            a
+        };
+        assert_eq!(app.active, 0);
+        assert_eq!(
+            app.active_tab_id(),
+            Some(&TabId::vendor(VendorId::Anthropic))
+        );
     }
 }

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -8,6 +8,7 @@ use ratatui_bubbletea_components::{Help, KeyBinding, ListItem, SelectList};
 
 use crate::format::local_time_hms;
 use crate::tui::app::App;
+use crate::tui::app::TabId;
 use crate::tui::app::TabState;
 use crate::tui::panels;
 use crate::tui::style::bubble_theme;
@@ -56,17 +57,38 @@ fn compact_vendor_label(id: VendorId) -> &'static str {
     }
 }
 
+/// Tab label for the header/sidebar/detail title. A named Anthropic account
+/// (#14/#17) appends its label, e.g. `Claude · work`; a plain vendor tab is
+/// just the vendor name.
+fn tab_label(tab: &TabId) -> String {
+    match &tab.account {
+        Some(acct) => format!("{} · {}", vendor_label(tab.vendor), acct),
+        None => vendor_label(tab.vendor).to_string(),
+    }
+}
+
+/// Compact variant for the narrow top-nav strip.
+fn compact_tab_label(tab: &TabId) -> String {
+    match &tab.account {
+        Some(acct) => format!("{} · {}", compact_vendor_label(tab.vendor), acct),
+        None => compact_vendor_label(tab.vendor).to_string(),
+    }
+}
+
 fn draw_header(f: &mut Frame, app: &App, area: Rect) {
     let theme = bubble_theme(&app.theme);
     let block = theme.titled_block(" ai-usagebar ");
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let active = app.active_vendor().map(vendor_label).unwrap_or("no vendor");
+    let active = app
+        .active_tab_id()
+        .map(tab_label)
+        .unwrap_or_else(|| "no vendor".to_string());
     let line = Line::from(vec![
         theme.accent("  Usage dashboard"),
         theme.muted(" · "),
-        theme.span(format!("{} vendors", app.vendors.len())),
+        theme.span(format!("{} tabs", app.tabs_meta.len())),
         theme.muted(" · "),
         theme.span(format!("active {active}")),
         theme.muted(" · "),
@@ -102,11 +124,11 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(block, area);
 
     let items = app
-        .vendors
+        .tabs_meta
         .iter()
         .enumerate()
-        .map(|(index, vendor)| {
-            ListItem::new(vendor_label(*vendor)).description(tab_status(app.tabs.get(index)))
+        .map(|(index, tab)| {
+            ListItem::new(tab_label(tab)).description(tab_status(app.tabs.get(index)))
         })
         .collect::<Vec<_>>();
     let mut list = SelectList::new(items).theme(theme);
@@ -123,7 +145,7 @@ fn draw_top_nav(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(block, area);
 
     let mut spans = vec![theme.muted(" ")];
-    for (index, vendor) in app.vendors.iter().enumerate() {
+    for (index, tab) in app.tabs_meta.iter().enumerate() {
         if index > 0 {
             spans.push(theme.muted("  "));
         }
@@ -137,7 +159,7 @@ fn draw_top_nav(f: &mut Frame, app: &App, area: Rect) {
         let label_style = if selected { theme.selected } else { theme.text };
         spans.push(Span::styled(marker, marker_style));
         spans.push(theme.span(" "));
-        spans.push(Span::styled(compact_vendor_label(*vendor), label_style));
+        spans.push(Span::styled(compact_tab_label(tab), label_style));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), inner);
 }
@@ -145,8 +167,8 @@ fn draw_top_nav(f: &mut Frame, app: &App, area: Rect) {
 fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
     let theme = bubble_theme(&app.theme);
     let title = app
-        .active_vendor()
-        .map(|vendor| format!(" {} ", vendor_label(vendor)))
+        .active_tab_id()
+        .map(|tab| format!(" {} ", tab_label(tab)))
         .unwrap_or_else(|| " details ".to_string());
     let block = theme.titled_block(title);
     let inner = block.inner(area);

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -317,15 +317,14 @@ fn anthropic_target(cli: &Cli, config: &Config) -> Result<(CredsTarget, Cache)> 
 /// an Explicit target, so a missing/broken file fails loudly instead of
 /// falling back to the (different account's) macOS Keychain item (#15).
 fn named_account_target(cli: &Cli, config: &Config, label: &str) -> Result<(CredsTarget, Cache)> {
-    let account = config.anthropic.account(label)?;
+    let (creds, default_cache) = config.anthropic.account_target(label)?;
+    // `--cache-dir` still wins for scripted/multi-monitor setups; otherwise use
+    // the account's default `anthropic/<label>` cache from account_target.
     let cache = match cli.cache_dir.as_deref() {
         Some(p) => Cache::at(p.join("anthropic").join(label)),
-        None => Cache::for_vendor_account("anthropic", label)?,
+        None => default_cache,
     };
-    Ok((
-        CredsTarget::Explicit(account.credentials_path.clone()),
-        cache,
-    ))
+    Ok((creds, cache))
 }
 
 /// Default-account credentials: `--creds-path` wins, then the singular


### PR DESCRIPTION
Draft for #17 — per-account tabs in the TUI, the follow-up to #14. Rebased on v0.10.0.

### What it does

`ai-usagebar-tui` expands the Anthropic vendor into the default Claude tab plus one tab per `[[anthropic.accounts]]` entry, in config order. Each account tab fetches through its own credentials file (`CredsTarget::Explicit`) and its own `anthropic/<label>` cache. Everything else is one tab per vendor as before.

Here's the two-account layout (sidebar on the wide view):

```
 vendors
 › Claude            ready
   Claude · work     ready
   OpenAI            ready
   Z.AI              error
```

### How

- `TabId { vendor, account }` replaces the bare `VendorId` as a tab's identity; `tabs_from_config` builds the list.
- The account → `(CredsTarget::Explicit, anthropic/<label>` cache`)` mapping is extracted into `AnthropicConfig::account_target`, and the widget's `--account` path (`named_account_target`) now calls it too — so the widget and the TUI resolve accounts through the exact same code, strict-read and all (#15).
- `view.rs` labels an account tab `Claude · work`.

### Scope (matches what we discussed on #17)

- Anthropic only. Other vendors untouched.
- No config changes — reads the same `[[anthropic.accounts]]` from #14.
- No new keybindings — account tabs just join the Tab/`h`/`l` cycle.
- Settings overlay stays per-vendor; editable account arrays would be a separate, bigger UI.
- **Zero change with no extra accounts**: `tabs_from_config` returns exactly `enabled_vendors()`, same order — pinned by a test.

### Two open questions from the issue

1. Tab label format — I went with `Claude · work`. Easy to change.
2. Account tabs sit right after the default Claude tab. Happy to group differently if you'd rather.

### Tests / gates

New tests cover tab expansion + order, the no-accounts == `enabled_vendors()` invariant, `select_primary` landing on the default account tab, and `account_target` resolution. `cargo test` green (261 lib), `clippy -D warnings` clean, `fmt` clean. Also smoke-tested `--account` end to end against a real captured credential (fetch + token refresh + isolated cache). README + CHANGELOG (`[Unreleased]`) updated.

Left as **draft** for your read on the two questions above before I call it final.
