### PR TITLE
feat(context): dockable layouts for the context overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- The local Claude context monitor docks into the dashboard body instead of
+  floating: `v` cycles `full` (its own screen) → `split` (beside the vendor
+  panel) → `bottom`. `[context] layout` sets the one it opens with.
+
 ## [0.14.0] — 2026-07-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ make clippy                                        # cargo clippy -D warnings
 - `r` — refresh active tab
 - `R` — refresh all tabs
 - `s` — open Settings overlay (primary vendor + API keys)
-- `c` — open local Claude context sessions (only when `[context] enabled = true`)
+- `c` — open local Claude context sessions (only when `[context] enabled = true`); `v` cycles its layout
 - `q` / `Esc` / `Ctrl-C` — quit
 
 Auto-refresh runs every 60 seconds in the background. Vendors use the same layout. Here's OpenRouter showing the credit balance gauge (red because 98% is consumed), usage-by-period totals, and tier:
@@ -561,6 +561,7 @@ Enable it by hand, restart the TUI, and press `c`:
 ```toml
 [context]
 enabled = true
+layout = "full"                          # full | split | bottom  (`v` cycles)
 # projects_path = "~/.claude/projects"  # this is the default
 # context_window_tokens = 200000         # optional fallback
 
@@ -568,6 +569,10 @@ enabled = true
 [context.model_context_window_tokens]
 "claude-opus-4-6" = 1000000
 ```
+
+By default the overlay takes the whole dashboard body — its own screen, not a
+popup with the vendor panel bleeding around it. `v` cycles where it sits:
+`full` → `split` (beside the vendor panel) → `bottom`.
 
 Use `↑`/`↓` or `j`/`k` to select a session, `Enter` for its detail gauge,
 `Esc` to return, and `r` to rescan. The percentage follows

--- a/config.example.toml
+++ b/config.example.toml
@@ -17,6 +17,9 @@
 # discovered symlinks. Nothing is read while this remains disabled.
 [context]
 enabled = false
+# Where the view docks when opened: full (own screen) | split (beside the
+# dashboard) | bottom. `v` cycles it while open; this is the starting value.
+layout = "full"
 # projects_path = "~/.claude/projects"  # default
 # Set a fallback only when it matches the sessions you use. Without a known
 # denominator the overlay shows raw input tokens rather than inventing a %.

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -250,7 +250,9 @@ where
                         )
                         && app.context_enabled
                     {
-                        app.context = Some(ai_usagebar::tui::context::ContextState::default());
+                        app.context = Some(ai_usagebar::tui::context::ContextState::new(
+                            config.context.layout,
+                        ));
                         spawn_context_scan(app, config, &context_tx);
                         continue;
                     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,38 @@ pub struct UiConfig {
     pub primary: Option<VendorId>,
 }
 
+/// Where the context view docks in the dashboard body. `v` cycles it while the
+/// overlay is open; the config value is what it opens with.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContextLayout {
+    /// Takes the whole body, the way a vendor panel does.
+    #[default]
+    Full,
+    /// Beside the dashboard.
+    Split,
+    /// Below the dashboard.
+    Bottom,
+}
+
+impl ContextLayout {
+    pub fn next(self) -> Self {
+        match self {
+            ContextLayout::Full => ContextLayout::Split,
+            ContextLayout::Split => ContextLayout::Bottom,
+            ContextLayout::Bottom => ContextLayout::Full,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ContextLayout::Full => "full",
+            ContextLayout::Split => "split",
+            ContextLayout::Bottom => "bottom",
+        }
+    }
+}
+
 /// Optional local Claude Code context-window monitor. This is deliberately
 /// separate from vendors: sessions are discovered from local transcripts and
 /// change while the TUI is running, whereas vendor tabs are config-declared
@@ -76,6 +108,8 @@ pub struct ContextConfig {
     /// Exact Claude model id -> context-window size. This takes precedence
     /// over `context_window_tokens`, which keeps mixed 200K/1M histories safe.
     pub model_context_window_tokens: BTreeMap<String, u64>,
+    /// Where the view opens: full | split | bottom.
+    pub layout: ContextLayout,
 }
 
 impl ContextConfig {
@@ -758,6 +792,24 @@ enabled = false
         assert_eq!(
             config.context.window_tokens_for(Some("another-model")),
             Some(200_000)
+        );
+    }
+
+    #[test]
+    fn context_layout_defaults_to_full_and_parses_each_variant() {
+        assert_eq!(Config::default().context.layout, ContextLayout::Full);
+        for (text, want) in [
+            ("full", ContextLayout::Full),
+            ("split", ContextLayout::Split),
+            ("bottom", ContextLayout::Bottom),
+        ] {
+            let file = write_toml(&format!("[context]\nlayout = \"{text}\"\n"));
+            assert_eq!(Config::load_from(file.path()).unwrap().context.layout, want);
+        }
+        let file = write_toml("[context]\nlayout = \"floating\"\n");
+        assert!(
+            Config::load_from(file.path()).is_err(),
+            "an unknown layout must be rejected, not silently defaulted"
         );
     }
 

