### PR TITLE
feat(anthropic): render model-scoped weekly limits (Fable) from limits[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,16 @@ Each release is also published at
 
 ## [Unreleased]
 
-Nothing yet.
+### Added
+
+- **Model-scoped weekly limits (e.g. the Fable weekly cap)** now render in the
+  widget tooltip, the TUI Claude tab, and the bar's severity class. Anthropic's
+  usage endpoint reports these only inside the newer `limits[]` array
+  (`kind == "weekly_scoped"`, labeled by `scope.model.display_name`) — there is
+  no dedicated `seven_day_<model>` field — so they were previously invisible:
+  a Fable week at 84%/warning showed nothing while the bar stayed green on a
+  55% overall weekly. Labels come from the API, so future scoped models show
+  up without a code change. Accounts without scoped limits are unchanged.
 
 ## [0.11.0] — 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Then `hyprctl reload` (no logout needed).
 
 | Vendor | Endpoint | What you see |
 |---|---|---|
-| **Anthropic** | `api.anthropic.com/api/oauth/usage` (undocumented) | Session (5h), Weekly (7d), Sonnet (7d), Extra usage $ |
+| **Anthropic** | `api.anthropic.com/api/oauth/usage` (undocumented) | Session (5h), Weekly (7d), Sonnet (7d), model-scoped weekly (e.g. Fable), Extra usage $ |
 | **OpenAI** | `chatgpt.com/backend-api/wham/usage` (undocumented; used by official `codex` CLI) | Codex 5h, Codex weekly, Code-review weekly, Credits |
 | **Z.AI** | `api.z.ai/api/monitor/usage/quota/limit` (undocumented) | Session 5h, Weekly 7d, MCP tools monthly |
 | **OpenRouter** | `openrouter.ai/api/v1/{credits,key}` (documented) | Balance, today/week/month spend, free vs paid tier |

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -7,7 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::usage::{AnthropicSnapshot, Cents, ExtraUsage, UsageWindow};
+use crate::usage::{AnthropicSnapshot, Cents, ExtraUsage, ScopedWindow, UsageWindow};
 
 /// Top-level response from `GET /api/oauth/usage`.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
@@ -20,6 +20,38 @@ pub struct UsageResponse {
     pub seven_day_sonnet: Option<Window>,
     #[serde(default)]
     pub extra_usage: Option<ExtraUsageBlock>,
+    /// Newer per-limit array. Carries model-scoped weekly windows
+    /// (`kind == "weekly_scoped"`, e.g. the Fable weekly cap) that have no
+    /// dedicated `seven_day_*` field.
+    #[serde(default)]
+    pub limits: Vec<LimitEntry>,
+}
+
+/// One entry of the `limits[]` array. Only `weekly_scoped` entries with a
+/// model display name are lifted into the snapshot; everything else in the
+/// array duplicates `five_hour`/`seven_day`.
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LimitEntry {
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub percent: Option<f64>,
+    #[serde(default)]
+    pub resets_at: Option<String>,
+    #[serde(default)]
+    pub scope: Option<LimitScope>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LimitScope {
+    #[serde(default)]
+    pub model: Option<LimitModel>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
+pub struct LimitModel {
+    #[serde(default)]
+    pub display_name: Option<String>,
 }
 
 /// A single usage window — `utilization` is `0..=100` (integer percent).
@@ -107,12 +139,29 @@ impl UsageResponse {
                 limit: Cents(e.monthly_limit),
                 spent: Cents(e.used_credits),
             });
+        let scoped = self
+            .limits
+            .into_iter()
+            .filter(|l| l.kind.as_deref() == Some("weekly_scoped"))
+            .filter_map(|l| {
+                let label = l.scope?.model?.display_name?;
+                let window = to_window(
+                    Some(Window {
+                        utilization: l.percent.unwrap_or(0.0),
+                        resets_at: l.resets_at,
+                    }),
+                    WEEKLY,
+                );
+                Some(ScopedWindow { label, window })
+            })
+            .collect();
 
         AnthropicSnapshot {
             plan: plan_label,
             session,
             weekly,
             sonnet,
+            scoped,
             extra,
         }
     }
@@ -138,6 +187,47 @@ mod tests {
         assert_eq!(snap.extra.unwrap().limit.0, 5000);
         assert_eq!(snap.extra.unwrap().spent.0, 250);
         assert!(snap.session.resets_at.is_some());
+    }
+
+    #[test]
+    fn parses_weekly_scoped_limits() {
+        // Real shape observed 2026-07-08: the Fable weekly cap only exists
+        // inside `limits[]`; there is no `seven_day_fable` field.
+        let raw = r#"{
+            "five_hour": {"utilization": 10.0, "resets_at": "2026-07-08T22:59:59Z"},
+            "seven_day": {"utilization": 55.0, "resets_at": "2026-07-10T10:59:59Z"},
+            "limits": [
+                {"kind": "session", "group": "session", "percent": 10,
+                 "severity": "normal", "resets_at": "2026-07-08T22:59:59Z",
+                 "scope": null, "is_active": false},
+                {"kind": "weekly_all", "group": "weekly", "percent": 55,
+                 "severity": "normal", "resets_at": "2026-07-10T10:59:59Z",
+                 "scope": null, "is_active": false},
+                {"kind": "weekly_scoped", "group": "weekly", "percent": 84,
+                 "severity": "warning", "resets_at": "2026-07-10T10:59:59Z",
+                 "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null},
+                 "is_active": true}
+            ]
+        }"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        let snap = resp.into_snapshot("Pro".into());
+        assert_eq!(snap.scoped.len(), 1);
+        assert_eq!(snap.scoped[0].label, "Fable");
+        assert_eq!(snap.scoped[0].window.utilization_pct, 84);
+        assert!(snap.scoped[0].window.resets_at.is_some());
+        // Unscoped entries never duplicate into `scoped`.
+        assert_eq!(snap.weekly.utilization_pct, 55);
+    }
+
+    #[test]
+    fn missing_limits_array_yields_empty_scoped() {
+        let raw = r#"{
+            "five_hour": {"utilization": 0, "resets_at": "2026-05-23T17:30:00Z"},
+            "seven_day": {"utilization": 0, "resets_at": "2026-05-30T12:00:00Z"}
+        }"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        let snap = resp.into_snapshot("Pro".into());
+        assert!(snap.scoped.is_empty());
     }
 
     #[test]

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -123,6 +123,9 @@ fn anthropic_sections(
     if let Some(w) = &s.sonnet {
         push_window(&mut v, "Sonnet only", w, now, tol, false);
     }
+    for sw in &s.scoped {
+        push_window(&mut v, &format!("{} (7d)", sw.label), &sw.window, now, tol, false);
+    }
     if let Some(e) = &s.extra {
         v.push(Section::Spacer);
         let pct = e.percent().clamp(0, 100) as u16;
@@ -553,6 +556,7 @@ mod tests {
                 resets_at: Some(now() + chrono::Duration::hours(2)),
                 window_duration: chrono::Duration::days(7),
             }),
+            scoped: vec![],
             extra: Some(ExtraUsage {
                 limit: Cents(5000),
                 spent: Cents(250),
@@ -591,6 +595,7 @@ mod tests {
                 window_duration: chrono::Duration::days(7),
             },
             sonnet: None,
+            scoped: vec![],
             extra: None,
         };
         let sections = sections_for(&ready(VendorSnapshot::Anthropic(snap)), now(), 5);

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -54,8 +54,21 @@ pub struct AnthropicSnapshot {
     /// Some vendors of Claude (Pro, some Max tiers) don't have a separate
     /// Sonnet bucket — in which case this is None.
     pub sonnet: Option<UsageWindow>,
+    /// Model-scoped weekly windows from the newer `limits[]` array
+    /// (`kind == "weekly_scoped"`), e.g. the Fable weekly cap. Labels come
+    /// from the API (`scope.model.display_name`), so new models show up
+    /// without a code change. Empty when the account has none.
+    pub scoped: Vec<ScopedWindow>,
     /// `None` when `extra_usage.is_enabled` is false or the block is absent.
     pub extra: Option<ExtraUsage>,
+}
+
+/// A usage window scoped to a specific model, labeled by the API
+/// (e.g. "Fable"). Weekly (7d) duration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScopedWindow {
+    pub label: String,
+    pub window: UsageWindow,
 }
 
 /// "Extra usage" pay-as-you-go block (claudebar's `extra_usage`).
@@ -207,13 +220,19 @@ pub fn anthropic_severity(snap: &AnthropicSnapshot) -> crate::pacing::PaceSeveri
     {
         max = s.utilization_pct;
     }
+    for sw in &snap.scoped {
+        if sw.window.utilization_pct > max {
+            max = sw.window.utilization_pct;
+        }
+    }
     // Extra usage only promotes severity if a rate-limit window is at 100%.
     let any_at_cap = snap.session.utilization_pct >= 100
         || snap.weekly.utilization_pct >= 100
         || snap
             .sonnet
             .as_ref()
-            .is_some_and(|s| s.utilization_pct >= 100);
+            .is_some_and(|s| s.utilization_pct >= 100)
+        || snap.scoped.iter().any(|s| s.window.utilization_pct >= 100);
     if any_at_cap && let Some(extra) = snap.extra {
         let p = extra.percent();
         if p > max {
@@ -243,6 +262,7 @@ mod tests {
             session: w(s),
             weekly: w(w_),
             sonnet: sonnet.map(w),
+            scoped: vec![],
             extra: extra.map(|(limit, spent)| ExtraUsage {
                 limit: Cents(limit),
                 spent: Cents(spent),

--- a/src/widget/render.rs
+++ b/src/widget/render.rs
@@ -368,6 +368,42 @@ fn render_default_tooltip(input: &RenderInput) -> String {
         cd = escape(&countdown::format(snap.weekly.resets_at, input.now))
     )));
 
+    for sw in &snap.scoped {
+        let scoped_color = pango::severity_color(severity_for(sw.window.utilization_pct), theme);
+        let scoped_pacing = pacing::calc(
+            sw.window.utilization_pct,
+            sw.window.resets_at,
+            input.now,
+            sw.window.window_duration,
+            input.pace_tolerance,
+        );
+        let scoped_bar = if input.tooltip_pace_pts {
+            pango::progress_bar(
+                sw.window.utilization_pct,
+                scoped_color,
+                theme,
+                Some(scoped_pacing.elapsed_pct),
+            )
+        } else {
+            pango::progress_bar(sw.window.utilization_pct, scoped_color, theme, None)
+        };
+        lines.push(Line::Body("".into()));
+        lines.push(Line::Body(format!(
+            " <span foreground='{fg}'>  󰆧  {label} weekly</span>",
+            label = escape(&sw.label)
+        )));
+        lines.push(Line::Body(format!(
+            "   {bar}  <span font_weight='bold' foreground='{color}'>{pct}%</span>",
+            bar = scoped_bar,
+            color = scoped_color,
+            pct = sw.window.utilization_pct
+        )));
+        lines.push(Line::Body(format!(
+            " <span foreground='{dim}'>  ⏱  Resets in {cd}</span>",
+            cd = escape(&countdown::format(sw.window.resets_at, input.now))
+        )));
+    }
+
     if let Some(sw) = snap.sonnet.as_ref() {
         let sonnet_color = pango::severity_color(severity_for(sw.utilization_pct), theme);
         let sonnet_pacing = pacing::calc(
@@ -515,6 +551,7 @@ mod tests {
             session,
             weekly,
             sonnet: Some(sonnet),
+            scoped: vec![],
             extra: Some(ExtraUsage {
                 limit: Cents(5000),
                 spent: Cents(250),

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -397,6 +397,7 @@ mod tests {
                     window_duration: chrono::Duration::days(7),
                 },
                 sonnet: None,
+                scoped: vec![],
                 extra: None,
             },
             stale: false,


### PR DESCRIPTION
## Problem

Anthropic now enforces per-model weekly caps (currently the **Fable** weekly limit). The usage endpoint reports them **only inside the newer `limits[]` array** — there is no dedicated `seven_day_<model>` field:

```json
{
  "kind": "weekly_scoped", "group": "weekly",
  "percent": 84, "severity": "warning",
  "resets_at": "2026-07-10T10:59:59.628649+00:00",
  "scope": { "model": { "id": null, "display_name": "Fable" }, "surface": null },
  "is_active": true
}
```

(real response captured 2026-07-08 on a Claude Pro account)

Since `UsageResponse` only parses `five_hour` / `seven_day` / `seven_day_sonnet` / `extra_usage`, the widget silently drops this: my Fable week sat at **84% (severity `warning`)** while the tooltip showed only the 55% overall weekly and the bar class stayed `Mid`.

## Change

- `anthropic/types.rs`: parse `limits[]` (lossy, `serde(default)` like the rest of the wire types); lift `kind == "weekly_scoped"` entries with a `scope.model.display_name` into the snapshot.
- `usage.rs`: new `AnthropicSnapshot::scoped: Vec<ScopedWindow>` (API-provided label + weekly window); scoped windows participate in `anthropic_severity` (max + at-cap promotion), so the bar class reflects a scoped cap.
- `widget/render.rs`: tooltip renders one block per scoped window ("Fable weekly", bar, %, reset countdown), between Weekly and Sonnet.
- `tui/panels.rs`: one row per scoped window ("Fable (7d)") after the Sonnet row.
- Labels come from the API, so future scoped models show up without a code change. Accounts without scoped limits render byte-identical to before (covered by existing tests).

`--format` placeholders are deliberately left out: scoped labels are dynamic per account, which doesn't map cleanly onto the static `{sonnet_*}` placeholder pattern. Happy to add a `{scoped_*}` family for the first/worst scoped window as a follow-up if you want it.

## Before / after (`--pretty`, same cached response)

```
│   󰃰  Weekly                  │        │   󰃰  Weekly                  │
│   ███████████░░░░░░░░  55% ↓ │        │   ███████████░░░░░░░░  55% ↓ │
│   ⏱  Resets in 1d 14h        │        │   ⏱  Resets in 1d 14h        │
                                        │                              │
         (nothing)                      │   󰆧  Fable weekly            │
                                        │   ████████████████░░░░  84%  │
                                        │   ⏱  Resets in 1d 14h        │
class: Mid                              class: High
```

## Testing

- `cargo test --release`: 267 passed, 0 failed (adds `parses_weekly_scoped_limits` with the real wire shape above, and `missing_limits_array_yields_empty_scoped`).
- `cargo clippy --release --all-targets`: clean.
- Smoke-tested the built widget against a live Claude Pro account with an active Fable weekly cap (screenshot rendering above).
