### PR TITLE
fix: reject lenient wire values, escape API-controlled text, bound response bodies

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -22,9 +22,11 @@ enabled = true
 # Path to the Codex CLI OAuth credentials. Leave commented out to use
 # the default ~/.codex/auth.json.
 # codex_auth_path = "/home/you/.codex/auth.json"
-# Reserved for a future API-key-only fallback path (admin key reads
-# `/v1/organization/costs`). Today, OpenAI requires Codex OAuth.
-admin_key_env = "OPENAI_ADMIN_KEY"
+# RESERVED — setting this does nothing today. It names the env var a future
+# API-key-only path would read (admin key → `/v1/organization/costs`). No code
+# consumes it: OpenAI usage comes only from Codex OAuth. Left commented out so
+# it isn't mistaken for a working alternative to `codex login`.
+# admin_key_env = "OPENAI_ADMIN_KEY"
 
 [zai]
 enabled = true

--- a/gnome-extension/README.md
+++ b/gnome-extension/README.md
@@ -15,7 +15,8 @@ GNOME screenshot is currently bundled.
 
 The selector supports **Anthropic, OpenAI, Z.AI, OpenRouter, and DeepSeek**.
 **Kimi is widget/TUI-only in this release**; desktop protocol and marker parity
-for Kimi is dedicated future work.
+for Kimi is dedicated future work. DeepSeek is balance-only, so the extension
+shows its balance in the header and suppresses the 5h/weekly quota rows.
 
 ## Requirements
 
@@ -66,7 +67,7 @@ mkdir -p "$DEST" && cp -r * "$DEST"/      # or: ln -s "$PWD" "$DEST"
 It runs:
 
 ```
-ai-usagebar --vendor <vendor> --format '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;{scoped_model};;{scoped_pct};;{scoped_reset};;{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;__aiub_end__'
+ai-usagebar --vendor <vendor> --format '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;{scoped_model};;{scoped_pct};;{scoped_reset};;{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;{vendor_short};;__aiub_end__'
 ```
 
 parses the Waybar JSON (`{text, tooltip, class}`), extracts the formatted
@@ -85,7 +86,8 @@ point uses Rust's point-delta
 severity bands: at least 10 points ahead is red, 1–9 ahead is orange, -10
 through on-pace is yellow, and more than 10 under is green. A missing reset
 (including `—`) keeps its row visible but suppresses the marker, even if an
-older binary reports elapsed `0`. The final `__aiub_end__` literal is ignored;
+older binary reports elapsed `0`. `{vendor_short}` distinguishes balance-only
+DeepSeek from quota vendors. The final `__aiub_end__` literal is ignored;
 it receives a stale `⏸` suffix so the last elapsed field remains numeric.
 
 The subprocess is spawned **asynchronously** (`Gio.Subprocess` +

--- a/gnome-extension/extension.js
+++ b/gnome-extension/extension.js
@@ -17,8 +17,8 @@ import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
-import {barMarkup, colorForPct, field, FIELD, FORMAT, integer, markerElapsed,
-    splitFormatOutput} from './marker-logic.js';
+import {barMarkup, colorForPct, field, FIELD, FORMAT, hasUsageWindows, integer, markerElapsed,
+    plainTextFromPango, splitFormatOutput} from './marker-logic.js';
 
 const ROLE = 'ai-usagebar';
 
@@ -296,7 +296,7 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             this._setError('saída inválida', stdout);
             return;
         }
