### PR TITLE
feat(tui): add local Claude context-window monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Each release is also published at
 
 ### Added
 
+- **Opt-in local Claude Code context monitor in the TUI.** Press `c` to list
+  the 100 most recently modified top-level sessions from
+  `~/.claude/projects`, then `Enter` for a detail gauge. The percentage uses
+  Claude Code's input-only formula (fresh input + cache creation + cache
+  reads); mixed 200K/1M histories can supply exact per-model window sizes, and
+  an unknown denominator stays a raw token count instead of becoming a false
+  percentage. The scanner runs off the async runtime, reads only bounded JSONL
+  tails, skips subagent transcripts and symlinks, tolerates corrupt/unknown
+  records, sanitizes display text, and invalidates a pre-compaction reading
+  until the next assistant response. The feature is disabled by default and
+  performs no filesystem scan until explicitly enabled.
+
 - **Four account-balance vendors** that read remaining credit via each
   provider's API and render it as money, alongside the existing usage vendors:
   - **Kilo** — `GET api.kilo.ai/api/profile/balance` (USD; optional org id).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,9 @@ vendor's response shape drifts:
   resolves `$HOME` / `%USERPROFILE%` via `directories::BaseDirs` and is reused
   by both OAuth-credential vendors (`anthropic`, `openai`) so the OS convention
   lives in one place.
