### PR TITLE
fix: data integrity, credential and runtime defects in v0.13.0, plus CI/release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 name: CI
 
-# Native Windows test signal for PRs. The Waybar widget is Wayland-only, so the
-# Linux gate lives in the maintainer's existing flow; this job proves the CLI +
-# TUI build and test on a real windows-latest runner (no WSL).
+# Cross-platform test signal for PRs and main. Linux carries the strict quality
+# gate, macOS also compiles the native menu app, and Windows runs natively.
 on:
   push:
     branches: [main]
@@ -45,7 +44,7 @@ jobs:
         run: node gnome-extension/marker-logic.test.mjs
 
       - name: Unused dependencies
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@v0.9.2
 
   macos:
     name: test (macos-latest)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,58 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
+  # The platform the widget actually ships on. Until this existed, Linux was
+  # only exercised *after* a tag was pushed — by which point the tag is
+  # immutable and a failure costs a new patch release.
+  linux:
+    name: test (ubuntu-latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --locked -- -D warnings
+
+      - name: Test
+        run: cargo test --all-targets --locked
+
+      - name: Test GNOME marker logic
+        run: node gnome-extension/marker-logic.test.mjs
+
+      - name: Unused dependencies
+        uses: bnjbvr/cargo-machete@main
+
+  macos:
+    name: test (macos-latest)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        run: cargo test --all-targets --locked
+
+      # The menu bar app is 700+ lines of Swift with no test harness; at least
+      # prove it still compiles, which nothing verified before.
+      - name: Build the menu bar app
+        run: swiftc -O -o /tmp/ai-usagebar-menubar macos/ai-usagebar-menubar.swift
+
   windows:
     name: test (windows-latest)
     runs-on: windows-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Tag or commit to build (e.g. v0.2.0)"
+        description: "Existing release tag to build (e.g. v0.13.1)"
         required: true
         default: ""
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,67 @@ on:
         default: ""
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  # Nothing verified that the artifacts about to be published carry the version
+  # the tag claims. At v0.13.0 the packaging `.SRCINFO` files still said 0.8.0
+  # while Cargo.toml said 0.13.0, and the release went out anyway. Everything
+  # downstream depends on this job.
+  verify-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+          # Tags are needed to prove a workflow_dispatch ref is a real tag.
+          fetch-depth: 0
+
+      - id: check
+        name: Tag, Cargo.toml, changelog and packaging must agree
+        run: |
+          set -euo pipefail
+          ref="${{ inputs.ref || github.ref_name }}"
+          case "$ref" in
+            v*) ;;
+            *) echo "::error::refusing to publish from '$ref' — releases must build a vX.Y.Z tag"; exit 1 ;;
+          esac
+          version="${ref#v}"
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::'$ref' is not a vX.Y.Z tag"; exit 1
+          fi
+          # A workflow_dispatch ref must be an existing tag, not an arbitrary commit.
+          git rev-parse -q --verify "refs/tags/$ref" >/dev/null \
+            || { echo "::error::tag '$ref' does not exist"; exit 1; }
+
+          fail=0
+          check() { # check <what> <actual> <expected>
+            if [ "$2" != "$3" ]; then
+              echo "::error::$1 is '$2' but the tag says '$3'"; fail=1
+            fi
+          }
+          check "Cargo.toml version" \
+            "$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)" "$version"
+          check "PKGBUILD pkgver" \
+            "$(grep -m1 '^pkgver=' packaging/aur/PKGBUILD | cut -d= -f2)" "$version"
+          check "PKGBUILD-bin pkgver" \
+            "$(grep -m1 '^pkgver=' packaging/aur/PKGBUILD-bin | cut -d= -f2)" "$version"
+          check ".SRCINFO pkgver" \
+            "$(grep -m1 'pkgver = ' packaging/aur/.SRCINFO | awk '{print $3}')" "$version"
+          check ".SRCINFO-bin pkgver" \
+            "$(grep -m1 'pkgver = ' packaging/aur/.SRCINFO-bin | awk '{print $3}')" "$version"
+
+          grep -q "^## \[$version\]" CHANGELOG.md \
+            || { echo "::error::CHANGELOG.md has no '## [$version]' section"; fail=1; }
+
+          [ "$fail" -eq 0 ] || exit 1
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "verified $ref"
+
   build:
+    needs: [verify-version]
     strategy:
       matrix:
         include:
@@ -84,8 +141,11 @@ jobs:
             ${{ matrix.artifact }}.tar.gz.sha256
 
   release:
-    needs: build
+    needs: [verify-version, build]
     runs-on: ubuntu-latest
+    # Only this job publishes anything to the repo; the rest read.
+    permissions:
+      contents: write
     steps:
       - name: Checkout source (for CHANGELOG + previous tag)
         uses: actions/checkout@v5
@@ -172,7 +232,7 @@ jobs:
           fi
 
   publish-crates-io:
-    needs: [build, release]
+    needs: [verify-version, build, release]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || inputs.ref != ''
     steps:
@@ -207,7 +267,7 @@ jobs:
           exit "$status"
 
   publish-aur:
-    needs: [build, release]
+    needs: [verify-version, build, release]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v') || inputs.ref != ''
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ Each release is also published at
 
 ### Fixed
 
+- **A rotated OAuth refresh token is no longer lost silently.** Both Anthropic
+  and OpenAI persisted refreshed credentials with `let _ = write_back(...)`.
+  When the server rotates the refresh token and that write fails, the old token
+  on disk is already spent: the current run works, and the *next* one cannot
+  refresh, so the user appears to be logged out for no visible reason. A failed
+  write-back after a rotation is now reported and treated as an auth failure.
+  A failed write that only carried a new *access* token is still ignored —
+  nothing is lost there, the next run simply refreshes again.
+
+- **OpenAI no longer re-refreshes on every run after an id_token-less refresh.**
+  Expiry was read exclusively from the `id_token` exp claim, and the explicit
+  `expires_at` field in `auth.json` was ignored. A refresh response without a
+  new `id_token` therefore left the old, expired claim in place. `expires_at`
+  is now used as the fallback source and is written from the response's
+  `expires_in`.
+
 - **An invalid config is no longer silently replaced by the defaults.** Every
   caller used `Config::load().unwrap_or_default()`, so a TOML syntax error, a
   permission problem, or a failed validation produced the default vendor set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,25 @@ Each release is also published at
 
 ### Fixed
 
+- **The config file is found at one agreed location on every platform.** The
+  binary resolved it through `directories::ProjectDirs` (macOS:
+  `~/Library/Application Support/ai-usagebar/`), while the README, the shipped
+  example, `--help`, the GNOME preferences and the macOS menu bar all used
+  `~/.config/ai-usagebar/`. The two never had to be the same file, so the
+  desktop integrations could report "no key configured" for a key the binary
+  was using. The platform path stays canonical; the legacy Unix path is honored
+  when the canonical file does not exist, and both desktop surfaces now check
+  the same pair. Nothing is moved or rewritten — the file can hold API keys,
+  and relocating a secret behind the user's back is not this tool's business.
+  GNOME additionally honors `$XDG_CONFIG_HOME` instead of hard-coding
+  `~/.config`.
+
+- **`~` in configured paths is expanded.** `credentials_path = "~/..."` — the
+  form the README documents — was kept literally by `PathBuf` and resolved to a
+  directory named `~` relative to the working directory. Applies to
+  `[anthropic] credentials_path`, `[openai] codex_auth_path` and every
+  `[[anthropic.accounts]]` entry. `~user` is left untouched.
+
 - **macOS: a locked Keychain is no longer reported as "not logged in".**
   `keychain::read_raw` mapped *every* `security(1)` failure to "no item",
   so a locked login Keychain, a denied ACL, or an operational error all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Each release is also published at
 
 ### Fixed
 
+- **Switching vendors no longer leaves the previous vendor's numbers on the
+  desktop bars.** GNOME dropped any refresh requested while one was in flight,
+  so a vendor change during a fetch never started one for the new vendor: the
+  old vendor's result was applied and stayed until the next timer tick. The
+  request is now queued and run when the current attempt settles, and a result
+  is discarded if it has been superseded or if the selection changed while it
+  ran. The macOS menu bar had no such protection at all — the timer, the
+  Preferences window and a vendor change could each start a subprocess, and
+  whichever finished last won. It now runs at most one at a time, tags each
+  attempt with a generation, and ignores stale results. macOS also gains a
+  45-second watchdog: the subprocess can block on the cache lock and then
+  refresh OAuth, and without a bound a hung run left the panel frozen with no
+  explanation.
+
 - **The config file is found at one agreed location on every platform.** The
   binary resolved it through `directories::ProjectDirs` (macOS:
   `~/Library/Application Support/ai-usagebar/`), while the README, the shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,27 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Changed
+
+- **A misspelled config *section* is now an error instead of being ignored.**
+  `[openrouer]` used to parse cleanly, leave OpenRouter on its defaults, and
+  give no hint that the section had been dropped. `Config` denies unknown
+  top-level keys. This is deliberately section-level only: the set of sections
+  is small and stable, whereas denying unknown keys inside every section would
+  hard-fail configs carrying a field from a future or removed version.
+
 ### Fixed
+
+- **An invalid config is no longer silently replaced by the defaults.** Every
+  caller used `Config::load().unwrap_or_default()`, so a TOML syntax error, a
+  permission problem, or a failed validation produced the default vendor set
+  with no diagnostic — the user saw the wrong tabs and credentials and had
+  nothing to go on. The widget now reports it through the existing `⚠` fallback
+  (still exiting 0, as Waybar requires), the TUI prints the path and the parse
+  error *before* entering raw mode, in-session reloads keep the last good
+  config instead of reverting to defaults, and `--cycle-next/--cycle-prev` does
+  nothing rather than persisting a selection derived from the wrong vendor set.
+  A missing file remains the legitimate "use defaults" case.
 
 - **Cached data is no longer served forever after a failure.** `MAX_STALE`
   (7 days) was declared but never referenced, so every vendor's fallback path

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Each release is also published at
 
 ## [Unreleased]
 
+### CI
+
+- **PRs are now gated on Linux — the platform the widget actually ships on.**
+  Only Windows ran on pull requests; Linux was first exercised *after* a tag
+  was pushed, by which point the tag is immutable and any failure costs a new
+  patch release. The Linux job also runs `cargo fmt --check`, `cargo clippy
+  --all-targets -- -D warnings` and `cargo machete`, none of which ran in CI at
+  all. A macOS job runs the test suite and compiles the menu bar app, whose
+  700+ lines of Swift nothing verified.
+
+- **A release can no longer publish artifacts that disagree with its tag.** A
+  new `verify-version` job — which every downstream job depends on — requires
+  the tag to be an existing `vX.Y.Z`, and `Cargo.toml`, both PKGBUILDs, both
+  `.SRCINFO`s and a `CHANGELOG.md` section to match it. This is not
+  hypothetical: at the v0.13.0 tag both `.SRCINFO` files still declared
+  `0.8.0`, and the release shipped anyway. `workflow_dispatch` also stops
+  accepting an arbitrary commit — it must name a tag that exists — and
+  `contents: write` is now scoped to the single job that publishes rather than
+  granted to the whole workflow.
+
 ### Changed
 
 - **A misspelled config *section* is now an error instead of being ignored.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- **Cached data is no longer served forever after a failure.** `MAX_STALE`
+  (7 days) was declared but never referenced, so every vendor's fallback path
+  called `maybe_payload()` with no age limit: after weeks without network or
+  credentials the bar kept showing historical numbers as if they were current,
+  distinguished only by a `⏸` and an old timestamp. Failure paths now use the
+  new `Cache::fallback_payload(MAX_STALE)` and surface the real error once the
+  last good value ages out.
+
+- **A corrupt or incompatible *fresh* cache no longer renders as a zeroed
+  snapshot.** Anthropic, OpenAI, Z.AI, OpenRouter and DeepSeek turned an
+  unparseable payload into "$0.00" / "0%" / "Unknown plan" and displayed it as
+  current data; they now fall through to a live fetch, matching what Kimi
+  already did. Cached monetary fields are required rather than
+  `unwrap_or(0.0)`, so a truncated write is refetched instead of shown as an
+  empty balance.
+
+- **Z.AI no longer accepts an in-band failure as valid usage.** The API signals
+  errors inside HTTP 200 (`success: false`, non-200 `code`, `data: null`).
+  That body deserialized cleanly, was written to the cache — clearing the
+  previously recorded error — and rendered as an unknown plan with empty
+  windows, indistinguishable from an account with no usage. The envelope is now
+  validated before anything is cached, so a failure keeps the last good payload
+  and reports the error.
+
 ## [0.13.0] — 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@ Each release is also published at
 
 ### Fixed
 