-        const raw = (data.text ?? '').toString().replace(/<[^>]*>/g, '');
+        const raw = plainTextFromPango(data.text);
         const f = splitFormatOutput(raw);
         if (f.length <= FIELD.extraLimit) {
             // Loading… / ⚠ — show the binary's own text.
@@ -306,6 +306,7 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         }
         this._data = {
             plan: field(f[FIELD.plan]),
+            hasUsageWindows: hasUsageWindows(f[FIELD.vendorShort]),
             session: {pct: integer(f[FIELD.sessionPct]) ?? 0, reset: field(f[FIELD.sessionReset]),
                 elapsed: markerElapsed(field(f[FIELD.sessionReset]), integer(f[FIELD.sessionElapsed]))},
             weekly: {pct: integer(f[FIELD.weeklyPct]) ?? 0, reset: field(f[FIELD.weeklyReset]),
@@ -360,9 +361,9 @@ class AiUsageBarIndicator extends PanelMenu.Button {
         };
 
         const parts = [];
-        if (this._settings.get_boolean('show-session'))
+        if (d.hasUsageWindows && this._settings.get_boolean('show-session'))
             parts.push(seg('5h', d.session.pct, `${d.session.pct}%`, d.session.elapsed));
-        if (this._settings.get_boolean('show-weekly'))
+        if (d.hasUsageWindows && this._settings.get_boolean('show-weekly'))
             parts.push(seg('7d', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.elapsed));
         if (this._settings.get_boolean('show-extra') &&
             d.extra.pct != null && d.extra.spent && d.extra.limit)
@@ -390,8 +391,10 @@ class AiUsageBarIndicator extends PanelMenu.Button {
             }
         };
 
-        upd('session', d.session.pct, `${d.session.pct}%`, d.session.reset, true, d.session.elapsed);
-        upd('weekly', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.reset, true, d.weekly.elapsed);
+        upd('session', d.session.pct, `${d.session.pct}%`, d.session.reset,
+            d.hasUsageWindows, d.session.elapsed);
+        upd('weekly', d.weekly.pct, `${d.weekly.pct}%`, d.weekly.reset,
+            d.hasUsageWindows, d.weekly.elapsed);
         // Label the per-model weekly row by the scoped model (e.g. "Fable").
         this._rows.sonnet.nameL.text = d.sonnet.label || 'Sonnet only';
         upd('sonnet', d.sonnet.pct, `${d.sonnet.pct ?? 0}%`, d.sonnet.reset, d.sonnet.pct != null, d.sonnet.elapsed);

--- a/gnome-extension/marker-logic.js
+++ b/gnome-extension/marker-logic.js
@@ -6,16 +6,30 @@ export const POINT_CRITICAL_MIN = 10;
 export const FORMAT = '{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;' +
     '{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;' +
     '{scoped_model};;{scoped_pct};;{scoped_reset};;' +
-    '{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;__aiub_end__';
+    '{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;{vendor_short};;__aiub_end__';
 export const FIELD = Object.freeze({
     plan: 0, sessionPct: 1, sessionReset: 2, weeklyPct: 3, weeklyReset: 4,
     sonnetPct: 5, sonnetReset: 6, extraPct: 7, extraSpent: 8, extraLimit: 9,
     scopedModel: 10, scopedPct: 11, scopedReset: 12,
-    sessionElapsed: 13, weeklyElapsed: 14, scopedElapsed: 15, sentinel: 16,
+    sessionElapsed: 13, weeklyElapsed: 14, scopedElapsed: 15, vendorShort: 16,
+    sentinel: 17,
 });
 
 export function splitFormatOutput(text) {
     return String(text).split(';;');
+}
+
+// The CLI output is Pango markup. Strip only tags first, then decode one layer
+// of XML entities so API labels escaped by Rust display as literal text rather
+// than "&amp;". Decoding after tag removal cannot reintroduce active markup.
+export function plainTextFromPango(value) {
+    return String(value ?? '')
+        .replace(/<[^>]*>/g, '')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&amp;/g, '&');
 }
 
 export function field(value) {
@@ -31,6 +45,13 @@ export function integer(value) {
 
 export function markerElapsed(reset, elapsed) {
     return reset && reset !== '—' && Number.isFinite(elapsed) ? elapsed : null;
+}
+
+// Balance-only vendors do not expose generic rolling quota windows. Keep this
+// vendor-aware at the native surface so their compatibility aliases cannot
+// turn into confident 0% bars.
+export function hasUsageWindows(vendorShort) {
+    return field(vendorShort) !== 'dsk';
 }
 
 // Matches pacing::pace_severity: < -10 low, -10..=0 mid, 1..=9 high, >= 10 critical.

--- a/gnome-extension/marker-logic.test.mjs
+++ b/gnome-extension/marker-logic.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import {barMarkup, colorForDelta, field, FIELD, FORMAT, integer, markerElapsed,
-    splitFormatOutput} from './marker-logic.js';
+import {barMarkup, colorForDelta, field, FIELD, FORMAT, hasUsageWindows, integer, markerElapsed,
+    plainTextFromPango, splitFormatOutput} from './marker-logic.js';
 
 const colors = {low: 'low', mid: 'mid', high: 'high', critical: 'critical', empty: 'empty'};
 const visibleCells = markup => markup.replace(/<[^>]+>/g, '');
@@ -15,18 +15,24 @@ assert.equal(integer('27'), 27);
 assert.equal(integer('27 ⏸'), null);
 assert.equal(integer('{scoped_elapsed}'), null);
 assert.equal(field('{scoped_model}'), '');
+assert.equal(plainTextFromPango('<span>A &amp; B &lt;b&gt;</span>'), 'A & B <b>');
+assert.equal(plainTextFromPango('&amp;lt;literal&amp;gt;'), '&lt;literal&gt;');
+assert.equal(hasUsageWindows('dsk'), false);
+assert.equal(hasUsageWindows('gpt'), true);
+assert.equal(hasUsageWindows('{vendor_short}'), true); // older binary compatibility
 const formatFields = FORMAT.split(';;');
 assert.deepEqual(formatFields, [
     '{plan}', '{session_pct}', '{session_reset}', '{weekly_pct}', '{weekly_reset}',
     '{sonnet_pct}', '{sonnet_reset}', '{extra_pct}', '{extra_spent}', '{extra_limit}',
     '{scoped_model}', '{scoped_pct}', '{scoped_reset}', '{session_elapsed}',
-    '{weekly_elapsed}', '{scoped_elapsed}', '__aiub_end__',
+    '{weekly_elapsed}', '{scoped_elapsed}', '{vendor_short}', '__aiub_end__',
 ]);
 assert.deepEqual(FIELD, {
     plan: 0, sessionPct: 1, sessionReset: 2, weeklyPct: 3, weeklyReset: 4,
     sonnetPct: 5, sonnetReset: 6, extraPct: 7, extraSpent: 8, extraLimit: 9,
     scopedModel: 10, scopedPct: 11, scopedReset: 12,
-    sessionElapsed: 13, weeklyElapsed: 14, scopedElapsed: 15, sentinel: 16,
+    sessionElapsed: 13, weeklyElapsed: 14, scopedElapsed: 15, vendorShort: 16,
+    sentinel: 17,
 });
 const values = {'{scoped_elapsed}': '27'};
 const framed = splitFormatOutput(formatFields.map(value => values[value] ?? value).join(';;') + ' ⏸');

--- a/macos/README.md
+++ b/macos/README.md
@@ -15,7 +15,8 @@ A single Swift file (`NSStatusItem` + `NSAttributedString`); no Xcode project.
 
 The selector supports **Anthropic, OpenAI, Z.AI, OpenRouter, and DeepSeek**.
 **Kimi is widget/TUI-only in this release**; desktop protocol and marker parity
-for Kimi is dedicated future work.
+for Kimi is dedicated future work. DeepSeek is balance-only, so the app shows
+its balance in the header and suppresses the 5h/weekly quota rows.
 
 ## Requirements
 

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -70,12 +70,13 @@ let POINT_CRITICAL_MIN = 10
 // The `{scoped_*}` fields (10-12) carry the model-scoped weekly window (e.g.
 // "Fable") from the API's `limits[]`; empty on older binaries → the row falls
 // back to the flat `{sonnet_*}` window and the "Sonnet only" label. The trailing
-// `*_elapsed` fields (13-15) carry the meta (pace) position. A final literal
-// sentinel absorbs the widget's stale suffix, preserving the elapsed fields.
+// `*_elapsed` fields (13-15) carry the meta (pace) position; `vendor_short`
+// (16) lets balance-only vendors suppress meaningless quota rows. A final
+// literal sentinel absorbs the widget's stale suffix, preserving these fields.
 let FORMAT = "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;" +
              "{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;" +
              "{scoped_model};;{scoped_pct};;{scoped_reset};;" +
-             "{session_elapsed};;{weekly_elapsed};;{scoped_elapsed}"
+             "{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;{vendor_short}"
 
 let FORMAT_WITH_SENTINEL = FORMAT + ";;__aiub_end__"
 
@@ -183,6 +184,7 @@ func resolveBinary(_ name: String) -> String? {
 struct Window { let pct: Int; let reset: String; let elapsed: Int? }
 struct Snapshot {
     let plan: String
+    let hasUsageWindows: Bool
     let session: Window
     let weekly: Window
     /// The per-model weekly bar (model-scoped window, e.g. Fable, or the legacy
@@ -194,7 +196,15 @@ struct Snapshot {
 }
 
 func stripMarkup(_ s: String) -> String {
+    // Decode exactly one layer after removing tags. Rust escapes API-controlled
+    // labels for Pango; the native surface consumes plain text and must not
+    // display those entities literally or reactivate decoded markup.
     s.replacingOccurrences(of: "<[^>]*>", with: "", options: .regularExpression)
+        .replacingOccurrences(of: "&lt;", with: "<")
+        .replacingOccurrences(of: "&gt;", with: ">")
+        .replacingOccurrences(of: "&quot;", with: "\"")
+        .replacingOccurrences(of: "&apos;", with: "'")
+        .replacingOccurrences(of: "&amp;", with: "&")
 }
 
 func parse(_ text: String) -> Snapshot? {
@@ -238,6 +248,7 @@ func parse(_ text: String) -> Snapshot? {
     let extra: (pct: Int, spent: String, limit: String)? =
         (spent.isEmpty || limit.isEmpty) ? nil : n(7).map { (pct: $0, spent: spent, limit: limit) }
     return Snapshot(plan: t(0),
+                    hasUsageWindows: t(16) != "dsk",
                     session: Window(pct: n(1) ?? 0, reset: t(2), elapsed: markerElapsed(reset: t(2), elapsed: n(13))),
                     weekly: Window(pct: n(3) ?? 0, reset: t(4), elapsed: markerElapsed(reset: t(4), elapsed: n(14))),
                     sonnet: sonnet,
@@ -743,8 +754,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if SHOW_BARS { title.append(barAttr(pct: pct, width: BAR_WIDTH, elapsed: elapsed)) }
             if !SHOW_PERCENT && !SHOW_BARS { title.append(run(value, colorForPct(pct))) }
         }
-        if SHOW_SESSION { seg("5h", s.session.pct, "\(s.session.pct)%", s.session.elapsed) }
-        if SHOW_WEEKLY { seg("7d", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.elapsed) }
+        if s.hasUsageWindows && SHOW_SESSION {
+            seg("5h", s.session.pct, "\(s.session.pct)%", s.session.elapsed)
+        }
+        if s.hasUsageWindows && SHOW_WEEKLY {
+            seg("7d", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.elapsed)
+        }
         if SHOW_EXTRA, let e = s.extra { seg("ex", e.pct, e.spent, nil) } // $ budget → no meta
         statusItem.button?.attributedTitle = title.length > 0 ? title : run("ai", .secondaryLabelColor)
     }
@@ -766,8 +781,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if let r = reset, !r.isEmpty { a.append(run("   ↺ \(r)", .secondaryLabelColor)) }
             item.attributedTitle = a
         }
-        row("session", "Session", s.session.pct, "\(s.session.pct)%", s.session.reset, s.session.elapsed)
-        row("weekly", "Weekly", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.reset, s.weekly.elapsed)
+        if s.hasUsageWindows {
+            row("session", "Session", s.session.pct, "\(s.session.pct)%", s.session.reset, s.session.elapsed)
+            row("weekly", "Weekly", s.weekly.pct, "\(s.weekly.pct)%", s.weekly.reset, s.weekly.elapsed)
+        } else {
+            rows["session"]?.isHidden = true
+            rows["weekly"]?.isHidden = true
+        }
         if let sn = s.sonnet { row("sonnet", s.sonnetLabel, sn.pct, "\(sn.pct)%", sn.reset, sn.elapsed) }
         else { rows["sonnet"]?.isHidden = true }
         if let e = s.extra { row("extra", "Extra usage", e.pct, "\(e.spent) / \(e.limit)", nil, nil) }

--- a/src/active.rs
+++ b/src/active.rs
@@ -7,10 +7,17 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use crate::cache::atomic_write;
+use crate::cache::{acquire_lock, atomic_write};
 use crate::error::{AppError, Result};
 use crate::vendor::VendorId;
+
+/// Much shorter than the vendors' fetch locks (15–45s): the critical section
+/// here is one small read plus a rename, so a wait this long already means a
+/// wedged holder — and a scroll event that blocks for seconds is worse than a
+/// dropped one.
+const LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn state_dir() -> Result<PathBuf> {
     let base = directories::BaseDirs::new()
@@ -54,6 +61,14 @@ pub fn cycle(enabled: &[VendorId], start: VendorId, delta: i32) -> Result<Vendor
     cycle_at(&state_path()?, enabled, start, delta)
 }
 
+/// The flock guarding a state file's read-modify-write, as a sibling of the
+/// state file itself (mirroring `Cache::lock_path`'s `.fetch.lock`).
+fn lock_path_for(state: &Path) -> PathBuf {
+    let mut p = state.as_os_str().to_os_string();
+    p.push(".lock");
+    PathBuf::from(p)
+}
+
 /// Cycle using an explicit state-file path. The real-path [`cycle`] is a thin
 /// wrapper over this; tests drive this with a `TempDir` path so the cycle +
 /// persistence logic is covered without reading or writing the real cache.
@@ -66,6 +81,11 @@ pub fn cycle_at(
     if enabled.is_empty() {
         return Err(AppError::Other("no enabled vendors to cycle".into()));
     }
+    // One flick of a scroll wheel fires several `--cycle-next` processes at
+    // once. An atomic *write* only guarantees no torn file — it does not stop
+    // two of them reading the same current vendor and both persisting the same
+    // next one, silently eating a step. The lock has to span read→compute→write.
+    let _lock = acquire_lock(&lock_path_for(path), LOCK_TIMEOUT)?;
     let current = read_from(path)
         .filter(|v| enabled.contains(v))
         .unwrap_or(start);
@@ -102,6 +122,38 @@ mod tests {
         VendorId::Zai,
         VendorId::Openrouter,
     ];
+
+    /// One flick of a scroll wheel fires several `--cycle-next` processes at
+    /// once. Before the lock spanned the read-modify-write, two of them could
+    /// read the same current vendor and both persist the same next one, so N
+    /// events advanced fewer than N steps. With the lock held across the whole
+    /// operation, every cycle observes its predecessor's write.
+    #[test]
+    fn concurrent_cycles_do_not_lose_a_step() {
+        let td = TempDir::new().unwrap();
+        let path = td.path().join("active_vendor");
+        let start = VendorId::Anthropic;
+
+        // Four threads, each doing one +1 step, over a 4-vendor set: if no step
+        // is lost the value returns exactly to `start`.
+        const THREADS: usize = 4;
+        std::thread::scope(|s| {
+            for _ in 0..THREADS {
+                s.spawn(|| {
+                    let _ = cycle_at(&path, &CYCLE_SET, start, 1);
+                });
+            }
+        });
+
+        let landed = read_from(&path).expect("a vendor must have been persisted");
+        assert_eq!(
+            landed,
+            start,
+            "{THREADS} single steps over {} vendors must return to the start; \
+             landing on {landed:?} means a step was lost to a race",
+            CYCLE_SET.len()
+        );
+    }
 
     #[test]
     fn parse_slug_round_trip() {

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -269,7 +269,7 @@ async fn fetch_usage(client: &reqwest::Client, url: &str, creds: &OauthCreds) ->
         .await?;
 
     let status = resp.status();
-    let bytes = resp.bytes().await?;
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
 
     if status.is_success() {
         // Validate it's a usage shape — keep claudebar's "must have five_hour"

--- a/src/anthropic/oauth.rs
+++ b/src/anthropic/oauth.rs
@@ -79,7 +79,10 @@ pub async fn refresh(
         .await?;
 
     let status = resp.status();
-    let body = resp.text().await.unwrap_or_default();
+    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES)
+        .await
+        .map(|b| String::from_utf8_lossy(&b).into_owned())
+        .unwrap_or_default();
 
     if !status.is_success() {
         // claudebar tolerates three error-body shapes (claudebar:464-476):

--- a/src/anthropic/oauth.rs
+++ b/src/anthropic/oauth.rs
@@ -4,7 +4,7 @@
 //! - `client_id` is the public Claude CLI ID (not a secret).
 //! - Beta header `anthropic-beta: oauth-2025-04-20` is required.
 //! - `User-Agent: claude-cli/1.0` matches the CLI; some endpoints gate on it.
-//! - `expires_in` may arrive as float; we accept either.
+//! - `expires_in` may arrive as an integral float; we accept either form.
 //! - The server sometimes returns a rotated `refresh_token`, sometimes not —
 //!   callers fall back to the old one when absent.
 
@@ -30,11 +30,39 @@ struct RefreshRequest<'a> {
 
 #[derive(Debug, Deserialize)]
 pub struct RefreshResponse {
+    #[serde(deserialize_with = "de_nonempty_string")]
     pub access_token: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_nonempty_string")]
     pub refresh_token: Option<String>,
     #[serde(deserialize_with = "de_expires_in")]
     pub expires_in: u64,
+}
+
+fn de_nonempty_string<'de, D>(d: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(d)?;
+    if value.trim().is_empty() {
+        Err(serde::de::Error::custom("token cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn de_opt_nonempty_string<'de, D>(d: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(d)?
+        .map(|value| {
+            if value.trim().is_empty() {
+                Err(serde::de::Error::custom("token cannot be empty"))
+            } else {
+                Ok(value)
+            }
+        })
+        .transpose()
 }
 
 fn de_expires_in<'de, D>(d: D) -> std::result::Result<u64, D::Error>
@@ -44,12 +72,19 @@ where
     let v = serde_json::Value::deserialize(d)?;
     match v {
         serde_json::Value::Number(n) => {
-            if let Some(u) = n.as_u64() {
+            const MAX_SAFE_EXPIRES_IN: u64 = (i64::MAX as u64) / 2_000;
+            if let Some(u) = n.as_u64().filter(|u| *u <= MAX_SAFE_EXPIRES_IN) {
                 Ok(u)
-            } else if let Some(f) = n.as_f64() {
+            } else if let Some(f) = n.as_f64()
+                && f.is_finite()
+                && f.fract() == 0.0
+                && (0.0..=MAX_SAFE_EXPIRES_IN as f64).contains(&f)
+            {
                 Ok(f as u64)
             } else {
-                Err(serde::de::Error::custom("expires_in not numeric"))
+                Err(serde::de::Error::custom(
+                    "expires_in must be a non-negative integer in range",
+                ))
             }
         }
         _ => Err(serde::de::Error::custom("expires_in must be a number")),
@@ -79,10 +114,8 @@ pub async fn refresh(
         .await?;
 
     let status = resp.status();
-    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES)
-        .await
-        .map(|b| String::from_utf8_lossy(&b).into_owned())
-        .unwrap_or_default();
+    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
+    let body = String::from_utf8_lossy(&body).into_owned();
 
     if !status.is_success() {
         // claudebar tolerates three error-body shapes (claudebar:464-476):
@@ -188,6 +221,37 @@ mod tests {
     #[test]
     fn parse_error_body_invalid_json_returns_none() {
         assert!(parse_error_body("not json").is_none());
+    }
+
+    #[test]
+    fn malformed_expires_in_is_not_truncated_or_saturated() {
+        for value in [
+            "3600.5",
+            "-1",
+            "1e300",
+            "18446744073709551615",
+            "true",
+            r#""3600""#,
+        ] {
+            let body = format!(r#"{{"access_token":"new","expires_in":{value}}}"#);
+            assert!(
+                serde_json::from_str::<RefreshResponse>(&body).is_err(),
+                "{body}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_refresh_tokens_are_schema_drift_not_credentials_to_persist() {
+        for body in [
+            r#"{"access_token":"","expires_in":3600}"#,
+            r#"{"access_token":"new","refresh_token":"   ","expires_in":3600}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<RefreshResponse>(body).is_err(),
+                "{body}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -34,7 +34,7 @@ pub struct UsageResponse {
 pub struct LimitEntry {
     #[serde(default)]
     pub kind: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_percent_opt")]
     pub percent: Option<f64>,
     #[serde(default)]
     pub resets_at: Option<String>,
@@ -57,7 +57,7 @@ pub struct LimitModel {
 /// A single usage window — `utilization` is `0..=100` (integer percent).
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
 pub struct Window {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_percent")]
     pub utilization: f64,
     #[serde(default)]
     pub resets_at: Option<String>,
@@ -99,6 +99,47 @@ where
     }
 }
 
+/// Slack tolerated above 100. The endpoint occasionally reports a hair over its
+/// own cap — `used/limit` rounding, or usage that landed just before the block
+/// did — and `to_window` saturates that back to 100.
+const PCT_SLACK: f64 = 1.0;
+
+/// Gate a wire percentage into `0..=100` (+ [`PCT_SLACK`]).
+///
+/// Rejecting here rather than in `to_window` is deliberate: `to_window` is
+/// infallible and `into_snapshot` has no error channel, so the parse boundary
+/// is the only place a bad value can still become a loud failure. A rejection
+/// surfaces as `AppError::Json` and reaches the user as `⚠` — never as a
+/// number we invented. Past the slack the field simply isn't a percentage on
+/// this scale (rescaled to per-mille, a raw counter, a sentinel), and clamping
+/// it would paint a "100%" bar we cannot vouch for. Non-finite values matter
+/// most: `f64::NAN as i32` is silently `0`.
+fn checked_percent<E: serde::de::Error>(v: f64) -> std::result::Result<f64, E> {
+    if !v.is_finite() {
+        return Err(E::custom(format!("percentage {v} is not finite")));
+    }
+    if !(0.0..=100.0 + PCT_SLACK).contains(&v) {
+        return Err(E::custom(format!("percentage {v} outside 0..=100")));
+    }
+    Ok(v)
+}
+
+fn de_percent<'de, D>(d: D) -> std::result::Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    checked_percent(f64::deserialize(d)?)
+}
+
+fn de_percent_opt<'de, D>(d: D) -> std::result::Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<f64>::deserialize(d)?
+        .map(checked_percent)
+        .transpose()
+}
+
 impl UsageResponse {
     /// Lift the wire response into our canonical [`AnthropicSnapshot`].
     ///
@@ -118,8 +159,10 @@ impl UsageResponse {
                 };
             };
             UsageWindow {
-                // Round to nearest, matching claudebar's `| round` jq filter.
-                utilization_pct: w.utilization.round() as i32,
+                // Round to nearest, matching claudebar's `| round` jq filter,
+                // then absorb the overshoot `de_percent` deliberately lets
+                // through (100.4 → 100) so the bar never renders past full.
+                utilization_pct: (w.utilization.round() as i32).clamp(0, 100),
                 resets_at: w
                     .resets_at
                     .as_deref()
@@ -145,9 +188,14 @@ impl UsageResponse {
             .filter(|l| l.kind.as_deref() == Some("weekly_scoped"))
             .filter_map(|l| {
                 let label = l.scope?.model?.display_name?;
+                // Same `?` discipline as the label above: an entry without a
+                // percentage is dropped, not defaulted. `unwrap_or(0.0)` drew a
+                // confident "Fable 0%" bar under a real model name — a number
+                // the API never sent, which is worse than no bar at all.
+                let utilization = l.percent?;
                 let window = to_window(
                     Some(Window {
-                        utilization: l.percent.unwrap_or(0.0),
+                        utilization,
                         resets_at: l.resets_at,
                     }),
                     WEEKLY,
@@ -261,6 +309,79 @@ mod tests {
         assert_eq!(snap.session.utilization_pct, 0);
         assert_eq!(snap.weekly.utilization_pct, 0);
         assert!(snap.session.resets_at.is_none());
+    }
+
+    #[test]
+    fn benign_overshoot_saturates_to_hundred() {
+        // A hair over the cap is rounding noise, not drift — it must render as
+        // a full bar, not break the widget.
+        let raw = r#"{
+            "five_hour": {"utilization": 100.4},
+            "seven_day": {"utilization": 100.6}
+        }"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        let snap = resp.into_snapshot("Pro".into());
+        assert_eq!(snap.session.utilization_pct, 100);
+        assert_eq!(snap.weekly.utilization_pct, 100); // rounds to 101, saturated
+    }
+
+    #[test]
+    fn out_of_range_utilization_is_rejected_not_clamped() {
+        for raw in [
+            r#"{"five_hour": {"utilization": 500}}"#,
+            r#"{"five_hour": {"utilization": -1}}"#,
+            r#"{"seven_day": {"utilization": 101.5}}"#,
+        ] {
+            let err = serde_json::from_str::<UsageResponse>(raw).unwrap_err();
+            assert!(err.to_string().contains("outside 0..=100"), "{raw}: {err}");
+        }
+    }
+
+    #[test]
+    fn out_of_range_scoped_percent_is_rejected() {
+        // `limits[].percent` reaches the same bar via the synthesized Window.
+        let raw = r#"{
+            "limits": [{"kind": "weekly_scoped", "percent": 420,
+                        "scope": {"model": {"display_name": "Fable"}}}]
+        }"#;
+        let err = serde_json::from_str::<UsageResponse>(raw).unwrap_err();
+        assert!(err.to_string().contains("outside 0..=100"), "{err}");
+    }
+
+    #[test]
+    fn non_finite_percentage_is_rejected() {
+        // `f64::NAN as i32` is silently 0 — the fabricated number this gate
+        // exists to prevent. JSON has no NaN literal, so drive it directly.
+        for v in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(checked_percent::<serde_json::Error>(v).is_err(), "{v}");
+        }
+    }
+
+    #[test]
+    fn scoped_limit_without_a_percentage_is_dropped_not_zeroed() {
+        // The gate rejects impossible numbers; an absent one is not a parse
+        // failure. But it must not become a bar either: `unwrap_or(0.0)` drew a
+        // confident "Fable 0%" under a real model name that the API never sent.
+        let raw = r#"{
+            "limits": [{"kind": "weekly_scoped", "percent": null,
+                        "scope": {"model": {"display_name": "Fable"}}}]
+        }"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        let snap = resp.into_snapshot("Pro".into());
+        assert!(
+            snap.scoped.is_empty(),
+            "a scoped limit with no percentage must not render a fabricated bar"
+        );
+
+        // A real percentage still produces the window, so the drop is targeted.
+        let ok = r#"{
+            "limits": [{"kind": "weekly_scoped", "percent": 84,
+                        "scope": {"model": {"display_name": "Fable"}}}]
+        }"#;
+        let resp: UsageResponse = serde_json::from_str(ok).unwrap();
+        let snap = resp.into_snapshot("Pro".into());
+        assert_eq!(snap.scoped[0].label, "Fable");
+        assert_eq!(snap.scoped[0].window.utilization_pct, 84);
     }
 
     #[test]

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -63,32 +63,42 @@ pub struct Window {
     pub resets_at: Option<String>,
 }
 
-/// Pay-as-you-go extra usage. Both money values are integer cents, but the
-/// API sometimes returns them as floats (e.g. `0.0`) so we accept either.
+/// Pay-as-you-go extra usage. Both money values are non-negative integer cents,
+/// but the API sometimes returns integral floats (e.g. `0.0`). Missing values
+/// remain absent so an enabled but incomplete block cannot manufacture $0.00.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ExtraUsageBlock {
     #[serde(default)]
     pub is_enabled: bool,
-    #[serde(default, deserialize_with = "de_int_or_float")]
-    pub monthly_limit: i64,
-    #[serde(default, deserialize_with = "de_int_or_float")]
-    pub used_credits: i64,
+    #[serde(default, deserialize_with = "de_opt_cents")]
+    pub monthly_limit: Option<i64>,
+    #[serde(default, deserialize_with = "de_opt_cents")]
+    pub used_credits: Option<i64>,
 }
 
-/// Accept JSON int or float, truncating floats. Mirrors claudebar's
-/// `(.field // 0) | floor` jq pattern.
-fn de_int_or_float<'de, D>(d: D) -> std::result::Result<i64, D::Error>
+fn de_opt_cents<'de, D>(d: D) -> std::result::Result<Option<i64>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
     match v {
-        serde_json::Value::Null => Ok(0),
+        serde_json::Value::Null => Ok(None),
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Ok(i)
+                if i >= 0 {
+                    Ok(Some(i))
+                } else {
+                    Err(serde::de::Error::custom("cents cannot be negative"))
+                }
             } else if let Some(f) = n.as_f64() {
-                Ok(f as i64)
+                const MAX_EXACT_F64_INT: f64 = (1_u64 << 53) as f64;
+                if f.is_finite() && f.fract() == 0.0 && (0.0..=MAX_EXACT_F64_INT).contains(&f) {
+                    Ok(Some(f as i64))
+                } else {
+                    Err(serde::de::Error::custom(
+                        "cents must be a non-negative integer in range",
+                    ))
+                }
             } else {
                 Err(serde::de::Error::custom("number out of i64 range"))
             }
@@ -175,13 +185,12 @@ impl UsageResponse {
         let session = to_window(self.five_hour, SESSION);
         let weekly = to_window(self.seven_day, WEEKLY);
         let sonnet = self.seven_day_sonnet.map(|w| to_window(Some(w), WEEKLY));
-        let extra = self
-            .extra_usage
-            .filter(|e| e.is_enabled)
-            .map(|e| ExtraUsage {
-                limit: Cents(e.monthly_limit),
-                spent: Cents(e.used_credits),
-            });
+        let extra = self.extra_usage.filter(|e| e.is_enabled).and_then(|e| {
+            Some(ExtraUsage {
+                limit: Cents(e.monthly_limit?),
+                spent: Cents(e.used_credits?),
+            })
+        });
         let scoped = self
             .limits
             .into_iter()
@@ -300,6 +309,39 @@ mod tests {
         let resp: UsageResponse = serde_json::from_str(raw).unwrap();
         let snap = resp.into_snapshot("Pro".into());
         assert!(snap.extra.is_none());
+    }
+
+    #[test]
+    fn enabled_incomplete_extra_usage_does_not_invent_zero_money() {
+        for raw in [
+            r#"{"extra_usage":{"is_enabled":true,"monthly_limit":5000}}"#,
+            r#"{"extra_usage":{"is_enabled":true,"used_credits":250}}"#,
+            r#"{"extra_usage":{"is_enabled":true,"monthly_limit":null,"used_credits":250}}"#,
+        ] {
+            let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+            assert!(resp.into_snapshot("Pro".into()).extra.is_none(), "{raw}");
+        }
+    }
+
+    #[test]
+    fn malformed_cent_values_are_schema_drift() {
+        for value in ["-1", "1.5", "1e300", "true", r#""lots""#] {
+            let raw = format!(
+                r#"{{"extra_usage":{{"is_enabled":true,"monthly_limit":{value},"used_credits":0}}}}"#
+            );
+            assert!(
+                serde_json::from_str::<UsageResponse>(&raw).is_err(),
+                "{raw}"
+            );
+        }
+
+        let resp: UsageResponse = serde_json::from_str(
+            r#"{"extra_usage":{"is_enabled":true,"monthly_limit":5000.0,"used_credits":250.0}}"#,
+        )
+        .unwrap();
+        let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
+        assert_eq!(extra.limit.0, 5000);
+        assert_eq!(extra.spent.0, 250);
     }
 
     #[test]

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -194,6 +194,7 @@ where
                                 app.select_primary(config.ui.primary);
                                 spawn_all(app, client, config, &tx);
                             }
+                            SAction::Quit => return Ok(()),
                         }
                         continue;
                     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -169,9 +169,9 @@ impl Cache {
         self.stale_path().exists()
     }
 
-    /// Write the `.last_error` marker — first line `code`, second line `msg`.
-    /// Best-effort, never errors (matches claudebar:478-486 which silently
-    /// continues if the cache dir isn't writable).
+    /// Write the `.last_error` marker — first line `code`, everything after it
+    /// `msg`. Best-effort, never errors (matches claudebar:478-486 which
+    /// silently continues if the cache dir isn't writable).
     pub fn write_last_error(&self, code: u16, msg: &str) {
         let _ = self.ensure_dir();
         let path = self.last_error_path();
@@ -186,10 +186,13 @@ impl Cache {
 
     pub fn read_last_error(&self) -> Option<(u16, String)> {
         let raw = fs::read_to_string(self.last_error_path()).ok()?;
-        let mut lines = raw.lines();
-        let code = lines.next()?.parse::<u16>().ok()?;
-        let msg = lines.next().unwrap_or_default().to_string();
-        Some((code, msg))
+        // The message is *everything* past the first newline, not just the next
+        // line: vendors store the raw HTTP body here and those are routinely
+        // multi-line JSON, so taking one line truncated the user's diagnostic.
+        // Files from before this fix parse unchanged — the writer always framed
+        // them this way, only the reader threw the tail away.
+        let (code, msg) = raw.split_once('\n').unwrap_or((raw.as_str(), ""));
+        Some((code.parse::<u16>().ok()?, msg.to_string()))
     }
 }
 
@@ -430,6 +433,45 @@ mod tests {
         let (code, msg) = cache.read_last_error().unwrap();
         assert_eq!(code, 429);
         assert_eq!(msg, "");
+    }
+
+    /// The regression this guards: vendors write the raw HTTP body, which is
+    /// usually multi-line JSON. The reader kept only line 2, so the tooltip
+    /// showed `{` and dropped the actual API explanation.
+    #[test]
+    fn last_error_round_trips_a_multi_line_message() {
+        let (_td, cache) = fixture();
+        let body = "{\n  \"error\": \"quota exhausted\",\n  \"retry_after\": 3600\n}";
+        cache.write_last_error(429, body);
+
+        let (code, msg) = cache.read_last_error().unwrap();
+        assert_eq!(code, 429);
+        assert_eq!(msg, body);
+        assert!(
+            msg.contains("quota exhausted"),
+            "message was truncated to its first line: {msg:?}"
+        );
+    }
+
+    /// A user upgrades with a `.last_error` already on disk; it must still
+    /// parse. Trailing-newline-free files (the whole marker being just a code)
+    /// count too — that is the one shape the old `lines()` reader tolerated.
+    #[test]
+    fn last_error_reads_files_written_by_the_previous_version() {
+        let (_td, cache) = fixture();
+
+        fs::write(cache.last_error_path(), "503\nservice unavailable").unwrap();
+        assert_eq!(
+            cache.read_last_error(),
+            Some((503, "service unavailable".into()))
+        );
+
+        fs::write(cache.last_error_path(), "429").unwrap();
+        assert_eq!(cache.read_last_error(), Some((429, String::new())));
+
+        // A non-numeric first line is still no error at all, never a fake 0.
+        fs::write(cache.last_error_path(), "not-a-code\nboom").unwrap();
+        assert!(cache.read_last_error().is_none());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -153,7 +153,13 @@ pub struct OpenAiConfig {
     pub enabled: bool,
     /// Override the Codex auth file path (defaults to `~/.codex/auth.json`).
     pub codex_auth_path: Option<PathBuf>,
-    /// Optional admin key env var name for the API-key-only fallback path.
+    /// Reserved, and inert: names the env var an API-key-only path *would*
+    /// read (admin key → `/v1/organization/costs`). Nothing consumes it —
+    /// OpenAI usage comes solely from Codex OAuth. Kept because that path is
+    /// still intended, not for back-compat: `[openai]` doesn't deny unknown
+    /// fields, so an existing `admin_key_env` would load either way. See
+    /// `config.example.toml`, which ships it commented out so nobody sets it
+    /// expecting an effect.
     pub admin_key_env: String,
 }
 
@@ -893,5 +899,69 @@ enabled = false
         // No [[anthropic.accounts]] → the single default account, empty list,
         // nothing to migrate (issue #14, back-compat rule 1).
         assert!(Config::default().anthropic.accounts.is_empty());
+    }
+
+    /// The shipped example, which `make install` puts in
+    /// `share/ai-usagebar/config.example.toml`. Repo-relative, so this stays
+    /// hermetic — it never touches the user's real config.
+    fn config_example() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.example.toml")
+    }
+
+    #[test]
+    fn shipped_example_parses_as_a_real_config() {
+        // The example is documentation users copy verbatim, but nothing used
+        // to parse it — so a renamed section or field could rot there
+        // unnoticed, and `deny_unknown_fields` would reject the copy on the
+        // user's machine instead of in CI.
+        let c = Config::load_from(&config_example()).unwrap();
+        assert!(c.is_enabled(VendorId::Anthropic));
+        assert!(c.is_enabled(VendorId::Openai));
+        assert!(!c.is_enabled(VendorId::Deepseek));
+        assert!(!c.is_enabled(VendorId::Kimi));
+    }
+
+    #[test]
+    fn shipped_example_does_not_advertise_admin_key_env_as_working() {
+        // The regression: the example shipped an *uncommented*
+        // `admin_key_env = "OPENAI_ADMIN_KEY"`, indistinguishable from a live
+        // setting. Nothing reads it, so a user could set it, skip
+        // `codex login`, and wait for usage that never arrives.
+        let text = std::fs::read_to_string(config_example()).unwrap();
+        let live: Vec<&str> = text
+            .lines()
+            .map(str::trim)
+            .filter(|l| l.contains("admin_key_env") && !l.starts_with('#'))
+            .collect();
+        assert!(
+            live.is_empty(),
+            "admin_key_env must stay commented out while it is inert: {live:?}"
+        );
+        // Still documented, though — silently dropping it would leave users
+        // who already set it with no explanation of why it does nothing.
+        assert!(
+            text.contains("admin_key_env") && text.contains("RESERVED"),
+            "the example should keep describing admin_key_env as reserved"
+        );
+    }
+
+    #[test]
+    fn admin_key_env_is_accepted_but_changes_nothing() {
+        // The field survives because the API-key-only path is still intended.
+        // What has to hold today is narrower: setting it loads without error
+        // and moves nothing the code actually acts on.
+        let f = write_toml(
+            r#"
+            [openai]
+            admin_key_env = "SOME_ADMIN_KEY"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        assert_eq!(c.openai.admin_key_env, "SOME_ADMIN_KEY");
+        // Nothing else moved: OpenAI still resolves through Codex OAuth only.
+        let default = OpenAiConfig::default();
+        assert_eq!(c.openai.enabled, default.enabled);
+        assert_eq!(c.openai.codex_auth_path, default.codex_auth_path);
+        assert_eq!(c.enabled_vendors(), Config::default().enabled_vendors());
     }
 }

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -53,7 +53,7 @@ pub async fn fetch_snapshot(
 
     match fetch_live(client, &endpoints.balance, api_key).await {
         Ok(snap) => {
-            let bytes = serde_json::to_vec(&snap_to_json(&snap)).unwrap_or_default();
+            let bytes = serde_json::to_vec(&snap_to_json(&snap))?;
             cache.write_payload(&bytes)?;
             Ok(FetchOutcome {
                 snapshot: snap,
@@ -120,6 +120,14 @@ fn parse_cache(bytes: &[u8]) -> Result<DeepseekSnapshot> {
             )))
         }
     };
+    let currency = v["currency"]
+        .as_str()
+        .ok_or_else(|| AppError::Schema("deepseek cache missing 'currency'".into()))?;
+    if !matches!(currency, "USD" | "CNY") {
+        return Err(AppError::Schema(format!(
+            "deepseek cache has unsupported currency {currency:?}"
+        )));
+    }
     Ok(DeepseekSnapshot {
         is_available: v["is_available"]
             .as_bool()
@@ -127,10 +135,7 @@ fn parse_cache(bytes: &[u8]) -> Result<DeepseekSnapshot> {
         balance: money("balance")?,
         granted: money("granted")?,
         topped_up: money("topped_up")?,
-        currency: v["currency"]
-            .as_str()
-            .ok_or_else(|| AppError::Schema("deepseek cache missing 'currency'".into()))?
-            .to_string(),
+        currency: currency.to_string(),
     })
 }
 
@@ -186,6 +191,22 @@ mod tests {
         let cache = Cache::at(td.path().join("deepseek"));
         cache.ensure_dir().unwrap();
         (td, cache)
+    }
+
+    #[test]
+    fn cached_unknown_currency_is_rejected_like_a_live_response() {
+        let cache = serde_json::json!({
+            "is_available": true,
+            "balance": 10.0,
+            "granted": 10.0,
+            "topped_up": 0.0,
+            "currency": "EUR"
+        });
+        let error = parse_cache(cache.to_string().as_bytes()).unwrap_err();
+        assert!(
+            error.to_string().contains("unsupported currency"),
+            "{error}"
+        );
     }
 
     #[tokio::test]

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -161,7 +161,7 @@ async fn fetch_live(
     .map_err(|_| AppError::Transport(format!("deepseek timeout: {url}")))??;
 
     let status = resp.status();
-    let bytes = resp.bytes().await?;
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
 
     if !status.is_success() {
         let body = String::from_utf8_lossy(&bytes).chars().take(200).collect();
@@ -173,7 +173,7 @@ async fn fetch_live(
 
     let r: BalanceResponse = serde_json::from_slice(&bytes)
         .map_err(|e| AppError::Schema(format!("deepseek balance response: {e}")))?;
-    Ok(r.into_snapshot())
+    r.into_snapshot()
 }
 
 #[cfg(test)]

--- a/src/deepseek/types.rs
+++ b/src/deepseek/types.rs
@@ -2,17 +2,16 @@
 
 use serde::Deserialize;
 
+use crate::error::{AppError, Result};
 use crate::usage::DeepseekSnapshot;
 
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct BalanceResponse {
     pub is_available: bool,
     pub balance_infos: Vec<BalanceInfo>,
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct BalanceInfo {
     pub currency: String,
     pub total_balance: String,
@@ -21,7 +20,12 @@ pub struct BalanceInfo {
 }
 
 impl BalanceResponse {
-    pub fn into_snapshot(self) -> DeepseekSnapshot {
+    /// Project the wire response into the canonical snapshot.
+    ///
+    /// Every monetary field is required: an empty or error body used to
+    /// deserialize into a confident $0.00 that then overwrote a good cache.
+    /// Drift must surface as a schema error instead.
+    pub fn into_snapshot(self) -> Result<DeepseekSnapshot> {
         // Prefer USD, fall back to CNY, then whatever's first.
         let info = self
             .balance_infos
@@ -29,21 +33,34 @@ impl BalanceResponse {
             .find(|b| b.currency == "USD")
             .or_else(|| self.balance_infos.iter().find(|b| b.currency == "CNY"))
             .or_else(|| self.balance_infos.first())
-            .cloned()
-            .unwrap_or_default();
+            .ok_or_else(|| {
+                AppError::Schema("deepseek: response carried no balance records".into())
+            })?;
 
-        DeepseekSnapshot {
+        Ok(DeepseekSnapshot {
             is_available: self.is_available,
-            balance: parse_f64(&info.total_balance),
-            granted: parse_f64(&info.granted_balance),
-            topped_up: parse_f64(&info.topped_up_balance),
-            currency: info.currency,
-        }
+            balance: parse_money(&info.total_balance, "total_balance")?,
+            granted: parse_money(&info.granted_balance, "granted_balance")?,
+            topped_up: parse_money(&info.topped_up_balance, "topped_up_balance")?,
+            currency: info.currency.clone(),
+        })
     }
 }
 
-fn parse_f64(s: &str) -> f64 {
-    s.trim().parse::<f64>().unwrap_or(0.0)
+/// DeepSeek sends amounts as decimal strings. `"NaN"` and `"inf"` both parse
+/// successfully in Rust, so the finiteness check is load-bearing — an
+/// infinite balance would render and cache as a plausible-looking number.
+fn parse_money(s: &str, field: &str) -> Result<f64> {
+    let n: f64 = s.trim().parse().map_err(|_| {
+        AppError::Schema(format!("deepseek balance '{field}' is not numeric: {s:?}"))
+    })?;
+    if n.is_finite() {
+        Ok(n)
+    } else {
+        Err(AppError::Schema(format!(
+            "deepseek balance '{field}' is not finite"
+        )))
+    }
 }
 
 #[cfg(test)]
@@ -60,7 +77,7 @@ mod tests {
             ]
         }"#;
         let r: BalanceResponse = serde_json::from_str(raw).unwrap();
-        let snap = r.into_snapshot();
+        let snap = r.into_snapshot().unwrap();
         assert!(snap.is_available);
         assert_eq!(snap.currency, "USD");
         assert!((snap.balance - 1.50).abs() < 1e-9);
@@ -75,18 +92,107 @@ mod tests {
             ]
         }"#;
         let r: BalanceResponse = serde_json::from_str(raw).unwrap();
-        let snap = r.into_snapshot();
+        let snap = r.into_snapshot().unwrap();
         assert_eq!(snap.currency, "CNY");
         assert!((snap.balance - 20.0).abs() < 1e-9);
     }
 
+    /// The legitimate zero: a drained account still renders, it is not an error.
     #[test]
-    fn empty_balance_infos() {
-        let raw = r#"{"is_available": false, "balance_infos": []}"#;
+    fn genuine_zero_balance_is_preserved() {
+        let raw = r#"{
+            "is_available": false,
+            "balance_infos": [
+                {"currency": "USD", "total_balance": "0.00", "granted_balance": "0.00", "topped_up_balance": "0.00"}
+            ]
+        }"#;
         let r: BalanceResponse = serde_json::from_str(raw).unwrap();
-        let snap = r.into_snapshot();
+        let snap = r.into_snapshot().unwrap();
         assert!(!snap.is_available);
         assert_eq!(snap.balance, 0.0);
-        assert_eq!(snap.currency, "");
+        assert_eq!(snap.currency, "USD");
+    }
+
+    #[test]
+    fn empty_balance_infos_is_schema_error() {
+        let raw = r#"{"is_available": false, "balance_infos": []}"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        assert!(matches!(r.into_snapshot(), Err(AppError::Schema(_))));
+    }
+
+    #[test]
+    fn non_numeric_amount_is_schema_error() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "USD", "total_balance": "n/a", "granted_balance": "0.00", "topped_up_balance": "0.00"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        assert!(matches!(r.into_snapshot(), Err(AppError::Schema(_))));
+    }
+
+    #[test]
+    fn empty_amount_is_schema_error() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "USD", "total_balance": "", "granted_balance": "0.00", "topped_up_balance": "0.00"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        assert!(matches!(r.into_snapshot(), Err(AppError::Schema(_))));
+    }
+
+    /// Rust parses these to real `f64` values, so only the finiteness check
+    /// catches them.
+    #[test]
+    fn non_finite_amounts_are_schema_errors() {
+        for amount in ["NaN", "inf", "-inf", "infinity"] {
+            let raw = format!(
+                r#"{{"is_available": true, "balance_infos": [
+                    {{"currency": "USD", "total_balance": "{amount}",
+                      "granted_balance": "0.00", "topped_up_balance": "0.00"}}
+                ]}}"#
+            );
+            let r: BalanceResponse = serde_json::from_str(&raw).unwrap();
+            assert!(
+                matches!(r.into_snapshot(), Err(AppError::Schema(_))),
+                "{amount} should be rejected"
+            );
+        }
+    }
+
+    /// A non-`total_balance` component is just as unvouchable as the headline.
+    #[test]
+    fn non_numeric_component_is_schema_error() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "USD", "total_balance": "5.00", "granted_balance": "5.00", "topped_up_balance": "oops"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        assert!(matches!(r.into_snapshot(), Err(AppError::Schema(_))));
+    }
+
+    #[test]
+    fn empty_body_does_not_deserialize() {
+        assert!(serde_json::from_str::<BalanceResponse>("{}").is_err());
+    }
+
+    #[test]
+    fn error_body_does_not_deserialize() {
+        let raw = r#"{"error": {"message": "Authentication Fails"}}"#;
+        assert!(serde_json::from_str::<BalanceResponse>(raw).is_err());
+    }
+
+    #[test]
+    fn missing_money_field_does_not_deserialize() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [{"currency": "USD", "total_balance": "5.00"}]
+        }"#;
+        assert!(serde_json::from_str::<BalanceResponse>(raw).is_err());
     }
 }

--- a/src/deepseek/types.rs
+++ b/src/deepseek/types.rs
@@ -26,15 +26,34 @@ impl BalanceResponse {
     /// deserialize into a confident $0.00 that then overwrote a good cache.
     /// Drift must surface as a schema error instead.
     pub fn into_snapshot(self) -> Result<DeepseekSnapshot> {
-        // Prefer USD, fall back to CNY, then whatever's first.
-        let info = self
-            .balance_infos
-            .iter()
-            .find(|b| b.currency == "USD")
-            .or_else(|| self.balance_infos.iter().find(|b| b.currency == "CNY"))
-            .or_else(|| self.balance_infos.first())
+        // The documented endpoint reports USD and/or CNY. Rendering an unknown
+        // currency through the USD-scale balance UI would attach meaning and
+        // severity thresholds we cannot justify, so do not select one merely
+        // because it happened to be first.
+        fn unique<'a>(infos: &'a [BalanceInfo], currency: &str) -> Result<Option<&'a BalanceInfo>> {
+            let mut matching = infos.iter().filter(|info| info.currency == currency);
+            let first = matching.next();
+            if matching.next().is_some() {
+                return Err(AppError::Schema(format!(
+                    "deepseek: response carried duplicate {currency} balances"
+                )));
+            }
+            Ok(first)
+        }
+        let info = unique(&self.balance_infos, "USD")?
+            .or(unique(&self.balance_infos, "CNY")?)
             .ok_or_else(|| {
-                AppError::Schema("deepseek: response carried no balance records".into())
+                let currencies = self
+                    .balance_infos
+                    .iter()
+                    .map(|info| info.currency.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                AppError::Schema(if currencies.is_empty() {
+                    "deepseek: response carried no balance records".into()
+                } else {
+                    format!("deepseek: response carried no USD or CNY balance (saw {currencies})")
+                })
             })?;
 
         Ok(DeepseekSnapshot {
@@ -118,6 +137,34 @@ mod tests {
         let raw = r#"{"is_available": false, "balance_infos": []}"#;
         let r: BalanceResponse = serde_json::from_str(raw).unwrap();
         assert!(matches!(r.into_snapshot(), Err(AppError::Schema(_))));
+    }
+
+    #[test]
+    fn unsupported_currency_is_schema_error_not_usd_scaled() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "EUR", "total_balance": "20.00", "granted_balance": "20.00", "topped_up_balance": "0.00"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        let err = r.into_snapshot().unwrap_err().to_string();
+        assert!(err.contains("no USD or CNY"), "{err}");
+        assert!(err.contains("EUR"), "{err}");
+    }
+
+    #[test]
+    fn duplicate_supported_currency_is_schema_error_not_first_wins() {
+        let raw = r#"{
+            "is_available": true,
+            "balance_infos": [
+                {"currency": "USD", "total_balance": "1.00", "granted_balance": "1.00", "topped_up_balance": "0.00"},
+                {"currency": "USD", "total_balance": "2.00", "granted_balance": "2.00", "topped_up_balance": "0.00"}
+            ]
+        }"#;
+        let r: BalanceResponse = serde_json::from_str(raw).unwrap();
+        let err = r.into_snapshot().unwrap_err().to_string();
+        assert!(err.contains("duplicate USD"), "{err}");
     }
 
     #[test]

--- a/src/deepseek/vendor.rs
+++ b/src/deepseek/vendor.rs
@@ -27,15 +27,10 @@ pub fn build_placeholders(snap: &DeepseekSnapshot) -> HashMap<&'static str, Stri
         // spend denominator (`/user/balance` reports only money *remaining*),
         // so these percentages are structurally meaningless for this vendor.
         //
-        // They stay "0" rather than a "—" marker on purpose: both native
-        // surfaces coerce a non-numeric percentage straight back to zero
-        // (`n(1) ?? 0` in macos/ai-usagebar-menubar.swift, `integer(…) ?? 0` in
-        // gnome-extension/extension.js), so emitting "—" would change nothing
-        // they render while implying a fix that is not there. Suppressing the
-        // two bars for a balance vendor has to happen on the surface side —
-        // both already do exactly that for the scoped window, which they only
-        // draw when its percentage parses — and that is a rendering change for
-        // every vendor, so it is left as its own piece of work.
+        // These remain numeric for compatibility with generic third-party
+        // formats. The bundled native surfaces key off `vendor_short` and hide
+        // both quota rows for DeepSeek, so the aliases never become fake 0%
+        // bars there.
         ("session_pct", "0".to_string()),
         ("session_reset", "—".to_string()),
         ("weekly_pct", "0".to_string()),

--- a/src/deepseek/vendor.rs
+++ b/src/deepseek/vendor.rs
@@ -19,16 +19,33 @@ pub const DEFAULT_FORMAT: &str = "{ds_balance}";
 
 pub fn build_placeholders(snap: &DeepseekSnapshot) -> HashMap<&'static str, String> {
     let avail = if snap.is_available { "up" } else { "down" };
+    let balance = format_money(snap.balance, &snap.currency);
     placeholders(vec![
         ("icon", "󰧑".to_string()),
         ("vendor_short", "dsk".to_string()),
-        // Cross-vendor aliases — no rate-limit windows for DeepSeek.
+        // Cross-vendor aliases — DeepSeek has neither rate-limit windows nor a
+        // spend denominator (`/user/balance` reports only money *remaining*),
+        // so these percentages are structurally meaningless for this vendor.
+        //
+        // They stay "0" rather than a "—" marker on purpose: both native
+        // surfaces coerce a non-numeric percentage straight back to zero
+        // (`n(1) ?? 0` in macos/ai-usagebar-menubar.swift, `integer(…) ?? 0` in
+        // gnome-extension/extension.js), so emitting "—" would change nothing
+        // they render while implying a fix that is not there. Suppressing the
+        // two bars for a balance vendor has to happen on the surface side —
+        // both already do exactly that for the scoped window, which they only
+        // draw when its percentage parses — and that is a rendering change for
+        // every vendor, so it is left as its own piece of work.
         ("session_pct", "0".to_string()),
         ("session_reset", "—".to_string()),
         ("weekly_pct", "0".to_string()),
         ("weekly_reset", "—".to_string()),
-        ("plan", "DeepSeek".to_string()),
-        ("ds_balance", format_money(snap.balance, &snap.currency)),
+        // `plan` is the only generic alias the native surfaces render as free
+        // text (GNOME dropdown title, macOS menu header), so it carries the
+        // headline number a balance vendor actually has. Mirrors OpenRouter's
+        // "OpenRouter — {label}".
+        ("plan", format!("DeepSeek — {balance}")),
+        ("ds_balance", balance),
         ("ds_granted", format_money(snap.granted, &snap.currency)),
         ("ds_topped_up", format_money(snap.topped_up, &snap.currency)),
         ("ds_available", avail.to_string()),
@@ -256,6 +273,35 @@ mod tests {
         let theme = Theme::default();
         let out = render(&outcome, &snap, &theme, &opts(), Utc::now());
         assert!(out.text.contains("⏸"));
+    }
+
+    #[test]
+    fn plan_alias_carries_balance_in_snapshot_currency() {
+        assert_eq!(
+            build_placeholders(&sample_snap())["plan"],
+            "DeepSeek — $5.50"
+        );
+
+        let mut snap = sample_snap();
+        snap.balance = 20.0;
+        snap.currency = "CNY".into();
+        assert_eq!(build_placeholders(&snap)["plan"], "DeepSeek — ¥20.00");
+    }
+
+    // The prefix both native surfaces request verbatim — see the `FORMAT`
+    // constants in gnome-extension/marker-logic.js and macos/ai-usagebar-menubar.swift.
+    // `plan` is the one generic field they render as free text, so it is the
+    // only place a balance vendor can get its headline number onto the panel
+    // without a change on the surface side.
+    #[test]
+    fn desktop_format_header_shows_balance() {
+        let values = build_placeholders(&sample_snap());
+        let out = substitute(
+            "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset}",
+            &values,
+        );
+        let fields: Vec<&str> = out.split(";;").collect();
+        assert_eq!(fields[0], "DeepSeek — $5.50");
     }
 
     #[test]

--- a/src/kimi/fetch.rs
+++ b/src/kimi/fetch.rs
@@ -58,7 +58,7 @@ pub async fn fetch_snapshot(
 
     match fetch_live(client, &endpoints.usages, api_key).await {
         Ok(snap) => {
-            let bytes = serde_json::to_vec(&snap_to_json(&snap)).unwrap_or_default();
+            let bytes = serde_json::to_vec(&snap_to_json(&snap))?;
             cache.write_payload(&bytes)?;
             Ok(FetchOutcome {
                 snapshot: snap,

--- a/src/kimi/fetch.rs
+++ b/src/kimi/fetch.rs
@@ -194,7 +194,7 @@ async fn fetch_live(client: &reqwest::Client, url: &str, api_key: &str) -> Resul
         });
     }
 
-    let bytes = resp.bytes().await?;
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
     let r: UsagesResponse = serde_json::from_slice(&bytes)
         .map_err(|e| AppError::Schema(format!("kimi usages response: {e}")))?;
     r.into_snapshot()

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -224,7 +224,7 @@ async fn fetch_usage(client: &reqwest::Client, url: &str, t: &Tokens) -> Result<
     }
     let resp = req.send().await?;
     let status = resp.status();
-    let bytes = resp.bytes().await?.to_vec();
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
 
     if !status.is_success() {
         let body: String = String::from_utf8_lossy(&bytes).chars().take(200).collect();

--- a/src/openai/oauth.rs
+++ b/src/openai/oauth.rs
@@ -67,7 +67,10 @@ pub async fn refresh(
         .await?;
 
     let status = resp.status();
-    let body = resp.text().await.unwrap_or_default();
+    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES)
+        .await
+        .map(|b| String::from_utf8_lossy(&b).into_owned())
+        .unwrap_or_default();
     if !status.is_success() {
         let msg = crate::anthropic::oauth::parse_error_body(&body)
             .unwrap_or_else(|| "Refresh failed".into());

--- a/src/openai/oauth.rs
+++ b/src/openai/oauth.rs
@@ -26,13 +26,41 @@ struct RefreshRequest<'a> {
 
 #[derive(Debug, Deserialize)]
 pub struct RefreshResponse {
+    #[serde(deserialize_with = "de_nonempty_string")]
     pub access_token: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_nonempty_string")]
     pub refresh_token: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "de_opt_nonempty_string")]
     pub id_token: Option<String>,
     #[serde(default, deserialize_with = "de_expires_in")]
     pub expires_in: Option<u64>,
+}
+
+fn de_nonempty_string<'de, D>(d: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(d)?;
+    if value.trim().is_empty() {
+        Err(serde::de::Error::custom("token cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn de_opt_nonempty_string<'de, D>(d: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(d)?
+        .map(|value| {
+            if value.trim().is_empty() {
+                Err(serde::de::Error::custom("token cannot be empty"))
+            } else {
+                Ok(value)
+            }
+        })
+        .transpose()
 }
 
 fn de_expires_in<'de, D>(d: D) -> std::result::Result<Option<u64>, D::Error>
@@ -40,11 +68,28 @@ where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
-    Ok(match v {
-        serde_json::Value::Null => None,
-        serde_json::Value::Number(n) => n.as_u64().or_else(|| n.as_f64().map(|f| f as u64)),
-        _ => None,
-    })
+    match v {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Number(n) => {
+            const MAX_SAFE_EXPIRES_IN: u64 = (i64::MAX as u64) / 2;
+            if let Some(value) = n.as_u64().filter(|value| *value <= MAX_SAFE_EXPIRES_IN) {
+                Ok(Some(value))
+            } else if let Some(value) = n.as_f64()
+                && value.is_finite()
+                && value.fract() == 0.0
+                && (0.0..=MAX_SAFE_EXPIRES_IN as f64).contains(&value)
+            {
+                Ok(Some(value as u64))
+            } else {
+                Err(serde::de::Error::custom(
+                    "expires_in must be a non-negative integer in range",
+                ))
+            }
+        }
+        other => Err(serde::de::Error::custom(format!(
+            "expires_in must be a number or null, got {other:?}"
+        ))),
+    }
 }
 
 pub async fn refresh(
@@ -67,10 +112,8 @@ pub async fn refresh(
         .await?;
 
     let status = resp.status();
-    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES)
-        .await
-        .map(|b| String::from_utf8_lossy(&b).into_owned())
-        .unwrap_or_default();
+    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
+    let body = String::from_utf8_lossy(&body).into_owned();
     if !status.is_success() {
         let msg = crate::anthropic::oauth::parse_error_body(&body)
             .unwrap_or_else(|| "Refresh failed".into());
@@ -96,6 +139,41 @@ mod tests {
         let now = 1_000_000;
         assert!(needs_refresh(now + 100, now));
         assert!(!needs_refresh(now + 1000, now));
+    }
+
+    #[test]
+    fn malformed_optional_expires_in_is_not_treated_as_absent() {
+        for value in [
+            "3600.5",
+            "-1",
+            "1e300",
+            "18446744073709551615",
+            "true",
+            r#""3600""#,
+        ] {
+            let body = format!(r#"{{"access_token":"new","expires_in":{value}}}"#);
+            assert!(
+                serde_json::from_str::<RefreshResponse>(&body).is_err(),
+                "{body}"
+            );
+        }
+        let response: RefreshResponse =
+            serde_json::from_str(r#"{"access_token":"new","expires_in":null}"#).unwrap();
+        assert_eq!(response.expires_in, None);
+    }
+
+    #[test]
+    fn empty_refresh_tokens_are_schema_drift_not_credentials_to_persist() {
+        for body in [
+            r#"{"access_token":""}"#,
+            r#"{"access_token":"new","refresh_token":"   "}"#,
+            r#"{"access_token":"new","id_token":""}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<RefreshResponse>(body).is_err(),
+                "{body}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -65,19 +65,48 @@ pub struct CreditsBlock {
     pub approx_cloud_messages: Option<Vec<i64>>,
 }
 
+/// Accept a JSON int or float (the API returns these counters as either),
+/// plus a numeric string — the same value in a third coat of paint. Anything
+/// else (null, bool, array, object, unparseable string) is schema drift and
+/// must fail the parse: `fetch_usage` validates before writing the cache, so a
+/// fabricated `0` here would be persisted and rendered as a real 0% bar.
 fn de_int_or_float_lenient<'de, D>(d: D) -> Result<i64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
-    Ok(match v {
-        serde_json::Value::Null => 0,
-        serde_json::Value::Number(n) => n
-            .as_i64()
-            .or_else(|| n.as_f64().map(|f| f as i64))
-            .unwrap_or(0),
-        _ => 0,
-    })
+    match v {
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i)
+            } else if let Some(i) = n.as_f64().and_then(exact_i64) {
+                Ok(i)
+            } else {
+                Err(serde::de::Error::custom("number out of i64 range"))
+            }
+        }
+        serde_json::Value::String(s) => s
+            .parse::<i64>()
+            .ok()
+            .or_else(|| s.parse::<f64>().ok().and_then(exact_i64))
+            .ok_or_else(|| serde::de::Error::custom(format!("expected numeric string, got {s:?}"))),
+        other => Err(serde::de::Error::custom(format!(
+            "expected number or numeric string, got {other:?}"
+        ))),
+    }
+}
+
+/// `f as i64` saturates instead of failing, so `NaN` would coin a `0` and
+/// `1e300` an `i64::MAX` — both indistinguishable from a counter the API
+/// really sent. Only a magnitude the cast reproduces exactly survives.
+fn exact_i64(f: f64) -> Option<i64> {
+    // `i64::MAX as f64` rounds up to 2^63, hence the strict upper bound;
+    // `i64::MIN as f64` is exact, so its bound is inclusive.
+    if f.is_finite() && f >= i64::MIN as f64 && f < i64::MAX as f64 {
+        Some(f as i64)
+    } else {
+        None
+    }
 }
 
 fn de_opt_int_or_float<'de, D>(d: D) -> Result<Option<i64>, D::Error>
@@ -149,16 +178,18 @@ fn window_or_default(w: Option<Window>, default_dur: chrono::Duration) -> UsageW
 }
 
 fn to_window(w: &Window, default_dur: chrono::Duration) -> UsageWindow {
-    let dur = if w.limit_window_seconds > 0 {
-        chrono::Duration::seconds(w.limit_window_seconds)
-    } else {
-        default_dur
+    // `Duration::seconds` panics past ~1e16, and the widget must always exit 0
+    // — so an absurd counter degrades to the caller's default, never a crash.
+    let dur = match chrono::Duration::try_seconds(w.limit_window_seconds) {
+        Some(d) if w.limit_window_seconds > 0 => d,
+        _ => default_dur,
     };
     let resets_at = match w.reset_at {
         Some(secs) => chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0),
         None => w
             .reset_after_seconds
-            .map(|s| chrono::Utc::now() + chrono::Duration::seconds(s)),
+            .and_then(chrono::Duration::try_seconds)
+            .and_then(|d| chrono::Utc::now().checked_add_signed(d)),
     };
     UsageWindow {
         utilization_pct: (w.used_percent as i32).clamp(0, 100),
@@ -268,6 +299,88 @@ mod tests {
         let r: UsageResponse = serde_json::from_str("{}").unwrap();
         let s = r.into_snapshot(Some("team"));
         assert_eq!(s.plan, "ChatGPT Team");
+    }
+
+    #[test]
+    fn window_counters_accept_int_float_and_numeric_string() {
+        let w: Window =
+            serde_json::from_str(r#"{"used_percent":7,"limit_window_seconds":18000.9}"#).unwrap();
+        assert_eq!(w.used_percent, 7);
+        assert_eq!(w.limit_window_seconds, 18000);
+
+        let w: Window =
+            serde_json::from_str(r#"{"used_percent":"42","limit_window_seconds":"604800.5"}"#)
+                .unwrap();
+        assert_eq!(w.used_percent, 42);
+        assert_eq!(w.limit_window_seconds, 604800);
+    }
+
+    #[test]
+    fn null_counter_is_schema_drift() {
+        // `reset_at` is the only field the API is documented to omit, and it
+        // carries its own Option deserializer. A null counter is drift.
+        let body = r#"{"used_percent":null,"limit_window_seconds":1}"#;
+        assert!(serde_json::from_str::<Window>(body).is_err());
+        let body = r#"{"used_percent":1,"limit_window_seconds":null}"#;
+        assert!(serde_json::from_str::<Window>(body).is_err());
+    }
+
+    #[test]
+    fn non_numeric_counter_shapes_are_schema_drift() {
+        for bad in [
+            r#""many""#,
+            r#"{"value":1}"#,
+            "[1]",
+            "true",
+            // Each parses as an f64, but `as i64` saturates rather than
+            // failing, so it would coin a 0 / i64::MAX that reads as real.
+            r#""NaN""#,
+            r#""inf""#,
+            "1e300",
+            "-1e300",
+            r#""1e300""#,
+        ] {
+            let body = format!(r#"{{"used_percent":{bad},"limit_window_seconds":1}}"#);
+            assert!(
+                serde_json::from_str::<Window>(&body).is_err(),
+                "used_percent {bad} must not deserialize"
+            );
+        }
+    }
+
+    #[test]
+    fn drifted_counter_fails_whole_usage_response() {
+        // The error has to reach `parse_payload` so the widget shows `⚠`
+        // rather than caching and rendering a 0% bar.
+        let body = r#"{"plan_type":"plus","rate_limit":{
+            "primary_window":{"used_percent":"n/a","limit_window_seconds":18000}
+        }}"#;
+        assert!(serde_json::from_str::<UsageResponse>(body).is_err());
+    }
+
+    #[test]
+    fn omitted_counters_still_default_to_zero() {
+        // Deliberate boundary: an *absent* counter keeps the struct-level
+        // `#[serde(default)]`, matching the optional `code_review_rate_limit`
+        // blocks. Only a present-but-wrong value counts as drift.
+        let w: Window = serde_json::from_str("{}").unwrap();
+        assert_eq!(w.used_percent, 0);
+        assert_eq!(w.limit_window_seconds, 0);
+    }
+
+    #[test]
+    fn oversized_window_seconds_degrades_instead_of_panicking() {
+        // i64::MAX is a faithful integer, so it clears the deserializer — but
+        // `chrono::Duration::seconds` panics on it, and a panicking widget
+        // exits non-zero and gets hidden by Waybar.
+        let body = r#"{"rate_limit":{"primary_window":{
+            "used_percent":1,"limit_window_seconds":9223372036854775807,
+            "reset_after_seconds":9223372036854775807
+        }}}"#;
+        let r: UsageResponse = serde_json::from_str(body).unwrap();
+        let s = r.into_snapshot(None);
+        assert_eq!(s.session.window_duration, chrono::Duration::hours(5));
+        assert!(s.session.resets_at.is_none());
     }
 
     #[test]

--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -37,12 +37,11 @@ pub struct RateLimit {
     pub secondary_window: Option<Window>,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Window {
-    #[serde(deserialize_with = "de_int_or_float_lenient")]
-    pub used_percent: i64,
-    #[serde(deserialize_with = "de_int_or_float_lenient")]
+    #[serde(deserialize_with = "de_percent_number_or_string")]
+    pub used_percent: f64,
+    #[serde(deserialize_with = "de_i64_number_or_string")]
     pub limit_window_seconds: i64,
     /// Unix seconds. May be absent on older Codex CLIs.
     #[serde(default, deserialize_with = "de_opt_int_or_float")]
@@ -52,11 +51,10 @@ pub struct Window {
     pub reset_after_seconds: Option<i64>,
 }
 
-#[derive(Debug, Default, Clone, Deserialize)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CreditsBlock {
-    #[serde(deserialize_with = "de_money_string")]
-    pub balance: String,
+    #[serde(default, deserialize_with = "de_opt_money_string")]
+    pub balance: Option<String>,
     pub has_credits: bool,
     pub unlimited: bool,
     #[serde(default)]
@@ -65,44 +63,78 @@ pub struct CreditsBlock {
     pub approx_cloud_messages: Option<Vec<i64>>,
 }
 
-/// Accept a JSON int or float (the API returns these counters as either),
-/// plus a numeric string — the same value in a third coat of paint. Anything
-/// else (null, bool, array, object, unparseable string) is schema drift and
-/// must fail the parse: `fetch_usage` validates before writing the cache, so a
-/// fabricated `0` here would be persisted and rendered as a real 0% bar.
-fn de_int_or_float_lenient<'de, D>(d: D) -> Result<i64, D::Error>
+/// Accept a JSON number or numeric string without turning malformed, non-finite
+/// or out-of-range values into plausible counters. `fetch_usage` validates
+/// before writing the cache, so a fabricated value here would be persisted and
+/// rendered as genuine usage.
+fn numeric_value<E: serde::de::Error>(v: serde_json::Value) -> Result<f64, E> {
+    let value = match v {
+        serde_json::Value::Number(n) => n
+            .as_f64()
+            .ok_or_else(|| E::custom("number is not representable as f64"))?,
+        serde_json::Value::String(s) => s
+            .parse::<f64>()
+            .map_err(|_| E::custom(format!("expected numeric string, got {s:?}")))?,
+        other => {
+            return Err(E::custom(format!(
+                "expected number or numeric string, got {other:?}"
+            )));
+        }
+    };
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(E::custom("number is not finite"))
+    }
+}
+
+fn de_percent_number_or_string<'de, D>(d: D) -> Result<f64, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
-    match v {
+    let value = numeric_value::<D::Error>(v)?;
+    if (0.0..=101.0).contains(&value) {
+        Ok(value)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "percentage {value} outside 0..=100"
+        )))
+    }
+}
+
+fn de_i64_number_or_string<'de, D>(d: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    i64_value(serde_json::Value::deserialize(d)?)
+}
+
+fn i64_value<E: serde::de::Error>(v: serde_json::Value) -> Result<i64, E> {
+    match &v {
         serde_json::Value::Number(n) => {
             if let Some(i) = n.as_i64() {
-                Ok(i)
-            } else if let Some(i) = n.as_f64().and_then(exact_i64) {
-                Ok(i)
-            } else {
-                Err(serde::de::Error::custom("number out of i64 range"))
+                return Ok(i);
             }
         }
-        serde_json::Value::String(s) => s
-            .parse::<i64>()
-            .ok()
-            .or_else(|| s.parse::<f64>().ok().and_then(exact_i64))
-            .ok_or_else(|| serde::de::Error::custom(format!("expected numeric string, got {s:?}"))),
-        other => Err(serde::de::Error::custom(format!(
-            "expected number or numeric string, got {other:?}"
-        ))),
+        serde_json::Value::String(s) => {
+            if let Ok(i) = s.parse::<i64>() {
+                return Ok(i);
+            }
+        }
+        _ => {}
     }
+    exact_i64(numeric_value::<E>(v)?).ok_or_else(|| E::custom("expected an integer in i64 range"))
 }
 
 /// `f as i64` saturates instead of failing, so `NaN` would coin a `0` and
 /// `1e300` an `i64::MAX` — both indistinguishable from a counter the API
-/// really sent. Only a magnitude the cast reproduces exactly survives.
+/// really sent. Only an integral magnitude that an `f64` represents exactly
+/// survives; timestamps and window lengths cannot silently lose a fraction or
+/// low bit. Plain JSON/string integers take the exact `i64` path above.
 fn exact_i64(f: f64) -> Option<i64> {
-    // `i64::MAX as f64` rounds up to 2^63, hence the strict upper bound;
-    // `i64::MIN as f64` is exact, so its bound is inclusive.
-    if f.is_finite() && f >= i64::MIN as f64 && f < i64::MAX as f64 {
+    const MAX_EXACT_F64_INT: f64 = (1_u64 << 53) as f64;
+    if f.is_finite() && f.trunc() == f && f.abs() <= MAX_EXACT_F64_INT {
         Some(f as i64)
     } else {
         None
@@ -114,24 +146,33 @@ where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
-    Ok(match v {
-        serde_json::Value::Null => None,
-        serde_json::Value::Number(n) => n.as_i64().or_else(|| n.as_f64().map(|f| f as i64)),
-        _ => None,
-    })
+    if v.is_null() {
+        Ok(None)
+    } else {
+        i64_value::<D::Error>(v).map(Some)
+    }
 }
 
-/// Accept either a string ("$0.00") or a number (0.0) — codexbar treats both.
-fn de_money_string<'de, D>(d: D) -> Result<String, D::Error>
+/// Accept either a string ("$0.00") or a finite number (0.0) — codexbar
+/// treats both. Null and an omitted field mean that no balance was supplied.
+fn de_opt_money_string<'de, D>(d: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
-    Ok(match v {
-        serde_json::Value::String(s) => s,
-        serde_json::Value::Number(n) => format!("${:.2}", n.as_f64().unwrap_or(0.0)),
-        _ => "$0.00".to_string(),
-    })
+    match v {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(s) => Ok(Some(s)),
+        serde_json::Value::Number(n) => match n.as_f64() {
+            Some(value) if value.is_finite() => Ok(Some(format!("${value:.2}"))),
+            _ => Err(serde::de::Error::custom(
+                "credit balance is not a finite number",
+            )),
+        },
+        other => Err(serde::de::Error::custom(format!(
+            "expected credit balance string, number, or null; got {other:?}"
+        ))),
+    }
 }
 
 impl UsageResponse {
@@ -148,7 +189,7 @@ impl UsageResponse {
             .map(|w| to_window(&w, chrono::Duration::days(7)));
 
         let credits = self.credits.map(|c| OpenAiCredits {
-            balance: c.balance,
+            balance: c.balance.unwrap_or_default(),
             has_credits: c.has_credits,
             unlimited: c.unlimited,
             approx_local_messages: range_from_vec(c.approx_local_messages),
@@ -192,7 +233,7 @@ fn to_window(w: &Window, default_dur: chrono::Duration) -> UsageWindow {
             .and_then(|d| chrono::Utc::now().checked_add_signed(d)),
     };
     UsageWindow {
-        utilization_pct: (w.used_percent as i32).clamp(0, 100),
+        utilization_pct: (w.used_percent.round() as i32).clamp(0, 100),
         resets_at,
         window_duration: dur,
     }
@@ -286,12 +327,25 @@ mod tests {
     }
 
     #[test]
-    fn used_percent_clamps_to_hundred() {
+    fn benign_percent_overshoot_clamps_to_hundred() {
         let body =
-            r#"{"rate_limit":{"primary_window":{"used_percent":250,"limit_window_seconds":1}}}"#;
+            r#"{"rate_limit":{"primary_window":{"used_percent":100.6,"limit_window_seconds":1}}}"#;
         let r: UsageResponse = serde_json::from_str(body).unwrap();
         let s = r.into_snapshot(None);
         assert_eq!(s.session.utilization_pct, 100);
+    }
+
+    #[test]
+    fn out_of_range_percent_is_schema_drift() {
+        for used_percent in ["-1", "101.5", "250"] {
+            let body = format!(
+                r#"{{"rate_limit":{{"primary_window":{{"used_percent":{used_percent},"limit_window_seconds":1}}}}}}"#
+            );
+            assert!(
+                serde_json::from_str::<UsageResponse>(&body).is_err(),
+                "{used_percent} must not become a clamped usage value"
+            );
+        }
     }
 
     #[test]
@@ -302,17 +356,31 @@ mod tests {
     }
 
     #[test]
-    fn window_counters_accept_int_float_and_numeric_string() {
+    fn window_counters_accept_fractional_percent_and_integral_number_forms() {
         let w: Window =
-            serde_json::from_str(r#"{"used_percent":7,"limit_window_seconds":18000.9}"#).unwrap();
-        assert_eq!(w.used_percent, 7);
+            serde_json::from_str(r#"{"used_percent":7.4,"limit_window_seconds":18000.0}"#).unwrap();
+        assert_eq!(w.used_percent, 7.4);
         assert_eq!(w.limit_window_seconds, 18000);
 
         let w: Window =
-            serde_json::from_str(r#"{"used_percent":"42","limit_window_seconds":"604800.5"}"#)
+            serde_json::from_str(r#"{"used_percent":"42.7","limit_window_seconds":"604800.0"}"#)
                 .unwrap();
-        assert_eq!(w.used_percent, 42);
+        assert_eq!(w.used_percent, 42.7);
         assert_eq!(w.limit_window_seconds, 604800);
+
+        let r: UsageResponse = serde_json::from_str(
+            r#"{"rate_limit":{"primary_window":{"used_percent":42.7,"limit_window_seconds":18000}}}"#,
+        )
+        .unwrap();
+        assert_eq!(r.into_snapshot(None).session.utilization_pct, 43);
+    }
+
+    #[test]
+    fn fractional_integer_counters_are_schema_drift() {
+        for value in ["18000.9", r#""604800.5""#] {
+            let body = format!(r#"{{"used_percent":7,"limit_window_seconds":{value}}}"#);
+            assert!(serde_json::from_str::<Window>(&body).is_err(), "{value}");
+        }
     }
 
     #[test]
@@ -359,13 +427,45 @@ mod tests {
     }
 
     #[test]
-    fn omitted_counters_still_default_to_zero() {
-        // Deliberate boundary: an *absent* counter keeps the struct-level
-        // `#[serde(default)]`, matching the optional `code_review_rate_limit`
-        // blocks. Only a present-but-wrong value counts as drift.
-        let w: Window = serde_json::from_str("{}").unwrap();
-        assert_eq!(w.used_percent, 0);
-        assert_eq!(w.limit_window_seconds, 0);
+    fn a_present_window_requires_both_counters() {
+        for body in [
+            r#"{"used_percent":1}"#,
+            r#"{"limit_window_seconds":18000}"#,
+            "{}",
+        ] {
+            assert!(serde_json::from_str::<Window>(body).is_err(), "{body}");
+        }
+    }
+
+    #[test]
+    fn malformed_optional_counters_are_not_treated_as_absent() {
+        for field in ["reset_at", "reset_after_seconds"] {
+            for bad in ["true", r#""tomorrow""#, "1.5", "{}"] {
+                let body =
+                    format!(r#"{{"used_percent":1,"limit_window_seconds":18000,"{field}":{bad}}}"#);
+                assert!(serde_json::from_str::<Window>(&body).is_err(), "{body}");
+            }
+        }
+    }
+
+    #[test]
+    fn credits_reject_invalid_present_values_without_inventing_zero() {
+        for balance in ["true", "{}", "[]"] {
+            let body = format!(
+                r#"{{"credits":{{"balance":{balance},"has_credits":true,"unlimited":false}}}}"#
+            );
+            assert!(serde_json::from_str::<UsageResponse>(&body).is_err());
+        }
+        assert!(
+            serde_json::from_str::<UsageResponse>(r#"{"credits":{"balance":"$1.00"}}"#).is_err(),
+            "a present credits block must not default its status flags"
+        );
+
+        let response: UsageResponse = serde_json::from_str(
+            r#"{"credits":{"balance":null,"has_credits":false,"unlimited":true}}"#,
+        )
+        .unwrap();
+        assert_eq!(response.into_snapshot(None).credits.unwrap().balance, "");
     }
 
     #[test]

--- a/src/openrouter/fetch.rs
+++ b/src/openrouter/fetch.rs
@@ -63,7 +63,7 @@ pub async fn fetch_snapshot(
             let cache_repr = serde_json::json!({
                 "snapshot": serde_repr(&snap),
             });
-            let bytes = serde_json::to_vec(&cache_repr).unwrap_or_default();
+            let bytes = serde_json::to_vec(&cache_repr)?;
             cache.write_payload(&bytes)?;
             Ok(FetchOutcome {
                 snapshot: snap,
@@ -123,19 +123,41 @@ fn parse_cache(bytes: &[u8]) -> Result<OpenRouterSnapshot> {
         .get("snapshot")
         .ok_or_else(|| AppError::Schema("openrouter cache missing 'snapshot' field".into()))?;
     let money = |name: &str| -> Result<f64> {
-        let n = s[name]
-            .as_f64()
+        let n = s
+            .get(name)
+            .and_then(serde_json::Value::as_f64)
             .ok_or_else(|| AppError::Schema(format!("openrouter cache missing '{name}'")))?;
-        if n.is_finite() {
+        if n.is_finite() && n >= 0.0 {
             Ok(n)
         } else {
             Err(AppError::Schema(format!(
-                "openrouter cache '{name}' is not finite"
+                "openrouter cache '{name}' is not finite and non-negative"
             )))
         }
     };
+    let optional_money = |name: &str, nonnegative: bool| -> Result<Option<f64>> {
+        match s.get(name) {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(value) => {
+                let number = value.as_f64().ok_or_else(|| {
+                    AppError::Schema(format!("openrouter cache '{name}' is not numeric or null"))
+                })?;
+                if number.is_finite() && (!nonnegative || number >= 0.0) {
+                    Ok(Some(number))
+                } else {
+                    Err(AppError::Schema(format!(
+                        "openrouter cache '{name}' is outside its valid range"
+                    )))
+                }
+            }
+        }
+    };
     Ok(OpenRouterSnapshot {
-        label: s["label"].as_str().unwrap_or("OpenRouter").to_string(),
+        label: s
+            .get("label")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| AppError::Schema("openrouter cache missing 'label'".into()))?
+            .to_string(),
         total_credits: money("total_credits")?,
         total_usage: money("total_usage")?,
         usage_daily: money("usage_daily")?,
@@ -144,8 +166,8 @@ fn parse_cache(bytes: &[u8]) -> Result<OpenRouterSnapshot> {
         is_free_tier: s["is_free_tier"]
             .as_bool()
             .ok_or_else(|| AppError::Schema("openrouter cache missing 'is_free_tier'".into()))?,
-        limit: s["limit"].as_f64(),
-        limit_remaining: s["limit_remaining"].as_f64(),
+        limit: optional_money("limit", true)?,
+        limit_remaining: optional_money("limit_remaining", false)?,
     })
 }
 

--- a/src/openrouter/fetch.rs
+++ b/src/openrouter/fetch.rs
@@ -191,7 +191,7 @@ async fn fetch_one<T: for<'de> serde::Deserialize<'de>>(
     .map_err(|_| AppError::Transport(format!("openrouter timeout: {url}")))??;
 
     let status = resp.status();
-    let bytes = resp.bytes().await?;
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
 
     if !status.is_success() {
         let body = String::from_utf8_lossy(&bytes).chars().take(200).collect();

--- a/src/openrouter/types.rs
+++ b/src/openrouter/types.rs
@@ -14,25 +14,72 @@ pub struct OrEnvelope<T> {
 }
 
 /// `GET /api/v1/credits` — total_credits and total_usage, both USD doubles.
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct CreditsData {
+    #[serde(deserialize_with = "de_nonnegative_finite")]
     pub total_credits: f64,
+    #[serde(deserialize_with = "de_nonnegative_finite")]
     pub total_usage: f64,
 }
 
 /// `GET /api/v1/key` — per-key usage and free-tier flag.
-#[derive(Debug, Clone, Deserialize, Default)]
-#[serde(default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct KeyData {
+    #[serde(default)]
     pub label: String,
+    #[serde(default, deserialize_with = "de_opt_nonnegative_finite")]
     pub limit: Option<f64>,
+    #[serde(default, deserialize_with = "de_opt_finite")]
     pub limit_remaining: Option<f64>,
-    pub usage: f64,
+    #[serde(deserialize_with = "de_nonnegative_finite")]
     pub usage_daily: f64,
+    #[serde(deserialize_with = "de_nonnegative_finite")]
     pub usage_weekly: f64,
+    #[serde(deserialize_with = "de_nonnegative_finite")]
     pub usage_monthly: f64,
     pub is_free_tier: bool,
+}
+
+fn checked_finite<E: serde::de::Error>(value: f64) -> Result<f64, E> {
+    if value.is_finite() {
+        Ok(value)
+    } else {
+        Err(E::custom("money value is not finite"))
+    }
+}
+
+fn checked_nonnegative<E: serde::de::Error>(value: f64) -> Result<f64, E> {
+    let value = checked_finite(value)?;
+    if value >= 0.0 {
+        Ok(value)
+    } else {
+        Err(E::custom("money value cannot be negative"))
+    }
+}
+
+fn de_nonnegative_finite<'de, D>(d: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    checked_nonnegative(f64::deserialize(d)?)
+}
+
+fn de_opt_nonnegative_finite<'de, D>(d: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<f64>::deserialize(d)?
+        .map(checked_nonnegative)
+        .transpose()
+}
+
+fn de_opt_finite<'de, D>(d: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<f64>::deserialize(d)?
+        .map(checked_finite)
+        .transpose()
 }
 
 /// Combine the two endpoint responses into the canonical snapshot.
@@ -92,7 +139,6 @@ mod tests {
             label: "key-A".into(),
             limit: Some(50.0),
             limit_remaining: Some(20.0),
-            usage: 30.0,
             usage_daily: 1.0,
             usage_weekly: 5.0,
             usage_monthly: 30.0,
@@ -107,8 +153,44 @@ mod tests {
 
     #[test]
     fn combine_with_empty_label() {
-        let snap = combine(CreditsData::default(), KeyData::default());
+        let snap = combine(
+            CreditsData {
+                total_credits: 0.0,
+                total_usage: 0.0,
+            },
+            KeyData {
+                label: String::new(),
+                limit: None,
+                limit_remaining: None,
+                usage_daily: 0.0,
+                usage_weekly: 0.0,
+                usage_monthly: 0.0,
+                is_free_tier: false,
+            },
+        );
         assert_eq!(snap.label, "OpenRouter");
+    }
+
+    #[test]
+    fn missing_required_money_does_not_deserialize_as_zero() {
+        assert!(serde_json::from_str::<OrEnvelope<CreditsData>>(r#"{"data":{}}"#).is_err());
+        assert!(
+            serde_json::from_str::<OrEnvelope<KeyData>>(
+                r#"{"data":{"label":"key","is_free_tier":false}}"#
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn invalid_money_values_are_schema_drift() {
+        for total in ["-1", "1e400", "true", r#""zero""#] {
+            let raw = format!(r#"{{"data":{{"total_credits":{total},"total_usage":0}}}}"#);
+            assert!(
+                serde_json::from_str::<OrEnvelope<CreditsData>>(&raw).is_err(),
+                "{raw}"
+            );
+        }
     }
 
     #[test]

--- a/src/openrouter/vendor.rs
+++ b/src/openrouter/vendor.rs
@@ -81,6 +81,15 @@ pub fn render(
     // The default format above uses ${…} (legible in a shell context), so
     // strip the $ to match our placeholder syntax.
     values.insert("or_balance_bar", or_balance_bar(snap, theme));
+    // Both sinks fed by this map (bar text and --tooltip-format) end up as
+    // Pango markup, and the label is API-controlled — escape it here, its only
+    // markup insertion point. The default tooltip escapes the raw snapshot
+    // itself, and or_balance_bar is markup we emit, so neither is touched.
+    for key in ["plan", "or_label"] {
+        if let Some(value) = values.get_mut(key) {
+            *value = escape(value);
+        }
+    }
 
     let format_clean = format.replace("${", "{");
     let mut text = substitute(&format_clean, &values);
@@ -264,6 +273,45 @@ mod tests {
             format_pace_color: false,
             tooltip_pace_pts: false,
         }
+    }
+
+    #[test]
+    fn api_controlled_label_is_pango_escaped_in_custom_formats() {
+        // The label comes from the API and both sinks fed by the placeholder
+        // map are Pango markup. Unescaped, a label like `a & b <span…>` either
+        // breaks the markup or lets an attacker-shaped key name paint text the
+        // widget never intended.
+        let mut snap = sample_snap();
+        snap.label = "A & B <b>spoof</b>".into();
+
+        let mut o = opts();
+        o.format = Some("{plan}|{or_label}".into());
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &o,
+            Utc::now(),
+        );
+        assert!(
+            out.text.contains("A &amp; B &lt;b&gt;spoof&lt;/b&gt;"),
+            "label was not escaped: {}",
+            out.text
+        );
+        assert!(!out.text.contains("<b>spoof</b>"));
+
+        // ...and the same through the tooltip sink.
+        let mut o2 = opts();
+        o2.tooltip_format = Some("{or_label}".into());
+        let out2 = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &o2,
+            Utc::now(),
+        );
+        assert!(out2.tooltip.contains("A &amp; B"));
+        assert!(!out2.tooltip.contains("<b>spoof</b>"));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -90,7 +90,6 @@ pub struct App {
     /// previous Settings reload cannot land in a new tab at the old index.
     pub tab_generation: u64,
     pub theme: Theme,
-    pub last_refresh: chrono::DateTime<chrono::Utc>,
     pub quit: bool,
     /// When `Some`, the Settings overlay is open and consuming key events.
     pub settings: Option<crate::tui::settings::SettingsState>,
@@ -116,7 +115,6 @@ impl App {
             tabs: vec![TabState::Loading; n],
             tab_generation: 0,
             theme,
-            last_refresh: Utc::now(),
             quit: false,
             settings: None,
         }
@@ -163,7 +161,6 @@ impl App {
             return false;
         };
         self.tabs[index] = state;
-        self.last_refresh = Utc::now();
         true
     }
 
@@ -335,6 +332,7 @@ pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
 
     // Use `App::with_theme(.., Theme::default())` rather than `App::new`, which
     // would read the real Omarchy theme file + `$HOME`. The tab-selection logic
@@ -459,6 +457,46 @@ mod tests {
         assert!(app.apply_refresh(generation, &anthropic, TabState::Error("ready".into())));
         assert!(matches!(app.tabs[0], TabState::Loading));
         assert!(matches!(&app.tabs[1], TabState::Error(message) if message == "ready"));
+    }
+
+    fn ready_at(fetched_at: chrono::DateTime<Utc>) -> TabState {
+        TabState::Ready(Box::new(ReadyTab {
+            snapshot: crate::usage::VendorSnapshot::Openrouter(crate::usage::OpenRouterSnapshot {
+                label: "test".into(),
+                total_credits: 0.0,
+                total_usage: 0.0,
+                usage_daily: 0.0,
+                usage_weekly: 0.0,
+                usage_monthly: 0.0,
+                is_free_tier: false,
+                limit: None,
+                limit_remaining: None,
+            }),
+            stale: false,
+            last_error: None,
+            fetched_at: Some(fetched_at),
+        }))
+    }
+
+    #[test]
+    fn apply_refresh_stamps_fetched_at_on_only_the_matching_tab() {
+        // Pins the per-tab `fetched_at` the header now reads: a landed Anthropic
+        // response leaves the still-loading OpenAI tab with no time of its own.
+        // Dropping the global `last_refresh` clock is not observable from here
+        // (it was write-only) — that is asserted against the rendered header in
+        // `view::tests::header_refresh_*`.
+        let anthropic = TabId::vendor(VendorId::Anthropic);
+        let openai = TabId::vendor(VendorId::Openai);
+        let mut app = App::with_theme(vec![anthropic.clone(), openai], Theme::default());
+        let generation = app.tab_generation;
+        let fetched_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap();
+
+        assert!(app.apply_refresh(generation, &anthropic, ready_at(fetched_at)));
+        match &app.tabs[0] {
+            TabState::Ready(ready) => assert_eq!(ready.fetched_at, Some(fetched_at)),
+            other => panic!("expected Anthropic tab Ready, got {other:?}"),
+        }
+        assert!(matches!(app.tabs[1], TabState::Loading));
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -200,6 +200,9 @@ pub enum Action {
     Close,
     /// Save just succeeded — caller should refresh affected vendors.
     SavedAndClose,
+    /// Quit the host TUI. Ctrl-C remains global even while the overlay owns
+    /// keyboard focus.
+    Quit,
 }
 
 /// Permission note appended to the "saved" status line. The overlay `chmod
@@ -225,6 +228,9 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
     // Esc always closes without saving.
     if matches!(code, KeyCode::Esc) {
         return Action::Close;
+    }
+    if matches!(code, KeyCode::Char('c')) && mods.contains(KeyModifiers::CONTROL) {
+        return Action::Quit;
     }
     // Ctrl-S triggers save from any field.
     if matches!(code, KeyCode::Char('s')) && mods.contains(KeyModifiers::CONTROL) {
@@ -273,12 +279,17 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
     }
 
     // A modifier chord is not text. The overlay swallows every key while open,
-    // so without this Ctrl-C types "c" into the focused API key instead of
-    // reaching the app's quit binding, and every other chord corrupts the
+    // so every unhandled chord must be ignored rather than corrupting the
     // secret silently. SHIFT is deliberately not rejected — it is how
-    // uppercase arrives.
+    // uppercase arrives. Ctrl-C was handled above because it is a global quit.
     if matches!(code, KeyCode::Char(_))
-        && mods.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+        && mods.intersects(
+            KeyModifiers::CONTROL
+                | KeyModifiers::ALT
+                | KeyModifiers::SUPER
+                | KeyModifiers::HYPER
+                | KeyModifiers::META,
+        )
     {
         return Action::Continue;
     }
@@ -353,7 +364,11 @@ fn save_to_config_default(state: &SettingsState) -> Result<()> {
 /// Same as `save_to_config_default` but with an explicit path — exposed
 /// for tests.
 pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
-    let original = std::fs::read_to_string(path).unwrap_or_default();
+    let original = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(AppError::io_at(path, error)),
+    };
     let mut doc: DocumentMut = if original.trim().is_empty() {
         DocumentMut::new()
     } else {
@@ -824,6 +839,17 @@ api_key_env = "OPENROUTER_API_KEY"
     }
 
     #[test]
+    fn save_refuses_to_replace_an_unreadable_existing_config() {
+        let (_dir, path) = temp_config(None);
+        let original = [0xff, 0xfe, 0xfd];
+        std::fs::write(&path, original).unwrap();
+        let state = state_with("new-secret", "", VendorId::Zai);
+
+        assert!(save_to_path(&state, &path).is_err());
+        assert_eq!(std::fs::read(&path).unwrap(), original);
+    }
+
+    #[test]
     fn save_does_not_write_empty_key_when_dirty_but_blank() {
         let (_dir, path) = temp_config(None);
         let mut s = state_with("", "", VendorId::Anthropic);
@@ -1079,11 +1105,11 @@ primary = "deepseek"
     }
 
     #[test]
-    fn handle_key_ctrl_c_does_not_type_into_key_field() {
+    fn handle_key_ctrl_c_quits_without_typing_into_key_field() {
         let mut s = state_focused_on_zai();
         assert_eq!(
             handle_key(&mut s, KeyCode::Char('c'), KeyModifiers::CONTROL),
-            Action::Continue
+            Action::Quit
         );
         assert!(s.zai.buf.is_empty());
         // Untouched means save still leaves an existing key on disk alone.
@@ -1096,6 +1122,16 @@ primary = "deepseek"
         handle_key(&mut s, KeyCode::Char('x'), KeyModifiers::ALT);
         assert!(s.zai.buf.is_empty());
         assert!(!s.zai.dirty);
+    }
+
+    #[test]
+    fn handle_key_platform_modifier_chords_do_not_type_into_key_field() {
+        for modifier in [KeyModifiers::SUPER, KeyModifiers::HYPER, KeyModifiers::META] {
+            let mut s = state_focused_on_zai();
+            handle_key(&mut s, KeyCode::Char('x'), modifier);
+            assert!(s.zai.buf.is_empty(), "modifier {modifier:?}");
+            assert!(!s.zai.dirty, "modifier {modifier:?}");
+        }
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -272,6 +272,17 @@ pub fn handle_key(state: &mut SettingsState, code: KeyCode, mods: KeyModifiers) 
         _ => {}
     }
 
+    // A modifier chord is not text. The overlay swallows every key while open,
+    // so without this Ctrl-C types "c" into the focused API key instead of
+    // reaching the app's quit binding, and every other chord corrupts the
+    // secret silently. SHIFT is deliberately not rejected — it is how
+    // uppercase arrives.
+    if matches!(code, KeyCode::Char(_))
+        && mods.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+    {
+        return Action::Continue;
+    }
+
     // Field-specific handling.
     match state.focus {
         Focus::Primary => handle_primary(state, code),
@@ -1052,6 +1063,63 @@ primary = "deepseek"
         assert!(s.zai.revealed);
         handle_key(&mut s, KeyCode::Char('v'), KeyModifiers::CONTROL);
         assert!(!s.zai.revealed);
+    }
+
+    fn state_focused_on_zai() -> SettingsState {
+        SettingsState {
+            focus: Focus::ZaiKey,
+            primary_choices: VendorId::all().to_vec(),
+            primary: VendorId::Anthropic,
+            zai: KeyInput::default(),
+            openrouter: KeyInput::default(),
+            deepseek: KeyInput::default(),
+            kimi: KeyInput::default(),
+            status: String::new(),
+        }
+    }
+
+    #[test]
+    fn handle_key_ctrl_c_does_not_type_into_key_field() {
+        let mut s = state_focused_on_zai();
+        assert_eq!(
+            handle_key(&mut s, KeyCode::Char('c'), KeyModifiers::CONTROL),
+            Action::Continue
+        );
+        assert!(s.zai.buf.is_empty());
+        // Untouched means save still leaves an existing key on disk alone.
+        assert!(!s.zai.dirty);
+    }
+
+    #[test]
+    fn handle_key_alt_chord_does_not_type_into_key_field() {
+        let mut s = state_focused_on_zai();
+        handle_key(&mut s, KeyCode::Char('x'), KeyModifiers::ALT);
+        assert!(s.zai.buf.is_empty());
+        assert!(!s.zai.dirty);
+    }
+
+    #[test]
+    fn handle_key_shift_still_types_uppercase() {
+        let mut s = state_focused_on_zai();
+        handle_key(&mut s, KeyCode::Char('A'), KeyModifiers::SHIFT);
+        assert_eq!(s.zai.buf, "A");
+        assert!(s.zai.dirty);
+    }
+
+    #[test]
+    fn handle_key_plain_space_still_cycles_primary_vendor() {
+        let mut s = SettingsState {
+            focus: Focus::Primary,
+            primary_choices: VendorId::all().to_vec(),
+            primary: VendorId::Anthropic,
+            zai: KeyInput::default(),
+            openrouter: KeyInput::default(),
+            deepseek: KeyInput::default(),
+            kimi: KeyInput::default(),
+            status: String::new(),
+        };
+        handle_key(&mut s, KeyCode::Char(' '), KeyModifiers::NONE);
+        assert_eq!(s.primary, VendorId::Openai);
     }
 
     #[test]

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -94,9 +94,27 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
         theme.muted(" · "),
         theme.span(format!("active {active}")),
         theme.muted(" · "),
-        theme.muted(format!("last refresh {}", local_time_hms(app.last_refresh))),
+        theme.muted(header_refresh_text(app)),
     ]);
     f.render_widget(Paragraph::new(line), inner);
+}
+
+/// The header's refresh stamp, read from the ACTIVE tab's own `fetched_at`.
+///
+/// This used to be a single `App::last_refresh` bumped by whichever vendor
+/// finished last, so a tab that was still loading — or had failed minutes ago —
+/// advertised a sibling's success as its own. A tab with no landed response has
+/// no time to show, so it gets the same `—` the panels use for an unknown
+/// fetched-at rather than a borrowed or invented one.
+fn header_refresh_text(app: &App) -> String {
+    let fetched_at = match app.tabs.get(app.active) {
+        Some(TabState::Ready(ready)) => ready.fetched_at,
+        _ => None,
+    };
+    match fetched_at {
+        Some(at) => format!("last refresh {}", local_time_hms(at)),
+        None => "last refresh —".to_string(),
+    }
 }
 
 fn draw_main(f: &mut Frame, app: &App, area: Rect) {
@@ -216,4 +234,87 @@ fn draw_footer(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     ])
     .theme(theme);
     f.render_widget(&help, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::theme::Theme;
+    use crate::tui::app::ReadyTab;
+    use crate::usage::{OpenRouterSnapshot, VendorSnapshot};
+    use chrono::{DateTime, TimeZone, Utc};
+
+    fn ready_at(fetched_at: Option<DateTime<Utc>>) -> TabState {
+        TabState::Ready(Box::new(ReadyTab {
+            snapshot: VendorSnapshot::Openrouter(OpenRouterSnapshot {
+                label: "test".into(),
+                total_credits: 0.0,
+                total_usage: 0.0,
+                usage_daily: 0.0,
+                usage_weekly: 0.0,
+                usage_monthly: 0.0,
+                is_free_tier: false,
+                limit: None,
+                limit_remaining: None,
+            }),
+            stale: false,
+            last_error: None,
+            fetched_at,
+        }))
+    }
+
+    // `App::with_theme(.., Theme::default())` rather than `App::new`, which
+    // would read the real Omarchy theme file + `$HOME`. The header stamp under
+    // test is theme-agnostic.
+    fn app_with(tabs: Vec<TabState>) -> App {
+        let mut app = App::with_theme(
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::vendor(VendorId::Openrouter),
+            ],
+            Theme::default(),
+        );
+        app.tabs = tabs;
+        app
+    }
+
+    #[test]
+    fn header_refresh_follows_the_active_tab() {
+        let anthropic_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap();
+        let openrouter_at = Utc.with_ymd_and_hms(2026, 5, 23, 9, 30, 0).unwrap();
+        let mut app = app_with(vec![
+            ready_at(Some(anthropic_at)),
+            ready_at(Some(openrouter_at)),
+        ]);
+
+        // Compare against the formatting helper, not a literal, so the test
+        // doesn't depend on the machine's timezone.
+        let anthropic_header = format!("last refresh {}", local_time_hms(anthropic_at));
+        let openrouter_header = format!("last refresh {}", local_time_hms(openrouter_at));
+        assert_ne!(anthropic_header, openrouter_header);
+
+        assert_eq!(header_refresh_text(&app), anthropic_header);
+        app.next_tab();
+        assert_eq!(header_refresh_text(&app), openrouter_header);
+    }
+
+    #[test]
+    fn header_refresh_is_dash_when_active_tab_never_fetched() {
+        // The sibling's successful fetch is exactly what the old global clock
+        // would have displayed here.
+        let sibling = ready_at(Some(Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap()));
+        let mut app = app_with(vec![TabState::Loading, sibling]);
+        assert_eq!(header_refresh_text(&app), "last refresh —");
+
+        app.tabs[0] = TabState::Error("401 Unauthorized".into());
+        assert_eq!(header_refresh_text(&app), "last refresh —");
+    }
+
+    #[test]
+    fn header_refresh_is_dash_when_ready_tab_has_no_fetched_at() {
+        // Ready but the cache never reported an age — show nothing rather than
+        // passing off "now" as a response time.
+        let app = app_with(vec![ready_at(None), TabState::Loading]);
+        assert_eq!(header_refresh_text(&app), "last refresh —");
+    }
 }

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -101,7 +101,7 @@ pub struct DeepseekSnapshot {
     pub granted: f64,
     /// Topped-up (purchased) credits component.
     pub topped_up: f64,
-    /// The currency of the above amounts ("USD", "CNY", etc.).
+    /// The currency of the above amounts (currently "USD" or "CNY").
     pub currency: String,
 }
 

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -14,6 +14,43 @@ use crate::widget::cli::Cli;
 /// Vendor fetchers still apply their own tighter per-request timeouts.
 pub const HTTP_CLIENT_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Upper bound on a vendor response body. Every one of these endpoints returns
+/// a small JSON document — the largest observed is a few kilobytes — so this is
+/// generous by three orders of magnitude while still bounding the damage from a
+/// misbehaving proxy or a hijacked endpoint.
+pub const MAX_BODY_BYTES: usize = 2 * 1024 * 1024;
+
+/// Read a response body with an upper bound.
+///
+/// Every vendor buffered the whole body with `resp.bytes()` *before* anything
+/// validated it. The widget is re-executed by Waybar every 60s, so an endpoint
+/// answering with an unbounded stream had a free hand at the machine's memory.
+/// `Content-Length` is checked first when present, then the body is read in
+/// chunks so a lying or absent length cannot get past the cap either.
+pub async fn read_body_capped(
+    mut resp: reqwest::Response,
+    max: usize,
+) -> crate::error::Result<Vec<u8>> {
+    let too_big = |n: u64| {
+        crate::error::AppError::Schema(format!(
+            "response body exceeds the {max}-byte limit ({n} bytes); refusing to buffer it"
+        ))
+    };
+    if let Some(len) = resp.content_length()
+        && len > max as u64
+    {
+        return Err(too_big(len));
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        if buf.len() + chunk.len() > max {
+            return Err(too_big((buf.len() + chunk.len()) as u64));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
 /// Stable enum used by `--vendor` and in config files.
 #[derive(
     Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize,
@@ -89,6 +126,45 @@ impl RenderOpts {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn body_over_the_cap_is_refused_and_under_it_round_trips() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/big")
+            .with_status(200)
+            .with_body("x".repeat(4096))
+            .create_async()
+            .await;
+        server
+            .mock("GET", "/small")
+            .with_status(200)
+            .with_body("hello")
+            .create_async()
+            .await;
+
+        let client = reqwest::Client::new();
+
+        // Over the cap: refused rather than buffered.
+        let resp = client
+            .get(format!("{}/big", server.url()))
+            .send()
+            .await
+            .unwrap();
+        let err = read_body_capped(resp, 1024).await.unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds"),
+            "unexpected error: {err}"
+        );
+
+        // Under the cap: identical to the previous `resp.bytes()` behaviour.
+        let resp = client
+            .get(format!("{}/small", server.url()))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(read_body_capped(resp, 1024).await.unwrap(), b"hello");
+    }
 
     #[test]
     fn vendor_id_slug_round_trip() {

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -43,8 +43,8 @@ pub async fn read_body_capped(
     }
     let mut buf: Vec<u8> = Vec::new();
     while let Some(chunk) = resp.chunk().await? {
-        if buf.len() + chunk.len() > max {
-            return Err(too_big((buf.len() + chunk.len()) as u64));
+        if chunk.len() > max.saturating_sub(buf.len()) {
+            return Err(too_big(buf.len().saturating_add(chunk.len()) as u64));
         }
         buf.extend_from_slice(&chunk);
     }
@@ -164,6 +164,26 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(read_body_capped(resp, 1024).await.unwrap(), b"hello");
+    }
+
+    #[tokio::test]
+    async fn chunked_body_without_content_length_still_hits_the_cap() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/chunked")
+            .with_status(200)
+            .with_chunked_body(|writer| writer.write_all(&[b'x'; 4096]))
+            .create_async()
+            .await;
+
+        let response = reqwest::Client::new()
+            .get(format!("{}/chunked", server.url()))
+            .send()
+            .await
+            .unwrap();
+        assert!(response.content_length().is_none());
+        let error = read_body_capped(response, 1024).await.unwrap_err();
+        assert!(error.to_string().contains("exceeds"), "{error}");
     }
 
     #[test]

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -60,7 +60,12 @@ async fn run_cycle(cli: &Cli) -> i32 {
         _ => enabled[0],
     };
     let delta = if cli.cycle_next { 1 } else { -1 };
-    let _ = crate::active::cycle(&enabled, start, delta);
+    // Signalling after a *failed* persist told Waybar to re-render a selection
+    // that was never written, so the bar redrew the same vendor and the scroll
+    // looked like it had been swallowed. Only announce a change that happened.
+    if crate::active::cycle(&enabled, start, delta).is_err() {
+        return 0;
+    }
 
     // Refresh the bar immediately. The Waybar module's `signal: 13` setting
     // means SIGRTMIN+13 re-runs the exec. SIGRTMIN is libc-dependent; the
@@ -69,11 +74,24 @@ async fn run_cycle(cli: &Cli) -> i32 {
     0
 }
 
+/// `--watch` repaints in place, which only makes sense on a terminal. Piped or
+/// redirected, the escape sequence is just garbage in the captured output.
+/// Split out from the loop so the decision is testable without a real TTY.
+fn should_clear_screen(stdout_is_tty: bool) -> bool {
+    stdout_is_tty
+}
+
 async fn run_watch(cli: Cli, secs: u64) -> i32 {
     let interval = Duration::from_secs(secs.max(1));
+    let clear = {
+        use std::io::IsTerminal;
+        should_clear_screen(std::io::stdout().is_terminal())
+    };
     loop {
-        // Clear screen + home cursor.
-        print!("\x1b[2J\x1b[H");
+        if clear {
+            // Clear screen + home cursor.
+            print!("\x1b[2J\x1b[H");
+        }
         let _ = std::io::stdout().flush();
         run_once(&cli, &mut std::io::stdout()).await;
         println!();
@@ -478,6 +496,29 @@ mod tests {
         let out = fallback(&err, &cli_default());
         assert_eq!(out.text, "⚠");
         assert!(out.tooltip.contains("missing token"));
+    }
+
+    #[test]
+    fn watch_only_clears_the_screen_on_a_terminal() {
+        // Redirected to a file or piped, the clear-screen escape is garbage in
+        // the captured output.
+        assert!(should_clear_screen(true));
+        assert!(!should_clear_screen(false));
+    }
+
+    #[test]
+    fn a_failed_cycle_persist_is_not_announced_to_waybar() {
+        // Signalling after a failed persist made Waybar re-render the *same*
+        // vendor, so the scroll looked swallowed. An empty vendor set is the
+        // reachable failure: `cycle_at` errors and nothing is written.
+        let td = tempfile::TempDir::new().unwrap();
+        let path = td.path().join("active_vendor");
+        let r = crate::active::cycle_at(&path, &[], crate::vendor::VendorId::Anthropic, 1);
+        assert!(r.is_err());
+        assert!(
+            crate::active::read_from(&path).is_none(),
+            "a failed cycle must not have persisted anything"
+        );
     }
 
     #[test]

--- a/src/zai/fetch.rs
+++ b/src/zai/fetch.rs
@@ -317,7 +317,7 @@ mod tests {
 
         let (_td, cache) = cache_fixture();
         let seed = r#"{"code":200,"data":{"limits":[
-            {"type":"TOKENS_LIMIT","percentage":10}
+            {"type":"TOKENS_LIMIT","unit":3,"percentage":10}
         ],"level":"lite"},"success":true}"#;
         cache.write_payload(seed.as_bytes()).unwrap();
 

--- a/src/zai/fetch.rs
+++ b/src/zai/fetch.rs
@@ -135,7 +135,7 @@ async fn fetch_live(
     .map_err(|_| AppError::Transport(format!("zai timeout: {url}")))??;
 
     let status = resp.status();
-    let bytes = resp.bytes().await?.to_vec();
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
 
     if !status.is_success() {
         let body = String::from_utf8_lossy(&bytes).chars().take(200).collect();

--- a/src/zai/types.rs
+++ b/src/zai/types.rs
@@ -76,10 +76,18 @@ impl Envelope {
         // A body whose token buckets we cannot name is drift, not usage: let it
         // through and the widget would render one window's figure under the
         // other's label, and cache it as if it were vouched for.
-        if let Err(why) = classify_token_buckets(&data.limits) {
-            return Err(crate::error::AppError::Schema(format!(
-                "zai: unrecognised limits layout: {why}"
-            )));
+        let (session, weekly) = classify_token_buckets(&data.limits).map_err(|why| {
+            crate::error::AppError::Schema(format!("zai: unrecognised limits layout: {why}"))
+        })?;
+        let mcp = classify_time_bucket(&data.limits).map_err(|why| {
+            crate::error::AppError::Schema(format!("zai: unrecognised limits layout: {why}"))
+        })?;
+        for (label, bucket) in [("session", session), ("weekly", weekly), ("MCP", mcp)] {
+            if bucket.is_some_and(|entry| entry.percentage.is_none()) {
+                return Err(crate::error::AppError::Schema(format!(
+                    "zai: {label} limit carried no percentage"
+                )));
+            }
         }
         Ok(())
     }
@@ -97,19 +105,17 @@ type TokenBuckets<'a> = (Option<&'a LimitEntry>, Option<&'a LimitEntry>);
 /// Match the TOKENS_LIMIT entries to the (session, weekly) windows by `unit`.
 ///
 /// Buckets carrying an unknown `unit` are dropped rather than shown under a
-/// label we can't justify, so Z.AI adding a third window is inert here. `Err`
-/// is reserved for layouts where guessing would be the only alternative:
-/// duplicate codes, or unit-bearing buckets none of which we recognise.
+/// label we can't justify, so Z.AI adding a third window is inert here. A
+/// non-empty set with no discriminator is drift, not a backwards-compatibility
+/// case: caches retain the raw `unit` field, so position would still be a guess.
 fn classify_token_buckets(limits: &[LimitEntry]) -> Result<TokenBuckets<'_>, String> {
     let tokens: Vec<&LimitEntry> = limits.iter().filter(|l| l.kind == "TOKENS_LIMIT").collect();
 
-    // Bodies predating the `unit` field (and caches written from them) have no
-    // discriminator at all; position is all there ever was for those.
+    if tokens.is_empty() {
+        return Ok((None, None));
+    }
     if tokens.iter().all(|l| l.unit.is_none()) {
-        let mut it = tokens.into_iter();
-        let session = it.next();
-        let weekly = it.next();
-        return Ok((session, weekly));
+        return Err("TOKENS_LIMIT buckets carry no unit discriminator".into());
     }
 
     let session = unique_by_unit(&tokens, UNIT_SESSION)?;
@@ -126,6 +132,15 @@ fn classify_token_buckets(limits: &[LimitEntry]) -> Result<TokenBuckets<'_>, Str
         ));
     }
     Ok((session, weekly))
+}
+
+fn classify_time_bucket(limits: &[LimitEntry]) -> Result<Option<&LimitEntry>, String> {
+    let mut matching = limits.iter().filter(|l| l.kind == "TIME_LIMIT");
+    let first = matching.next();
+    if matching.next().is_some() {
+        return Err("two TIME_LIMIT buckets are present".into());
+    }
+    Ok(first)
 }
 
 fn unique_by_unit<'a>(
@@ -152,7 +167,8 @@ pub struct MonitorData {
 pub struct LimitEntry {
     #[serde(rename = "type")]
     pub kind: String,
-    pub percentage: f64,
+    #[serde(default, deserialize_with = "de_percent_opt")]
+    pub percentage: Option<f64>,
     /// Unix milliseconds — `null` / `0` / missing → None.
     #[serde(rename = "nextResetTime", default, deserialize_with = "de_opt_ms")]
     pub next_reset_time: Option<i64>,
@@ -165,11 +181,50 @@ where
     D: serde::Deserializer<'de>,
 {
     let v = serde_json::Value::deserialize(d)?;
-    Ok(match v {
-        serde_json::Value::Null => None,
-        serde_json::Value::Number(n) => n.as_i64().or_else(|| n.as_f64().map(|f| f as i64)),
-        _ => None,
-    })
+    match v {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::Number(n) => {
+            let millis = if let Some(i) = n.as_i64() {
+                i
+            } else if let Some(f) = n.as_f64()
+                && f.is_finite()
+                && f.fract() == 0.0
+                && f.abs() <= (1_u64 << 53) as f64
+            {
+                f as i64
+            } else {
+                return Err(serde::de::Error::custom(
+                    "nextResetTime must be an integer in range",
+                ));
+            };
+            match millis {
+                0 => Ok(None),
+                1.. => Ok(Some(millis)),
+                _ => Err(serde::de::Error::custom("nextResetTime cannot be negative")),
+            }
+        }
+        other => Err(serde::de::Error::custom(format!(
+            "nextResetTime must be an integer or null, got {other:?}"
+        ))),
+    }
+}
+
+fn de_percent_opt<'de, D>(d: D) -> Result<Option<f64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<f64>::deserialize(d)?;
+    value
+        .map(|pct| {
+            if pct.is_finite() && (0.0..=101.0).contains(&pct) {
+                Ok(pct)
+            } else {
+                Err(serde::de::Error::custom(format!(
+                    "percentage {pct} outside 0..=100"
+                )))
+            }
+        })
+        .transpose()
 }
 
 impl Envelope {
@@ -180,13 +235,12 @@ impl Envelope {
         // On the fetch path `check_ok` has already turned an unnameable layout
         // into an error; direct callers get empty windows for the same reason.
         let (session, weekly) = classify_token_buckets(&data.limits).unwrap_or((None, None));
-        let session = session.map(|l| to_window(l, chrono::Duration::hours(5)));
-        let weekly = weekly.map(|l| to_window(l, chrono::Duration::days(7)));
-        let mcp = data
-            .limits
-            .iter()
-            .find(|l| l.kind == "TIME_LIMIT")
-            .map(|l| to_window(l, chrono::Duration::days(30)));
+        let session = session.and_then(|l| to_window(l, chrono::Duration::hours(5)));
+        let weekly = weekly.and_then(|l| to_window(l, chrono::Duration::days(7)));
+        let mcp = classify_time_bucket(&data.limits)
+            .ok()
+            .flatten()
+            .and_then(|l| to_window(l, chrono::Duration::days(30)));
 
         // Prefer the response's `level` field, then any config-provided tier.
         let level = if !data.level.is_empty() {
@@ -205,16 +259,16 @@ impl Envelope {
     }
 }
 
-fn to_window(l: &LimitEntry, dur: chrono::Duration) -> UsageWindow {
-    let utilization_pct = l.percentage.round().clamp(0.0, 100.0) as i32;
+fn to_window(l: &LimitEntry, dur: chrono::Duration) -> Option<UsageWindow> {
+    let utilization_pct = l.percentage?.round().clamp(0.0, 100.0) as i32;
     let resets_at = l
         .next_reset_time
         .and_then(chrono::DateTime::<chrono::Utc>::from_timestamp_millis);
-    UsageWindow {
+    Some(UsageWindow {
         utilization_pct,
         resets_at,
         window_duration: dur,
-    }
+    })
 }
 
 fn capitalize(s: &str) -> String {
@@ -269,7 +323,7 @@ mod tests {
     #[test]
     fn percentage_with_float_rounds() {
         let body = r#"{"data":{"limits":[
-            {"type":"TOKENS_LIMIT","percentage":42.7}
+            {"type":"TOKENS_LIMIT","unit":3,"percentage":42.7}
         ],"level":"max"},"success":true}"#;
         let env: Envelope = serde_json::from_str(body).unwrap();
         let snap = env.into_snapshot(None);
@@ -277,9 +331,9 @@ mod tests {
     }
 
     #[test]
-    fn percentage_clamps_to_hundred() {
+    fn benign_percentage_overshoot_clamps_to_hundred() {
         let body = r#"{"data":{"limits":[
-            {"type":"TOKENS_LIMIT","percentage":150}
+            {"type":"TOKENS_LIMIT","unit":3,"percentage":100.6}
         ]},"success":true}"#;
         let env: Envelope = serde_json::from_str(body).unwrap();
         let snap = env.into_snapshot(None);
@@ -380,19 +434,57 @@ mod tests {
         assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 15);
     }
 
-    /// Carve-out: bodies (and caches) predating `unit` carry no discriminator,
-    /// so position is all there ever was for them.
     #[test]
-    fn bodies_without_any_unit_still_fall_back_to_position() {
+    fn bodies_without_any_unit_are_rejected_not_guessed_by_position() {
         let body = r#"{"data":{"limits":[
             {"type":"TOKENS_LIMIT","percentage":10},
             {"type":"TOKENS_LIMIT","percentage":20}
         ],"level":"lite"},"success":true}"#;
         let env: Envelope = serde_json::from_str(body).unwrap();
-        env.check_ok().unwrap();
+        let err = env.check_ok().unwrap_err().to_string();
+        assert!(err.contains("no unit discriminator"), "{err}");
         let snap = env.into_snapshot(None);
-        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 10);
-        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 20);
+        assert!(snap.session.is_none());
+        assert!(snap.weekly.is_none());
+    }
+
+    #[test]
+    fn a_named_bucket_without_percentage_is_rejected_not_zeroed() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","unit":3,"number":5}
+        ]},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        let err = env.check_ok().unwrap_err().to_string();
+        assert!(err.contains("session limit carried no percentage"), "{err}");
+        assert!(env.into_snapshot(None).session.is_none());
+    }
+
+    #[test]
+    fn duplicate_time_limit_is_rejected_not_selected_by_position() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TIME_LIMIT","unit":5,"percentage":10},
+            {"type":"TIME_LIMIT","unit":5,"percentage":20}
+        ]},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        let err = env.check_ok().unwrap_err().to_string();
+        assert!(err.contains("two TIME_LIMIT"), "{err}");
+        assert!(env.into_snapshot(None).mcp.is_none());
+    }
+
+    #[test]
+    fn invalid_percentage_and_reset_values_are_schema_drift() {
+        for percentage in ["-1", "101.5", "150"] {
+            let body = format!(
+                r#"{{"data":{{"limits":[{{"type":"TOKENS_LIMIT","unit":3,"percentage":{percentage}}}]}},"success":true}}"#
+            );
+            assert!(serde_json::from_str::<Envelope>(&body).is_err(), "{body}");
+        }
+        for reset in ["-1", "1.5", "true", r#""later""#] {
+            let body = format!(
+                r#"{{"data":{{"limits":[{{"type":"TOKENS_LIMIT","unit":3,"percentage":0,"nextResetTime":{reset}}}]}},"success":true}}"#
+            );
+            assert!(serde_json::from_str::<Envelope>(&body).is_err(), "{body}");
+        }
     }
 
     #[test]
@@ -404,7 +496,7 @@ mod tests {
     #[test]
     fn reset_time_zero_or_null_becomes_none() {
         let body = r#"{"data":{"limits":[
-            {"type":"TOKENS_LIMIT","percentage":0,"nextResetTime":null}
+            {"type":"TOKENS_LIMIT","unit":3,"percentage":0,"nextResetTime":null}
         ]},"success":true}"#;
         let env: Envelope = serde_json::from_str(body).unwrap();
         let snap = env.into_snapshot(None);

--- a/src/zai/types.rs
+++ b/src/zai/types.rs
@@ -23,11 +23,14 @@
 //! }
 //! ```
 //!
-//! The `unit`/`number` codes don't have a documented mapping, so we classify
-//! limits by **position + type**: the first TOKENS_LIMIT entry is treated as
-//! the session bucket, the second as weekly, and the TIME_LIMIT entry as the
-//! monthly MCP tool ceiling. When the shape drifts the smoke test will catch
-//! it and we can update this mapping.
+//! The `unit`/`number` codes have no documented mapping, but `unit` is the one
+//! field that tells the two TOKENS_LIMIT buckets apart independently of where
+//! they sit in the array: the 5h window carries `unit:3`, the 7d one `unit:6`.
+//! So the session/weekly split keys off `unit`, not off position — Z.AI is free
+//! to reorder `limits` or insert a bucket, and a positional split would silently
+//! swap the two windows or promote a stranger to "session". A layout we cannot
+//! name is an error via [`Envelope::check_ok`], never a guess. The TIME_LIMIT
+//! entry is the monthly MCP tool ceiling.
 
 use serde::Deserialize;
 
@@ -65,13 +68,76 @@ impl Envelope {
                 self.code, self.success
             )));
         }
-        if self.data.is_none() {
+        let Some(data) = &self.data else {
             return Err(crate::error::AppError::Schema(
                 "zai: success response carried no `data`".into(),
             ));
+        };
+        // A body whose token buckets we cannot name is drift, not usage: let it
+        // through and the widget would render one window's figure under the
+        // other's label, and cache it as if it were vouched for.
+        if let Err(why) = classify_token_buckets(&data.limits) {
+            return Err(crate::error::AppError::Schema(format!(
+                "zai: unrecognised limits layout: {why}"
+            )));
         }
         Ok(())
     }
+}
+
+/// `unit` codes of the two TOKENS_LIMIT buckets in the captured response. The
+/// enum behind them is undocumented — `number` (5 and 1) is consistent with
+/// "5 hours" / "1 week", but we don't lean on that, so the window durations
+/// stay hardcoded and only the *identity* of each bucket comes from `unit`.
+const UNIT_SESSION: i64 = 3;
+const UNIT_WEEKLY: i64 = 6;
+
+type TokenBuckets<'a> = (Option<&'a LimitEntry>, Option<&'a LimitEntry>);
+
+/// Match the TOKENS_LIMIT entries to the (session, weekly) windows by `unit`.
+///
+/// Buckets carrying an unknown `unit` are dropped rather than shown under a
+/// label we can't justify, so Z.AI adding a third window is inert here. `Err`
+/// is reserved for layouts where guessing would be the only alternative:
+/// duplicate codes, or unit-bearing buckets none of which we recognise.
+fn classify_token_buckets(limits: &[LimitEntry]) -> Result<TokenBuckets<'_>, String> {
+    let tokens: Vec<&LimitEntry> = limits.iter().filter(|l| l.kind == "TOKENS_LIMIT").collect();
+
+    // Bodies predating the `unit` field (and caches written from them) have no
+    // discriminator at all; position is all there ever was for those.
+    if tokens.iter().all(|l| l.unit.is_none()) {
+        let mut it = tokens.into_iter();
+        let session = it.next();
+        let weekly = it.next();
+        return Ok((session, weekly));
+    }
+
+    let session = unique_by_unit(&tokens, UNIT_SESSION)?;
+    let weekly = unique_by_unit(&tokens, UNIT_WEEKLY)?;
+    if session.is_none() && weekly.is_none() {
+        let seen: Vec<String> = tokens
+            .iter()
+            .filter_map(|l| l.unit)
+            .map(|u| u.to_string())
+            .collect();
+        return Err(format!(
+            "no TOKENS_LIMIT bucket carries a known unit code (saw {})",
+            seen.join(", ")
+        ));
+    }
+    Ok((session, weekly))
+}
+
+fn unique_by_unit<'a>(
+    tokens: &[&'a LimitEntry],
+    code: i64,
+) -> Result<Option<&'a LimitEntry>, String> {
+    let mut matching = tokens.iter().filter(|l| l.unit == Some(code));
+    let first = matching.next().copied();
+    if matching.next().is_some() {
+        return Err(format!("two TOKENS_LIMIT buckets carry unit {code}"));
+    }
+    Ok(first)
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -111,13 +177,11 @@ impl Envelope {
     /// snapshot with all windows `None` when `data` is missing.
     pub fn into_snapshot(self, config_plan_tier: Option<&str>) -> ZaiSnapshot {
         let data = self.data.unwrap_or_default();
-        let mut tokens_iter = data.limits.iter().filter(|l| l.kind == "TOKENS_LIMIT");
-        let session = tokens_iter
-            .next()
-            .map(|l| to_window(l, chrono::Duration::hours(5)));
-        let weekly = tokens_iter
-            .next()
-            .map(|l| to_window(l, chrono::Duration::days(7)));
+        // On the fetch path `check_ok` has already turned an unnameable layout
+        // into an error; direct callers get empty windows for the same reason.
+        let (session, weekly) = classify_token_buckets(&data.limits).unwrap_or((None, None));
+        let session = session.map(|l| to_window(l, chrono::Duration::hours(5)));
+        let weekly = weekly.map(|l| to_window(l, chrono::Duration::days(7)));
         let mcp = data
             .limits
             .iter()
@@ -240,6 +304,101 @@ mod tests {
         let env: Envelope = serde_json::from_str(body).unwrap();
         let snap = env.into_snapshot(Some("max"));
         assert_eq!(snap.plan, "GLM Coding Max");
+    }
+
+    /// The regression: session/weekly used to be "first TOKENS_LIMIT, second
+    /// TOKENS_LIMIT", so a reordered array swapped the two windows.
+    #[test]
+    fn buckets_are_identified_by_unit_not_by_position() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":15,"nextResetTime":1779792169974},
+            {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":42}
+        ],"level":"pro"},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        env.check_ok().unwrap();
+        let snap = env.into_snapshot(None);
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 42);
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 15);
+        assert!(snap.weekly.as_ref().unwrap().resets_at.is_some());
+        assert!(snap.session.as_ref().unwrap().resets_at.is_none());
+    }
+
+    /// A third bucket must not be promoted to "session" just by leading the array.
+    #[test]
+    fn unknown_extra_bucket_is_dropped_not_shown_as_session() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","unit":4,"number":1,"percentage":99},
+            {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":42},
+            {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":15}
+        ],"level":"pro"},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        env.check_ok().unwrap();
+        let snap = env.into_snapshot(None);
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 42);
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 15);
+    }
+
+    #[test]
+    fn duplicate_unit_is_an_error_not_a_coin_flip() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":42},
+            {"type":"TOKENS_LIMIT","unit":3,"number":5,"percentage":7}
+        ],"level":"pro"},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        let err = env.check_ok().unwrap_err().to_string();
+        assert!(err.contains("unit 3"), "unhelpful error: {err}");
+        // And the projection refuses to pick one rather than showing either.
+        let snap = env.into_snapshot(None);
+        assert!(snap.session.is_none());
+        assert!(snap.weekly.is_none());
+    }
+
+    #[test]
+    fn all_unknown_units_is_an_error() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","unit":4,"number":1,"percentage":42},
+            {"type":"TOKENS_LIMIT","unit":7,"number":1,"percentage":15}
+        ],"level":"pro"},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        let err = env.check_ok().unwrap_err().to_string();
+        assert!(err.contains("4, 7"), "unhelpful error: {err}");
+        assert!(env.into_snapshot(None).session.is_none());
+    }
+
+    /// A bucket whose `unit` went missing can't be named, so it is dropped —
+    /// never quietly slotted into whichever window is still free.
+    #[test]
+    fn unit_less_bucket_alongside_a_known_one_is_dropped() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","percentage":99},
+            {"type":"TOKENS_LIMIT","unit":6,"number":1,"percentage":15}
+        ],"level":"pro"},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        env.check_ok().unwrap();
+        let snap = env.into_snapshot(None);
+        assert!(snap.session.is_none());
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 15);
+    }
+
+    /// Carve-out: bodies (and caches) predating `unit` carry no discriminator,
+    /// so position is all there ever was for them.
+    #[test]
+    fn bodies_without_any_unit_still_fall_back_to_position() {
+        let body = r#"{"data":{"limits":[
+            {"type":"TOKENS_LIMIT","percentage":10},
+            {"type":"TOKENS_LIMIT","percentage":20}
+        ],"level":"lite"},"success":true}"#;
+        let env: Envelope = serde_json::from_str(body).unwrap();
+        env.check_ok().unwrap();
+        let snap = env.into_snapshot(None);
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 10);
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 20);
+    }
+
+    #[test]
+    fn check_ok_accepts_the_real_response_shape() {
+        let env: Envelope = serde_json::from_str(REAL_BODY).unwrap();
+        env.check_ok().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Rebased onto merged PR #26. The final diff is the original follow-up plus maintainer audit corrections.

## Final scope

- Reject malformed Anthropic, OpenAI, Z.AI, OpenRouter, and DeepSeek wire values instead of caching or rendering fabricated values.
- Keep legitimate fractional OpenAI percentages while requiring exact integer duration and reset counters.
- Identify Z.AI windows by unit and reject unitless, duplicate, incomplete, or out-of-range layouts.
- Validate OAuth token text and expiry values; propagate bounded-body read failures.
- Escape API-controlled OpenRouter labels, then decode exactly one entity layer after native surfaces strip Pango tags.
- Serialize concurrent vendor cycling and only signal Waybar after persistence succeeds.
- Keep refresh timestamps per TUI tab; make Ctrl-C quit from Settings; ignore modifier chords; preserve multiline diagnostics.
- Refuse to overwrite unreadable config files and propagate cache serialization errors.
- Add `vendor_short` to the native protocol so GNOME and macOS suppress meaningless DeepSeek quota bars while retaining its balance header.
- Bound every vendor and OAuth response body, including chunked bodies without `Content-Length`.
- Keep the OpenAI admin-key setting for compatibility but document that it is currently reserved and inert.

## Verification

Local gate on the rebased head:

- `cargo fmt --all --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --all-targets --locked`: 430 unit and 3 integration tests passed; 5 live tests ignored by design
- GNOME marker and protocol tests passed
- `cargo machete` passed
- `git diff --check` passed

The hosted Ubuntu, macOS including Swift compilation, and Windows jobs are the final merge gate.