--- a/src/tui/context.rs
+++ b/src/tui/context.rs
@@ -6,6 +6,7 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Clear, Paragraph};
 use ratatui_bubbletea_components::{Help, KeyBinding, ListItem, SelectList};
 
+use crate::config::ContextLayout;
 use crate::context::{ContextScan, ContextSession, ContextUsage};
 use crate::format::local_time_hms;
 use crate::pango::severity_for;
@@ -19,6 +20,7 @@ pub struct ContextState {
     pub detail: bool,
     pub generation: u64,
     pub load: ContextLoad,
+    pub layout: ContextLayout,
     selection_id: Option<String>,
 }
 
@@ -36,12 +38,21 @@ impl Default for ContextState {
             detail: false,
             generation: 0,
             load: ContextLoad::Loading,
+            layout: ContextLayout::default(),
             selection_id: None,
         }
     }
 }
 
 impl ContextState {
+    /// Open with the configured starting layout; `v` cycles it afterwards.
+    pub fn new(layout: ContextLayout) -> Self {
+        Self {
+            layout,
+            ..Self::default()
+        }
+    }
+
     /// Begin a scan with an identity allocated by the long-lived host app.
     /// The host, rather than this disposable overlay, owns monotonicity across
     /// close/reopen cycles.
@@ -125,6 +136,10 @@ pub fn handle_key(state: &mut ContextState, code: KeyCode, mods: KeyModifiers) -
         }
         KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('c') => Action::Close,
         KeyCode::Char('r') => Action::Refresh,
+        KeyCode::Char('v') => {
+            state.layout = state.layout.next();
+            Action::Continue
+        }
         KeyCode::Enter if state.selected_session().is_some() => {
             state.detail = true;
             Action::Continue
@@ -156,14 +171,17 @@ pub fn handle_key(state: &mut ContextState, code: KeyCode, mods: KeyModifiers) -
     }
 }
 
+/// Render the overlay docked into `area` (the view layer decides how much of
+/// the dashboard body that is). Fills `area` like a vendor panel rather than
+/// floating, so it reads as its own surface.
 pub fn render(f: &mut Frame, area: Rect, state: &ContextState, theme: &Theme) {
-    let modal = centered_rect(90, 90, area);
-    f.render_widget(Clear, modal);
-
     let bubble = bubble_theme(theme);
-    let block = bubble.titled_modal_block(" Claude context ");
-    let inner = block.inner(modal);
-    f.render_widget(block, modal);
+    f.render_widget(Clear, area);
+    let block = bubble
+        .titled_block(" Claude context ")
+        .border_style(bubble.focused_border);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -211,6 +229,7 @@ pub fn render(f: &mut Frame, area: Rect, state: &ContextState, theme: &Theme) {
         Help::new([
             KeyBinding::with_keys(["↑/↓", "j/k"], "session"),
             KeyBinding::new("r", "rescan"),
+            KeyBinding::new("v", "layout"),
             KeyBinding::new("esc", "back"),
             KeyBinding::new("q", "close"),
         ])
@@ -219,6 +238,7 @@ pub fn render(f: &mut Frame, area: Rect, state: &ContextState, theme: &Theme) {
             KeyBinding::with_keys(["↑/↓", "j/k"], "select"),
             KeyBinding::new("enter", "details"),
             KeyBinding::new("r", "rescan"),
+            KeyBinding::new("v", "layout"),
             KeyBinding::with_keys(["q", "esc"], "close"),
         ])
     }
@@ -250,6 +270,7 @@ fn render_list(f: &mut Frame, area: Rect, state: &ContextState, scan: &ContextSc
     if scan.walk_capped {
         status.push_str(" · directory scan capped");
     }
+    status.push_str(&format!(" · layout: {}", state.layout.label()));
     f.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled(status, bubble.muted),
@@ -385,17 +406,6 @@ fn format_tokens(value: u64) -> String {
     out
 }
 
-fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let height = (area.height * percent_y) / 100;
-    let width = (area.width * percent_x) / 100;
-    Rect {
-        x: area.x + (area.width - width) / 2,
-        y: area.y + (area.height - height) / 2,
-        width,
-        height,
-    }
-}
-
 pub use ratatui::crossterm::event::{KeyCode, KeyModifiers};
 
 #[cfg(test)]