+- **macOS: a locked Keychain is no longer reported as "not logged in".**
+  `keychain::read_raw` mapped *every* `security(1)` failure to "no item",
+  so a locked login Keychain, a denied ACL, or an operational error all
+  produced the friendly "run `claude` to authenticate" message while the
+  credentials sat there intact. Only `errSecItemNotFound` (44) now means
+  absent; anything else surfaces with the exit code, `security`'s own stderr,
+  and what to do about it — and it takes precedence over the file's error,
+  since it is the more actionable one.
+
+- **macOS: a refresh can no longer create a second, unreadable Keychain item.**
+  With `$USER` unset the read selected by service alone while the write passed
+  `-a ""`, so the two no longer addressed the same item. Both now use the same
+  selection.
+
 - **The TUI no longer freezes while a cache lock is contended.** `acquire_lock`
   parks the thread in a sleep loop for up to 15–45s, and the TUI runs on a
   current-thread runtime — so a lock held by a concurrent widget invocation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ Each release is also published at
 
 ### Fixed
 
+- **The TUI no longer freezes while a cache lock is contended.** `acquire_lock`
+  parks the thread in a sleep loop for up to 15–45s, and the TUI runs on a
+  current-thread runtime — so a lock held by a concurrent widget invocation
+  stalled keyboard input, the refresh timer and every other vendor's request at
+  once. Adds `Cache::acquire_lock_async`, which waits on the blocking pool, and
+  routes every vendor through it.
+
+- **The TUI no longer leaks a blocking task per event-loop iteration.** A fresh
+  `spawn_blocking(event::poll)` was created on every `select!`; whenever another
+  branch won, the previous one kept running, so several orphaned pollers raced
+  on `event::read()` and could swallow keypresses. A single reader thread now
+  feeds keys through a channel.
+
+- **The terminal is restored even when the TUI exits through an error or a
+  panic.** Raw mode, the alternate screen and the cursor are now owned by an
+  RAII guard rather than undone by straight-line code after the event loop,
+  which was skipped entirely on any early return.
+
 - **A rotated OAuth refresh token is no longer lost silently.** Both Anthropic
   and OpenAI persisted refreshed credentials with `let _ = write_back(...)`.
   When the server rotates the refresh token and that write fails, the old token

--- a/gnome-extension/extension.js
+++ b/gnome-extension/extension.js
@@ -59,6 +59,8 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         this._openPrefs = openPrefs;
         this._data = null;          // parsed snapshot for redraws
         this._busy = false;
+        // A refresh asked for while one was in flight, to run once it settles.
+        this._refreshPending = false;
         this._timer = 0;
         this._refreshTimeoutId = 0;
         this._refreshCancellable = null;
@@ -179,12 +181,22 @@ class AiUsageBarIndicator extends PanelMenu.Button {
     }
 
     _refresh() {
-        if (this._busy)
+        // Dropping the request while busy meant a vendor change *during* a
+        // fetch never started one for the new vendor: the in-flight result for
+        // the OLD vendor was applied and stayed on the panel until the next
+        // timer tick. Remember that a refresh was asked for and run it as soon
+        // as the current one settles.
+        if (this._busy) {
+            this._refreshPending = true;
             return;
+        }
         this._busy = true;
         const token = ++this._refreshToken;
 
         const bin = resolveBinary(this._settings);
+        // Captured for THIS attempt: the setting can change while we wait, and
+        // a late result must not be rendered as if it belonged to the vendor
+        // now selected.
         const vendor = this._settings.get_string('vendor') || 'anthropic';
         const argv = [bin, '--vendor', vendor, '--format', FORMAT];
         const cancellable = new Gio.Cancellable();
@@ -200,6 +212,7 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         } catch (e) {
             this._busy = false;
             this._refreshCancellable = null;
+            this._refreshPending = false;
             this._setError(`não consegui executar "${bin}"`, String(e));
             return;
         }
@@ -217,6 +230,11 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             if (this._refreshToken === token) {
                 this._busy = false;
                 this._setError('ai-usagebar demorou demais', `timeout após ${REFRESH_TIMEOUT_SECS}s`);
+                // Do not strand a request that arrived while this one hung.
+                if (this._refreshPending) {
+                    this._refreshPending = false;
+                    this._refresh();
+                }
             }
             return GLib.SOURCE_REMOVE;
         });
