### PR TITLE
Render the meta pace marker on the macOS + GNOME desktop bars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ gnome-extension/schemas/gschemas.compiled
 
 # Compiled macOS menu bar app (built by macos/build.sh)
 macos/ai-usagebar-menubar
+
+# Local screenshots for PR bodies (not tracked; drag into the PR on GitHub)
+macos/printscreen/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ Each release is also published at
   common case is one, e.g. **Fable**) exposed as flat fields. The tooltip
   already rendered every `snap.scoped` entry, but the desktop surfaces redraw
   from `--format` and had no way to read them.
+- **The meta reference (pace marker) now renders on the macOS menu bar and GNOME
+  desktop bars**, matching the Waybar tooltip. Each time-windowed bar draws a
+  thin blue `│` at the elapsed-time position; the fill stays in the calm
+  absolute-usage color up to the marker, and only the part that overshoots it —
+  how far ahead of pace you are, i.e. the risk of spilling into **paid extra
+  usage** if you keep the pace — is painted in the warning color. So a bar at
+  41% used but only 20% into the week reads calm with a small red tail, not all
+  red. macOS adds a *"Mostrar referência da meta"* toggle to switch it off;
+  GNOME draws it whenever the window reports a reset.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Each release is also published at
 
 ### Fixed
 
+- **Desktop pace markers no longer appear on windows without a reset.** A
+  missing reset still displays the scoped model row with `—`, but suppresses
+  the marker even when a legacy formatter supplies neutral elapsed `0`.
+
 - **macOS menu bar and GNOME extension showed a stale "Sonnet only 0%" bar
   instead of the model-scoped weekly window (e.g. Fable).** Both redraw from
   `--format` and read `{sonnet_pct}` (the flat `seven_day_sonnet` field, now

--- a/gnome-extension/README.md
+++ b/gnome-extension/README.md
@@ -60,7 +60,7 @@ mkdir -p "$DEST" && cp -r * "$DEST"/      # or: ln -s "$PWD" "$DEST"
 It runs:
 
 ```
-ai-usagebar --vendor <vendor> --format '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;{scoped_model};;{scoped_pct};;{scoped_reset}'
+ai-usagebar --vendor <vendor> --format '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;{scoped_model};;{scoped_pct};;{scoped_reset};;{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;__aiub_end__'
 ```
 
 parses the Waybar JSON (`{text, tooltip, class}`), extracts the formatted
@@ -69,6 +69,14 @@ and optional extra-usage values with native `St` widgets. Colors mirror the
 binary's default One Dark theme and `severity_for()` thresholds (≥90 red · ≥75
 orange · ≥50 yellow · else green), so it matches the Waybar widget. The
 dropdown is a native aligned menu, not the tooltip markup rendered verbatim.
+
+For windows with a real reset, the bar also draws a fixed blue `│` marker at
+the elapsed-time position. The fill after that point uses Rust's point-delta
+severity bands: at least 10 points ahead is red, 1–9 ahead is orange, -10
+through on-pace is yellow, and more than 10 under is green. A missing reset
+(including `—`) keeps its row visible but suppresses the marker, even if an
+older binary reports elapsed `0`. The final `__aiub_end__` literal is ignored;
+it receives a stale `⏸` suffix so the last elapsed field remains numeric.
 
 The subprocess is spawned **asynchronously** (`Gio.Subprocess` +
 `communicate_utf8_async`) so it never blocks the shell, and all timers /

--- a/gnome-extension/extension.js
+++ b/gnome-extension/extension.js
@@ -17,6 +17,8 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import {barMarkup, colorForPct, field, FIELD, FORMAT, integer, markerElapsed,
+    splitFormatOutput} from './marker-logic.js';
 
 const ROLE = 'ai-usagebar';
 
@@ -24,78 +26,15 @@ const ROLE = 'ai-usagebar';
 const DIM = '#5c6370';
 const FG = '#abb2bf';
 const RED = '#e06c75';
-// The meta marker (pace/elapsed reference line) is a fixed blue, matching the
-// binary's default `marker` theme color and distinct from the over-pace warning
-// fill. Pace tolerance mirrors the binary's `--pace-tolerance` default of 5.
-const MARKER = '#61afef';
-const PACE_TOL = 5;
-
-// The fields we pull from the binary, joined by ';;'. `{scoped_*}` carry the
-// model-scoped weekly window (e.g. Fable) from `limits[]`; the trailing
-// `*_elapsed` carry the meta (pace) position — empty when the window has no
-// reset, which we treat as "no marker".
-const FORMAT = '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;' +
-    '{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;' +
-    '{scoped_model};;{scoped_pct};;{scoped_reset};;' +
-    '{session_elapsed};;{weekly_elapsed};;{scoped_elapsed}';
+// FORMAT's final ignored literal sentinel receives a stale suffix, keeping the
+// preceding elapsed fields numeric. It and its field indexes live in marker-logic.
 const REFRESH_TIMEOUT_SECS = 60;