@@ -486,6 +496,27 @@ mod tests {
         assert_eq!(
             handle_key(&mut state, KeyCode::Esc, KeyModifiers::NONE),
             Action::Close
+        );
+    }
+
+    #[test]
+    fn v_cycles_the_three_layouts_and_wraps() {
+        let mut state = ContextState::new(ContextLayout::Full);
+        state.detail = true;
+        for expected in [
+            ContextLayout::Split,
+            ContextLayout::Bottom,
+            ContextLayout::Full,
+        ] {
+            assert_eq!(
+                handle_key(&mut state, KeyCode::Char('v'), KeyModifiers::NONE),
+                Action::Continue
+            );
+            assert_eq!(state.layout, expected);
+        }
+        assert!(
+            state.detail,
+            "changing layout must not leave the detail view"
         );
     }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -28,14 +28,43 @@ pub fn draw(f: &mut Frame, app: &App) {
         .split(f.area());
 
     draw_header(f, app, chunks[0]);
-    draw_main(f, app, chunks[1]);
+    draw_body(f, app, chunks[1]);
     draw_footer(f, app, chunks[2]);
 
-    // Settings overlay sits on top — rendered last so it covers everything.
+    // Settings still floats on top of everything.
     if let Some(s) = &app.settings {
         crate::tui::settings::render(f, f.area(), s, &app.theme);
-    } else if let Some(context) = &app.context {
-        crate::tui::context::render(f, f.area(), context, &app.theme);
+    }
+}
+
+/// The dashboard body, plus the context view docked into it when open: `full`
+/// takes it over, `split` sits beside it, `bottom` sits below it.
+fn draw_body(f: &mut Frame, app: &App, area: Rect) {
+    use crate::config::ContextLayout;
+    use crate::tui::context;
+
+    let Some(state) = &app.context else {
+        draw_main(f, app, area);
+        return;
+    };
+    match state.layout {
+        ContextLayout::Full => context::render(f, area, state, &app.theme),
+        ContextLayout::Split => {
+            let cols = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(area);
+            draw_main(f, app, cols[0]);
+            context::render(f, cols[1], state, &app.theme);
+        }
+        ContextLayout::Bottom => {
+            let rows = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+                .split(area);
+            draw_main(f, app, rows[0]);
+            context::render(f, rows[1], state, &app.theme);
+        }
     }
 }
 
@@ -331,6 +360,53 @@ mod tests {
         // passing off "now" as a response time.
         let app = app_with(vec![ready_at(None), TabState::Loading]);
         assert_eq!(header_refresh_text(&app), "last refresh —");
+    }
+
+    fn app_with_context(layout: crate::config::ContextLayout) -> App {
+        let mut app = app_with(vec![TabState::Loading, TabState::Loading]);
+        app.context_enabled = true;
+        app.context = Some({
+            let mut state = crate::tui::context::ContextState::new(layout);
+            state.apply_scan(0, Err("scan error".into()));
+            state
+        });
+        app
+    }
+
+    fn body_text(app: &App) -> String {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(160, 40)).unwrap();
+        terminal.draw(|frame| draw(frame, app)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect::<Vec<_>>()
+            .concat()
+    }
+
+    #[test]
+    fn full_layout_takes_the_body_and_hides_the_vendor_sidebar() {
+        use crate::config::ContextLayout;
+        let out = body_text(&app_with_context(ContextLayout::Full));
+        assert!(out.contains("Claude context"), "{out}");
+        assert!(
+            !out.contains("vendors"),
+            "full layout must not leave the dashboard around it"
+        );
+    }
+
+    #[test]
+    fn split_and_bottom_layouts_keep_the_dashboard_visible() {
+        use crate::config::ContextLayout;
+        for layout in [ContextLayout::Split, ContextLayout::Bottom] {
+            let out = body_text(&app_with_context(layout));
+            assert!(out.contains("Claude context"), "{layout:?}: {out}");
+            assert!(out.contains("vendors"), "{layout:?}: {out}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

A small follow-up to the local context monitor (#25 / #28): let the overlay **dock into the dashboard body** instead of floating, and let `v` cycle where it sits.

- **full** — takes the whole body, its own screen (the default)
- **split** — beside the vendor panel
- **bottom** — below it

`[context] layout` sets the mode it opens with; `v` cycles at runtime and the current mode shows in the list's status line.

## Why

The overlay currently floats as a centered 90%×90% modal, so the vendor dashboard bleeds around its edges and the session list gets only a slice of the vertical space. A docked `full` view reads as its own screen; `split` / `bottom` keep the vendor panel and the sessions visible at once. It's your call on the presentation you just shipped — if you'd rather keep the floating modal, or want only `full` without `split`/`bottom`, I'm glad to adjust or close.

## How

- `context::render` now fills the `Rect` it's given as a titled, focus-bordered panel rather than centering a modal (the `centered_rect` helper is gone).
- `view::draw_body` places it per layout — 50/50 split of the dashboard body for `split` / `bottom`, the whole body for `full`. Settings still floats on top as before.
- `ContextLayout` is a plain config enum with a `next()` cycle; `ContextState` carries the current layout and `handle_key` maps `v` to it.
- Additive and back-compatible: `[context] layout` is a new optional field defaulting to `full`, so existing configs and the `enabled = false` default are unchanged. No new dependencies (`Cargo.toml` / `Cargo.lock` untouched), and no edits to `vendor.rs`, `usage.rs`, `widget/run.rs`, `widget/cli.rs`, or `tui/panels.rs`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings` — clean
- `cargo test --all-targets --locked` — 546 passed (4 new: the `v` layout cycle, the config parse + `full` default, and — against a `TestBackend` buffer — that `full` takes the body while `split` / `bottom` keep the dashboard visible)

Thanks again for ai-usagebar.