@@ -234,12 +252,21 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         };
 
         proc.communicate_utf8_async(null, cancellable, (p, res) => {
-            if (this._refreshToken === token)
+            const current = this._refreshToken === token;
+            if (current)
                 this._busy = false;
             try {
                 const [, out, err] = p.communicate_utf8_finish(res);
                 cleanup();
                 if (timedOut)
+                    return;
+                // A superseded attempt must not paint the panel: its numbers
+                // belong to whatever vendor was selected when it started.
+                if (!current)
+                    return;
+                // The selection may have changed while this ran even without a
+                // newer attempt (the change is queued as `_refreshPending`).
+                if ((this._settings.get_string('vendor') || 'anthropic') !== vendor)
                     return;
                 if ((!out || !out.trim()) && !p.get_successful()) {
                     this._setError('ai-usagebar falhou', err || '');
@@ -248,9 +275,15 @@ class AiUsageBarIndicator extends PanelMenu.Button {
                 this._consume(out || '');
             } catch (e) {
                 cleanup();
-                if (!(e instanceof GLib.Error &&
+                if (current && !(e instanceof GLib.Error &&
                       e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) && !timedOut)
                     this._setError('erro ao ler a saída', String(e));
+            } finally {
+                // Run whatever was requested while we were busy.
+                if (current && this._refreshPending) {
+                    this._refreshPending = false;
+                    this._refresh();
+                }
             }
         });
     }

--- a/gnome-extension/prefs.js
+++ b/gnome-extension/prefs.js
@@ -17,9 +17,21 @@ const VENDOR_AUTH = [
     {id: 'deepseek', name: 'DeepSeek', kind: 'apikey', env: 'DEEPSEEK_API_KEY'},
 ];
 
-// Does ~/.config/ai-usagebar/config.toml have an uncommented api_key in [section]?
+// The config file the Rust binary would actually read. It resolves the
+// platform config dir, which honors $XDG_CONFIG_HOME — hard-coding
+// ~/.config meant a user with XDG_CONFIG_HOME set saw "no key configured"
+// for keys that were configured. Falls back to the legacy path so a config
+// written before this is still found.
+function configPath() {
+    const xdg = `${GLib.get_user_config_dir()}/ai-usagebar/config.toml`;
+    if (GLib.file_test(xdg, GLib.FileTest.EXISTS))
+        return xdg;
+    return `${GLib.get_home_dir()}/.config/ai-usagebar/config.toml`;
+}
+
+// Does the config have an uncommented api_key in [section]?
 function configHasApiKey(section) {
-    const path = `${GLib.get_home_dir()}/.config/ai-usagebar/config.toml`;
+    const path = configPath();
     if (!GLib.file_test(path, GLib.FileTest.EXISTS))
         return false;
     try {

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -276,8 +276,19 @@ let VENDOR_AUTH: [VendorAuth] = [
     VendorAuth(id: "deepseek", name: "DeepSeek", kind: "apikey", cli: "", login: "", pkg: "", env: "DEEPSEEK_API_KEY"),
 ]
 
+// The config file the Rust binary would actually read. On macOS
+// `directories::ProjectDirs` resolves to ~/Library/Application Support, so
+// checking only ~/.config reported "no key configured" for a key the binary
+// was happily using. Prefer the canonical location, fall back to the legacy
+// Unix path the docs have always shown (the binary accepts both).
+func configPathTOML() -> String {
+    let appSupport = "\(NSHomeDirectory())/Library/Application Support/ai-usagebar/config.toml"
+    if FileManager.default.fileExists(atPath: appSupport) { return appSupport }
+    return "\(NSHomeDirectory())/.config/ai-usagebar/config.toml"
+}
+
 func configHasApiKeyTOML(_ section: String) -> Bool {
-    let path = "\(NSHomeDirectory())/.config/ai-usagebar/config.toml"
+    let path = configPathTOML()
     guard let text = try? String(contentsOfFile: path, encoding: .utf8) else { return false }
     var inSection = false
     for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -41,6 +41,11 @@ let SETTINGS_DEFAULTS: [String: Any] = [
 
 var VENDOR: String { DEF.string(forKey: "vendor") ?? "anthropic" }
 var INTERVAL: Double { let v = DEF.double(forKey: "interval"); return v > 0 ? v : 30 }
+/// Upper bound on one `ai-usagebar` invocation. It can block on the cache
+/// flock (up to 15s) and then refresh OAuth over the network, so without a
+/// bound a hung run holds a worker indefinitely and the panel simply stops
+/// updating with no explanation. Matches the GNOME extension's own timeout.
+let REFRESH_TIMEOUT: Double = 45
 var BAR_WIDTH: Int { max(4, min(20, DEF.integer(forKey: "barWidth"))) }
 let MENU_BAR_W = 14
 var SHOW_SESSION: Bool { DEF.bool(forKey: "showSession") }
@@ -528,6 +533,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var prefsHost: NSHostingController<SettingsView>?
     var lastSnapshot: Snapshot?
     var pendingRefresh: DispatchWorkItem?
+    /// Bumped on every refresh attempt. A result whose generation is no longer
+    /// current belongs to a superseded attempt — most often the previously
+    /// selected vendor — and must not be rendered. Without this, the timer,
+    /// the Preferences window and a vendor change could each start their own
+    /// subprocess and whichever finished last won, regardless of what the user
+    /// had actually selected. Main-thread only.
+    var refreshGeneration: Int = 0
+    /// At most one subprocess in flight; a request arriving while one runs is
+    /// coalesced rather than stacked.
+    var refreshInFlight = false
+    var refreshQueued = false
     let headerItem = NSMenuItem()
     var rows: [String: NSMenuItem] = [:]
 
@@ -630,13 +646,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setError("ai-usagebar não encontrado (PATH / ~/.cargo/bin / homebrew)")
             return
         }
+        // Coalesce: one subprocess at a time, and remember that another was
+        // asked for so a vendor change during a fetch is not simply dropped.
+        if refreshInFlight {
+            refreshQueued = true
+            return
+        }
+        refreshInFlight = true
+        refreshGeneration += 1
+        let generation = refreshGeneration
+        // Captured for THIS attempt: reading `VENDOR` again on completion would
+        // label a late result with whatever is selected by then.
+        let vendor = VENDOR
+
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let p = Process()
             p.executableURL = URL(fileURLWithPath: bin)
-            p.arguments = ["--vendor", VENDOR, "--format", FORMAT_WITH_SENTINEL]
+            p.arguments = ["--vendor", vendor, "--format", FORMAT_WITH_SENTINEL]
             let pipe = Pipe()
             p.standardOutput = pipe
             p.standardError = FileHandle.nullDevice
+
+            // The subprocess takes the cache lock and may refresh OAuth over
+            // the network; without a bound it can hold this worker for a very
+            // long time. Kill it and report instead of hanging silently.
+            let watchdog = DispatchWorkItem { if p.isRunning { p.terminate() } }
+            DispatchQueue.global(qos: .utility)
+                .asyncAfter(deadline: .now() + REFRESH_TIMEOUT, execute: watchdog)
+
             var out = ""
             do {
                 try p.run()
@@ -644,10 +681,39 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 p.waitUntilExit()
                 out = String(data: data, encoding: .utf8) ?? ""
             } catch {
-                DispatchQueue.main.async { self?.setError("falha ao executar ai-usagebar") }
+                watchdog.cancel()
+                DispatchQueue.main.async {
+                    self?.finishRefresh(generation) { $0.setError("falha ao executar ai-usagebar") }
+                }
                 return
             }
-            DispatchQueue.main.async { self?.consume(out) }
+            watchdog.cancel()
+            let timedOut = out.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            DispatchQueue.main.async {
+                self?.finishRefresh(generation) { me in
+                    // Selection may have changed while this ran.
+                    guard vendor == VENDOR else { return }
+                    if timedOut {
+                        me.setError("ai-usagebar demorou demais (>\(Int(REFRESH_TIMEOUT))s)")
+                    } else {
+                        me.consume(out)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Applies `body` only when `generation` is still the current attempt, then
+    /// releases the in-flight slot and runs any request that arrived meanwhile.
+    private func finishRefresh(_ generation: Int, _ body: (AppDelegate) -> Void) {
+        let current = generation == refreshGeneration
+        if current {
+            refreshInFlight = false
+            body(self)
+        }
+        if current && refreshQueued {
+            refreshQueued = false
+            refresh()
         }
     }
 

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -190,9 +190,15 @@ pub fn resolve(target: &CredsTarget) -> Result<(CredentialsFile, CredsSource)> {
 /// | missing             | usable          | keychain                   |
 /// | missing             | absent          | original I/O error         |
 /// | unusable (#15)      | usable          | keychain                   |
-/// | unusable (#15)      | absent/broken   | file result, unchanged     |
+/// | unusable (#15)      | absent          | file result, unchanged     |
 /// | unparsable JSON     | usable          | keychain                   |
-/// | unparsable JSON     | absent/broken   | original parse error       |
+/// | unparsable JSON     | absent          | original parse error       |
+/// | any                 | **unreadable**  | the Keychain error         |
+///
+/// The last row matters: a *locked* login Keychain or a denied ACL is not the
+/// same as "no credentials". Reporting it as absent surfaced a "run `claude`"
+/// message and sent users to re-authenticate while their credentials were
+/// sitting there intact, so that failure now wins over the file's own error.
 ///
 /// *usable file short-circuits — no `security(1)` subprocess on the happy path.
 fn read_default_with(
@@ -431,6 +437,24 @@ mod tests {
         let path = dir.path().join("missing.json");
         let err = read_default_with(&path, || Ok(None)).unwrap_err();
         assert!(matches!(err, AppError::Io { .. }));
+    }
+
+    #[test]
+    fn a_locked_keychain_wins_over_the_file_missing_error() {
+        // The regression this guards: `read_raw` mapped *every* `security`
+        // failure to Ok(None), so a locked login Keychain looked identical to
+        // "not logged in" and the user was told to run `claude` while their
+        // credentials sat there intact.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        let err = read_default_with(&path, || {
+            Err(AppError::Credentials("the Keychain is locked".into()))
+        })
+        .unwrap_err();
+        assert!(
+            matches!(err, AppError::Credentials(ref m) if m.contains("locked")),
+            "expected the Keychain error to surface, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::AnthropicSnapshot;
 
@@ -64,7 +64,7 @@ pub async fn fetch_snapshot(
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
-    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
     // Fast path: cache is fresh, no work needed. We still need creds for the
     // plan label though, so read them either way. `resolve` also reports where

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -73,8 +73,12 @@ pub async fn fetch_snapshot(
     let (mut creds, creds_source) = creds::resolve(creds_target)?;
     let plan_label = creds.claude_ai_oauth.plan_label();
 
-    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
-        return Ok(reuse_cache(bytes, plan_label, cache, false));
+    // Corrupt fresh cache falls through to a live fetch rather than returning
+    // an all-zero snapshot labelled "Unknown".
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse_cache(bytes, plan_label.clone(), cache, false)
+    {
+        return Ok(outcome);
     }
 
     // Maybe refresh.
@@ -179,15 +183,19 @@ pub async fn fetch_snapshot(
     }
 }
 
-fn reuse_cache(bytes: Vec<u8>, plan_label: String, cache: &Cache, stale: bool) -> FetchOutcome {
-    let snap =
-        parse_payload(&bytes, plan_label).unwrap_or_else(|_| empty_snapshot("Unknown".into()));
-    FetchOutcome {
+fn reuse_cache(
+    bytes: Vec<u8>,
+    plan_label: String,
+    cache: &Cache,
+    stale: bool,
+) -> Result<FetchOutcome> {
+    let snap = parse_payload(&bytes, plan_label)?;
+    Ok(FetchOutcome {
         snapshot: snap,
         stale,
         last_error: cache.read_last_error(),
         cache_age: cache.payload_age(),
-    }
+    })
 }
 
 fn fallback_to_cache(
@@ -246,10 +254,6 @@ fn handle_auth_failure(cache: &Cache, plan_label: String, transient: bool) -> Re
 fn parse_payload(bytes: &[u8], plan_label: String) -> Result<AnthropicSnapshot> {
     let resp: UsageResponse = serde_json::from_slice(bytes)?;
     Ok(resp.into_snapshot(plan_label))
-}
-
-fn empty_snapshot(plan_label: String) -> AnthropicSnapshot {
-    UsageResponse::default().into_snapshot(plan_label)
 }
 
 async fn fetch_usage(client: &reqwest::Client, url: &str, creds: &OauthCreds) -> Result<Vec<u8>> {
@@ -328,6 +332,43 @@ mod tests {
         let cache = Cache::at(td.path().join("anthropic"));
         cache.ensure_dir().unwrap();
         (td, cache)
+    }
+
+    #[tokio::test]
+    async fn corrupt_fresh_cache_refetches_instead_of_showing_unknown() {
+        // `reuse_cache` used to swallow a parse failure into an all-zero
+        // snapshot labelled "Unknown" and serve it for the rest of the TTL —
+        // a fabricated reading presented as current.
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/api/oauth/usage")
+            .with_status(200)
+            .with_body(r#"{"five_hour":{"utilization":42},"seven_day":{"utilization":15}}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        cache.write_payload(b"{ truncated").unwrap();
+
+        let creds = future_creds();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            usage: format!("{}/api/oauth/usage", server.url()),
+            token: format!("{}/token", server.url()),
+        };
+        // A long TTL: the payload IS fresh, it is simply unusable.
+        let outcome = fetch_snapshot(
+            &client,
+            &creds::CredsTarget::Explicit(creds.path().to_path_buf()),
+            &cache,
+            &endpoints,
+            Duration::from_secs(3600),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outcome.snapshot.session.utilization_pct, 42);
+        assert_ne!(outcome.snapshot.plan, "Unknown");
+        assert!(!outcome.stale);
     }
 
     #[tokio::test]

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 
-use crate::cache::{Cache, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock};
 use crate::error::{AppError, Result};
 use crate::usage::AnthropicSnapshot;
 
@@ -180,7 +180,7 @@ fn fallback_to_cache(
     plan_label: String,
     last_error: Option<(u16, String)>,
 ) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Other("no usable cache".into()));
     };
     let snap = parse_payload(&bytes, plan_label)?;
@@ -193,7 +193,7 @@ fn fallback_to_cache(
 }
 
 fn fallback_to_cache_silent(cache: &Cache, plan_label: String) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Transport(
             "no cache and network unreachable".into(),
         ));
@@ -208,7 +208,7 @@ fn fallback_to_cache_silent(cache: &Cache, plan_label: String) -> Result<FetchOu
 }
 
 fn handle_auth_failure(cache: &Cache, plan_label: String, transient: bool) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return if transient {
             Err(AppError::Transport(
                 "no cache and refresh failed transiently".into(),

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -103,14 +103,29 @@ pub async fn fetch_snapshot(
         {
             Ok(Ok(rr)) => {
                 creds.claude_ai_oauth.access_token = rr.access_token;
+                // A rotated refresh token exists *only* in memory until it is
+                // persisted. If the server rotated it and the write-back fails,
+                // the old token on disk is already spent: the next run cannot
+                // refresh and the user is silently logged out. That is a hard
+                // failure, not a best-effort detail.
+                let rotated = rr.refresh_token.is_some();
                 if let Some(new_rt) = rr.refresh_token {
                     creds.claude_ai_oauth.refresh_token = new_rt;
                 }
                 creds.claude_ai_oauth.expires_at_ms =
                     Utc::now().timestamp_millis() + (rr.expires_in as i64) * 1000;
-                // Best-effort persist; the refresh worked, so callers should
-                // still see fresh data even if writing the creds back failed.
-                let _ = creds::write_back_to(&creds_source, &creds.claude_ai_oauth);
+                // When only the access token changed, a failed write loses
+                // nothing — the next run just refreshes again — so carry on.
+                if let Err(e) = creds::write_back_to(&creds_source, &creds.claude_ai_oauth)
+                    && rotated
+                {
+                    let msg = format!(
+                        "refreshed token could not be saved ({e}); the rotated \
+                         refresh token is lost — re-run `claude` to log in again"
+                    );
+                    cache.write_last_error(0, &msg);
+                    return handle_auth_failure(cache, plan_label, false);
+                }
             }
             Ok(Err(AppError::Http { status, body })) => {
                 cache.write_last_error(status, &body);

--- a/src/anthropic/keychain.rs
+++ b/src/anthropic/keychain.rs
@@ -20,20 +20,29 @@ const SERVICE: &str = "Claude Code-credentials";
 
 /// The Keychain item's *account* is the macOS short username. We match on it
 /// when updating so we touch exactly the item Claude Code created.
-fn account() -> String {
-    std::env::var("USER").unwrap_or_default()
+///
+/// `None` when `$USER` is unset or empty: read and write must then agree to
+/// select by service alone. Previously the read omitted `-a` while the write
+/// passed `-a ""`, so a refresh could create a *second*, empty-account item
+/// that the read would never find again.
+fn account() -> Option<String> {
+    std::env::var("USER").ok().filter(|u| !u.is_empty())
 }
+
+/// `security` exits with the raw OSStatus. 44 is `errSecItemNotFound`.
+const ERR_SEC_ITEM_NOT_FOUND: i32 = 44;
 
 /// Read the raw credentials JSON from the login Keychain.
 ///
-/// Returns `Ok(None)` when no such item exists (so callers can fall through to
-/// the file path / a "run `claude`" error), and `Err` only on an unexpected
-/// `security` failure.
+/// Returns `Ok(None)` only when the item genuinely does not exist, so callers
+/// can fall through to the file path / a "run `claude`" error. Every other
+/// `security` failure is an `Err`: a locked Keychain or a denied ACL is not the
+/// same as "you are not logged in", and reporting it as such sent users off to
+/// re-authenticate when the credentials were there all along.
 pub fn read_raw() -> Result<Option<String>> {
     let mut cmd = Command::new("/usr/bin/security");
     cmd.args(["find-generic-password", "-s", SERVICE, "-w"]);
-    let acct = account();
-    if !acct.is_empty() {
+    if let Some(acct) = account() {
         cmd.args(["-a", &acct]);
     }
 
@@ -42,10 +51,22 @@ pub fn read_raw() -> Result<Option<String>> {
         .map_err(|e| AppError::Other(format!("could not run `security`: {e}")))?;
 
     if !out.status.success() {
-        // `security` exits 44 (errSecItemNotFound) when the item is absent.
-        // Treat any non-success as "not in Keychain" — never a hard error,
-        // so the caller can still surface the friendlier file-missing message.
-        return Ok(None);
+        if out.status.code() == Some(ERR_SEC_ITEM_NOT_FOUND) {
+            return Ok(None);
+        }
+        let detail = String::from_utf8_lossy(&out.stderr);
+        let detail = detail.trim();
+        return Err(AppError::Credentials(format!(
+            "could not read the Claude credentials from the macOS Keychain \
+             (security exited {}): {}. If the login Keychain is locked, unlock \
+             it and retry; if access was denied, allow ai-usagebar when prompted.",
+            out.status.code().unwrap_or(-1),
+            if detail.is_empty() {
+                "no detail"
+            } else {
+                detail
+            }
+        )));
     }
 
     let value = String::from_utf8(out.stdout)
@@ -68,25 +89,32 @@ pub fn read_raw() -> Result<Option<String>> {
 /// rare proactive token refresh, so we accept the local-only exposure of a
 /// secret that already lives in this user's Keychain.
 pub fn write_raw(json: &str) -> Result<()> {
-    let status = Command::new("/usr/bin/security")
-        .args([
-            "add-generic-password",
-            "-U",
-            "-s",
-            SERVICE,
-            "-a",
-            &account(),
-            "-w",
-            json,
-        ])
-        .status()
+    let mut cmd = Command::new("/usr/bin/security");
+    cmd.args(["add-generic-password", "-U", "-s", SERVICE]);
+    // Must mirror `read_raw`'s selection exactly, or an update can create a
+    // second item the read will never find.
+    if let Some(acct) = account() {
+        cmd.args(["-a", &acct]);
+    }
+    cmd.args(["-w", json]);
+
+    let out = cmd
+        .output()
         .map_err(|e| AppError::Other(format!("could not run `security`: {e}")))?;
 
-    if status.success() {
-        Ok(())
-    } else {
-        Err(AppError::Other(
-            "failed to update Claude credentials in the macOS Keychain".into(),
-        ))
+    if out.status.success() {
+        return Ok(());
     }
+    let detail = String::from_utf8_lossy(&out.stderr);
+    let detail = detail.trim();
+    Err(AppError::Credentials(format!(
+        "failed to update the Claude credentials in the macOS Keychain \
+         (security exited {}): {}",
+        out.status.code().unwrap_or(-1),
+        if detail.is_empty() {
+            "no detail"
+        } else {
+            detail
+        }
+    )))
 }

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -38,7 +38,15 @@ async fn main() {
 }
 
 async fn run() -> io::Result<()> {
-    let mut config = Config::load().unwrap_or_default();
+    // Report a broken config instead of silently starting on defaults, and do
+    // it before raw mode so the message is actually readable.
+    let mut config = Config::load().map_err(|e| {
+        io::Error::other(format!(
+            "{} could not be loaded: {e}\n\
+             Fix the file (or move it aside) and try again.",
+            ai_usagebar::config::config_path_hint()
+        ))
+    })?;
     let tabs = tabs_from_config(&config);
     if tabs.is_empty() {
         eprintln!(
@@ -133,7 +141,12 @@ where
                                 // while the TUI was open appear without a
                                 // restart, and queue an immediate refresh of
                                 // every tab so newly-set API keys are picked up.
-                                *config = ai_usagebar::config::Config::load().unwrap_or_default();
+                                // Keep the config we already have if the reload
+                                // fails — reverting to defaults would silently
+                                // drop the user's real settings mid-session.
+                                if let Ok(reloaded) = ai_usagebar::config::Config::load() {
+                                    *config = reloaded;
+                                }
                                 app.set_tabs(tabs_from_config(config));
                                 app.select_primary(config.ui.primary);
                                 spawn_all(app, client, config, &tx);
@@ -143,7 +156,10 @@ where
                     }
                     // Normal key handling (settings closed).
                     if matches!(k.code, KeyCode::Char('s')) {
-                        let cfg = ai_usagebar::config::Config::load().unwrap_or_default();
+                        // Prefer the file (it may have changed on disk), but fall
+                        // back to the config in memory rather than to defaults.
+                        let cfg = ai_usagebar::config::Config::load()
+                            .unwrap_or_else(|_| config.clone());
                         app.settings = Some(
                             ai_usagebar::tui::settings::SettingsState::from_config(&cfg),
                         );

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -9,7 +9,6 @@
 //!   q / Esc / Ctrl-C   quit
 
 use std::io;
-use std::time::Duration;
 
 use ai_usagebar::config::Config;
 use ai_usagebar::tui::app::{
@@ -63,22 +62,44 @@ async fn run() -> io::Result<()> {
 
     let mut app = App::new_with_primary(tabs, config.ui.primary);
 
-    enable_raw_mode()?;
-    let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+    // RAII: restoring the terminal must survive an error or a panic in the
+    // loop below. Doing it inline left the user in raw mode on the alternate
+    // screen with no cursor whenever anything went wrong.
+    let _guard = TerminalGuard::enter()?;
+    let backend = CrosstermBackend::new(io::stdout());
     let mut terminal = Terminal::new(backend)?;
 
-    let res = event_loop(&mut terminal, &mut app, &client, &mut config).await;
+    event_loop(&mut terminal, &mut app, &client, &mut config).await
+}
 
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-    res
+/// Owns the terminal mode changes and undoes them on drop, in reverse order.
+struct TerminalGuard;
+
+impl TerminalGuard {
+    fn enter() -> io::Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        if let Err(e) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
+            // Do not leave raw mode enabled if only half the setup succeeded.
+            let _ = disable_raw_mode();
+            return Err(e);
+        }
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        // Best-effort: we are often unwinding, so there is nowhere to report.
+        let mut stdout = io::stdout();
+        let _ = execute!(
+            stdout,
+            LeaveAlternateScreen,
+            DisableMouseCapture,
+            ratatui::crossterm::cursor::Show
+        );
+        let _ = disable_raw_mode();
+    }
 }
 
 async fn event_loop<B: ratatui::backend::Backend>(
@@ -93,6 +114,29 @@ where
     // Kick off initial fetches for every vendor in parallel.
     let (tx, mut rx) = mpsc::unbounded_channel::<(u64, TabId, TabState)>();
     spawn_all(app, client, config, &tx);
+
+    // ONE reader thread for the whole session. Spawning a fresh
+    // `spawn_blocking(event::poll)` on every `select!` iteration leaked a
+    // blocking task each time another branch won: those tasks kept running and
+    // raced each other on `event::read()`, so keypresses could be consumed by
+    // an orphan and lost. A dedicated thread also means a slow branch can never
+    // delay input.
+    let (key_tx, mut key_rx) = mpsc::unbounded_channel::<event::KeyEvent>();
+    std::thread::spawn(move || {
+        loop {
+            // A blocking read is fine here: this thread does nothing else, and
+            // the channel send wakes the runtime.
+            match event::read() {
+                Ok(Event::Key(k)) => {
+                    if key_tx.send(k).is_err() {
+                        return; // receiver gone: the TUI is shutting down.
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => return,
+            }
+        }
+    });
 
     let mut tick = tokio::time::interval(REFRESH_INTERVAL);
     tick.tick().await; // consume the immediate tick.
@@ -110,12 +154,11 @@ where
             _ = tick.tick() => {
                 spawn_all(app, client, config, &tx);
             }
-            // Keyboard events. Poll with a small budget so the select wakes
-            // up promptly when nothing else is going on.
-            res = tokio::task::spawn_blocking(|| event::poll(Duration::from_millis(150))) => {
-                let polled = res.unwrap_or(Ok(false)).unwrap_or(false);
-                if polled
-                    && let Ok(Event::Key(k)) = event::read()
+            // Keyboard events, delivered by the single reader thread.
+            maybe_key = key_rx.recv() => {
+                let Some(k) = maybe_key else {
+                    return Ok(()); // reader thread ended: stdin closed.
+                };
                 {
                     // On Windows Terminal (and terminals advertising the
                     // Kitty keyboard protocol) crossterm reports key Repeat

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -198,6 +198,20 @@ impl Cache {
 ///
 /// The flock file is created if missing, but its content is unused — only
 /// the lock matters.
+/// Async wrapper around [`acquire_lock`].
+///
+/// The blocking version parks the calling thread in a sleep loop for up to
+/// `timeout`. On a current-thread runtime — which is what the TUI uses — that
+/// stalls *everything*: keyboard input, the refresh timer, and every other
+/// vendor's in-flight request. Running the wait on the blocking pool keeps the
+/// reactor free while a contended lock is waited on.
+pub async fn acquire_lock_async(path: &Path, timeout: Duration) -> Result<LockGuard> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || acquire_lock(&path, timeout))
+        .await
+        .map_err(|e| AppError::Other(format!("cache lock task failed: {e}")))?
+}
+
 pub fn acquire_lock(path: &Path, timeout: Duration) -> Result<LockGuard> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| AppError::io_at(parent, e))?;
@@ -422,6 +436,44 @@ mod tests {
 
         let res = acquire_lock(&lock_path, Duration::from_millis(100));
         assert!(matches!(res, Err(AppError::Other(_))));
+    }
+
+    /// The regression this guards: `acquire_lock` parks the thread in a sleep
+    /// loop, so on the TUI's current-thread runtime a contended lock froze
+    /// keyboard input, the refresh timer and every other vendor's fetch until
+    /// it timed out. `acquire_lock_async` moves the wait to the blocking pool,
+    /// so unrelated timers must keep firing while the lock is held elsewhere.
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_lock_does_not_stall_the_runtime() {
+        let (_td, cache) = fixture();
+        let lock_path = cache.lock_path();
+        let _held = acquire_lock(&lock_path, Duration::from_millis(500)).unwrap();
+
+        // This will wait the full timeout — it can never win the lock.
+        let waiter = acquire_lock_async(&lock_path, Duration::from_millis(400));
+
+        // Meanwhile the runtime must still be able to make progress.
+        let mut ticks = 0usize;
+        let ticker = async {
+            let mut iv = tokio::time::interval(Duration::from_millis(20));
+            iv.tick().await;
+            loop {
+                iv.tick().await;
+                ticks += 1;
+            }
+        };
+
+        tokio::select! {
+            res = waiter => {
+                // The lock attempt is expected to time out.
+                assert!(matches!(res, Err(AppError::Other(_))));
+            }
+            _ = ticker => unreachable!("the ticker loops forever"),
+        }
+        assert!(
+            ticks > 1,
+            "runtime was starved while the lock was contended ({ticks} ticks)"
+        );
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -381,30 +381,36 @@ mod tests {
     }
 
     #[test]
-    fn fallback_payload_refuses_a_payload_older_than_max_stale() {
-        use std::time::SystemTime;
-
+    fn fallback_payload_refuses_a_payload_older_than_the_limit() {
         let (_td, cache) = fixture();
         cache.write_payload(b"old").unwrap();
 
-        // Backdate the payload past the limit. `MAX_STALE` was dead code
-        // before this: every failure path served history forever.
-        let eight_days_ago = SystemTime::now() - Duration::from_secs(8 * 24 * 3600);
-        let f = File::options()
-            .write(true)
-            .open(cache.payload_path())
-            .unwrap();
-        f.set_modified(eight_days_ago).unwrap();
+        // Let the payload acquire real age rather than rewriting its mtime:
+        // Windows denies reopening the just-persisted file for an attribute
+        // write, and the boundary being tested is the same either way. The
+        // margin is ~12x the threshold so filesystem timestamp granularity
+        // cannot make this flaky.
+        std::thread::sleep(Duration::from_millis(60));
 
-        // Still readable when age is not considered...
+        // Still readable when age is not considered — `maybe_payload` is the
+        // unbounded reader, which is exactly why failure paths must not use it.
         assert!(cache.maybe_payload().unwrap().is_some());
-        // ...but refused as a fallback.
-        assert!(cache.fallback_payload(MAX_STALE).unwrap().is_none());
-        // A payload inside the window is still served.
-        cache.write_payload(b"new").unwrap();
+
+        // Past the limit, the failure path gets nothing and the caller has to
+        // surface the real error. `MAX_STALE` was dead code before this:
+        // every fallback served history forever.
+        assert!(
+            cache
+                .fallback_payload(Duration::from_millis(5))
+                .unwrap()
+                .is_none()
+        );
+
+        // Inside the window it is still served, so the guard is a limit and
+        // not a blanket refusal.
         assert_eq!(
             cache.fallback_payload(MAX_STALE).unwrap().as_deref(),
-            Some(&b"new"[..])
+            Some(&b"old"[..])
         );
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -104,8 +104,26 @@ impl Cache {
 
     /// Read the payload regardless of age. `Err` if the file exists but is
     /// unreadable; `Ok(None)` if it just doesn't exist.
+    ///
+    /// Prefer [`Cache::fallback_payload`] on failure paths — this one imposes
+    /// no age limit, so it will happily hand back a month-old figure.
     pub fn maybe_payload(&self) -> Result<Option<Vec<u8>>> {
         if !self.payload_path().exists() {
+            return Ok(None);
+        }
+        self.read_payload().map(Some)
+    }
+
+    /// Payload for the *failure* path: the last good value, but only while it
+    /// is still worth showing. Beyond `max_stale` this returns `Ok(None)` so
+    /// the caller surfaces the real error instead of presenting week-old
+    /// numbers as if they were current — a bar that silently freezes on
+    /// history is worse than one that says it cannot reach the API.
+    pub fn fallback_payload(&self, max_stale: Duration) -> Result<Option<Vec<u8>>> {
+        let Some(age) = self.payload_age() else {
+            return Ok(None);
+        };
+        if age > max_stale {
             return Ok(None);
         }
         self.read_payload().map(Some)
@@ -346,6 +364,34 @@ mod tests {
         cache.write_payload(b"fresh").unwrap();
         assert!(!cache.is_stale());
         assert!(cache.read_last_error().is_none());
+    }
+
+    #[test]
+    fn fallback_payload_refuses_a_payload_older_than_max_stale() {
+        use std::time::SystemTime;
+
+        let (_td, cache) = fixture();
+        cache.write_payload(b"old").unwrap();
+
+        // Backdate the payload past the limit. `MAX_STALE` was dead code
+        // before this: every failure path served history forever.
+        let eight_days_ago = SystemTime::now() - Duration::from_secs(8 * 24 * 3600);
+        let f = File::options()
+            .write(true)
+            .open(cache.payload_path())
+            .unwrap();
+        f.set_modified(eight_days_ago).unwrap();
+
+        // Still readable when age is not considered...
+        assert!(cache.maybe_payload().unwrap().is_some());
+        // ...but refused as a fallback.
+        assert!(cache.fallback_payload(MAX_STALE).unwrap().is_none());
+        // A payload inside the window is still served.
+        cache.write_payload(b"new").unwrap();
+        assert_eq!(
+            cache.fallback_payload(MAX_STALE).unwrap().as_deref(),
+            Some(&b"new"[..])
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,8 +24,14 @@ use crate::cache::Cache;
 use crate::error::{AppError, Result};
 use crate::vendor::VendorId;
 
+/// A misspelled section name is silently ignored without this: `[openrouer]`
+/// leaves OpenRouter on its defaults and the user sees the wrong vendor set
+/// with no diagnostic. Denying unknown keys is deliberately applied at the
+/// *section* level only — the set of sections is small and stable, whereas
+/// denying unknown keys inside every section would hard-fail configs that
+/// carry a field from a future or removed version.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub ui: UiConfig,
     pub anthropic: AnthropicConfig,
@@ -607,6 +613,40 @@ enabled = false
         assert!(c.is_enabled(VendorId::Deepseek));
         assert!(c.enabled_vendors().contains(&VendorId::Deepseek));
         assert_eq!(c.deepseek.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn misspelled_section_is_rejected_not_ignored() {
+        // The regression this guards: `[openrouer]` used to parse fine, leave
+        // OpenRouter on its defaults, and give the user no hint at all.
+        let f = write_toml(
+            r#"
+            [openrouer]
+            enabled = true
+            api_key = "sk-or-v1-typo"
+            "#,
+        );
+        let err = Config::load_from(f.path()).unwrap_err().to_string();
+        assert!(
+            err.contains("openrouer"),
+            "error should name the typo: {err}"
+        );
+    }
+
+    #[test]
+    fn invalid_toml_is_an_error_not_silent_defaults() {
+        let f = write_toml("[zai\nenabled = true\n");
+        assert!(Config::load_from(f.path()).is_err());
+    }
+
+    #[test]
+    fn a_missing_file_is_still_just_defaults() {
+        // Absence stays the legitimate "use defaults" case — only real parse
+        // and I/O failures are errors.
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope").join("config.toml");
+        let c = Config::load_from(&missing).unwrap();
+        assert!(c.is_enabled(VendorId::Anthropic));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -289,7 +289,7 @@ impl Config {
     /// Load from `~/.config/ai-usagebar/config.toml`. Returns defaults if the
     /// file doesn't exist; errors only on actual parse failures.
     pub fn load() -> Result<Self> {
-        let Some(path) = default_path() else {
+        let Some(path) = resolved_path() else {
             return Ok(Self::default());
         };
         Self::load_from(&path)
@@ -298,12 +298,24 @@ impl Config {
     pub fn load_from(path: &std::path::Path) -> Result<Self> {
         match std::fs::read_to_string(path) {
             Ok(s) => {
-                let config: Self = toml::from_str(&s)?;
+                let mut config: Self = toml::from_str(&s)?;
+                // `~` is shell syntax, not path syntax: `PathBuf` keeps it
+                // literally, so a documented `credentials_path = "~/..."`
+                // silently pointed at a directory named `~`.
+                config.expand_paths();
                 config.validate()?;
                 Ok(config)
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
             Err(e) => Err(AppError::io_at(path, e)),
+        }
+    }
+
+    fn expand_paths(&mut self) {
+        expand_tilde_opt(&mut self.anthropic.credentials_path);
+        expand_tilde_opt(&mut self.openai.codex_auth_path);
+        for account in &mut self.anthropic.accounts {
+            account.credentials_path = expand_tilde(&account.credentials_path);
         }
     }
 
@@ -349,12 +361,70 @@ pub fn default_path() -> Option<PathBuf> {
     Some(proj.config_dir().join("config.toml"))
 }
 
+/// The Unix-conventional location, which is what every doc, the config
+/// example, and both desktop integrations have always pointed at. On Linux it
+/// *is* [`default_path`]; on macOS `ProjectDirs` resolves to
+/// `~/Library/Application Support/…` instead, so the two diverge.
+fn legacy_xdg_path() -> Option<PathBuf> {
+    let home = crate::cache::home_dir().ok()?;
+    Some(home.join(".config").join("ai-usagebar").join("config.toml"))
+}
+
+/// The config file actually in effect.
+///
+/// [`default_path`] stays canonical, but on macOS a file at the documented
+/// `~/.config/ai-usagebar/config.toml` is honored when the canonical one does
+/// not exist — otherwise everyone who followed the README (and both desktop
+/// integrations, which read that path) silently got defaults. The legacy file
+/// is never moved or rewritten: it may hold API keys, and relocating a secret
+/// behind the user's back is not this tool's business.
+pub fn resolved_path() -> Option<PathBuf> {
+    let canonical = default_path();
+    if let Some(p) = &canonical
+        && p.exists()
+    {
+        return canonical;
+    }
+    if let Some(legacy) = legacy_xdg_path()
+        && legacy.exists()
+    {
+        return Some(legacy);
+    }
+    canonical
+}
+
+/// Expand a leading `~` (or `~/`) against the user's home directory. Anything
+/// else — including `~user` — is left untouched.
+fn expand_tilde(p: &std::path::Path) -> PathBuf {
+    let Some(s) = p.to_str() else {
+        return p.to_path_buf();
+    };
+    let rest = if s == "~" {
+        ""
+    } else if let Some(r) = s.strip_prefix("~/") {
+        r
+    } else {
+        return p.to_path_buf();
+    };
+    match crate::cache::home_dir() {
+        Ok(home) if rest.is_empty() => home,
+        Ok(home) => home.join(rest),
+        Err(_) => p.to_path_buf(),
+    }
+}
+
+fn expand_tilde_opt(p: &mut Option<PathBuf>) {
+    if let Some(inner) = p.as_ref() {
+        *p = Some(expand_tilde(inner));
+    }
+}
+
 /// Resolved `config.toml` path as a string for user-facing messages. Uses the
 /// platform's config dir (`directories::ProjectDirs`), so it reads correctly on
 /// Linux, macOS, and Windows instead of hard-coding the Unix `~/.config` path.
 /// Falls back to the bare filename if the path can't be resolved.
 pub fn config_path_hint() -> String {
-    default_path()
+    resolved_path()
         .map(|p| p.display().to_string())
         .unwrap_or_else(|| "config.toml".to_string())
 }
@@ -613,6 +683,76 @@ enabled = false
         assert!(c.is_enabled(VendorId::Deepseek));
         assert!(c.enabled_vendors().contains(&VendorId::Deepseek));
         assert_eq!(c.deepseek.api_key.as_deref(), Some("sk-test"));
+    }
+
+    #[test]
+    fn tilde_paths_are_expanded_on_load() {
+        // `PathBuf` keeps `~` literally, so the documented
+        // `credentials_path = "~/..."` used to resolve to a directory named
+        // `~` relative to the process's cwd.
+        let f = write_toml(
+            r#"
+            [anthropic]
+            credentials_path = "~/.claude/.credentials.json"
+
+            [[anthropic.accounts]]
+            label = "work"
+            credentials_path = "~/work.json"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        let home = crate::cache::home_dir().unwrap();
+
+        let got = c.anthropic.credentials_path.unwrap();
+        assert_eq!(got, home.join(".claude/.credentials.json"));
+        assert!(!got.to_string_lossy().contains('~'));
+        assert_eq!(
+            c.anthropic.accounts[0].credentials_path,
+            home.join("work.json")
+        );
+    }
+
+    #[test]
+    fn absolute_and_relative_paths_are_left_alone() {
+        let f = write_toml(
+            r#"
+            [anthropic]
+            credentials_path = "/etc/creds.json"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        assert_eq!(
+            c.anthropic.credentials_path.unwrap(),
+            std::path::Path::new("/etc/creds.json")
+        );
+
+        // `~user` is not ours to interpret.
+        let f2 = write_toml(
+            r#"
+            [anthropic]
+            credentials_path = "~someone/creds.json"
+            "#,
+        );
+        let c2 = Config::load_from(f2.path()).unwrap();
+        assert_eq!(
+            c2.anthropic.credentials_path.unwrap(),
+            std::path::Path::new("~someone/creds.json")
+        );
+    }
+
+    #[test]
+    fn resolved_path_is_the_canonical_one_and_names_the_config_file() {
+        // Hermetic: only asserts the shape, never which file happens to exist
+        // on the machine running the tests.
+        let p = resolved_path().expect("a config path must resolve");
+        assert!(p.ends_with("config.toml"));
+        let canonical = default_path().unwrap();
+        let legacy = legacy_xdg_path().unwrap();
+        assert!(
+            p == canonical || p == legacy,
+            "resolved to an unexpected location: {}",
+            p.display()
+        );
     }
 
     #[test]

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::DeepseekSnapshot;
 
@@ -41,7 +41,7 @@ pub async fn fetch_snapshot(
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
-    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
     if let Some(bytes) = cache.fresh_payload(cache_ttl)?
         && let Ok(outcome) = reuse_cache(bytes, cache, false)

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use crate::cache::{Cache, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock};
 use crate::error::{AppError, Result};
 use crate::usage::DeepseekSnapshot;
 
@@ -43,9 +43,13 @@ pub async fn fetch_snapshot(
     cache.ensure_dir()?;
     let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
 
-    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
-        return Ok(reuse_cache(bytes, cache, false));
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse_cache(bytes, cache, false)
+    {
+        return Ok(outcome);
     }
+    // Corrupt fresh cache: fall through to live fetch rather than return a
+    // fabricated zero balance.
 
     match fetch_live(client, &endpoints.balance, api_key).await {
         Ok(snap) => {
@@ -73,41 +77,60 @@ pub async fn fetch_snapshot(
 }
 
 fn fallback_silent(cache: &Cache) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Transport(
             "deepseek: no cache and network unreachable".into(),
         ));
     };
-    Ok(reuse_cache(bytes, cache, true))
+    reuse_cache(bytes, cache, true)
 }
 
 fn fallback_with_error(cache: &Cache, last_error: Option<(u16, String)>) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Other("deepseek: no usable cache".into()));
     };
-    let mut outcome = reuse_cache(bytes, cache, true);
+    let mut outcome = reuse_cache(bytes, cache, true)?;
     outcome.last_error = last_error;
     Ok(outcome)
 }
 
-fn reuse_cache(bytes: Vec<u8>, cache: &Cache, stale: bool) -> FetchOutcome {
-    let snap = parse_cache(&bytes).unwrap_or_default();
-    FetchOutcome {
+fn reuse_cache(bytes: Vec<u8>, cache: &Cache, stale: bool) -> Result<FetchOutcome> {
+    let snap = parse_cache(&bytes)?;
+    Ok(FetchOutcome {
         snapshot: snap,
         stale,
         last_error: cache.read_last_error(),
         cache_age: cache.payload_age(),
-    }
+    })
 }
 
+/// Cached money is required, not optional: a truncated or half-written payload
+/// must be refetched rather than rendered as a $0.00 balance.
 fn parse_cache(bytes: &[u8]) -> Result<DeepseekSnapshot> {
     let v: serde_json::Value = serde_json::from_slice(bytes)?;
+    let money = |name: &str| -> Result<f64> {
+        let n = v[name]
+            .as_f64()
+            .ok_or_else(|| AppError::Schema(format!("deepseek cache missing '{name}'")))?;
+        if n.is_finite() {
+            Ok(n)
+        } else {
+            Err(AppError::Schema(format!(
+                "deepseek cache '{name}' is not finite"
+            )))
+        }
+    };
     Ok(DeepseekSnapshot {
-        is_available: v["is_available"].as_bool().unwrap_or(false),
-        balance: v["balance"].as_f64().unwrap_or(0.0),
-        granted: v["granted"].as_f64().unwrap_or(0.0),
-        topped_up: v["topped_up"].as_f64().unwrap_or(0.0),
-        currency: v["currency"].as_str().unwrap_or("").to_string(),
+        is_available: v["is_available"]
+            .as_bool()
+            .ok_or_else(|| AppError::Schema("deepseek cache missing 'is_available'".into()))?,
+        balance: money("balance")?,
+        granted: money("granted")?,
+        topped_up: money("topped_up")?,
+        currency: v["currency"]
+            .as_str()
+            .ok_or_else(|| AppError::Schema("deepseek cache missing 'currency'".into()))?
+            .to_string(),
     })
 }
 

--- a/src/kimi/fetch.rs
+++ b/src/kimi/fetch.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::KimiSnapshot;
 
@@ -46,7 +46,7 @@ pub async fn fetch_snapshot(
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
-    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
     if let Some(bytes) = cache.fresh_payload(cache_ttl)?
         && let Ok(outcome) = reuse_cache(bytes, cache, false)

--- a/src/kimi/fetch.rs
+++ b/src/kimi/fetch.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 
-use crate::cache::{Cache, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock};
 use crate::error::{AppError, Result};
 use crate::usage::KimiSnapshot;
 
@@ -79,7 +79,7 @@ pub async fn fetch_snapshot(
 }
 
 fn fallback_silent(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(original);
     };
     match reuse_cache(bytes, cache, true) {
@@ -89,7 +89,7 @@ fn fallback_silent(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
 }
 
 fn fallback_with_error(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(original);
     };
     match reuse_cache(bytes, cache, true) {

--- a/src/openai/creds.rs
+++ b/src/openai/creds.rs
@@ -59,10 +59,21 @@ pub fn write_back(path: &Path, auth: &AuthFile) -> Result<()> {
 }
 
 impl Tokens {
-    /// Compute the Unix-seconds expiry from the embedded id_token. Returns
-    /// 0 (forcing immediate refresh) when the token isn't parseable.
+    /// Compute the Unix-seconds expiry. The id_token's `exp` claim is the
+    /// primary source (Codex CLI does not always write `expires_at`), but the
+    /// explicit field is used when the claim is absent or unparseable —
+    /// otherwise a refresh that returns no new id_token leaves the old expired
+    /// claim in place and every subsequent run refreshes again.
+    /// Returns 0 (forcing an immediate refresh) when neither is usable.
     pub fn expires_at_secs(&self) -> i64 {
-        parse_jwt_exp(&self.id_token).unwrap_or(0)
+        if let Some(exp) = parse_jwt_exp(&self.id_token) {
+            return exp;
+        }
+        self.expires_at
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.timestamp())
+            .unwrap_or(0)
     }
 
     /// Plan tier from the id_token's nested claim
@@ -164,6 +175,28 @@ mod tests {
         let auth = read_from(f.path()).unwrap();
         assert_eq!(auth.tokens.expires_at_secs(), 0);
         assert!(auth.tokens.plan_type_from_id_token().is_none());
+    }
+
+    #[test]
+    fn explicit_expires_at_is_used_when_the_id_token_has_no_exp() {
+        // A refresh that returns no new id_token used to leave the old expired
+        // claim in place, so every later run refreshed again.
+        let mut tokens = Tokens {
+            access_token: "AT".into(),
+            refresh_token: "RT".into(),
+            id_token: "not-a-jwt".into(),
+            account_id: None,
+            expires_at: Some("2030-01-01T00:00:00Z".into()),
+            extra: Default::default(),
+        };
+        let expected = chrono::DateTime::parse_from_rfc3339("2030-01-01T00:00:00Z")
+            .unwrap()
+            .timestamp();
+        assert_eq!(tokens.expires_at_secs(), expected);
+
+        // Unparseable on both sides still forces a refresh.
+        tokens.expires_at = Some("whenever".into());
+        assert_eq!(tokens.expires_at_secs(), 0);
     }
 
     #[test]

--- a/src/openai/creds.rs
+++ b/src/openai/creds.rs
@@ -59,20 +59,20 @@ pub fn write_back(path: &Path, auth: &AuthFile) -> Result<()> {
 }
 
 impl Tokens {
-    /// Compute the Unix-seconds expiry. The id_token's `exp` claim is the
-    /// primary source (Codex CLI does not always write `expires_at`), but the
-    /// explicit field is used when the claim is absent or unparseable —
-    /// otherwise a refresh that returns no new id_token leaves the old expired
-    /// claim in place and every subsequent run refreshes again.
+    /// Compute the Unix-seconds expiry. A persisted `expires_at` is the newest
+    /// information after a refresh and must win over the id_token's claim: the
+    /// token endpoint may return `expires_in` without returning a replacement
+    /// id_token, leaving the old (expired) claim in place. Fall back to the
+    /// access-token JWT (the source current Codex itself uses), then the legacy
+    /// id-token claim, for auth files that do not carry the explicit field.
     /// Returns 0 (forcing an immediate refresh) when neither is usable.
     pub fn expires_at_secs(&self) -> i64 {
-        if let Some(exp) = parse_jwt_exp(&self.id_token) {
-            return exp;
-        }
         self.expires_at
             .as_deref()
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.timestamp())
+            .or_else(|| parse_jwt_exp(&self.access_token))
+            .or_else(|| parse_jwt_exp(&self.id_token))
             .unwrap_or(0)
     }
 
@@ -178,13 +178,15 @@ mod tests {
     }
 
     #[test]
-    fn explicit_expires_at_is_used_when_the_id_token_has_no_exp() {
+    fn explicit_expires_at_overrides_an_old_expired_id_token() {
         // A refresh that returns no new id_token used to leave the old expired
-        // claim in place, so every later run refreshed again.
+        // claim in place. The refreshed `expires_at` must win or every later
+        // run refreshes again.
+        let expired_jwt = fake_jwt(serde_json::json!({"exp": 1}));
         let mut tokens = Tokens {
             access_token: "AT".into(),
             refresh_token: "RT".into(),
-            id_token: "not-a-jwt".into(),
+            id_token: expired_jwt,
             account_id: None,
             expires_at: Some("2030-01-01T00:00:00Z".into()),
             extra: Default::default(),
@@ -194,9 +196,22 @@ mod tests {
             .timestamp();
         assert_eq!(tokens.expires_at_secs(), expected);
 
-        // Unparseable on both sides still forces a refresh.
+        // An invalid explicit value still falls back to the JWT.
         tokens.expires_at = Some("whenever".into());
-        assert_eq!(tokens.expires_at_secs(), 0);
+        assert_eq!(tokens.expires_at_secs(), 1);
+    }
+
+    #[test]
+    fn access_token_expiry_wins_over_the_legacy_id_token_claim() {
+        let tokens = Tokens {
+            access_token: fake_jwt(serde_json::json!({"exp": 2_000_000_000})),
+            refresh_token: "RT".into(),
+            id_token: fake_jwt(serde_json::json!({"exp": 1})),
+            account_id: None,
+            expires_at: None,
+            extra: Default::default(),
+        };
+        assert_eq!(tokens.expires_at_secs(), 2_000_000_000);
     }
 
     #[test]

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -56,8 +56,12 @@ pub async fn fetch_snapshot(
     let mut auth = creds::read_from(creds_path)?;
     let plan_hint = auth.tokens.plan_type_from_id_token();
 
-    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
-        return Ok(reuse(bytes, cache, false, plan_hint.as_deref()));
+    // Corrupt fresh cache falls through to a live fetch rather than returning
+    // an all-zero snapshot.
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse(bytes, cache, false, plan_hint.as_deref())
+    {
+        return Ok(outcome);
     }
 
     // Maybe refresh — Codex CLI doesn't always populate expires_at, so we use
@@ -149,14 +153,19 @@ pub async fn fetch_snapshot(
     }
 }
 
-fn reuse(bytes: Vec<u8>, cache: &Cache, stale: bool, plan_hint: Option<&str>) -> FetchOutcome {
-    let snap = parse_payload(&bytes, plan_hint).unwrap_or_else(|_| empty(plan_hint));
-    FetchOutcome {
+fn reuse(
+    bytes: Vec<u8>,
+    cache: &Cache,
+    stale: bool,
+    plan_hint: Option<&str>,
+) -> Result<FetchOutcome> {
+    let snap = parse_payload(&bytes, plan_hint)?;
+    Ok(FetchOutcome {
         snapshot: snap,
         stale,
         last_error: cache.read_last_error(),
         cache_age: cache.payload_age(),
-    }
+    })
 }
 
 fn fallback(
@@ -167,7 +176,7 @@ fn fallback(
     let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Other("openai: no usable cache".into()));
     };
-    let mut out = reuse(bytes, cache, true, plan_hint);
+    let mut out = reuse(bytes, cache, true, plan_hint)?;
     out.last_error = last_error;
     Ok(out)
 }
@@ -178,7 +187,7 @@ fn fallback_silent(cache: &Cache, plan_hint: Option<&str>) -> Result<FetchOutcom
             "openai: no cache and network unreachable".into(),
         ));
     };
-    Ok(reuse(bytes, cache, true, plan_hint))
+    reuse(bytes, cache, true, plan_hint)
 }
 
 fn handle_auth_failure(
@@ -197,16 +206,12 @@ fn handle_auth_failure(
             ))
         };
     };
-    Ok(reuse(bytes, cache, true, plan_hint))
+    reuse(bytes, cache, true, plan_hint)
 }
 
 fn parse_payload(bytes: &[u8], plan_hint: Option<&str>) -> Result<OpenAiSnapshot> {
     let r: UsageResponse = serde_json::from_slice(bytes)?;
     Ok(r.into_snapshot(plan_hint))
-}
-
-fn empty(plan_hint: Option<&str>) -> OpenAiSnapshot {
-    UsageResponse::default().into_snapshot(plan_hint)
 }
 
 async fn fetch_usage(client: &reqwest::Client, url: &str, t: &Tokens) -> Result<Vec<u8>> {
@@ -304,6 +309,43 @@ mod tests {
         .unwrap();
         assert_eq!(out.snapshot.plan, "ChatGPT Plus");
         assert_eq!(out.snapshot.session.utilization_pct, 1);
+        assert!(!out.stale);
+    }
+
+    #[tokio::test]
+    async fn corrupt_fresh_cache_refetches_instead_of_showing_an_empty_snapshot() {
+        // `reuse` used to swallow a parse failure into `empty(plan_hint)` and
+        // serve that all-zero snapshot for the rest of the TTL.
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/backend-api/wham/usage")
+            .with_status(200)
+            .with_body(
+                r#"{"plan_type":"pro","rate_limit":{"primary_window":{"used_percent":37,"limit_window_seconds":18000}}}"#,
+            )
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        cache.write_payload(b"{ truncated").unwrap();
+
+        let creds = future_creds();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            usage: format!("{}/backend-api/wham/usage", server.url()),
+            token: format!("{}/oauth/token", server.url()),
+        };
+        // A long TTL: the payload IS fresh, it is simply unusable.
+        let out = fetch_snapshot(
+            &client,
+            creds.path(),
+            &cache,
+            &endpoints,
+            Duration::from_secs(3600),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.snapshot.session.utilization_pct, 37);
         assert!(!out.stale);
     }
 

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::OpenAiSnapshot;
 
@@ -51,7 +51,7 @@ pub async fn fetch_snapshot(
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
-    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
     let mut auth = creds::read_from(creds_path)?;
     let plan_hint = auth.tokens.plan_type_from_id_token();

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 
-use crate::cache::{Cache, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock};
 use crate::error::{AppError, Result};
 use crate::usage::OpenAiSnapshot;
 
@@ -141,7 +141,7 @@ fn fallback(
     plan_hint: Option<&str>,
     last_error: Option<(u16, String)>,
 ) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Other("openai: no usable cache".into()));
     };
     let mut out = reuse(bytes, cache, true, plan_hint);
@@ -150,7 +150,7 @@ fn fallback(
 }
 
 fn fallback_silent(cache: &Cache, plan_hint: Option<&str>) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Transport(
             "openai: no cache and network unreachable".into(),
         ));
@@ -163,7 +163,7 @@ fn handle_auth_failure(
     plan_hint: Option<&str>,
     transient: bool,
 ) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return if transient {
             Err(AppError::Transport(
                 "openai: no cache and refresh failed transiently".into(),

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -72,13 +72,36 @@ pub async fn fetch_snapshot(
         {
             Ok(Ok(rr)) => {
                 auth.tokens.access_token = rr.access_token;
+                // A rotated refresh token exists only in memory until it is
+                // persisted; losing it silently logs the user out on the next
+                // run. See the matching comment in `anthropic::fetch`.
+                let rotated = rr.refresh_token.is_some();
                 if let Some(rt) = rr.refresh_token {
                     auth.tokens.refresh_token = rt;
                 }
                 if let Some(id) = rr.id_token {
                     auth.tokens.id_token = id;
                 }
-                let _ = creds::write_back(creds_path, &auth);
+                // Expiry is normally read from the id_token's exp claim, so a
+                // refresh that returns no new id_token would leave the old
+                // (expired) claim in place and make every later run refresh
+                // again. Record the response's own `expires_in` as the explicit
+                // `expires_at` so the expiry is known either way.
+                if let Some(secs) = rr.expires_in
+                    && let Some(dt) = chrono::DateTime::from_timestamp(now + secs as i64, 0)
+                {
+                    auth.tokens.expires_at = Some(dt.to_rfc3339());
+                }
+                if let Err(e) = creds::write_back(creds_path, &auth)
+                    && rotated
+                {
+                    let msg = format!(
+                        "refreshed token could not be saved ({e}); the rotated \
+                         refresh token is lost — re-run `codex login`"
+                    );
+                    cache.write_last_error(0, &msg);
+                    return handle_auth_failure(cache, plan_hint.as_deref(), false);
+                }
             }
             Ok(Err(AppError::Http { status, body })) => {
                 cache.write_last_error(status, &body);

--- a/src/openrouter/fetch.rs
+++ b/src/openrouter/fetch.rs
@@ -3,7 +3,7 @@
 
 use std::time::Duration;
 
-use crate::cache::{Cache, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock};
 use crate::error::{AppError, Result};
 use crate::usage::OpenRouterSnapshot;
 
@@ -48,9 +48,13 @@ pub async fn fetch_snapshot(
     cache.ensure_dir()?;
     let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
 
-    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
-        return Ok(reuse_cache(bytes, cache, false));
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse_cache(bytes, cache, false)
+    {
+        return Ok(outcome);
     }
+    // Corrupt fresh cache: fall through to live fetch rather than return a
+    // fabricated zero-credit snapshot.
 
     match fetch_live(client, endpoints, api_key).await {
         Ok((credits, key)) => {
@@ -83,56 +87,63 @@ pub async fn fetch_snapshot(
 }
 
 fn fallback_silent(cache: &Cache) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Transport(
             "openrouter: no cache and network unreachable".into(),
         ));
     };
-    Ok(reuse_cache(bytes, cache, true))
+    reuse_cache(bytes, cache, true)
 }
 
 fn fallback_with_error(cache: &Cache, last_error: Option<(u16, String)>) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Other("openrouter: no usable cache".into()));
     };
-    let mut outcome = reuse_cache(bytes, cache, true);
+    let mut outcome = reuse_cache(bytes, cache, true)?;
     outcome.last_error = last_error;
     Ok(outcome)
 }
 
-fn reuse_cache(bytes: Vec<u8>, cache: &Cache, stale: bool) -> FetchOutcome {
-    let snap = parse_cache(&bytes).unwrap_or_else(|_| OpenRouterSnapshot {
-        label: "OpenRouter".into(),
-        total_credits: 0.0,
-        total_usage: 0.0,
-        usage_daily: 0.0,
-        usage_weekly: 0.0,
-        usage_monthly: 0.0,
-        is_free_tier: true,
-        limit: None,
-        limit_remaining: None,
-    });
-    FetchOutcome {
+fn reuse_cache(bytes: Vec<u8>, cache: &Cache, stale: bool) -> Result<FetchOutcome> {
+    let snap = parse_cache(&bytes)?;
+    Ok(FetchOutcome {
         snapshot: snap,
         stale,
         last_error: cache.read_last_error(),
         cache_age: cache.payload_age(),
-    }
+    })
 }
 
+/// Cached money is required, not optional: a truncated or half-written payload
+/// must be refetched rather than rendered as $0.00 with a free-tier badge.
+/// `limit`/`limit_remaining` stay optional — the API itself returns them null.
 fn parse_cache(bytes: &[u8]) -> Result<OpenRouterSnapshot> {
     let v: serde_json::Value = serde_json::from_slice(bytes)?;
     let s = v
         .get("snapshot")
         .ok_or_else(|| AppError::Schema("openrouter cache missing 'snapshot' field".into()))?;
+    let money = |name: &str| -> Result<f64> {
+        let n = s[name]
+            .as_f64()
+            .ok_or_else(|| AppError::Schema(format!("openrouter cache missing '{name}'")))?;
+        if n.is_finite() {
+            Ok(n)
+        } else {
+            Err(AppError::Schema(format!(
+                "openrouter cache '{name}' is not finite"
+            )))
+        }
+    };
     Ok(OpenRouterSnapshot {
         label: s["label"].as_str().unwrap_or("OpenRouter").to_string(),
-        total_credits: s["total_credits"].as_f64().unwrap_or(0.0),
-        total_usage: s["total_usage"].as_f64().unwrap_or(0.0),
-        usage_daily: s["usage_daily"].as_f64().unwrap_or(0.0),
-        usage_weekly: s["usage_weekly"].as_f64().unwrap_or(0.0),
-        usage_monthly: s["usage_monthly"].as_f64().unwrap_or(0.0),
-        is_free_tier: s["is_free_tier"].as_bool().unwrap_or(false),
+        total_credits: money("total_credits")?,
+        total_usage: money("total_usage")?,
+        usage_daily: money("usage_daily")?,
+        usage_weekly: money("usage_weekly")?,
+        usage_monthly: money("usage_monthly")?,
+        is_free_tier: s["is_free_tier"]
+            .as_bool()
+            .ok_or_else(|| AppError::Schema("openrouter cache missing 'is_free_tier'".into()))?,
         limit: s["limit"].as_f64(),
         limit_remaining: s["limit_remaining"].as_f64(),
     })

--- a/src/openrouter/fetch.rs
+++ b/src/openrouter/fetch.rs
@@ -3,7 +3,7 @@
 
 use std::time::Duration;
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::OpenRouterSnapshot;
 
@@ -46,7 +46,7 @@ pub async fn fetch_snapshot(
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
-    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
     if let Some(bytes) = cache.fresh_payload(cache_ttl)?
         && let Ok(outcome) = reuse_cache(bytes, cache, false)

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -418,7 +418,11 @@ fn update_key(doc: &mut DocumentMut, section: &str, input: &KeyInput) -> Result<
 }
 
 fn default_config_path() -> Result<PathBuf> {
-    crate::config::default_path()
+    // Save back to the same file Config::load() selected. On macOS this may be
+    // the legacy ~/.config path when the canonical Application Support file is
+    // absent; writing a new canonical file would shadow the existing config on
+    // the next load and silently discard all settings the overlay did not copy.
+    crate::config::resolved_path()
         .ok_or_else(|| AppError::Other("could not resolve config dir".into()))
 }
 
@@ -1079,5 +1083,13 @@ primary = "deepseek"
         let raw = std::fs::read_to_string(&path).unwrap();
         assert!(raw.contains("[kimi]"));
         assert!(raw.contains("api_key = \"kk\""));
+    }
+
+    #[test]
+    fn settings_save_uses_the_same_config_path_as_load() {
+        assert_eq!(
+            default_config_path().unwrap(),
+            crate::config::resolved_path().unwrap()
+        );
     }
 }

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -42,7 +42,12 @@ pub async fn run(cli: Cli) -> i32 {
 /// Cycle to the next/prev enabled vendor and signal waybar to refresh.
 /// Always exits 0 — Waybar swallows non-zero exits anyway.
 async fn run_cycle(cli: &Cli) -> i32 {
-    let config = Config::load().unwrap_or_default();
+    // Cycling against the *default* vendor set because the config failed to
+    // parse would persist a selection the user never made. Do nothing instead;
+    // the next render surfaces the config error through the `⚠` fallback.
+    let Ok(config) = Config::load() else {
+        return 0;
+    };
     let enabled = config.enabled_vendors();
     if enabled.is_empty() {
         return 0;
@@ -95,7 +100,10 @@ async fn run_once(cli: &Cli, out: &mut impl Write) {
 }
 
 async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
-    let config = Config::load().unwrap_or_default();
+    // A broken config is reported through the `⚠` fallback (still exit 0)
+    // rather than silently reverting to the default vendor set — otherwise a
+    // typo'd section shows another account's usage with no diagnostic.
+    let config = Config::load()?;
     let vendor = cli.resolved_vendor(&config);
     if !dispatch_is_eligible(cli, &config, vendor) {
         return Err(AppError::Other(format!(
@@ -470,6 +478,17 @@ mod tests {
         let out = fallback(&err, &cli_default());
         assert_eq!(out.text, "⚠");
         assert!(out.tooltip.contains("missing token"));
+    }
+
+    #[test]
+    fn fallback_reports_a_broken_config_without_breaking_exit_0() {
+        // Propagating the config error must still land in the `⚠` fallback —
+        // Waybar hides modules that exit non-zero, so a broken config has to
+        // be *visible*, not fatal.
+        let toml_err = toml::from_str::<Config>("[zai\nenabled = true\n").unwrap_err();
+        let out = fallback(&AppError::Toml(toml_err), &cli_default());
+        assert_eq!(out.text, "⚠");
+        assert!(out.tooltip.contains("TOML error"));
     }
 
     #[test]

--- a/src/zai/fetch.rs
+++ b/src/zai/fetch.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::ZaiSnapshot;
 
@@ -44,7 +44,7 @@ pub async fn fetch_snapshot(
     config_plan_tier: Option<&str>,
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
-    let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
     if let Some(bytes) = cache.fresh_payload(cache_ttl)?
         && let Ok(outcome) = reuse(bytes, cache, false, config_plan_tier)

--- a/src/zai/fetch.rs
+++ b/src/zai/fetch.rs
@@ -4,7 +4,7 @@
 
 use std::time::Duration;
 
-use crate::cache::{Cache, acquire_lock};
+use crate::cache::{Cache, MAX_STALE, acquire_lock};
 use crate::error::{AppError, Result};
 use crate::usage::ZaiSnapshot;
 
@@ -46,14 +46,20 @@ pub async fn fetch_snapshot(
     cache.ensure_dir()?;
     let _lock = acquire_lock(&cache.lock_path(), LOCK_TIMEOUT)?;
 
-    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
-        return Ok(reuse(bytes, cache, false, config_plan_tier));
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse(bytes, cache, false, config_plan_tier)
+    {
+        return Ok(outcome);
     }
+    // Corrupt fresh cache: fall through to live fetch rather than return a
+    // fabricated "GLM Coding Unknown" snapshot with empty windows.
 
     match fetch_live(client, &endpoints.quota, api_key).await {
-        Ok(bytes) => {
+        Ok((bytes, env)) => {
+            // Only a validated envelope reaches the cache, so a 200 carrying
+            // `success: false` can never overwrite the last good payload nor
+            // clear the recorded error.
             cache.write_payload(&bytes)?;
-            let env: Envelope = serde_json::from_slice(&bytes)?;
             Ok(FetchOutcome {
                 snapshot: env.into_snapshot(config_plan_tier),
                 stale: false,
@@ -75,30 +81,25 @@ pub async fn fetch_snapshot(
     }
 }
 
-fn reuse(bytes: Vec<u8>, cache: &Cache, stale: bool, tier: Option<&str>) -> FetchOutcome {
-    let snapshot = serde_json::from_slice::<Envelope>(&bytes)
-        .map(|e| e.into_snapshot(tier))
-        .unwrap_or_else(|_| ZaiSnapshot {
-            plan: "GLM Coding Unknown".into(),
-            session: None,
-            weekly: None,
-            mcp: None,
-        });
-    FetchOutcome {
-        snapshot,
+fn reuse(bytes: Vec<u8>, cache: &Cache, stale: bool, tier: Option<&str>) -> Result<FetchOutcome> {
+    let env: Envelope = serde_json::from_slice(&bytes)?;
+    // A cached failure envelope is not usage data, even if it parses.
+    env.check_ok()?;
+    Ok(FetchOutcome {
+        snapshot: env.into_snapshot(tier),
         stale,
         last_error: cache.read_last_error(),
         cache_age: cache.payload_age(),
-    }
+    })
 }
 
 fn fallback_silent(cache: &Cache, tier: Option<&str>) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Transport(
             "zai: no cache and network unreachable".into(),
         ));
     };
-    Ok(reuse(bytes, cache, true, tier))
+    reuse(bytes, cache, true, tier)
 }
 
 fn fallback_with_error(
@@ -106,15 +107,21 @@ fn fallback_with_error(
     last_error: Option<(u16, String)>,
     tier: Option<&str>,
 ) -> Result<FetchOutcome> {
-    let Some(bytes) = cache.maybe_payload()? else {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
         return Err(AppError::Other("zai: no usable cache".into()));
     };
-    let mut out = reuse(bytes, cache, true, tier);
+    let mut out = reuse(bytes, cache, true, tier)?;
     out.last_error = last_error;
     Ok(out)
 }
 
-async fn fetch_live(client: &reqwest::Client, url: &str, api_key: &str) -> Result<Vec<u8>> {
+/// Returns the raw bytes (for the cache) alongside the *validated* envelope,
+/// so the caller cannot accidentally cache a body it never checked.
+async fn fetch_live(
+    client: &reqwest::Client,
+    url: &str,
+    api_key: &str,
+) -> Result<(Vec<u8>, Envelope)> {
     let resp = tokio::time::timeout(
         HTTP_TIMEOUT,
         client
@@ -138,10 +145,13 @@ async fn fetch_live(client: &reqwest::Client, url: &str, api_key: &str) -> Resul
         });
     }
 
-    // Sanity check we got a valid envelope. Schema drift surfaces here.
-    let _: Envelope = serde_json::from_slice(&bytes)
+    // Schema drift surfaces here — and so does Z.AI's in-band failure shape,
+    // which arrives as HTTP 200 with `success: false`. Both are errors, so the
+    // caller's fallback path runs and the good cache survives.
+    let env: Envelope = serde_json::from_slice(&bytes)
         .map_err(|e| AppError::Schema(format!("zai quota response: {e}")))?;
-    Ok(bytes)
+    env.check_ok()?;
+    Ok((bytes, env))
 }
 
 #[cfg(test)]
@@ -154,6 +164,108 @@ mod tests {
         let cache = Cache::at(td.path().join("zai"));
         cache.ensure_dir().unwrap();
         (td, cache)
+    }
+
+    const GOOD_BODY: &str = r#"{"code":200,"msg":"Operation successful","data":{
+        "limits":[{"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":42}],
+        "level":"pro"},"success":true}"#;
+
+    #[tokio::test]
+    async fn in_band_failure_on_200_is_rejected_and_keeps_the_good_cache() {
+        // The regression this guards: a 200 carrying `success:false` used to be
+        // written to cache, clearing the recorded error, and rendered as an
+        // unknown plan with empty windows — visually identical to "no usage".
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/api/monitor/usage/quota/limit")
+            .with_status(200)
+            .with_body(r#"{"code":401,"msg":"Unauthorized","data":null,"success":false}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        cache.write_payload(GOOD_BODY.as_bytes()).unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            quota: format!("{}/api/monitor/usage/quota/limit", server.url()),
+        };
+        let out = fetch_snapshot(
+            &client,
+            "k",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+            None,
+        )
+        .await
+        .unwrap();
+
+        // The last good figure is still shown, flagged stale...
+        assert!(out.stale);
+        assert_eq!(out.snapshot.plan, "GLM Coding Pro");
+        // ...and the good payload was NOT overwritten by the failure envelope.
+        let cached = String::from_utf8(cache.maybe_payload().unwrap().unwrap()).unwrap();
+        assert!(cached.contains("\"success\":true"), "cache was clobbered");
+    }
+
+    #[tokio::test]
+    async fn in_band_failure_with_no_cache_surfaces_the_error() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/api/monitor/usage/quota/limit")
+            .with_status(200)
+            .with_body(r#"{"code":500,"msg":"boom","data":null,"success":false}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            quota: format!("{}/api/monitor/usage/quota/limit", server.url()),
+        };
+        let out = fetch_snapshot(
+            &client,
+            "k",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+            None,
+        )
+        .await;
+        assert!(out.is_err(), "expected an error, got {out:?}");
+    }
+
+    #[tokio::test]
+    async fn corrupt_fresh_cache_refetches_instead_of_showing_unknown_plan() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/api/monitor/usage/quota/limit")
+            .with_status(200)
+            .with_body(GOOD_BODY)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        cache.write_payload(b"{ truncated").unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            quota: format!("{}/api/monitor/usage/quota/limit", server.url()),
+        };
+        // Long TTL: the payload IS fresh, it is just unusable.
+        let out = fetch_snapshot(
+            &client,
+            "k",
+            &cache,
+            &endpoints,
+            Duration::from_secs(3600),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.snapshot.plan, "GLM Coding Pro");
+        assert!(!out.stale);
     }
 
     #[tokio::test]

--- a/src/zai/types.rs
+++ b/src/zai/types.rs
@@ -45,6 +45,35 @@ pub struct Envelope {
     pub msg: String,
 }
 
+impl Envelope {
+    /// Z.AI signals failure *inside* a 200 response: `success: false` with a
+    /// non-200 `code` and the reason in `msg`, and `data: null`. Without this
+    /// check such a body deserializes cleanly, overwrites a good cache, clears
+    /// the previous error, and renders as an unknown plan with empty windows —
+    /// indistinguishable from a real account with no usage.
+    ///
+    /// `code` is accepted when absent (0) or 200; anything else is a failure.
+    pub fn check_ok(&self) -> crate::error::Result<()> {
+        if !self.success || (self.code != 0 && self.code != 200) {
+            let msg = if self.msg.is_empty() {
+                "no message".to_string()
+            } else {
+                self.msg.clone()
+            };
+            return Err(crate::error::AppError::Schema(format!(
+                "zai: API reported failure (code {}, success {}): {msg}",
+                self.code, self.success
+            )));
+        }
+        if self.data.is_none() {
+            return Err(crate::error::AppError::Schema(
+                "zai: success response carried no `data`".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
 pub struct MonitorData {


### PR DESCRIPTION
Independent of #23 and #24 — this branches from `main` and fixes defects in the **released** v0.13.0, not in the new vendors.

The review you left on #23/#24 was about one principle: never display or cache a number the code cannot actually vouch for. Applying that lens to the rest of the codebase turned up the same defect class in shipped vendors, plus several ways the tool can freeze or lose credentials. Every finding below was verified against the `v0.13.0` tag before being fixed, and every fix has a test.

Eight commits, each self-contained and separately reviewable. **Happy to split this into three PRs (data integrity / runtime + credentials / CI) if that reviews better — say the word.**

---

### `7bce7bc` — cache contract

- `MAX_STALE` (7 days) was **declared and never referenced**. Every failure path called `maybe_payload()` with no age check, so after weeks offline the bar kept rendering history as current, distinguished only by `⏸`. Adds `fallback_payload(max_stale)`; all 14 fallback sites go through it.
- A corrupt *fresh* cache became a zeroed snapshot in Anthropic, OpenAI, Z.AI, OpenRouter and DeepSeek — "$0.00", "0%", "Unknown plan", presented as current. They now fall through to a live fetch, which is what Kimi already did.
- **Z.AI accepted an in-band failure as usage.** Errors arrive as HTTP 200 with `success: false` / non-200 `code` / `data: null`. That body parsed cleanly and — worse — was written to the cache *before* anything examined it, destroying the last good payload and clearing the recorded error, then rendered as an unknown plan with empty windows. Now validated before caching.

### `f31b683` — config strictness

All five call sites used `Config::load().unwrap_or_default()`, discarding the distinction `load()` carefully makes between "file absent" and "file broken". A syntax error or permission problem silently produced the *default* vendor set. Each caller now handles it per its contract — the widget reports it through the existing `⚠` fallback and still exits 0. Also denies unknown top-level keys so `[openrouer]` fails by name; deliberately section-level only, so a config carrying a field from a future version still loads.

### `45ca361` — OAuth as a transaction

Both vendors persisted refreshed credentials with `let _ = write_back(...)`, commented as best-effort "because the refresh worked". That holds only while the refresh token is unchanged. On **rotation** the new token exists solely in memory: if the write fails, the token on disk is already spent, this run succeeds, and the next one cannot refresh — the user is logged out with no explanation. Now reported and handled as an auth failure. A failed write carrying only a new access token is still ignored, since nothing is lost. Also fixes OpenAI expiry: `expires_at_secs()` read only the `id_token` exp claim and ignored `auth.json`'s explicit `expires_at`, so a refresh with no new `id_token` left the old expired claim in place and every later run refreshed again.

### `f1d6073` — TUI runtime

- `acquire_lock` parks the thread in a sleep loop for up to 15–45s, and the TUI runs `flavor = "current_thread"`. One blocked task took the reactor with it: keyboard, timer and every other vendor's request stopped. A single concurrent widget invocation was enough. Adds `acquire_lock_async`.
- The keyboard branch created a fresh `spawn_blocking(event::poll)` **every** `select!` iteration; when another branch won, that task was not cancelled and orphans raced on `event::read()`, swallowing keypresses. One reader thread now owns stdin.
- Terminal restoration was straight-line code after the loop, skipped by any early return or panic — leaving raw mode, alternate screen, no cursor. Now an RAII guard.

Test holds the lock and proves an unrelated interval keeps firing on the same current-thread runtime.

### `958bac7` — macOS Keychain

`read_raw` mapped **every** `security(1)` failure to "no item", so a locked login Keychain or denied ACL produced "run `claude` to authenticate" while the credentials sat there intact. Only `errSecItemNotFound` (44) now means absent. Also fixes item selection: with `$USER` unset the read selected by service alone while the write passed `-a ""`, so a refresh could create a second item the read would never find.

**Not fixed here, deliberately:** the OAuth JSON is still passed to `security` in argv. Your comment says there is no stdin path — I checked, and that's correct: `add-generic-password -w` with no value prompts on the tty and asks for confirmation, so it cannot be piped. Removing that exposure needs the native Keychain API (a new macOS-only `security-framework` dependency), which felt like your call rather than something to slip into a fix PR.

### `1044dac` — config location

The binary resolved `config.toml` via `ProjectDirs` (macOS: `~/Library/Application Support/`), while the README, the example, `--help`, the GNOME prefs and the macOS menu bar all said `~/.config/`. Nothing made those the same file — so following the docs got you defaults, and the desktop surfaces reported "no key configured" for keys the binary was using. Platform path stays canonical; the legacy path is honored when it doesn't exist; both desktop surfaces check the same pair. **Nothing is moved or rewritten** — that file can hold API keys. GNOME also stops hard-coding `~/.config` and honors `$XDG_CONFIG_HOME`. Separately, `~` in `credentials_path` (the form the README shows) was kept literally by `PathBuf` and resolved to a directory named `~`; now expanded.

### `b178c5d` — desktop vendor-switch races

GNOME dropped any refresh requested while busy, so a vendor change mid-fetch never started one for the new vendor and the old result landed and stayed. `_refreshToken` didn't help — it's only bumped *inside* `_refresh()`, which had already returned. Now queued, with the vendor captured per attempt and stale results discarded. macOS had no coordination at all: timer, Preferences hook and vendor change could each spawn a subprocess and the last to finish won. Now one in flight, generation-tagged, plus a 45s watchdog matching GNOME's.

### `600c2b8` — CI and release gates

PRs ran **Windows only**. Linux — the platform the widget ships on — was first exercised *after* a tag was pushed, and tags are immutable by this project's own rule, so a failure costs a new patch release. `fmt`, `clippy` and `machete` were in the release checklist but ran nowhere.

More seriously, nothing checked that a release publishes what its tag claims. **At the `v0.13.0` tag, both `.SRCINFO` files still declare `0.8.0`** while `Cargo.toml` says `0.13.0` — and the release shipped. The new `verify-version` job (everything depends on it) requires an existing `vX.Y.Z` tag and agreement across `Cargo.toml`, both PKGBUILDs, both `.SRCINFO`s and `CHANGELOG.md`. I ran it against the real v0.13.0 tree: it fails on both `.SRCINFO`s, which is exactly the release it should have blocked. `workflow_dispatch` also stops accepting an arbitrary commit, and `contents: write` is scoped to the one publishing job.

---

**Gate:** 359 tests green, `cargo clippy --all-targets --locked -- -D warnings` clean, `cargo fmt --all --check` clean, GNOME marker tests pass, the Swift menu bar app compiles.

**Behavior changes worth flagging:** a misspelled config section is now an error rather than ignored; a failure with nothing usable cached now surfaces the error instead of week-old numbers. Both are intentional, but they are user-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