-
-// severity_for(pct) from src/pango.rs: >=90 critical, >=75 high, >=50 mid, else low.
-function colorForPct(pct, colors) {
-    if (pct >= 90)
-        return colors.critical;
-    if (pct >= 75)
-        return colors.high;
-    if (pct >= 50)
-        return colors.mid;
-    return colors.low;
-}
-
-// pace_fill_severity(delta) from src/pacing.rs: <=0 green, <=tol amber, else red.
-function colorForDelta(delta, colors) {
-    if (delta <= 0)
-        return colors.low;
-    if (delta <= PACE_TOL)
-        return colors.high;
-    return colors.critical;
-}
 
 function esc(s) {
     return String(s)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;');
-}
-
-// Block bar as Pango markup, `width` cells wide. When `elapsed` (0..100) is a
-// number, the fill stays in the calm absolute-usage color up to a blue marker at
-// the elapsed position and only the part that overshoots the meta (how far ahead
-// of pace you are → risk of paid extra usage) is painted in the warning color;
-// otherwise it's a plain two-segment absolute-color bar with no marker.
-function barMarkup(pct, width, colors, elapsed) {
-    const p = Math.max(0, Math.min(100, Math.round(pct)));
-    const filled = Math.round((p * width) / 100);
-
-    if (!Number.isFinite(elapsed)) {
-        return `<span foreground="${colorForPct(p, colors)}">${'█'.repeat(filled)}</span>` +
-            `<span foreground="${colors.empty}">${'░'.repeat(width - filled)}</span>`;
-    }
-
-    const e = Math.max(0, Math.min(100, Math.round(elapsed)));
-    const base = colorForPct(p, colors);
-    const over = colorForDelta(p - e, colors);
-    let m = Math.floor((e * width) / 100);
-    if (m > width - 1)
-        m = width - 1;
-    const preF = Math.min(filled, m);
-    const postF = filled > m + 1 ? filled - m - 1 : 0;
-    const preE = m - preF;
-    const postE = width - m - 1 - postF;
-    return `<span foreground="${base}">${'█'.repeat(preF)}</span>` +
-        `<span foreground="${colors.empty}">${'░'.repeat(preE)}</span>` +
-        `<span foreground="${MARKER}">│</span>` +
-        `<span foreground="${over}">${'█'.repeat(postF)}</span>` +
-        `<span foreground="${colors.empty}">${'░'.repeat(postE)}</span>`;
 }
 
 function resolveBinary(settings) {
@@ -325,45 +264,38 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             return;
         }
         const raw = (data.text ?? '').toString().replace(/<[^>]*>/g, '');
-        const f = raw.split(';;');
-        if (f.length < 10) {
+        const f = splitFormatOutput(raw);
+        if (f.length <= FIELD.extraLimit) {
             // Loading… / ⚠ — show the binary's own text.
             this._data = null;
             this._label.clutter_text.set_markup(`<span foreground="${FG}">${esc(raw) || '…'}</span>`);
             return;
         }
-        const isPlaceholder = s => /^\{[^}]+\}$/.test(String(s).trim());
-        const field = s => {
-            const t = String(s ?? '').trim();
-            return t && !isPlaceholder(t) ? t : '';
-        };
-        const num = s => {
-            const t = field(s);
-            if (!t)
-                return null;
-            const n = parseInt(t, 10);
-            return Number.isFinite(n) ? n : null;
-        };
         this._data = {
-            plan: field(f[0]),
-            session: {pct: num(f[1]) ?? 0, reset: field(f[2]), elapsed: num(f[13])},
-            weekly: {pct: num(f[3]) ?? 0, reset: field(f[4]), elapsed: num(f[14])},
+            plan: field(f[FIELD.plan]),
+            session: {pct: integer(f[FIELD.sessionPct]) ?? 0, reset: field(f[FIELD.sessionReset]),
+                elapsed: markerElapsed(field(f[FIELD.sessionReset]), integer(f[FIELD.sessionElapsed]))},
+            weekly: {pct: integer(f[FIELD.weeklyPct]) ?? 0, reset: field(f[FIELD.weeklyReset]),
+                elapsed: markerElapsed(field(f[FIELD.weeklyReset]), integer(f[FIELD.weeklyElapsed]))},
             // Per-model weekly bar: a non-empty scoped model is the presence
             // signal. A reset may be unavailable, which must not make us show
             // the unrelated legacy Sonnet window instead.
             sonnet: (() => {
-                const scopedModel = field(f[10]);
+                const scopedModel = field(f[FIELD.scopedModel]);
                 if (scopedModel) {
-                    const scopedPct = num(f[11]);
+                    const scopedPct = integer(f[FIELD.scopedPct]);
                     if (scopedPct != null && scopedPct >= 0 && scopedPct <= 100)
-                        return {pct: scopedPct, reset: field(f[12]) || '—', label: scopedModel, elapsed: num(f[15])};
+                        return {pct: scopedPct, reset: field(f[FIELD.scopedReset]) || '—', label: scopedModel,
+                            elapsed: markerElapsed(field(f[FIELD.scopedReset]), integer(f[FIELD.scopedElapsed]))};
                     // A scoped model with malformed data is unavailable; do
                     // not fall back to a potentially unrelated Sonnet window.
                     return {pct: null, reset: '—', label: scopedModel, elapsed: null};
                 }
-                return {pct: num(f[5]), reset: field(f[6]), label: 'Sonnet only', elapsed: null};
+                return {pct: integer(f[FIELD.sonnetPct]), reset: field(f[FIELD.sonnetReset]),
+                    label: 'Sonnet only', elapsed: null};
             })(),
-            extra: {pct: num(f[7]), spent: field(f[8]), limit: field(f[9])},
+            extra: {pct: integer(f[FIELD.extraPct]), spent: field(f[FIELD.extraSpent]),
+                limit: field(f[FIELD.extraLimit])},
         };
         this._render();
     }

--- a/gnome-extension/extension.js
+++ b/gnome-extension/extension.js
@@ -24,12 +24,20 @@ const ROLE = 'ai-usagebar';
 const DIM = '#5c6370';
 const FG = '#abb2bf';
 const RED = '#e06c75';
+// The meta marker (pace/elapsed reference line) is a fixed blue, matching the
+// binary's default `marker` theme color and distinct from the over-pace warning
+// fill. Pace tolerance mirrors the binary's `--pace-tolerance` default of 5.
+const MARKER = '#61afef';
+const PACE_TOL = 5;
 
-// The fields we pull from the binary, joined by ';;'. The trailing `{scoped_*}`
-// carry the model-scoped weekly window (e.g. Fable) from the API's `limits[]`.
+// The fields we pull from the binary, joined by ';;'. `{scoped_*}` carry the
+// model-scoped weekly window (e.g. Fable) from `limits[]`; the trailing
+// `*_elapsed` carry the meta (pace) position — empty when the window has no
+// reset, which we treat as "no marker".
 const FORMAT = '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;' +
     '{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;' +
-    '{scoped_model};;{scoped_pct};;{scoped_reset}';
+    '{scoped_model};;{scoped_pct};;{scoped_reset};;' +
+    '{session_elapsed};;{weekly_elapsed};;{scoped_elapsed}';
 const REFRESH_TIMEOUT_SECS = 60;
 
 // severity_for(pct) from src/pango.rs: >=90 critical, >=75 high, >=50 mid, else low.
@@ -43,6 +51,15 @@ function colorForPct(pct, colors) {
     return colors.low;
 }
 