+- `src/context/` — opt-in, bounded reader for local Claude Code JSONL
+  transcripts. This format is best-effort and schema-tolerant; tests must use
+  `scan_dir(&Path)` with a temp directory and never inspect a real user history.
 - `src/tui/settings.rs` — Settings overlay (toml_edit-backed,
   auto-signals waybar after save)
 - `src/tui/panels.rs` — native ratatui per-vendor panels

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This started as a Rust port of [`claudebar`](https://github.com/mryll/claudebar)
 
 - **Per-vendor Waybar modules** with the same JSON shape as claudebar.
 - **Tabbed TUI** (`ai-usagebar-tui`) with Tab/h/l switching, per-tab refresh, and 60-second auto-refresh. Native ratatui widgets fill the available terminal width and keep the vendor tabs visually consistent.
+- **Optional local Claude Code context monitor** in the TUI, with a bounded,
+  compaction-aware view of recent session input-context usage.
 - **Native desktop integrations** for GNOME Shell and the macOS menu bar, with selectors for Anthropic, OpenAI, Z.AI, OpenRouter, and DeepSeek.
 - **Scroll-to-cycle on the bar**: wire `on-scroll-up` / `on-scroll-down`, and one bar item cycles through your enabled vendors.
 - **Config-driven primary vendor**: set `[ui] primary` once; the widget shows that vendor by default and the TUI opens on its tab.
@@ -147,6 +149,13 @@ On macOS, recent Claude Code builds don't write `~/.claude/.credentials.json` �
 # primary = "anthropic"   # anthropic | anthropic_api | openai | zai
 #                         # | openrouter | deepseek | kimi | kilo | novita
 #                         # | moonshot | grok
+
+[context]
+enabled = false           # opt in, then press c in ai-usagebar-tui
+# projects_path = "~/.claude/projects"
+# context_window_tokens = 200000  # optional fallback denominator
+# [context.model_context_window_tokens]
+# "claude-opus-4-6" = 1000000    # exact model id overrides the fallback
 
 [anthropic]
 enabled = true
@@ -536,11 +545,45 @@ make clippy                                        # cargo clippy -D warnings
 - `r` — refresh active tab
 - `R` — refresh all tabs
 - `s` — open Settings overlay (primary vendor + API keys)
+- `c` — open local Claude context sessions (only when `[context] enabled = true`)
 - `q` / `Esc` / `Ctrl-C` — quit
 
 Auto-refresh runs every 60 seconds in the background. Vendors use the same layout. Here's OpenRouter showing the credit balance gauge (red because 98% is consumed), usage-by-period totals, and tier:
 
 ![ai-usagebar-tui showing the OpenRouter tab — Credit balance gauge at 98% in red ($13.67 left of $900), Usage by period with today/week/month, paid tier](screenshots/tui-openrouter.png)
+
+### Local context overlay
+
+The optional context overlay answers a different local question from the
+vendor tabs: how much input context was present in recent Claude Code sessions.
+Enable it by hand, restart the TUI, and press `c`:
+
+```toml
+[context]
+enabled = true
+# projects_path = "~/.claude/projects"  # this is the default
+# context_window_tokens = 200000         # optional fallback
+
+# Exact model ids override the fallback when 200K and 1M sessions coexist.
+[context.model_context_window_tokens]
+"claude-opus-4-6" = 1000000
+```
+
+Use `↑`/`↓` or `j`/`k` to select a session, `Enter` for its detail gauge,
+`Esc` to return, and `r` to rescan. The percentage follows
+[Claude Code's status-line definition](https://code.claude.com/docs/en/statusline):
+`input_tokens + cache_creation_input_tokens + cache_read_input_tokens`. If no
+trustworthy window size is configured for a model, the overlay shows the raw
+token count rather than guessing a percentage. After compaction it shows a
+waiting state until the next assistant response establishes the new context.
+
+This is a best-effort reader for Claude Code's undocumented local JSONL format,
+not an API. It reads only bounded tails from the 100 most recently modified
+top-level sessions, ignores unknown or corrupt lines, skips `subagents`
+sidechains, never follows discovered symlinks, and does the filesystem work on
+the blocking pool so the TUI remains responsive. Nothing under
+`~/.claude/projects` is read while the feature is disabled. Context controls
+stay in TOML rather than expanding the already-full Settings modal.
 
 ### Settings overlay
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -11,6 +11,21 @@
 # Valid: anthropic | openai | zai | openrouter | deepseek | kimi
 # primary = "anthropic"
 
+# Optional, TUI-only monitor for local Claude Code session context. When
+# enabled, press `c` in ai-usagebar-tui. The scanner reads only bounded tails
+# below ~/.claude/projects, skips subagent transcripts and never follows
+# discovered symlinks. Nothing is read while this remains disabled.
+[context]
+enabled = false
+# projects_path = "~/.claude/projects"  # default
+# Set a fallback only when it matches the sessions you use. Without a known
+# denominator the overlay shows raw input tokens rather than inventing a %.
+# context_window_tokens = 200000
+# Exact per-model values take precedence, which is useful when 200K and 1M
+# sessions coexist. Keys must match the model id stored in the transcript.
+# [context.model_context_window_tokens]
+# "claude-opus-4-6" = 1000000
+
 [anthropic]
 enabled = true
 # Path to the Claude CLI OAuth credentials. Leave commented out to use

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -6,6 +6,7 @@
 //!   Shift+Tab / h / ←   prev tab
 //!   r   refresh active tab
 //!   R   refresh all tabs
+//!   c   local Claude Code context sessions (when enabled)
 //!   q / Esc / Ctrl-C   quit
 
 use std::io;
@@ -61,6 +62,7 @@ async fn run() -> io::Result<()> {
         .map_err(io::Error::other)?;
 
     let mut app = App::new_with_primary(tabs, config.ui.primary);
+    app.context_enabled = config.context.enabled;
 
     // RAII: restoring the terminal must survive an error or a panic in the
     // loop below. Doing it inline left the user in raw mode on the alternate
@@ -113,6 +115,10 @@ where
 {
     // Kick off initial fetches for every vendor in parallel.
     let (tx, mut rx) = mpsc::unbounded_channel::<(u64, TabId, TabState)>();
+    let (context_tx, mut context_rx) = mpsc::unbounded_channel::<(
+        u64,
+        std::result::Result<ai_usagebar::context::ContextScan, String>,
+    )>();
     spawn_all(app, client, config, &tx);
 
     // ONE reader thread for the whole session. Spawning a fresh
@@ -150,6 +156,13 @@ where
             Some((generation, tab, state)) = rx.recv() => {
                 app.apply_refresh(generation, &tab, state);
             }
+            // Local transcript scans carry their own generation so a slow
+            // pre-`r` result cannot replace a newer scan.
+            Some((generation, result)) = context_rx.recv() => {
+                if let Some(context) = app.context.as_mut() {
+                    context.apply_scan(generation, result);
+                }
+            }
             // Periodic auto-refresh of all tabs.
             _ = tick.tick() => {
                 spawn_all(app, client, config, &tx);
@@ -168,6 +181,23 @@ where
                     // Treat each *press* as exactly one action; ignore
                     // Repeat and Release entirely.
                     if k.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    // Context overlay consumes all keys while open.
+                    if app.context.is_some() {
+                        use ai_usagebar::tui::context::{Action as CAction, handle_key as chandle};
+                        let action = {
+                            let context = app.context.as_mut().expect("checked above");
+                            chandle(context, k.code, k.modifiers)
+                        };
+                        match action {
+                            CAction::Continue => {}
+                            CAction::Close => app.context = None,
+                            CAction::Refresh => {
+                                spawn_context_scan(app, config, &context_tx);
+                            }
+                            CAction::Quit => return Ok(()),
+                        }
                         continue;
                     }
                     // Settings overlay consumes all keys when open.
@@ -190,6 +220,7 @@ where
                                 if let Ok(reloaded) = ai_usagebar::config::Config::load() {
                                     *config = reloaded;
                                 }
+                                app.context_enabled = config.context.enabled;
                                 app.set_tabs(tabs_from_config(config));
                                 app.select_primary(config.ui.primary);
                                 spawn_all(app, client, config, &tx);
@@ -207,6 +238,20 @@ where
                         app.settings = Some(
                             ai_usagebar::tui::settings::SettingsState::from_config(&cfg),
                         );
+                        continue;
+                    }
+                    if matches!(k.code, KeyCode::Char('c'))
+                        && !k.modifiers.intersects(
+                            KeyModifiers::CONTROL
+                                | KeyModifiers::ALT
+                                | KeyModifiers::SUPER
+                                | KeyModifiers::HYPER
+                                | KeyModifiers::META,
+                        )
+                        && app.context_enabled
+                    {
+                        app.context = Some(ai_usagebar::tui::context::ContextState::default());
+                        spawn_context_scan(app, config, &context_tx);
                         continue;
                     }
                     if handle_key(app, k.code, k.modifiers) {
@@ -229,6 +274,35 @@ where
             return Ok(());
         }
     }
+}
+
+fn spawn_context_scan(
+    app: &mut App,
+    config: &Config,
+    tx: &mpsc::UnboundedSender<(
+        u64,
+        std::result::Result<ai_usagebar::context::ContextScan, String>,
+    )>,
+) {
+    let Some(context) = app.context.as_mut() else {
+        return;
+    };
+    app.context_generation = app.context_generation.wrapping_add(1);
+    let generation = app.context_generation;
+    context.begin_refresh(generation);
+    let context_config = config.context.clone();
+    let tx = tx.clone();
+    tokio::task::spawn_blocking(move || {
+        let result = (|| {
+            let path = match context_config.projects_path.as_deref() {
+                Some(path) => path.to_path_buf(),
+                None => ai_usagebar::context::default_projects_path()?,
+            };
+            ai_usagebar::context::scan_dir(&path, &context_config)
+        })()
+        .map_err(|error| error.to_string());
+        let _ = tx.send((generation, result));
+    });
 }
 
 fn spawn_all(

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@
 //! treated as "use defaults". API keys are read from env vars (the relevant
 //! `*_api_key_env` field lets the user override which env var name).
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -34,6 +34,7 @@ use crate::vendor::VendorId;
 #[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub ui: UiConfig,
+    pub context: ContextConfig,
     pub anthropic: AnthropicConfig,
     pub anthropic_api: AnthropicApiConfig,
     pub openai: OpenAiConfig,
@@ -55,6 +56,35 @@ pub struct Config {
 pub struct UiConfig {
     /// `None` → fall back to anthropic for backward compatibility.
     pub primary: Option<VendorId>,
+}
+
+/// Optional local Claude Code context-window monitor. This is deliberately
+/// separate from vendors: sessions are discovered from local transcripts and
+/// change while the TUI is running, whereas vendor tabs are config-declared
+/// account identities.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ContextConfig {
+    /// Keep the filesystem scanner completely dormant unless explicitly
+    /// enabled. The `c` key and its footer hint are hidden while disabled.
+    pub enabled: bool,
+    /// Override Claude Code's normal `~/.claude/projects` transcript root.
+    pub projects_path: Option<PathBuf>,
+    /// Optional fallback denominator. When absent, sessions without an exact
+    /// model override show their input-token count without inventing a %.
+    pub context_window_tokens: Option<u64>,
+    /// Exact Claude model id -> context-window size. This takes precedence
+    /// over `context_window_tokens`, which keeps mixed 200K/1M histories safe.
+    pub model_context_window_tokens: BTreeMap<String, u64>,
+}
+
+impl ContextConfig {
+    pub fn window_tokens_for(&self, model: Option<&str>) -> Option<u64> {
+        model
+            .and_then(|model| self.model_context_window_tokens.get(model).copied())
+            .filter(|tokens| *tokens > 0)
+            .or_else(|| self.context_window_tokens.filter(|tokens| *tokens > 0))
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -437,6 +467,7 @@ impl Config {
     }
 
     fn expand_paths(&mut self) {
+        expand_tilde_opt(&mut self.context.projects_path);
         expand_tilde_opt(&mut self.anthropic.credentials_path);
         expand_tilde_opt(&mut self.openai.codex_auth_path);
         for account in &mut self.anthropic.accounts {
@@ -472,6 +503,23 @@ impl Config {
     /// labels are both CLI selectors and TUI tab identities, so duplicates
     /// would make either destination ambiguous.
     pub fn validate(&self) -> Result<()> {
+        if self.context.context_window_tokens == Some(0) {
+            return Err(AppError::Other(
+                "[context] context_window_tokens must be greater than zero".into(),
+            ));
+        }
+        for (model, tokens) in &self.context.model_context_window_tokens {
+            if model.trim().is_empty() {
+                return Err(AppError::Other(
+                    "[context] model_context_window_tokens keys must not be empty".into(),
+                ));
+            }
+            if *tokens == 0 {
+                return Err(AppError::Other(format!(
+                    "[context] model_context_window_tokens entry {model:?} must be greater than zero"
+                )));
+            }
+        }
         if let Some(limit) = self.anthropic_api.monthly_limit
             && (!limit.is_finite() || limit <= 0.0)
         {
@@ -677,6 +725,55 @@ enabled = false
         );
     }
 
+    #[test]
+    fn context_monitor_is_opt_in_and_window_sizes_are_explicit() {
+        let defaults = Config::default();
+        assert!(!defaults.context.enabled);
+        assert_eq!(
+            defaults.context.window_tokens_for(Some("claude-test")),
+            None
+        );
+
+        let file = write_toml(
+            r#"
+            [context]
+            enabled = true
+            context_window_tokens = 200000
+
+            [context.model_context_window_tokens]
+            claude-opus-1m = 1000000
+            "claude exact id" = 300000
+            "#,
+        );
+        let config = Config::load_from(file.path()).unwrap();
+        assert!(config.context.enabled);
+        assert_eq!(
+            config.context.window_tokens_for(Some("claude-opus-1m")),
+            Some(1_000_000)
+        );
+        assert_eq!(
+            config.context.window_tokens_for(Some("claude exact id")),
+            Some(300_000)
+        );
+        assert_eq!(
+            config.context.window_tokens_for(Some("another-model")),
+            Some(200_000)
+        );
+    }
+
+    #[test]
+    fn context_window_sizes_must_be_nonzero_and_model_ids_nonempty() {
+        for source in [
+            "[context]\ncontext_window_tokens = 0\n",
+            "[context.model_context_window_tokens]\nclaude = 0\n",
+            "[context.model_context_window_tokens]\n\" \" = 200000\n",
+        ] {
+            let file = write_toml(source);
+            let error = Config::load_from(file.path()).unwrap_err().to_string();
+            assert!(error.contains("context"), "{error}");
+        }
+    }
+
     // serial guard for env-var manipulation tests so they don't race
     fn env_guard() -> std::sync::MutexGuard<'static, ()> {
         static M: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -857,6 +954,9 @@ enabled = false
         // `~` relative to the process's cwd.
         let f = write_toml(
             r#"
+            [context]
+            projects_path = "~/.claude/projects"
+
             [anthropic]
             credentials_path = "~/.claude/.credentials.json"
 
@@ -868,6 +968,7 @@ enabled = false
         let c = Config::load_from(f.path()).unwrap();
         let home = crate::cache::home_dir().unwrap();
 
+        assert_eq!(c.context.projects_path, Some(home.join(".claude/projects")));
         let got = c.anthropic.credentials_path.unwrap();
         assert_eq!(got, home.join(".claude/.credentials.json"));
         assert!(!got.to_string_lossy().contains('~'));
@@ -1074,6 +1175,7 @@ enabled = false
         // unnoticed, and `deny_unknown_fields` would reject the copy on the
         // user's machine instead of in CI.
         let c = Config::load_from(&config_example()).unwrap();
+        assert!(!c.context.enabled);
         assert!(c.is_enabled(VendorId::Anthropic));
         assert!(c.is_enabled(VendorId::Openai));
         assert!(!c.is_enabled(VendorId::AnthropicApi));

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,0 +1,678 @@
+//! Best-effort, local-only Claude Code context-window discovery.
+//!
+//! Claude Code transcripts are an undocumented JSONL surface, so this module
+//! deliberately treats every line as optional data. It reads only bounded
+//! tails, ignores unknown/corrupt records, never follows discovered symlinks,
+//! and reports unknown usage instead of fabricating zero. A compaction record
+//! after the latest usage invalidates that reading until another assistant
+//! response supplies the new context size.
+
+use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+use crate::config::ContextConfig;
+use crate::error::{AppError, Result};
+
+/// The overlay is a recent-session monitor, not an unbounded history browser.
+pub const MAX_SESSIONS: usize = 100;
+const MAX_WALK_ENTRIES: usize = 10_000;
+const MAX_TAIL_BYTES: usize = 2 * 1024 * 1024;
+const MAX_LINE_BYTES: usize = 512 * 1024;
+const MAX_DISPLAY_CHARS: usize = 120;
+
+#[derive(Debug, Clone)]
+pub struct ContextScan {
+    pub sessions: Vec<ContextSession>,
+    /// JSONL candidates observed before the recent-session cap was applied.
+    pub discovered: usize,
+    /// Unreadable entries and malformed/oversized tail records ignored.
+    pub skipped: usize,
+    /// True when the directory-entry safety cap stopped traversal early.
+    pub walk_capped: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContextSession {
+    pub session_id: String,
+    pub title: Option<String>,
+    pub project: String,
+    pub model: Option<String>,
+    pub modified_at: DateTime<Utc>,
+    pub usage: ContextUsage,
+}
+
+impl ContextSession {
+    pub fn display_name(&self) -> String {
+        self.title
+            .clone()
+            .unwrap_or_else(|| format!("session {}", short_id(&self.session_id)))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ContextUsage {
+    Available {
+        /// Matches Claude Code's input-only context percentage: fresh input +
+        /// cache creation + cache reads from the most recent API response.
+        input_tokens: u64,
+        window_tokens: Option<u64>,
+        percent: Option<u16>,
+    },
+    /// A compact boundary landed after the last assistant usage record.
+    Compacted,
+    /// No usable assistant usage was present in the bounded transcript tail.
+    Unknown,
+}
+
+#[derive(Debug)]
+struct Candidate {
+    path: PathBuf,
+    modified: SystemTime,
+}
+
+#[derive(Debug, Default)]
+struct Discovery {
+    candidates: Vec<Candidate>,
+    skipped: usize,
+    walk_capped: bool,
+}
+
+#[derive(Debug, Default)]
+struct TailData {
+    session_id: Option<String>,
+    title: Option<String>,
+    cwd: Option<String>,
+    model: Option<String>,
+    usage: TailUsage,
+    skipped: usize,
+}
+
+#[derive(Debug, Default)]
+enum TailUsage {
+    Tokens(u64),
+    Compacted,
+    #[default]
+    Unknown,
+}
+
+/// Resolve Claude Code's conventional local transcript directory without
+/// reading it. Kept separate so tests always inject their own root.
+pub fn default_projects_path() -> Result<PathBuf> {
+    Ok(crate::cache::home_dir()?.join(".claude").join("projects"))
+}
+
+/// Scan the most recently modified top-level session transcripts below
+/// `root`. Subagent sidechains are excluded, and discovered symlinks are never
+/// followed. The caller should run this blocking filesystem work on Tokio's
+/// blocking pool.
+pub fn scan_dir(root: &Path, config: &ContextConfig) -> Result<ContextScan> {
+    let mut discovery = discover(root)?;
+    discovery.candidates.sort_by(|a, b| {
+        b.modified
+            .cmp(&a.modified)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    let discovered = discovery.candidates.len();
+    discovery.candidates.truncate(MAX_SESSIONS);
+
+    let mut sessions = Vec::with_capacity(discovery.candidates.len());
+    for candidate in discovery.candidates {
+        match parse_candidate(root, candidate, config) {
+            Ok((session, skipped)) => {
+                discovery.skipped += skipped;
+                sessions.push(session);
+            }
+            Err(_) => discovery.skipped += 1,
+        }
+    }
+
+    Ok(ContextScan {
+        sessions,
+        discovered,
+        skipped: discovery.skipped,
+        walk_capped: discovery.walk_capped,
+    })
+}
+
+fn discover(root: &Path) -> Result<Discovery> {
+    // Opening the configured root is the one error that should reach the user;
+    // failures inside it are isolated to the affected entry.
+    fs::read_dir(root).map_err(|e| AppError::io_at(root, e))?;
+
+    let mut result = Discovery::default();
+    let mut stack = vec![root.to_path_buf()];
+    let mut visited = 0usize;
+
+    'walk: while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => {
+                result.skipped += 1;
+                continue;
+            }
+        };
+        for entry in entries {
+            if visited >= MAX_WALK_ENTRIES {
+                result.walk_capped = true;
+                break 'walk;
+            }
+            visited += 1;
+
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => {
+                    result.skipped += 1;
+                    continue;
+                }
+            };
+            let file_type = match entry.file_type() {
+                Ok(kind) => kind,
+                Err(_) => {
+                    result.skipped += 1;
+                    continue;
+                }
+            };
+            if file_type.is_symlink() {
+                continue;
+            }
+            if file_type.is_dir() {
+                if entry.file_name() != "subagents" {
+                    stack.push(entry.path());
+                }
+                continue;
+            }
+            if !file_type.is_file()
+                || entry.path().extension().and_then(|ext| ext.to_str()) != Some("jsonl")
+            {
+                continue;
+            }
+            let metadata = match entry.metadata() {
+                Ok(metadata) => metadata,
+                Err(_) => {
+                    result.skipped += 1;
+                    continue;
+                }
+            };
+            result.candidates.push(Candidate {
+                path: entry.path(),
+                modified: metadata.modified().unwrap_or(SystemTime::UNIX_EPOCH),
+            });
+        }
+    }
+    Ok(result)
+}
+
+fn parse_candidate(
+    root: &Path,
+    candidate: Candidate,
+    config: &ContextConfig,
+) -> Result<(ContextSession, usize)> {
+    let tail = read_tail(&candidate.path)?;
+    let parsed = parse_tail(&tail);
+    let file_id = candidate
+        .path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown-session");
+    let session_id = parsed
+        .session_id
+        .filter(|id| !id.is_empty())
+        .unwrap_or_else(|| sanitize_display(file_id));
+    let project = parsed
+        .cwd
+        .as_deref()
+        .and_then(project_from_cwd)
+        .or_else(|| project_from_path(root, &candidate.path))
+        .unwrap_or_else(|| "unknown project".into());
+    let window_tokens = config.window_tokens_for(parsed.model.as_deref());
+    let usage = match parsed.usage {
+        TailUsage::Tokens(input_tokens) => ContextUsage::Available {
+            input_tokens,
+            window_tokens,
+            percent: window_tokens.map(|window| percent(input_tokens, window)),
+        },
+        TailUsage::Compacted => ContextUsage::Compacted,
+        TailUsage::Unknown => ContextUsage::Unknown,
+    };
+
+    Ok((
+        ContextSession {
+            session_id,
+            title: parsed.title.filter(|title| !title.is_empty()),
+            project,
+            model: parsed.model,
+            modified_at: DateTime::<Utc>::from(candidate.modified),
+            usage,
+        },
+        parsed.skipped,
+    ))
+}
+
+fn read_tail(path: &Path) -> Result<Vec<u8>> {
+    let mut file = File::open(path).map_err(|e| AppError::io_at(path, e))?;
+    let len = file.metadata().map_err(|e| AppError::io_at(path, e))?.len();
+    let read_len = len.min(MAX_TAIL_BYTES as u64);
+    let start = len.saturating_sub(read_len);
+    file.seek(SeekFrom::Start(start))
+        .map_err(|e| AppError::io_at(path, e))?;
+    let mut bytes = vec![0; read_len as usize];
+    file.read_exact(&mut bytes)
+        .map_err(|e| AppError::io_at(path, e))?;
+
+    // The first bytes of a bounded tail may be the middle of a JSON record.
+    // Drop that fragment rather than feeding it to the tolerant parser.
+    if start > 0 {
+        if let Some(newline) = bytes.iter().position(|byte| *byte == b'\n') {
+            bytes.drain(..=newline);
+        } else {
+            bytes.clear();
+        }
+    }
+    Ok(bytes)
+}
+
+fn parse_tail(bytes: &[u8]) -> TailData {
+    let mut out = TailData::default();
+    for raw in bytes.split(|byte| *byte == b'\n') {
+        let raw = raw.strip_suffix(b"\r").unwrap_or(raw);
+        if raw.is_empty() {
+            continue;
+        }
+        if raw.len() > MAX_LINE_BYTES {
+            out.skipped += 1;
+            continue;
+        }
+        let value: Value = match serde_json::from_slice(raw) {
+            Ok(value) => value,
+            Err(_) => {
+                out.skipped += 1;
+                continue;
+            }
+        };
+
+        capture_string(&value, "sessionId", &mut out.session_id);
+        capture_string(&value, "cwd", &mut out.cwd);
+        match value.get("type").and_then(Value::as_str) {
+            Some("custom-title") => {
+                capture_string(&value, "customTitle", &mut out.title);
+                capture_string(&value, "title", &mut out.title);
+            }
+            Some("assistant") => {
+                if let Some(model) = value.pointer("/message/model").and_then(Value::as_str) {
+                    out.model = Some(sanitize_display(model));
+                }
+                if let Some(tokens) = input_tokens(&value) {
+                    out.usage = TailUsage::Tokens(tokens);
+                }
+            }
+            Some("system")
+                if value.get("subtype").and_then(Value::as_str) == Some("compact_boundary") =>
+            {
+                out.usage = TailUsage::Compacted;
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+fn capture_string(value: &Value, key: &str, target: &mut Option<String>) {
+    if let Some(value) = value.get(key).and_then(Value::as_str) {
+        let value = sanitize_display(value);
+        if !value.is_empty() {
+            *target = Some(value);
+        }
+    }
+}
+
+fn input_tokens(value: &Value) -> Option<u64> {
+    let usage = value.pointer("/message/usage")?;
+    let input = usage.get("input_tokens")?.as_u64()?;
+    let cache_creation = optional_u64(usage, "cache_creation_input_tokens")?;
+    let cache_read = optional_u64(usage, "cache_read_input_tokens")?;
+    input.checked_add(cache_creation)?.checked_add(cache_read)
+}
+
+fn optional_u64(value: &Value, key: &str) -> Option<u64> {
+    match value.get(key) {
+        None | Some(Value::Null) => Some(0),
+        Some(value) => value.as_u64(),
+    }
+}
+
+fn percent(input_tokens: u64, window_tokens: u64) -> u16 {
+    debug_assert!(window_tokens > 0);
+    let value = (u128::from(input_tokens) * 100) / u128::from(window_tokens);
+    value.min(u128::from(u16::MAX)) as u16
+}
+
+fn project_from_cwd(cwd: &str) -> Option<String> {
+    Path::new(cwd)
+        .file_name()
+        .map(|name| sanitize_display(&name.to_string_lossy()))
+        .filter(|name| !name.is_empty())
+}
+
+fn project_from_path(root: &Path, transcript: &Path) -> Option<String> {
+    let relative = transcript.strip_prefix(root).ok()?;
+    let first = relative.components().next()?.as_os_str();
+    let project = sanitize_display(&first.to_string_lossy());
+    (!project.is_empty()).then_some(project)
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+/// Strip terminal control characters and cap untrusted transcript labels
+/// before they enter ratatui's backing buffer.
+pub fn sanitize_display(value: &str) -> String {
+    value
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_control() {
+                if ch.is_whitespace() { Some(' ') } else { None }
+            } else {
+                Some(ch)
+            }
+        })
+        .take(MAX_DISPLAY_CHARS)
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn assistant(
+        session: &str,
+        cwd: &str,
+        model: &str,
+        input: u64,
+        create: u64,
+        read: u64,
+    ) -> String {
+        json!({
+            "type": "assistant",
+            "sessionId": session,
+            "cwd": cwd,
+            "message": {
+                "model": model,
+                "usage": {
+                    "input_tokens": input,
+                    "cache_creation_input_tokens": create,
+                    "cache_read_input_tokens": read
+                }
+            }
+        })
+        .to_string()
+    }
+
+    fn write_session(root: &Path, project: &str, name: &str, lines: &[String]) -> PathBuf {
+        let dir = root.join(project);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(format!("{name}.jsonl"));
+        let mut file = File::create(&path).unwrap();
+        for line in lines {
+            writeln!(file, "{line}").unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn latest_assistant_usage_matches_claude_input_only_formula() {
+        let dir = TempDir::new().unwrap();
+        write_session(
+            dir.path(),
+            "-work-project",
+            "abc-123",
+            &[
+                assistant("abc-123", "/work/project", "claude-test", 1, 2, 3),
+                assistant("abc-123", "/work/project", "claude-test", 10, 20, 30),
+            ],
+        );
+        let mut config = ContextConfig {
+            context_window_tokens: Some(200),
+            ..ContextConfig::default()
+        };
+        config
+            .model_context_window_tokens
+            .insert("claude-test".into(), 100);
+
+        let scan = scan_dir(dir.path(), &config).unwrap();
+        assert_eq!(scan.sessions.len(), 1);
+        let session = &scan.sessions[0];
+        assert_eq!(session.session_id, "abc-123");
+        assert_eq!(session.project, "project");
+        assert_eq!(session.model.as_deref(), Some("claude-test"));
+        assert_eq!(
+            session.usage,
+            ContextUsage::Available {
+                input_tokens: 60,
+                window_tokens: Some(100),
+                percent: Some(60),
+            }
+        );
+    }
+
+    #[test]
+    fn compact_boundary_invalidates_the_previous_reading() {
+        let dir = TempDir::new().unwrap();
+        let compact = json!({"type": "system", "subtype": "compact_boundary"}).to_string();
+        write_session(
+            dir.path(),
+            "project",
+            "session",
+            &[
+                assistant("session", "/work/project", "claude-test", 90, 0, 0),
+                compact,
+            ],
+        );
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert_eq!(scan.sessions[0].usage, ContextUsage::Compacted);
+    }
+
+    #[test]
+    fn assistant_after_compaction_supplies_the_new_reading() {
+        let dir = TempDir::new().unwrap();
+        let compact = json!({"type": "system", "subtype": "compact_boundary"}).to_string();
+        write_session(
+            dir.path(),
+            "project",
+            "session",
+            &[
+                assistant("session", "/work/project", "claude-test", 90, 0, 0),
+                compact,
+                assistant("session", "/work/project", "claude-test", 12, 0, 0),
+            ],
+        );
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert_eq!(
+            scan.sessions[0].usage,
+            ContextUsage::Available {
+                input_tokens: 12,
+                window_tokens: None,
+                percent: None,
+            }
+        );
+    }
+
+    #[test]
+    fn corrupt_or_truncated_records_do_not_hide_the_last_good_usage() {
+        let dir = TempDir::new().unwrap();
+        let path = write_session(
+            dir.path(),
+            "project",
+            "session",
+            &[assistant(
+                "session",
+                "/work/project",
+                "claude-test",
+                42,
+                0,
+                0,
+            )],
+        );
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        write!(file, "{{\"type\":\"assistant\"").unwrap();
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert!(scan.skipped >= 1);
+        assert_eq!(
+            scan.sessions[0].usage,
+            ContextUsage::Available {
+                input_tokens: 42,
+                window_tokens: None,
+                percent: None,
+            }
+        );
+    }
+
+    #[test]
+    fn an_old_usage_record_outside_the_tail_cap_is_not_loaded_unboundedly() {
+        let dir = TempDir::new().unwrap();
+        let path = write_session(
+            dir.path(),
+            "project",
+            "session",
+            &[assistant(
+                "session",
+                "/work/project",
+                "claude-test",
+                42,
+                0,
+                0,
+            )],
+        );
+        let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+        file.write_all(&vec![b'x'; MAX_TAIL_BYTES + 1024]).unwrap();
+        writeln!(file).unwrap();
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert_eq!(scan.sessions[0].usage, ContextUsage::Unknown);
+    }
+
+    #[test]
+    fn subagent_transcripts_are_excluded() {
+        let dir = TempDir::new().unwrap();
+        write_session(
+            dir.path(),
+            "project",
+            "main",
+            &[assistant("main", "/work/project", "claude-test", 1, 0, 0)],
+        );
+        write_session(
+            &dir.path().join("project"),
+            "subagents",
+            "agent",
+            &[assistant("agent", "/work/project", "claude-test", 99, 0, 0)],
+        );
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert_eq!(scan.sessions.len(), 1);
+        assert_eq!(scan.sessions[0].session_id, "main");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn discovered_symlinks_are_not_followed() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let outside_file = write_session(
+            outside.path(),
+            "project",
+            "outside",
+            &[assistant("outside", "/outside", "claude-test", 99, 0, 0)],
+        );
+        fs::create_dir_all(dir.path().join("project")).unwrap();
+        symlink(outside_file, dir.path().join("project/linked.jsonl")).unwrap();
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert!(scan.sessions.is_empty());
+    }
+
+    #[test]
+    fn custom_titles_and_paths_are_sanitized_before_display() {
+        let dir = TempDir::new().unwrap();
+        let title =
+            json!({"type": "custom-title", "customTitle": "build\u{1b}[2J\nrelease"}).to_string();
+        write_session(
+            dir.path(),
+            "project",
+            "session",
+            &[
+                title,
+                assistant("session", "/work/proj\nname", "claude-test", 1, 0, 0),
+            ],
+        );
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        let session = &scan.sessions[0];
+        assert_eq!(session.title.as_deref(), Some("build[2J release"));
+        assert_eq!(session.project, "proj name");
+    }
+
+    #[test]
+    fn invalid_usage_numbers_are_unknown_not_zero() {
+        let dir = TempDir::new().unwrap();
+        let invalid = json!({
+            "type": "assistant",
+            "message": {"usage": {"input_tokens": "12"}}
+        })
+        .to_string();
+        write_session(dir.path(), "project", "session", &[invalid]);
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert_eq!(scan.sessions[0].usage, ContextUsage::Unknown);
+    }
+
+    #[test]
+    fn recent_session_result_is_capped() {
+        let dir = TempDir::new().unwrap();
+        for i in 0..=MAX_SESSIONS {
+            write_session(
+                dir.path(),
+                "project",
+                &format!("session-{i}"),
+                &[assistant(
+                    &format!("session-{i}"),
+                    "/work/project",
+                    "claude-test",
+                    i as u64,
+                    0,
+                    0,
+                )],
+            );
+        }
+
+        let scan = scan_dir(dir.path(), &ContextConfig::default()).unwrap();
+        assert_eq!(scan.discovered, MAX_SESSIONS + 1);
+        assert_eq!(scan.sessions.len(), MAX_SESSIONS);
+    }
+
+    #[test]
+    fn missing_root_is_an_actionable_error() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("missing");
+        let error = scan_dir(&missing, &ContextConfig::default())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains(missing.to_string_lossy().as_ref()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod anthropic;
 pub mod anthropic_api;
 pub mod cache;
 pub mod config;
+pub mod context;
 pub mod countdown;
 pub mod deepseek;
 pub mod error;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -93,6 +93,14 @@ pub struct App {
     pub quit: bool,
     /// When `Some`, the Settings overlay is open and consuming key events.
     pub settings: Option<crate::tui::settings::SettingsState>,
+    /// Local context monitoring is separately opt-in and never changes the
+    /// vendor tab set.
+    pub context_enabled: bool,
+    /// Monotonic across overlay close/reopen cycles so an old detached scan
+    /// can never share the new overlay's first generation number.
+    pub context_generation: u64,
+    /// When `Some`, the local Claude Code context overlay owns keyboard input.
+    pub context: Option<crate::tui::context::ContextState>,
 }
 
 impl App {
@@ -117,6 +125,9 @@ impl App {
             theme,
             quit: false,
             settings: None,
+            context_enabled: false,
+            context_generation: 0,
+            context: None,
         }
     }
 

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -1,0 +1,558 @@
+//! TUI overlay for local Claude Code context-window sessions.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Clear, Paragraph};
+use ratatui_bubbletea_components::{Help, KeyBinding, ListItem, SelectList};
+
+use crate::context::{ContextScan, ContextSession, ContextUsage};
+use crate::format::local_time_hms;
+use crate::pango::severity_for;
+use crate::theme::Theme;
+use crate::tui::panels::{self, Section};
+use crate::tui::style::bubble_theme;
+
+#[derive(Debug)]
+pub struct ContextState {
+    pub selected: usize,
+    pub detail: bool,
+    pub generation: u64,
+    pub load: ContextLoad,
+    selection_id: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum ContextLoad {
+    Loading,
+    Ready(ContextScan),
+    Error(String),
+}
+
+impl Default for ContextState {
+    fn default() -> Self {
+        Self {
+            selected: 0,
+            detail: false,
+            generation: 0,
+            load: ContextLoad::Loading,
+            selection_id: None,
+        }
+    }
+}
+
+impl ContextState {
+    /// Begin a scan with an identity allocated by the long-lived host app.
+    /// The host, rather than this disposable overlay, owns monotonicity across
+    /// close/reopen cycles.
+    pub fn begin_refresh(&mut self, generation: u64) {
+        if let Some(selection_id) = self
+            .selected_session()
+            .map(|session| session.session_id.clone())
+        {
+            self.selection_id = Some(selection_id);
+        }
+        self.generation = generation;
+        self.load = ContextLoad::Loading;
+    }
+
+    /// Ignore a result from an earlier `r` scan. The host also drops results
+    /// after the overlay closes by having no state to apply them to.
+    pub fn apply_scan(
+        &mut self,
+        generation: u64,
+        result: std::result::Result<ContextScan, String>,
+    ) -> bool {
+        if generation != self.generation {
+            return false;
+        }
+        self.load = match result {
+            Ok(scan) => {
+                self.selected = self
+                    .selection_id
+                    .take()
+                    .and_then(|id| {
+                        scan.sessions
+                            .iter()
+                            .position(|session| session.session_id == id)
+                    })
+                    .unwrap_or_else(|| self.selected.min(scan.sessions.len().saturating_sub(1)));
+                if scan.sessions.is_empty() {
+                    self.detail = false;
+                }
+                ContextLoad::Ready(scan)
+            }
+            Err(error) => {
+                self.selection_id = None;
+                self.detail = false;
+                ContextLoad::Error(error)
+            }
+        };
+        true
+    }
+
+    pub fn selected_session(&self) -> Option<&ContextSession> {
+        match &self.load {
+            ContextLoad::Ready(scan) => scan.sessions.get(self.selected),
+            ContextLoad::Loading | ContextLoad::Error(_) => None,
+        }
+    }
+
+    fn session_count(&self) -> usize {
+        match &self.load {
+            ContextLoad::Ready(scan) => scan.sessions.len(),
+            ContextLoad::Loading | ContextLoad::Error(_) => 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    Continue,
+    Close,
+    Refresh,
+    Quit,
+}
+
+pub fn handle_key(state: &mut ContextState, code: KeyCode, mods: KeyModifiers) -> Action {
+    if matches!(code, KeyCode::Char('c')) && mods.contains(KeyModifiers::CONTROL) {
+        return Action::Quit;
+    }
+    match code {
+        KeyCode::Esc if state.detail => {
+            state.detail = false;
+            Action::Continue
+        }
+        KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('c') => Action::Close,
+        KeyCode::Char('r') => Action::Refresh,
+        KeyCode::Enter if state.selected_session().is_some() => {
+            state.detail = true;
+            Action::Continue
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            let count = state.session_count();
+            if count > 0 {
+                state.selected = (state.selected + count - 1) % count;
+            }
+            Action::Continue
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            let count = state.session_count();
+            if count > 0 {
+                state.selected = (state.selected + 1) % count;
+            }
+            Action::Continue
+        }
+        KeyCode::Home => {
+            state.selected = 0;
+            Action::Continue
+        }
+        KeyCode::End => {
+            let count = state.session_count();
+            state.selected = count.saturating_sub(1);
+            Action::Continue
+        }
+        _ => Action::Continue,
+    }
+}
+
+pub fn render(f: &mut Frame, area: Rect, state: &ContextState, theme: &Theme) {
+    let modal = centered_rect(90, 90, area);
+    f.render_widget(Clear, modal);
+
+    let bubble = bubble_theme(theme);
+    let block = bubble.titled_modal_block(" Claude context ");
+    let inner = block.inner(modal);
+    f.render_widget(block, modal);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+    match &state.load {
+        ContextLoad::Loading => panels::render(
+            f,
+            chunks[0],
+            theme,
+            &[
+                Section::Spacer,
+                Section::Text {
+                    label: String::new(),
+                    value: "  Scanning recent Claude Code sessions…".into(),
+                },
+            ],
+        ),
+        ContextLoad::Error(error) => panels::render(
+            f,
+            chunks[0],
+            theme,
+            &[
+                Section::Spacer,
+                Section::Text {
+                    label: "Error".into(),
+                    value: error.clone(),
+                },
+                Section::Spacer,
+                Section::Text {
+                    label: String::new(),
+                    value: "Press `r` to retry or `esc` to close.".into(),
+                },
+            ],
+        ),
+        ContextLoad::Ready(scan) if state.detail => {
+            if let Some(session) = scan.sessions.get(state.selected) {
+                panels::render(f, chunks[0], theme, &sections_for(session));
+            }
+        }
+        ContextLoad::Ready(scan) => render_list(f, chunks[0], state, scan, theme),
+    }
+
+    let help = if state.detail {
+        Help::new([
+            KeyBinding::with_keys(["↑/↓", "j/k"], "session"),
+            KeyBinding::new("r", "rescan"),
+            KeyBinding::new("esc", "back"),
+            KeyBinding::new("q", "close"),
+        ])
+    } else {
+        Help::new([
+            KeyBinding::with_keys(["↑/↓", "j/k"], "select"),
+            KeyBinding::new("enter", "details"),
+            KeyBinding::new("r", "rescan"),
+            KeyBinding::with_keys(["q", "esc"], "close"),
+        ])
+    }
+    .theme(bubble);
+    f.render_widget(&help, chunks[1]);
+}
+
+fn render_list(f: &mut Frame, area: Rect, state: &ContextState, scan: &ContextScan, theme: &Theme) {
+    let bubble = bubble_theme(theme);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(1)])
+        .split(area);
+
+    let showing = scan.sessions.len();
+    let mut status = format!("  {showing} recent session");
+    if showing != 1 {
+        status.push('s');
+    }
+    if scan.discovered > showing {
+        status.push_str(&format!(" · {} discovered", scan.discovered));
+    }
+    if scan.skipped > 0 {
+        status.push_str(&format!(
+            " · {} unreadable/invalid records skipped",
+            scan.skipped
+        ));
+    }
+    if scan.walk_capped {
+        status.push_str(" · directory scan capped");
+    }
+    f.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(status, bubble.muted),
+            Span::styled(
+                "\n  Input-only usage from bounded local transcript tails",
+                bubble.muted,
+            ),
+        ])),
+        chunks[0],
+    );
+
+    if scan.sessions.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "  No Claude Code session transcripts found.",
+                bubble.muted,
+            ))),
+            chunks[1],
+        );
+        return;
+    }
+
+    let items = scan
+        .sessions
+        .iter()
+        .map(|session| {
+            ListItem::new(session.display_name()).description(session_description(session))
+        })
+        .collect::<Vec<_>>();
+    let mut list = SelectList::new(items).theme(bubble);
+    list.select(Some(state.selected));
+    f.render_widget(&list, chunks[1]);
+}
+
+fn session_description(session: &ContextSession) -> String {
+    let usage = match session.usage {
+        ContextUsage::Available {
+            input_tokens,
+            percent: Some(percent),
+            ..
+        } => format!("{percent}% · {} input tokens", format_tokens(input_tokens)),
+        ContextUsage::Available { input_tokens, .. } => {
+            format!(
+                "{} input tokens · window unknown",
+                format_tokens(input_tokens)
+            )
+        }
+        ContextUsage::Compacted => "compacted · waiting for next response".into(),
+        ContextUsage::Unknown => "context usage unavailable".into(),
+    };
+    let model = session.model.as_deref().unwrap_or("unknown model");
+    format!(
+        "{} · {model} · {usage} · {}",
+        session.project,
+        local_time_hms(session.modified_at)
+    )
+}
+
+pub fn sections_for(session: &ContextSession) -> Vec<Section> {
+    let mut sections = vec![Section::Title {
+        left: session.display_name(),
+        right: Some(format!("Updated {}", local_time_hms(session.modified_at))),
+    }];
+    match session.usage {
+        ContextUsage::Available {
+            input_tokens,
+            window_tokens: Some(window_tokens),
+            percent: Some(percent),
+        } => {
+            sections.push(Section::Spacer);
+            sections.push(Section::Metric {
+                label: "Input context".into(),
+                pct: percent.min(100),
+                severity: severity_for(i32::from(percent)),
+                value_label: format!(
+                    "{percent}% · {} / {} tokens",
+                    format_tokens(input_tokens),
+                    format_tokens(window_tokens)
+                ),
+                footnote: "Latest API input; output tokens are intentionally excluded".into(),
+            });
+        }
+        ContextUsage::Available { input_tokens, .. } => {
+            sections.push(Section::Spacer);
+            sections.push(Section::Text {
+                label: "Input context".into(),
+                value: format!(
+                    "{} tokens · window size is not configured",
+                    format_tokens(input_tokens)
+                ),
+            });
+        }
+        ContextUsage::Compacted => {
+            sections.push(Section::Spacer);
+            sections.push(Section::Text {
+                label: "Input context".into(),
+                value: "Compacted · waiting for the next assistant response".into(),
+            });
+        }
+        ContextUsage::Unknown => {
+            sections.push(Section::Spacer);
+            sections.push(Section::Text {
+                label: "Input context".into(),
+                value: "Unavailable in the bounded transcript tail".into(),
+            });
+        }
+    }
+    sections.push(Section::Spacer);
+    sections.push(Section::Text {
+        label: "Project".into(),
+        value: session.project.clone(),
+    });
+    sections.push(Section::Text {
+        label: "Model".into(),
+        value: session.model.clone().unwrap_or_else(|| "unknown".into()),
+    });
+    sections.push(Section::Text {
+        label: "Session".into(),
+        value: session.session_id.clone(),
+    });
+    sections
+}
+
+fn format_tokens(value: u64) -> String {
+    let digits = value.to_string();
+    let mut out = String::with_capacity(digits.len() + digits.len() / 3);
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let height = (area.height * percent_y) / 100;
+    let width = (area.width * percent_x) / 100;
+    Rect {
+        x: area.x + (area.width - width) / 2,
+        y: area.y + (area.height - height) / 2,
+        width,
+        height,
+    }
+}
+
+pub use ratatui::crossterm::event::{KeyCode, KeyModifiers};
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+
+    fn session(id: &str, usage: ContextUsage) -> ContextSession {
+        ContextSession {
+            session_id: id.into(),
+            title: None,
+            project: "project".into(),
+            model: Some("claude-test".into()),
+            modified_at: Utc.with_ymd_and_hms(2026, 7, 20, 12, 0, 0).unwrap(),
+            usage,
+        }
+    }
+
+    fn scan(ids: &[&str]) -> ContextScan {
+        ContextScan {
+            sessions: ids
+                .iter()
+                .map(|id| session(id, ContextUsage::Unknown))
+                .collect(),
+            discovered: ids.len(),
+            skipped: 0,
+            walk_capped: false,
+        }
+    }
+
+    #[test]
+    fn stale_scan_result_is_discarded() {
+        let mut state = ContextState::default();
+        state.begin_refresh(1);
+        let first = 1;
+        state.begin_refresh(2);
+        let current = 2;
+        assert!(!state.apply_scan(first, Ok(scan(&["old"]))));
+        assert!(state.apply_scan(current, Ok(scan(&["new"]))));
+        assert_eq!(state.selected_session().unwrap().session_id, "new");
+    }
+
+    #[test]
+    fn a_result_from_a_closed_overlay_cannot_land_after_reopen() {
+        let mut reopened = ContextState::default();
+        reopened.begin_refresh(2);
+        assert!(!reopened.apply_scan(1, Ok(scan(&["closed-overlay"]))));
+        assert!(matches!(reopened.load, ContextLoad::Loading));
+    }
+
+    #[test]
+    fn rescan_preserves_the_selected_session_across_reordering() {
+        let mut state = ContextState::default();
+        let generation = 1;
+        state.begin_refresh(generation);
+        state.apply_scan(generation, Ok(scan(&["one", "two"])));
+        state.selected = 1;
+        state.detail = true;
+
+        let generation = 2;
+        state.begin_refresh(generation);
+        state.apply_scan(generation, Ok(scan(&["two", "one"])));
+        assert_eq!(state.selected, 0);
+        assert_eq!(state.selected_session().unwrap().session_id, "two");
+        assert!(state.detail);
+    }
+
+    #[test]
+    fn list_and_detail_navigation_are_bounded_and_wrap() {
+        let mut state = ContextState::default();
+        let generation = 1;
+        state.begin_refresh(generation);
+        state.apply_scan(generation, Ok(scan(&["one", "two"])));
+
+        assert_eq!(
+            handle_key(&mut state, KeyCode::Up, KeyModifiers::NONE),
+            Action::Continue
+        );
+        assert_eq!(state.selected, 1);
+        handle_key(&mut state, KeyCode::Enter, KeyModifiers::NONE);
+        assert!(state.detail);
+        assert_eq!(
+            handle_key(&mut state, KeyCode::Esc, KeyModifiers::NONE),
+            Action::Continue
+        );
+        assert!(!state.detail);
+        assert_eq!(
+            handle_key(&mut state, KeyCode::Esc, KeyModifiers::NONE),
+            Action::Close
+        );
+    }
+
+    #[test]
+    fn refresh_and_global_quit_are_explicit_actions() {
+        let mut state = ContextState::default();
+        assert_eq!(
+            handle_key(&mut state, KeyCode::Char('r'), KeyModifiers::NONE),
+            Action::Refresh
+        );
+        assert_eq!(
+            handle_key(&mut state, KeyCode::Char('c'), KeyModifiers::CONTROL),
+            Action::Quit
+        );
+    }
+
+    #[test]
+    fn detail_sections_use_existing_severity_and_preserve_unknown_states() {
+        let available = session(
+            "available",
+            ContextUsage::Available {
+                input_tokens: 180_000,
+                window_tokens: Some(200_000),
+                percent: Some(90),
+            },
+        );
+        let sections = sections_for(&available);
+        assert!(sections.iter().any(|section| matches!(
+            section,
+            Section::Metric {
+                severity: crate::pacing::PaceSeverity::Critical,
+                value_label,
+                ..
+            } if value_label.contains("180,000 / 200,000")
+        )));
+
+        let compacted = sections_for(&session("compacted", ContextUsage::Compacted));
+        assert!(compacted.iter().any(|section| matches!(
+            section,
+            Section::Text { value, .. } if value.contains("waiting for the next assistant")
+        )));
+    }
+
+    #[test]
+    fn token_formatting_is_grouped_without_locale_state() {
+        assert_eq!(format_tokens(0), "0");
+        assert_eq!(format_tokens(999), "999");
+        assert_eq!(format_tokens(1_234_567), "1,234,567");
+    }
+
+    #[test]
+    fn list_and_detail_render_at_a_common_24_row_terminal() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        let mut state = ContextState::default();
+        let generation = 1;
+        state.begin_refresh(generation);
+        state.apply_scan(generation, Ok(scan(&["one", "two"])));
+        let mut terminal = Terminal::new(TestBackend::new(100, 24)).unwrap();
+        terminal
+            .draw(|frame| render(frame, frame.area(), &state, &Theme::default()))
+            .unwrap();
+
+        state.detail = true;
+        terminal
+            .draw(|frame| render(frame, frame.area(), &state, &Theme::default()))
+            .unwrap();
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,7 @@
 //! TUI binary support — ratatui app with one tab per enabled vendor.
 
 pub mod app;
+pub mod context;
 pub mod panels;
 pub mod settings;
 pub mod style;

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -34,6 +34,8 @@ pub fn draw(f: &mut Frame, app: &App) {
     // Settings overlay sits on top — rendered last so it covers everything.
     if let Some(s) = &app.settings {
         crate::tui::settings::render(f, f.area(), s, &app.theme);
+    } else if let Some(context) = &app.context {
+        crate::tui::context::render(f, f.area(), context, &app.theme);
     }
 }
 
@@ -235,14 +237,17 @@ fn draw_footer(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     // title row of every panel, and (b) prone to getting cropped on narrow
     // 875x600 windows. Keep the footer to just the keybinding hints.
     let theme = bubble_theme(&app.theme);
-    let help = Help::new([
+    let mut bindings = vec![
         KeyBinding::with_keys(["tab", "h/l"], "switch"),
         KeyBinding::new("r", "refresh"),
         KeyBinding::new("R", "refresh all"),
         KeyBinding::new("s", "settings"),
-        KeyBinding::with_keys(["q", "esc"], "quit"),
-    ])
-    .theme(theme);
+    ];
+    if app.context_enabled {
+        bindings.push(KeyBinding::new("c", "context"));
+    }
+    bindings.push(KeyBinding::with_keys(["q", "esc"], "quit"));
+    let help = Help::new(bindings).theme(theme);
     f.render_widget(&help, area);
 }
 
@@ -326,5 +331,31 @@ mod tests {
         // passing off "now" as a response time.
         let app = app_with(vec![ready_at(None), TabState::Loading]);
         assert_eq!(header_refresh_text(&app), "last refresh —");
+    }
+
+    #[test]
+    fn context_footer_hint_is_visible_only_when_the_feature_is_enabled() {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+
+        fn rendered(mut app: App, enabled: bool) -> String {
+            app.context_enabled = enabled;
+            let mut terminal = Terminal::new(TestBackend::new(160, 24)).unwrap();
+            terminal.draw(|frame| draw(frame, &app)).unwrap();
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .map(|cell| cell.symbol())
+                .collect::<Vec<_>>()
+                .concat()
+        }
+
+        let disabled = rendered(app_with(vec![TabState::Loading, TabState::Loading]), false);
+        assert!(!disabled.contains("context"));
+
+        let enabled = rendered(app_with(vec![TabState::Loading, TabState::Loading]), true);
+        assert!(enabled.contains("context"));
     }
 }


### PR DESCRIPTION
## What

Adds the opt-in, TUI-only local Claude Code context monitor proposed in #25. Press `c` to browse the 100 most recently modified top-level sessions and `Enter` for a detail gauge built from the existing TUI section renderer.

Closes #25.

## Safety and correctness

- Keeps ephemeral sessions separate from `VendorId`, `TabId`, widget cycling, and vendor caches.
- Reads at most a 2 MiB tail per recent transcript and caps directory traversal/session results.
- Skips `subagents` sidechains and discovered symlinks; tolerates corrupt, truncated, oversized, and unknown JSONL records.
- Runs filesystem work through `spawn_blocking`, with generations that reject stale rescans and results from a closed/reopened overlay.
- Detects `system/compact_boundary` after the last assistant usage and waits for a new response instead of showing the pre-compaction high-water mark.
- Sanitizes transcript-derived titles, paths, model ids, and session ids before rendering.
- Uses Claude Code input-context semantics: input + cache creation + cache reads; output tokens are intentionally excluded.
- Shows raw tokens when the context-window denominator is unknown. Optional exact per-model sizes override an optional fallback, supporting mixed 200K/1M histories without a fabricated percentage.
- Reuses the existing fixed 50/75/90 severity tiers. Context settings stay in TOML rather than overflowing the current Settings modal.
- Disabled by default; no transcript scan occurs until the feature is enabled and the overlay is opened.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo test --all-targets --locked`: 539 unit + 3 integration passed; 5 credentialed live tests ignored
- `node gnome-extension/marker-logic.test.mjs`
- `cargo machete`
- `git diff --check`

No new dependencies or version/release metadata changes.