+// pace_fill_severity(delta) from src/pacing.rs: <=0 green, <=tol amber, else red.
+function colorForDelta(delta, colors) {
+    if (delta <= 0)
+        return colors.low;
+    if (delta <= PACE_TOL)
+        return colors.high;
+    return colors.critical;
+}
+
 function esc(s) {
     return String(s)
         .replace(/&/g, '&amp;')
@@ -50,12 +67,35 @@ function esc(s) {
         .replace(/>/g, '&gt;');
 }
 
-// Two-segment block bar as Pango markup, `width` cells wide.
-function barMarkup(pct, width, colors) {
+// Block bar as Pango markup, `width` cells wide. When `elapsed` (0..100) is a
+// number, the fill stays in the calm absolute-usage color up to a blue marker at
+// the elapsed position and only the part that overshoots the meta (how far ahead
+// of pace you are → risk of paid extra usage) is painted in the warning color;
+// otherwise it's a plain two-segment absolute-color bar with no marker.
+function barMarkup(pct, width, colors, elapsed) {
     const p = Math.max(0, Math.min(100, Math.round(pct)));
     const filled = Math.round((p * width) / 100);
-    return `<span foreground="${colorForPct(p, colors)}">${'█'.repeat(filled)}</span>` +
-        `<span foreground="${colors.empty}">${'░'.repeat(width - filled)}</span>`;
+
+    if (!Number.isFinite(elapsed)) {
+        return `<span foreground="${colorForPct(p, colors)}">${'█'.repeat(filled)}</span>` +
+            `<span foreground="${colors.empty}">${'░'.repeat(width - filled)}</span>`;
+    }
+
+    const e = Math.max(0, Math.min(100, Math.round(elapsed)));
+    const base = colorForPct(p, colors);
+    const over = colorForDelta(p - e, colors);
+    let m = Math.floor((e * width) / 100);
+    if (m > width - 1)
+        m = width - 1;
+    const preF = Math.min(filled, m);
+    const postF = filled > m + 1 ? filled - m - 1 : 0;
+    const preE = m - preF;
+    const postE = width - m - 1 - postF;
+    return `<span foreground="${base}">${'█'.repeat(preF)}</span>` +
+        `<span foreground="${colors.empty}">${'░'.repeat(preE)}</span>` +
+        `<span foreground="${MARKER}">│</span>` +
+        `<span foreground="${over}">${'█'.repeat(postF)}</span>` +
+        `<span foreground="${colors.empty}">${'░'.repeat(postE)}</span>`;
 }
 
 function resolveBinary(settings) {
@@ -306,15 +346,15 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         };
         this._data = {
             plan: field(f[0]),
-            session: {pct: num(f[1]) ?? 0, reset: field(f[2])},
-            weekly: {pct: num(f[3]) ?? 0, reset: field(f[4])},
+            session: {pct: num(f[1]) ?? 0, reset: field(f[2]), elapsed: num(f[13])},
+            weekly: {pct: num(f[3]) ?? 0, reset: field(f[4]), elapsed: num(f[14])},
             // Per-model weekly bar: prefer the model-scoped window (scoped_*,
             // e.g. Fable); fall back to the legacy flat sonnet window.
             sonnet: (() => {
                 const scopedReset = field(f[12]);
                 if (scopedReset && scopedReset !== '—')
-                    return {pct: num(f[11]), reset: scopedReset, label: field(f[10]) || 'Sonnet only'};
-                return {pct: num(f[5]), reset: field(f[6]), label: 'Sonnet only'};
+                    return {pct: num(f[11]), reset: scopedReset, label: field(f[10]) || 'Sonnet only', elapsed: num(f[15])};
+                return {pct: num(f[5]), reset: field(f[6]), label: 'Sonnet only', elapsed: null};
             })(),
             extra: {pct: num(f[7]), spent: field(f[8]), limit: field(f[9])},
         };
@@ -336,12 +376,12 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         const showPct = this._settings.get_boolean('show-percent');
         const showBars = this._settings.get_boolean('show-bars');
 
-        const seg = (tag, pct, valueText) => {
+        const seg = (tag, pct, valueText, elapsed) => {
             const toks = [`<span foreground="${DIM}">${tag}</span>`];
             if (showPct)
                 toks.push(`<span foreground="${colorForPct(pct, colors)}">${esc(valueText)}</span>`);
             if (showBars)
-                toks.push(barMarkup(pct, w, colors));
+                toks.push(barMarkup(pct, w, colors, elapsed));
             if (!showPct && !showBars) // never render an empty segment
                 toks.push(`<span foreground="${colorForPct(pct, colors)}">${esc(valueText)}</span>`);
             return toks.join(' ');
@@ -349,12 +389,12 @@ class AiUsageBarIndicator extends PanelMenu.Button {
 
         const parts = [];
         if (this._settings.get_boolean('show-session'))
-            parts.push(seg('5h', d.session.pct, `${d.session.pct}%`));
+            parts.push(seg('5h', d.session.pct, `${d.session.pct}%`, d.session.elapsed));
         if (this._settings.get_boolean('show-weekly'))
-            parts.push(seg('7d', d.weekly.pct, `${d.weekly.pct}%`));
+            parts.push(seg('7d', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.elapsed));
         if (this._settings.get_boolean('show-extra') &&
             d.extra.pct != null && d.extra.spent && d.extra.limit)
-            parts.push(seg('ex', d.extra.pct, d.extra.spent));
+            parts.push(seg('ex', d.extra.pct, d.extra.spent, null)); // $ budget → no meta
 
         const gap = `<span foreground="${DIM}">   </span>`;
         this._label.clutter_text.set_markup(parts.join(gap) || ' ');
@@ -363,13 +403,13 @@ class AiUsageBarIndicator extends PanelMenu.Button {
     _renderDropdown(d, colors) {
         this._planLabel.text = d.plan || 'AI Usage';
 
-        const upd = (key, pct, valueText, reset, visible) => {
+        const upd = (key, pct, valueText, reset, visible, elapsed) => {
             const r = this._rows[key];
             r.item.visible = visible;
             if (!visible)
                 return;
             r.valL.text = valueText;
-            r.barL.clutter_text.set_markup(barMarkup(pct ?? 0, 18, colors));
+            r.barL.clutter_text.set_markup(barMarkup(pct ?? 0, 18, colors, elapsed));
             if (reset) {
                 r.resetL.text = `↺ resets in ${reset}`;
                 r.resetL.visible = true;
@@ -378,13 +418,13 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             }
         };
 
-        upd('session', d.session.pct, `${d.session.pct}%`, d.session.reset, true);
-        upd('weekly', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.reset, true);
+        upd('session', d.session.pct, `${d.session.pct}%`, d.session.reset, true, d.session.elapsed);
+        upd('weekly', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.reset, true, d.weekly.elapsed);
         // Label the per-model weekly row by the scoped model (e.g. "Fable").
         this._rows.sonnet.nameL.text = d.sonnet.label || 'Sonnet only';
-        upd('sonnet', d.sonnet.pct, `${d.sonnet.pct ?? 0}%`, d.sonnet.reset, d.sonnet.pct != null);
+        upd('sonnet', d.sonnet.pct, `${d.sonnet.pct ?? 0}%`, d.sonnet.reset, d.sonnet.pct != null, d.sonnet.elapsed);
         upd('extra', d.extra.pct, `${d.extra.spent} / ${d.extra.limit}`, null,
-            d.extra.pct != null && !!d.extra.spent && !!d.extra.limit);
+            d.extra.pct != null && !!d.extra.spent && !!d.extra.limit, null); // $ budget → no meta
     }
 
     _setError(short, detail) {

--- a/gnome-extension/marker-logic.js
+++ b/gnome-extension/marker-logic.js
@@ -1,0 +1,81 @@
+// Pure marker helpers shared by the GNOME indicator and its Node table tests.
+export const MARKER = '#61afef';
+export const POINT_MID_MIN = -10;
+export const POINT_CRITICAL_MIN = 10;
+// Keep the stale suffix after this ignored literal field, never on elapsed.
+export const FORMAT = '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;' +
+    '{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;' +
+    '{scoped_model};;{scoped_pct};;{scoped_reset};;' +
+    '{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;__aiub_end__';
+export const FIELD = Object.freeze({
+    plan: 0, sessionPct: 1, sessionReset: 2, weeklyPct: 3, weeklyReset: 4,
+    sonnetPct: 5, sonnetReset: 6, extraPct: 7, extraSpent: 8, extraLimit: 9,
+    scopedModel: 10, scopedPct: 11, scopedReset: 12,
+    sessionElapsed: 13, weeklyElapsed: 14, scopedElapsed: 15, sentinel: 16,
+});
+
+export function splitFormatOutput(text) {
+    return String(text).split(';;');
+}
+
+export function field(value) {
+    const text = String(value ?? '').trim();
+    return text && !/^\{[^}]+\}$/.test(text) ? text : '';
+}
+
+// Do not accept a numeric prefix: a stale suffix such as "27 ⏸" is not elapsed.
+export function integer(value) {
+    const text = field(value);
+    return /^-?\d+$/.test(text) ? Number(text) : null;
+}
+
+export function markerElapsed(reset, elapsed) {
+    return reset && reset !== '—' && Number.isFinite(elapsed) ? elapsed : null;
+}
+
+// Matches pacing::pace_severity: < -10 low, -10..=0 mid, 1..=9 high, >= 10 critical.
+export function colorForDelta(delta, colors) {
+    if (delta >= POINT_CRITICAL_MIN)
+        return colors.critical;
+    if (delta > 0)
+        return colors.high;
+    if (delta >= POINT_MID_MIN)
+        return colors.mid;
+    return colors.low;
+}
+
+export function colorForPct(pct, colors) {
+    if (pct >= 90)
+        return colors.critical;
+    if (pct >= 75)
+        return colors.high;
+    if (pct >= 50)
+        return colors.mid;
+    return colors.low;
+}
+
+export function barMarkup(pct, width, colors, elapsed) {
+    const p = Math.max(0, Math.min(100, Math.round(pct)));
+    const filled = Math.round((p * width) / 100);
+
+    if (!Number.isFinite(elapsed)) {
+        return `<span foreground="${colorForPct(p, colors)}">${'█'.repeat(filled)}</span>` +
+            `<span foreground="${colors.empty}">${'░'.repeat(width - filled)}</span>`;
+    }
+
+    const e = Math.max(0, Math.min(100, Math.round(elapsed)));
+    const base = colorForPct(p, colors);
+    const over = colorForDelta(p - e, colors);
+    let marker = Math.floor((e * width) / 100);
+    if (marker > width - 1)
+        marker = width - 1;
+    const preFilled = Math.min(filled, marker);
+    const postFilled = filled > marker + 1 ? filled - marker - 1 : 0;
+    const preEmpty = marker - preFilled;
+    const postEmpty = width - marker - 1 - postFilled;
+    return `<span foreground="${base}">${'█'.repeat(preFilled)}</span>` +
+        `<span foreground="${colors.empty}">${'░'.repeat(preEmpty)}</span>` +
+        `<span foreground="${MARKER}">│</span>` +
+        `<span foreground="${over}">${'█'.repeat(postFilled)}</span>` +
+        `<span foreground="${colors.empty}">${'░'.repeat(postEmpty)}</span>`;
+}

--- a/gnome-extension/marker-logic.test.mjs
+++ b/gnome-extension/marker-logic.test.mjs
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import {barMarkup, colorForDelta, field, FIELD, FORMAT, integer, markerElapsed,
+    splitFormatOutput} from './marker-logic.js';
+
+const colors = {low: 'low', mid: 'mid', high: 'high', critical: 'critical', empty: 'empty'};
+const visibleCells = markup => markup.replace(/<[^>]+>/g, '');
+
+assert.equal(markerElapsed('1h', 0), 0);
+assert.equal(markerElapsed('1h', 100), 100);
+assert.equal(markerElapsed('', 0), null);
+assert.equal(markerElapsed('—', 0), null);
+assert.equal(markerElapsed('1h', null), null);
+
+assert.equal(integer('27'), 27);
+assert.equal(integer('27 ⏸'), null);
+assert.equal(integer('{scoped_elapsed}'), null);
+assert.equal(field('{scoped_model}'), '');
+const formatFields = FORMAT.split(';;');
+assert.deepEqual(formatFields, [
+    '{plan}', '{session_pct}', '{session_reset}', '{weekly_pct}', '{weekly_reset}',
+    '{sonnet_pct}', '{sonnet_reset}', '{extra_pct}', '{extra_spent}', '{extra_limit}',
+    '{scoped_model}', '{scoped_pct}', '{scoped_reset}', '{session_elapsed}',
+    '{weekly_elapsed}', '{scoped_elapsed}', '__aiub_end__',
+]);
+assert.deepEqual(FIELD, {
+    plan: 0, sessionPct: 1, sessionReset: 2, weeklyPct: 3, weeklyReset: 4,
+    sonnetPct: 5, sonnetReset: 6, extraPct: 7, extraSpent: 8, extraLimit: 9,
+    scopedModel: 10, scopedPct: 11, scopedReset: 12,
+    sessionElapsed: 13, weeklyElapsed: 14, scopedElapsed: 15, sentinel: 16,
+});
+const values = {'{scoped_elapsed}': '27'};
+const framed = splitFormatOutput(formatFields.map(value => values[value] ?? value).join(';;') + ' ⏸');
+assert.equal(integer(framed[FIELD.scopedElapsed]), 27);
+assert.equal(framed[FIELD.sentinel], '__aiub_end__ ⏸');
+
+assert.equal(colorForDelta(-11, colors), 'low');
+assert.equal(colorForDelta(-10, colors), 'mid');
+assert.equal(colorForDelta(0, colors), 'mid');
+assert.equal(colorForDelta(1, colors), 'high');
+assert.equal(colorForDelta(9, colors), 'high');
+assert.equal(colorForDelta(10, colors), 'critical');
+
+for (const [pct, elapsed, expected] of [[25, 50, 'low'], [50, 50, 'mid'], [75, 50, 'critical']]) {
+    const markup = barMarkup(pct, 8, colors, elapsed);
+    assert.equal(visibleCells(markup).length, 8);
+    assert.ok(markup.includes('│'));
+    assert.ok(markup.includes(`foreground="${expected}"`));
+}
+assert.equal(visibleCells(barMarkup(50, 8, colors, 0)).length, 8);
+assert.equal(visibleCells(barMarkup(50, 8, colors, 100)).length, 8);
+assert.ok(!barMarkup(50, 8, colors, markerElapsed('—', 0)).includes('│'));
+
+console.log('marker logic tests passed');

--- a/gnome-extension/package.json
+++ b/gnome-extension/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/macos/README.md
+++ b/macos/README.md
@@ -48,6 +48,7 @@ Settings persist in `UserDefaults` and apply **live, no rebuild**.
 | Show 5h / weekly / extra | on / on / off | which bars appear |
 | Show percentage/value | on | numeric value next to each bar |
 | Show bars | on | off = numbers only |
+| Show pace marker | on | persisted `showMeta`; draws the elapsed-time marker only when the window has a reset |
 | Bar width | 8 | cells per menu-bar bar (4–20) |
 | Colors (low/mid/high/critical/empty) | One Dark | bar color per severity (≥90 / ≥75 / ≥50 / else) |
 | Refresh interval | 30 s | 5–3600 |
@@ -57,6 +58,12 @@ Settings persist in `UserDefaults` and apply **live, no rebuild**.
 The Preferences window needs **macOS 12+** (the menu bar itself works on
 10.15+). Tags/labels use the system label colors, so they adapt to a light or
 dark menu bar; only the bar fill/empty colors are configurable.
+
+When enabled, the fixed blue `│` pace marker is placed at elapsed time. Fill
+past the marker follows the point-delta colors used by the Rust widget: at
+least 10 points ahead is critical/red, 1–9 ahead is high/orange, -10 through
+on-pace is mid/yellow, and more than 10 under is low/green. Windows without a
+reset (including a displayed `—`) retain their row but do not draw a marker.
 
 ## How it works
 

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -57,20 +57,22 @@ var COLOR_EMPTY: String { DEF.string(forKey: "colorEmpty") ?? "#3e4451" }
 // over-meta segment of the fill. Off = plain absolute-usage bars, no marker.
 var SHOW_META: Bool { DEF.bool(forKey: "showMeta") }
 // The meta marker is a fixed blue, matching the binary's default theme `marker`
-// color and distinct from the over-pace warning fill. Pace tolerance mirrors the
-// binary's `--pace-tolerance` default of 5.
+// color and distinct from the over-pace warning fill.
 let COLOR_MARKER = "#61afef"
-let PACE_TOL = 5
+let POINT_MID_MIN = -10
+let POINT_CRITICAL_MIN = 10
 
 // The `{scoped_*}` fields (10-12) carry the model-scoped weekly window (e.g.
 // "Fable") from the API's `limits[]`; empty on older binaries → the row falls
 // back to the flat `{sonnet_*}` window and the "Sonnet only" label. The trailing
-// `*_elapsed` fields (13-15) carry the meta (pace) position, or empty when the
-// window has no reset → no marker.
+// `*_elapsed` fields (13-15) carry the meta (pace) position. A final literal
+// sentinel absorbs the widget's stale suffix, preserving the elapsed fields.
 let FORMAT = "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;" +
              "{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;" +
              "{scoped_model};;{scoped_pct};;{scoped_reset};;" +
              "{session_elapsed};;{weekly_elapsed};;{scoped_elapsed}"
+
+let FORMAT_WITH_SENTINEL = FORMAT + ";;__aiub_end__"
 
 // ─── Color / text helpers ────────────────────────────────────────────────
 func hexColor(_ hex: String) -> NSColor {
@@ -90,16 +92,19 @@ func colorForPct(_ pct: Int) -> NSColor {
     return hexColor(COLOR_LOW)
 }
 
-// pace_fill_severity(delta) from src/pacing.rs: <=0 green, <=tol amber, else red.
+// Matches pacing::pace_severity: < -10 low, -10...0 mid, 1...9 high, >= 10 critical.
 func colorForDelta(_ delta: Int) -> NSColor {
-    if delta <= 0 { return hexColor(COLOR_LOW) }
-    if delta <= PACE_TOL { return hexColor(COLOR_HIGH) }
-    return hexColor(COLOR_CRITICAL)
+    if delta >= POINT_CRITICAL_MIN { return hexColor(COLOR_CRITICAL) }
+    if delta > 0 { return hexColor(COLOR_HIGH) }
+    if delta >= POINT_MID_MIN { return hexColor(COLOR_MID) }
+    return hexColor(COLOR_LOW)
 }
 
-// When the meta reference is off, ignore `elapsed` everywhere → plain
-// absolute-usage bar, no marker.
-func metaElapsed(_ e: Int?) -> Int? { SHOW_META ? e : nil }
+// A missing reset keeps its row visible but never has a meaningful pace marker.
+func markerElapsed(reset: String, elapsed: Int?) -> Int? {
+    guard !reset.isEmpty, reset != "—" else { return nil }
+    return elapsed
+}
 
 let barFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
@@ -117,7 +122,7 @@ func barAttr(pct: Int, width: Int, elapsed: Int?) -> NSAttributedString {
     let filled = Int((Double(p) * Double(width) / 100.0).rounded())
     let out = NSMutableAttributedString()
 
-    guard let elapsedVal = metaElapsed(elapsed) else {
+    guard SHOW_META, let elapsedVal = elapsed else {
         out.append(run(String(repeating: "█", count: filled), colorForPct(p)))
         out.append(run(String(repeating: "░", count: max(0, width - filled)), hexColor(COLOR_EMPTY)))
         return out
@@ -198,7 +203,12 @@ func parse(_ text: String) -> Snapshot? {
         let v = f[i].trimmingCharacters(in: .whitespaces)
         return unknownPlaceholder(v) ? "" : v
     }
-    func n(_ i: Int) -> Int? { Int(t(i)) }
+    // Do not accept a numeric prefix: a stale suffix such as "27 ⏸" is not elapsed.
+    func n(_ i: Int) -> Int? {
+        let value = t(i)
+        guard value.range(of: "^-?[0-9]+$", options: .regularExpression) != nil else { return nil }
+        return Int(value)
+    }
     // Third bar = the per-model weekly window: a non-empty scoped model is the
     // presence signal. Its reset can legitimately be unavailable, so do not
     // mistake a missing reset for an absent scoped window and show Sonnet.
@@ -211,7 +221,8 @@ func parse(_ text: String) -> Snapshot? {
         // A malformed scoped percentage is unavailable too, but must not make
         // us fall back to the unrelated legacy Sonnet window.
         if let p = n(11), (0...100).contains(p) {
-            sonnet = Window(pct: p, reset: scopedReset.isEmpty ? "—" : scopedReset, elapsed: n(15))
+            let reset = scopedReset.isEmpty ? "—" : scopedReset
+            sonnet = Window(pct: p, reset: reset, elapsed: markerElapsed(reset: reset, elapsed: n(15)))
             sonnetLabel = scopedModel
         }
     } else if !sonnetReset.isEmpty, sonnetReset != "—", let p = n(5) {
@@ -222,8 +233,8 @@ func parse(_ text: String) -> Snapshot? {
     let extra: (pct: Int, spent: String, limit: String)? =
         (spent.isEmpty || limit.isEmpty) ? nil : n(7).map { (pct: $0, spent: spent, limit: limit) }
     return Snapshot(plan: t(0),
-                    session: Window(pct: n(1) ?? 0, reset: t(2), elapsed: n(13)),
-                    weekly: Window(pct: n(3) ?? 0, reset: t(4), elapsed: n(14)),
+                    session: Window(pct: n(1) ?? 0, reset: t(2), elapsed: markerElapsed(reset: t(2), elapsed: n(13))),
+                    weekly: Window(pct: n(3) ?? 0, reset: t(4), elapsed: markerElapsed(reset: t(4), elapsed: n(14))),
                     sonnet: sonnet,
                     sonnetLabel: sonnetLabel,
                     extra: extra)
@@ -611,7 +622,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let p = Process()
             p.executableURL = URL(fileURLWithPath: bin)
-            p.arguments = ["--vendor", VENDOR, "--format", FORMAT]
+            p.arguments = ["--vendor", VENDOR, "--format", FORMAT_WITH_SENTINEL]
             let pipe = Pipe()
             p.standardOutput = pipe
             p.standardError = FileHandle.nullDevice

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -30,6 +30,7 @@ let SETTINGS_DEFAULTS: [String: Any] = [
     "showExtra": false,
     "showPercent": true,
     "showBars": true,
+    "showMeta": true,
     "colorLow": "#98c379",
     "colorMid": "#e5c07b",
     "colorHigh": "#d19a66",
@@ -52,13 +53,24 @@ var COLOR_MID: String { DEF.string(forKey: "colorMid") ?? "#e5c07b" }
 var COLOR_HIGH: String { DEF.string(forKey: "colorHigh") ?? "#d19a66" }
 var COLOR_CRITICAL: String { DEF.string(forKey: "colorCritical") ?? "#e06c75" }
 var COLOR_EMPTY: String { DEF.string(forKey: "colorEmpty") ?? "#3e4451" }
+// Meta reference: draw a pace marker at the elapsed-time position and flag the
+// over-meta segment of the fill. Off = plain absolute-usage bars, no marker.
+var SHOW_META: Bool { DEF.bool(forKey: "showMeta") }
+// The meta marker is a fixed blue, matching the binary's default theme `marker`
+// color and distinct from the over-pace warning fill. Pace tolerance mirrors the
+// binary's `--pace-tolerance` default of 5.
+let COLOR_MARKER = "#61afef"
+let PACE_TOL = 5
 
 // The `{scoped_*}` fields (10-12) carry the model-scoped weekly window (e.g.
 // "Fable") from the API's `limits[]`; empty on older binaries → the row falls
-// back to the flat `{sonnet_*}` window and the "Sonnet only" label.
+// back to the flat `{sonnet_*}` window and the "Sonnet only" label. The trailing
+// `*_elapsed` fields (13-15) carry the meta (pace) position, or empty when the
+// window has no reset → no marker.
 let FORMAT = "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;" +
              "{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;" +
-             "{scoped_model};;{scoped_pct};;{scoped_reset}"
+             "{scoped_model};;{scoped_pct};;{scoped_reset};;" +
+             "{session_elapsed};;{weekly_elapsed};;{scoped_elapsed}"
 
 // ─── Color / text helpers ────────────────────────────────────────────────
 func hexColor(_ hex: String) -> NSColor {
@@ -78,18 +90,54 @@ func colorForPct(_ pct: Int) -> NSColor {
     return hexColor(COLOR_LOW)
 }
 
+// pace_fill_severity(delta) from src/pacing.rs: <=0 green, <=tol amber, else red.
+func colorForDelta(_ delta: Int) -> NSColor {
+    if delta <= 0 { return hexColor(COLOR_LOW) }
+    if delta <= PACE_TOL { return hexColor(COLOR_HIGH) }
+    return hexColor(COLOR_CRITICAL)
+}
+
+// When the meta reference is off, ignore `elapsed` everywhere → plain
+// absolute-usage bar, no marker.
+func metaElapsed(_ e: Int?) -> Int? { SHOW_META ? e : nil }
+
 let barFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
 func run(_ s: String, _ color: NSColor, _ font: NSFont = barFont) -> NSAttributedString {
     NSAttributedString(string: s, attributes: [.foregroundColor: color, .font: font])
 }
 
-func barAttr(pct: Int, width: Int) -> NSAttributedString {
+// Block bar. When `elapsed` (0..100) is known and the meta is on, the fill stays
+// in the calm absolute-usage color up to a blue marker at the elapsed position,
+// and only the part that overshoots the meta (how far ahead of pace you are →
+// risk of paid extra usage) is painted in the warning color. Otherwise it's a
+// plain absolute-color bar with no marker.
+func barAttr(pct: Int, width: Int, elapsed: Int?) -> NSAttributedString {
     let p = max(0, min(100, pct))
     let filled = Int((Double(p) * Double(width) / 100.0).rounded())
     let out = NSMutableAttributedString()
-    out.append(run(String(repeating: "█", count: filled), colorForPct(p)))
-    out.append(run(String(repeating: "░", count: max(0, width - filled)), hexColor(COLOR_EMPTY)))
+
+    guard let elapsedVal = metaElapsed(elapsed) else {
+        out.append(run(String(repeating: "█", count: filled), colorForPct(p)))
+        out.append(run(String(repeating: "░", count: max(0, width - filled)), hexColor(COLOR_EMPTY)))
+        return out
+    }
+
+    let e = max(0, min(100, elapsedVal))
+    let base = colorForPct(p)        // on-track portion → calm absolute color
+    let over = colorForDelta(p - e)  // excess beyond the meta → pace warning
+    var m = Int(Double(e) * Double(width) / 100.0) // floor
+    if m > width - 1 { m = width - 1 }
+    if m < 0 { m = 0 }
+    let preF = min(filled, m)
+    let postF = filled > m + 1 ? filled - m - 1 : 0
+    let preE = m - preF
+    let postE = width - m - 1 - postF
+    out.append(run(String(repeating: "█", count: max(0, preF)), base))
+    out.append(run(String(repeating: "░", count: max(0, preE)), hexColor(COLOR_EMPTY)))
+    out.append(run("│", hexColor(COLOR_MARKER)))
+    out.append(run(String(repeating: "█", count: max(0, postF)), over))
+    out.append(run(String(repeating: "░", count: max(0, postE)), hexColor(COLOR_EMPTY)))
     return out
 }
 
@@ -122,7 +170,7 @@ func resolveBinary(_ name: String) -> String? {
 }
 
 // ─── Data model ──────────────────────────────────────────────────────────
-struct Window { let pct: Int; let reset: String }
+struct Window { let pct: Int; let reset: String; let elapsed: Int? }
 struct Snapshot {
     let plan: String
     let session: Window
@@ -158,19 +206,19 @@ func parse(_ text: String) -> Snapshot? {
     var sonnet: Window? = nil
     var sonnetLabel = "Sonnet only"
     if !scopedReset.isEmpty, scopedReset != "—", let p = n(11) {
-        sonnet = Window(pct: p, reset: scopedReset)
+        sonnet = Window(pct: p, reset: scopedReset, elapsed: n(15))
         let model = t(10)
         if !model.isEmpty { sonnetLabel = model }
     } else if !sonnetReset.isEmpty, sonnetReset != "—", let p = n(5) {
-        sonnet = Window(pct: p, reset: sonnetReset)
+        sonnet = Window(pct: p, reset: sonnetReset, elapsed: nil)
     }
     let spent = t(8)
     let limit = t(9)
     let extra: (pct: Int, spent: String, limit: String)? =
         (spent.isEmpty || limit.isEmpty) ? nil : n(7).map { (pct: $0, spent: spent, limit: limit) }
     return Snapshot(plan: t(0),
-                    session: Window(pct: n(1) ?? 0, reset: t(2)),
-                    weekly: Window(pct: n(3) ?? 0, reset: t(4)),
+                    session: Window(pct: n(1) ?? 0, reset: t(2), elapsed: n(13)),
+                    weekly: Window(pct: n(3) ?? 0, reset: t(4), elapsed: n(14)),
                     sonnet: sonnet,
                     sonnetLabel: sonnetLabel,
                     extra: extra)
@@ -385,6 +433,7 @@ struct SettingsView: View {
     @AppStorage("showExtra") private var showExtra = false
     @AppStorage("showPercent") private var showPercent = true
     @AppStorage("showBars") private var showBars = true
+    @AppStorage("showMeta") private var showMeta = true
     @AppStorage("colorLow") private var colorLow = "#98c379"
     @AppStorage("colorMid") private var colorMid = "#e5c07b"
     @AppStorage("colorHigh") private var colorHigh = "#d19a66"
@@ -407,6 +456,7 @@ struct SettingsView: View {
                         Toggle("Mostrar barra de uso extra ($)", isOn: $showExtra)
                         Toggle("Mostrar porcentagem/valor", isOn: $showPercent)
                         Toggle("Mostrar barras (off = só números)", isOn: $showBars)
+                        Toggle("Mostrar referência da meta (linha de ritmo)", isOn: $showMeta)
                         Stepper("Largura da barra: \(barWidth)", value: $barWidth, in: 4...20)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -588,16 +638,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func renderPanel(_ s: Snapshot) {
         let title = NSMutableAttributedString()
-        func seg(_ tag: String, _ pct: Int, _ value: String) {
+        func seg(_ tag: String, _ pct: Int, _ value: String, _ elapsed: Int?) {
             if title.length > 0 { title.append(run("   ", .secondaryLabelColor)) }
             title.append(run("\(tag) ", .secondaryLabelColor))
             if SHOW_PERCENT { title.append(run(value + (SHOW_BARS ? " " : ""), colorForPct(pct))) }
-            if SHOW_BARS { title.append(barAttr(pct: pct, width: BAR_WIDTH)) }
+            if SHOW_BARS { title.append(barAttr(pct: pct, width: BAR_WIDTH, elapsed: elapsed)) }
             if !SHOW_PERCENT && !SHOW_BARS { title.append(run(value, colorForPct(pct))) }
         }
-        if SHOW_SESSION { seg("5h", s.session.pct, "\(s.session.pct)%") }
-        if SHOW_WEEKLY { seg("7d", s.weekly.pct, "\(s.weekly.pct)%") }
-        if SHOW_EXTRA, let e = s.extra { seg("ex", e.pct, e.spent) }
+        if SHOW_SESSION { seg("5h", s.session.pct, "\(s.session.pct)%", s.session.elapsed) }
+        if SHOW_WEEKLY { seg("7d", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.elapsed) }
+        if SHOW_EXTRA, let e = s.extra { seg("ex", e.pct, e.spent, nil) } // $ budget → no meta
         statusItem.button?.attributedTitle = title.length > 0 ? title : run("ai", .secondaryLabelColor)
     }
 
@@ -605,21 +655,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         headerItem.attributedTitle = run(s.plan.isEmpty ? "AI Usage" : s.plan,
                                          .labelColor, NSFont.boldSystemFont(ofSize: 13))
 
-        func row(_ key: String, _ name: String, _ pct: Int, _ value: String, _ reset: String?) {
+        func row(_ key: String, _ name: String, _ pct: Int, _ value: String, _ reset: String?, _ elapsed: Int?) {
             guard let item = rows[key] else { return }
             item.isHidden = false
             let a = NSMutableAttributedString()
             a.append(run(name.padding(toLength: 12, withPad: " ", startingAt: 0), .labelColor))
-            a.append(barAttr(pct: pct, width: MENU_BAR_W))
+            a.append(barAttr(pct: pct, width: MENU_BAR_W, elapsed: elapsed))
             a.append(run("  \(value)", colorForPct(pct)))
             if let r = reset, !r.isEmpty { a.append(run("   ↺ \(r)", .secondaryLabelColor)) }
             item.attributedTitle = a
         }
-        row("session", "Session", s.session.pct, "\(s.session.pct)%", s.session.reset)
-        row("weekly", "Weekly", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.reset)
-        if let sn = s.sonnet { row("sonnet", s.sonnetLabel, sn.pct, "\(sn.pct)%", sn.reset) }
+        row("session", "Session", s.session.pct, "\(s.session.pct)%", s.session.reset, s.session.elapsed)
+        row("weekly", "Weekly", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.reset, s.weekly.elapsed)
+        if let sn = s.sonnet { row("sonnet", s.sonnetLabel, sn.pct, "\(sn.pct)%", sn.reset, sn.elapsed) }
         else { rows["sonnet"]?.isHidden = true }
-        if let e = s.extra { row("extra", "Extra usage", e.pct, "\(e.spent) / \(e.limit)", nil) }
+        if let e = s.extra { row("extra", "Extra usage", e.pct, "\(e.spent) / \(e.limit)", nil, nil) }
         else { rows["extra"]?.isHidden = true }
     }
 


### PR DESCRIPTION
> **Ready — #20 is merged and this branch includes its audited fixes.**

## What

Upstream draws the meta marker (elapsed-time reference + pace) in the Waybar tooltip, but the **macOS menu bar** and **GNOME** desktop apps redraw their own bars from `--format` and show none of it. This brings them to parity.

**Why the meta marker matters:** at intense usage it tells you that *if you keep this pace* you'll exhaust the quota before it resets and spill into **paid extra usage ($)**. A glance shows whether you're ahead of or behind the pace of your quota — no mental math.

## Changes

- Read `{session,weekly,scoped}_elapsed` and draw a thin blue `│` at the elapsed position on each time-windowed bar.
- Color the fill by absolute usage **up to** the marker, and paint only the **over-meta excess** (how far ahead of pace you are) in the warning color. So a bar at 41% used but only 20% into the week reads calm with a small red tail, not entirely red. The per-window number stays absolute-colored.
- **macOS:** adds a *"Mostrar referência da meta"* toggle (UserDefaults) to switch it off.
- **GNOME:** draws the marker whenever the window reports a reset (no new gschema key).
- Windows with no reset ($ Extra usage) draw no marker.

## Screenshots (macOS)

**Meta off** — plain absolute-usage bars, and the third row correctly labelled "Fable":

_(drag `Captura … 23.39.43.png` here)_

**Meta on** — calm fill up to the `│` marker, only the over-meta excess in the warning color (see the Weekly bar):

_(drag `Captura … 23.39.55.png` here)_

## Testing

- Verification after integrating #20: 268 unit + 3 integration tests pass; clippy, Node marker tests, GNOME syntax/schema checks, and shell checks are clean. Swift compilation was unavailable on the Linux audit host; the original macOS build passed.
- End-to-end: binary emits `session_elapsed`, `weekly_elapsed`, `scoped_elapsed`; markers render at the expected positions.

🤖 Generated with Samir and [Claude Code](https://claude.com/claude-code)

<img width="1680" height="1050" alt="Captura de Tela 2026-07-15 às 23 39 43" src="https://github.com/user-attachments/assets/d02aef82-d1fb-4f5a-9cfa-0257ea1f7f63" />

Below with the goals mark
<img width="1680" height="1050" alt="Captura de Tela 2026-07-15 às 23 39 55" src="https://github.com/user-attachments/assets/e7777d81-365c-42c3-8dbf-e2b87c99ca0b" />


