### PR TITLE
fix(anthropic): keep uncapped-plan credit spend visible, in its own currency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,16 @@ Each release is also published at
   `decimal_places` fields were ignored and every amount was formatted as `$`
   with a hard-coded cent scale — the #30 reporter's R$ 141.57 would have shown
   as "$141.57", a claim about the wrong currency. Known codes get their symbol
-  (`R$`, `€`, `£`, `¥`), unknown ones render as `AMOUNT CODE`, zero-exponent
-  currencies (JPY) format without an invented decimal point, and payloads
-  without the fields keep the historical `$`/cents behaviour (JPY defaults to
-  its ISO zero-decimal scale when the field is absent). Both new fields are
-  gated at the parse boundary: `decimal_places` outside 0..=6 is schema drift
-  (integral floats are tolerated, since this endpoint floats its numbers), and
-  `currency` must be a three-letter ISO alpha code — the value is embedded in
-  Pango markup and the desktop `;;` protocol, so an arbitrary string would be
-  an injection vector besides being drift.
+  (`R$`, `€`, `£`, `¥`), unknown ones render as `AMOUNT CODE`, and an explicit
+  exponent is honored exactly, including zero- and three-decimal currencies.
+  If a currency is present but its exponent is absent, the raw value renders as
+  `N minor units CODE` rather than guessing and silently corrupting the amount;
+  payloads with neither field keep the historical `$`/cents behaviour. Both
+  new fields are gated at the parse boundary: `decimal_places` outside 0..=6 is
+  schema drift (integral floats are tolerated, since this endpoint floats its
+  numbers), and `currency` must be a three-letter ISO alpha code — the value is
+  embedded in Pango markup and the desktop `;;` protocol, so an arbitrary
+  string would be an injection vector besides being drift.
 
 ## [0.14.0] — 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,35 @@ Each release is also published at
   floating: `v` cycles `full` (its own screen) → `split` (beside the vendor
   panel) → `bottom`. `[context] layout` sets the one it opens with.
 
+### Fixed
+
+- **Credit spend is no longer hidden on plans without a spending cap** (#30).
+  The usage endpoint sends `extra_usage.monthly_limit: null` for uncapped
+  plans (e.g. Claude Pro); the whole block was discarded, hiding genuine
+  `used_credits`. A null limit is semantic — "no cap" — not schema drift, so
+  `ExtraUsage.limit` is now optional: the spend renders on every surface, the
+  tooltip says `Limit: none reported` (stating the wire fact rather than
+  inferring a plan tier), the TUI shows the amount without a denominator, and
+  `{extra_limit}` expands to `—` (deliberately non-empty: GNOME and the macOS
+  menu bar hide the whole extra row on an empty limit).
+  The block is still dropped when `used_credits` itself is missing — without
+  the spend there is nothing truthful to show — and no percentage is invented
+  when there is no denominator.
+
+- **Extra usage renders in its own currency.** The block's `currency` and
+  `decimal_places` fields were ignored and every amount was formatted as `$`
+  with a hard-coded cent scale — the #30 reporter's R$ 141.57 would have shown
+  as "$141.57", a claim about the wrong currency. Known codes get their symbol
+  (`R$`, `€`, `£`, `¥`), unknown ones render as `AMOUNT CODE`, zero-exponent
+  currencies (JPY) format without an invented decimal point, and payloads
+  without the fields keep the historical `$`/cents behaviour (JPY defaults to
+  its ISO zero-decimal scale when the field is absent). Both new fields are
+  gated at the parse boundary: `decimal_places` outside 0..=6 is schema drift
+  (integral floats are tolerated, since this endpoint floats its numbers), and
+  `currency` must be a three-letter ISO alpha code — the value is embedded in
+  Pango markup and the desktop `;;` protocol, so an arbitrary string would be
+  an injection vector besides being drift.
+
 ## [0.14.0] — 2026-07-20
 
 ### Added

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -7,7 +7,9 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::usage::{AnthropicSnapshot, Cents, ExtraUsage, ScopedWindow, UsageWindow};
+use crate::usage::{
+    AnthropicSnapshot, Cents, ExtraUsage, ScopedWindow, UsageWindow, default_decimal_places,
+};
 
 /// Top-level response from `GET /api/oauth/usage`.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
@@ -74,6 +76,58 @@ pub struct ExtraUsageBlock {
     pub monthly_limit: Option<i64>,
     #[serde(default, deserialize_with = "de_opt_cents")]
     pub used_credits: Option<i64>,
+    /// ISO currency code (`"BRL"`, `"USD"`, …). Absent on older payloads,
+    /// which were always formatted as `$`.
+    #[serde(default, deserialize_with = "de_opt_currency")]
+    pub currency: Option<String>,
+    /// Minor-unit digits for both money fields. Gated at the parse boundary:
+    /// an absurd scale would corrupt every formatted amount downstream.
+    #[serde(default, deserialize_with = "de_opt_decimal_places")]
+    pub decimal_places: Option<u32>,
+}
+
+/// Accept a plausible minor-unit scale (0..=6 covers every ISO 4217 currency;
+/// the largest real exponent is 4). Integral floats are tolerated for the same
+/// reason `de_opt_cents` tolerates them: this endpoint emits them (the #30
+/// payload carries `used_credits: 14157.0`), and rejecting `2.0` would fail
+/// the whole response over a value that is unambiguous. Null/absent falls back
+/// per-currency in the conversion. Anything else is drift: a wire
+/// `decimal_places: 100` would overflow the scale and mis-state every amount,
+/// so it fails loudly as `⚠` instead.
+fn de_opt_decimal_places<'de, D>(d: D) -> std::result::Result<Option<u32>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let n = match serde_json::Value::deserialize(d)? {
+        serde_json::Value::Null => return Ok(None),
+        serde_json::Value::Number(n) => n
+            .as_i64()
+            .or_else(|| n.as_f64().filter(|f| f.fract() == 0.0).map(|f| f as i64)),
+        _ => None,
+    };
+    match n {
+        Some(n) if (0..=6).contains(&n) => Ok(Some(n as u32)),
+        _ => Err(serde::de::Error::custom(
+            "decimal_places must be an integer in 0..=6",
+        )),
+    }
+}
+
+/// Gate the currency to a plausible ISO 4217 alpha code. The value is embedded
+/// verbatim in Pango bar markup and in the `;;`-delimited desktop FORMAT
+/// protocol, so an arbitrary string is an injection vector as well as drift;
+/// three ASCII uppercase letters can be neither.
+fn de_opt_currency<'de, D>(d: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<String>::deserialize(d)? {
+        None => Ok(None),
+        Some(s) if s.len() == 3 && s.bytes().all(|b| b.is_ascii_uppercase()) => Ok(Some(s)),
+        Some(s) => Err(serde::de::Error::custom(format!(
+            "currency {s:?} is not an ISO 4217 alpha code"
+        ))),
+    }
 }
 
 fn de_opt_cents<'de, D>(d: D) -> std::result::Result<Option<i64>, D::Error>
@@ -187,8 +241,19 @@ impl UsageResponse {
         let sonnet = self.seven_day_sonnet.map(|w| to_window(Some(w), WEEKLY));
         let extra = self.extra_usage.filter(|e| e.is_enabled).and_then(|e| {
             Some(ExtraUsage {
-                limit: Cents(e.monthly_limit?),
+                // `monthly_limit: null` is semantic, not drift: the endpoint
+                // sends it for plans with no spending cap (e.g. Pro), so it
+                // maps to None instead of discarding the block — which hid
+                // real credit spend (#30). Only an unusable `used_credits`
+                // still drops it: without the spend there is nothing to show.
+                limit: e.monthly_limit.map(Cents),
                 spent: Cents(e.used_credits?),
+                // Absent scale falls back per-currency (JPY has no minor
+                // unit; everything observed without the field was cents).
+                decimal_places: e
+                    .decimal_places
+                    .unwrap_or_else(|| default_decimal_places(e.currency.as_deref())),
+                currency: e.currency,
             })
         });
         let scoped = self
@@ -241,8 +306,9 @@ mod tests {
         assert_eq!(snap.session.utilization_pct, 43); // rounded
         assert_eq!(snap.weekly.utilization_pct, 27);
         assert_eq!(snap.sonnet.as_ref().unwrap().utilization_pct, 4);
-        assert_eq!(snap.extra.unwrap().limit.0, 5000);
-        assert_eq!(snap.extra.unwrap().spent.0, 250);
+        let extra = snap.extra.as_ref().unwrap();
+        assert_eq!(extra.limit, Some(Cents(5000)));
+        assert_eq!(extra.spent.0, 250);
         assert!(snap.session.resets_at.is_some());
     }
 
@@ -312,15 +378,122 @@ mod tests {
     }
 
     #[test]
-    fn enabled_incomplete_extra_usage_does_not_invent_zero_money() {
+    fn enabled_extra_usage_without_spend_is_dropped() {
+        // `used_credits` is the essential datum: without it there is nothing
+        // truthful to display, so the block is dropped rather than inventing
+        // a $0.00 spend.
         for raw in [
             r#"{"extra_usage":{"is_enabled":true,"monthly_limit":5000}}"#,
-            r#"{"extra_usage":{"is_enabled":true,"used_credits":250}}"#,
-            r#"{"extra_usage":{"is_enabled":true,"monthly_limit":null,"used_credits":250}}"#,
+            r#"{"extra_usage":{"is_enabled":true,"monthly_limit":5000,"used_credits":null}}"#,
         ] {
             let resp: UsageResponse = serde_json::from_str(raw).unwrap();
             assert!(resp.into_snapshot("Pro".into()).extra.is_none(), "{raw}");
         }
+    }
+
+    #[test]
+    fn uncapped_plan_keeps_real_spend_visible() {
+        // The #30 regression: the endpoint sends `monthly_limit: null` for
+        // plans with no spending cap (e.g. Pro). Discarding the block hid
+        // genuine credit spend — this fixture is the reporter's actual cached
+        // response (R$ 141.57, an integral float).
+        let resp: UsageResponse = serde_json::from_str(
+            r#"{"extra_usage":{"is_enabled":true,"monthly_limit":null,
+                "used_credits":14157.0,"currency":"BRL","decimal_places":2,
+                "disabled_reason":null}}"#,
+        )
+        .unwrap();
+        let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
+        assert_eq!(extra.limit, None);
+        assert_eq!(extra.spent.0, 14157);
+        // No denominator → no invented percentage; bar stays calm.
+        assert_eq!(extra.percent(), 0);
+        // The block's own currency and scale propagate, so the renderer can
+        // say R$141.57 instead of claiming `$` for reais.
+        assert_eq!(extra.currency.as_deref(), Some("BRL"));
+        assert_eq!(extra.decimal_places, 2);
+        assert_eq!(extra.fmt_spent(), "R$141.57");
+
+        // An *absent* limit renders the same way: with `#[serde(default)]`,
+        // absent and explicit null are indistinguishable at the struct level,
+        // and hiding real spend because a secondary field went missing is the
+        // exact failure mode of #30. Nothing is fabricated either way — the
+        // spend shown is exactly what the API sent.
+        let resp: UsageResponse =
+            serde_json::from_str(r#"{"extra_usage":{"is_enabled":true,"used_credits":250}}"#)
+                .unwrap();
+        let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
+        assert_eq!(extra.limit, None);
+        assert_eq!(extra.spent.0, 250);
+    }
+
+    #[test]
+    fn implausible_decimal_places_is_schema_drift() {
+        // A wire scale outside 0..=6 would mis-state every formatted amount
+        // (10^100 overflows outright), so it fails loudly instead.
+        for value in ["7", "-1", "100", "2.5"] {
+            let raw = format!(
+                r#"{{"extra_usage":{{"is_enabled":true,"used_credits":250,"decimal_places":{value}}}}}"#
+            );
+            assert!(
+                serde_json::from_str::<UsageResponse>(&raw).is_err(),
+                "{raw}"
+            );
+        }
+        // An integral float is fine — this endpoint floats its numbers (the
+        // #30 payload has `used_credits: 14157.0`), and rejecting 2.0 would
+        // fail the whole response over an unambiguous value. Worse: the fetch
+        // caches the body BEFORE parsing, so a rejected response would evict
+        // the last good payload and leave a persistent ⚠.
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":250,"decimal_places":2.0}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            resp.into_snapshot("Pro".into())
+                .extra
+                .unwrap()
+                .decimal_places,
+            2
+        );
+        // Null and absent both fall back to the historical cent scale.
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":250,"decimal_places":null}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            resp.into_snapshot("Pro".into())
+                .extra
+                .unwrap()
+                .decimal_places,
+            2
+        );
+        // ...except for a currency with no minor unit, where "2" would divide
+        // every amount by 100 (¥500 rendered as ¥5.00).
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":500,"currency":"JPY"}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
+        assert_eq!(extra.decimal_places, 0);
+        assert_eq!(extra.fmt_spent(), "¥500");
+    }
+
+    #[test]
+    fn currency_must_be_an_iso_alpha_code() {
+        // The value lands verbatim in Pango markup and in the `;;`-delimited
+        // desktop FORMAT protocol, so anything but three ASCII uppercase
+        // letters is rejected as drift — it is an injection vector besides.
+        for value in [r#""brl""#, r#""""#, r#""R$""#, r#""USD;;0""#, r#""<b>""#] {
+            let raw = format!(
+                r#"{{"extra_usage":{{"is_enabled":true,"used_credits":250,"currency":{value}}}}}"#
+            );
+            assert!(
+                serde_json::from_str::<UsageResponse>(&raw).is_err(),
+                "{raw}"
+            );
+        }
+        // Null stays acceptable — same as absent.
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":250,"currency":null}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            resp.into_snapshot("Pro".into()).extra.unwrap().currency,
+            None
+        );
     }
 
     #[test]
@@ -340,7 +513,7 @@ mod tests {
         )
         .unwrap();
         let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
-        assert_eq!(extra.limit.0, 5000);
+        assert_eq!(extra.limit, Some(Cents(5000)));
         assert_eq!(extra.spent.0, 250);
     }
 

--- a/src/anthropic/types.rs
+++ b/src/anthropic/types.rs
@@ -7,9 +7,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::usage::{
-    AnthropicSnapshot, Cents, ExtraUsage, ScopedWindow, UsageWindow, default_decimal_places,
-};
+use crate::usage::{AnthropicSnapshot, Cents, ExtraUsage, ScopedWindow, UsageWindow};
 
 /// Top-level response from `GET /api/oauth/usage`.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
@@ -65,9 +63,10 @@ pub struct Window {
     pub resets_at: Option<String>,
 }
 
-/// Pay-as-you-go extra usage. Both money values are non-negative integer cents,
-/// but the API sometimes returns integral floats (e.g. `0.0`). Missing values
-/// remain absent so an enabled but incomplete block cannot manufacture $0.00.
+/// Pay-as-you-go extra usage. Both money values are non-negative integer minor
+/// units, but the API sometimes returns integral floats (e.g. `0.0`). Missing
+/// values remain absent so an enabled but incomplete block cannot manufacture
+/// a zero balance.
 #[derive(Debug, Default, Clone, Deserialize, Serialize, PartialEq)]
 pub struct ExtraUsageBlock {
     #[serde(default)]
@@ -90,10 +89,10 @@ pub struct ExtraUsageBlock {
 /// the largest real exponent is 4). Integral floats are tolerated for the same
 /// reason `de_opt_cents` tolerates them: this endpoint emits them (the #30
 /// payload carries `used_credits: 14157.0`), and rejecting `2.0` would fail
-/// the whole response over a value that is unambiguous. Null/absent falls back
-/// per-currency in the conversion. Anything else is drift: a wire
-/// `decimal_places: 100` would overflow the scale and mis-state every amount,
-/// so it fails loudly as `⚠` instead.
+/// the whole response over a value that is unambiguous. Null/absent remains
+/// absent: a currency code alone is not enough to infer every ISO exponent.
+/// Anything else is drift: a wire `decimal_places: 100` would overflow the
+/// scale and mis-state every amount, so it fails loudly as `⚠` instead.
 fn de_opt_decimal_places<'de, D>(d: D) -> std::result::Result<Option<u32>, D::Error>
 where
     D: serde::Deserializer<'de>,
@@ -248,11 +247,10 @@ impl UsageResponse {
                 // still drops it: without the spend there is nothing to show.
                 limit: e.monthly_limit.map(Cents),
                 spent: Cents(e.used_credits?),
-                // Absent scale falls back per-currency (JPY has no minor
-                // unit; everything observed without the field was cents).
-                decimal_places: e
-                    .decimal_places
-                    .unwrap_or_else(|| default_decimal_places(e.currency.as_deref())),
+                // Preserve an absent scale. Currency codes span zero through
+                // four decimal minor units, so guessing would fabricate the
+                // displayed major-unit amount.
+                decimal_places: e.decimal_places,
                 currency: e.currency,
             })
         });
@@ -411,7 +409,7 @@ mod tests {
         // The block's own currency and scale propagate, so the renderer can
         // say R$141.57 instead of claiming `$` for reais.
         assert_eq!(extra.currency.as_deref(), Some("BRL"));
-        assert_eq!(extra.decimal_places, 2);
+        assert_eq!(extra.decimal_places, Some(2));
         assert_eq!(extra.fmt_spent(), "R$141.57");
 
         // An *absent* limit renders the same way: with `#[serde(default)]`,
@@ -452,25 +450,44 @@ mod tests {
                 .extra
                 .unwrap()
                 .decimal_places,
-            2
+            Some(2)
         );
-        // Null and absent both fall back to the historical cent scale.
+        // Null and absent stay absent. With no currency, legacy payloads still
+        // render using their historical USD/cent convention.
         let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":250,"decimal_places":null}}"#;
         let resp: UsageResponse = serde_json::from_str(raw).unwrap();
-        assert_eq!(
-            resp.into_snapshot("Pro".into())
-                .extra
-                .unwrap()
-                .decimal_places,
-            2
-        );
-        // ...except for a currency with no minor unit, where "2" would divide
-        // every amount by 100 (¥500 rendered as ¥5.00).
-        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":500,"currency":"JPY"}}"#;
+        let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
+        assert_eq!(extra.decimal_places, None);
+        assert_eq!(extra.fmt_spent(), "$2.50");
+
+        // If a currency is present without its exponent, expose the raw minor
+        // units rather than guessing. KRW is zero-decimal and KWD is
+        // three-decimal; a blanket cent fallback corrupts both.
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":500,"currency":"KRW"}}"#;
         let resp: UsageResponse = serde_json::from_str(raw).unwrap();
         let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
-        assert_eq!(extra.decimal_places, 0);
-        assert_eq!(extra.fmt_spent(), "¥500");
+        assert_eq!(extra.decimal_places, None);
+        assert_eq!(extra.fmt_spent(), "500 minor units KRW");
+
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":1234,"currency":"KWD"}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        let extra = resp.into_snapshot("Pro".into()).extra.unwrap();
+        assert_eq!(extra.decimal_places, None);
+        assert_eq!(extra.fmt_spent(), "1234 minor units KWD");
+
+        // Explicit exponents remain authoritative, including zero and three.
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":500,"currency":"KRW","decimal_places":0}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            resp.into_snapshot("Pro".into()).extra.unwrap().fmt_spent(),
+            "500 KRW"
+        );
+        let raw = r#"{"extra_usage":{"is_enabled":true,"used_credits":1234,"currency":"KWD","decimal_places":3}}"#;
+        let resp: UsageResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(
+            resp.into_snapshot("Pro".into()).extra.unwrap().fmt_spent(),
+            "1.234 KWD"
+        );
     }
 
     #[test]

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -772,7 +772,7 @@ mod tests {
                 limit: Some(Cents(5000)),
                 spent: Cents(250),
                 currency: None,
-                decimal_places: 2,
+                decimal_places: Some(2),
             }),
         };
         let sections = sections_for(&ready(VendorSnapshot::Anthropic(snap)), now(), 5);
@@ -815,7 +815,7 @@ mod tests {
                 limit: None,
                 spent: Cents(14157),
                 currency: Some("BRL".into()),
-                decimal_places: 2,
+                decimal_places: Some(2),
             }),
         };
         let sections = sections_for(&ready(VendorSnapshot::Anthropic(snap)), now(), 5);

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -209,12 +209,22 @@ fn anthropic_sections(
     if let Some(e) = &s.extra {
         v.push(Section::Spacer);
         let pct = e.percent().clamp(0, 100) as u16;
+        // An uncapped plan (`monthly_limit: null`) has spend but no
+        // denominator: show the amount alone rather than "of $0.00" or a
+        // percentage nobody can vouch for (#30).
+        let (value_label, footnote) = match e.fmt_limit() {
+            Some(l) => (
+                format!("{} of {}", e.fmt_spent(), l),
+                format!("{pct}% of monthly limit consumed"),
+            ),
+            None => (e.fmt_spent(), "no monthly limit reported".to_string()),
+        };
         v.push(Section::Metric {
             label: "Extra usage".into(),
             pct,
             severity: severity_for(pct as i32),
-            value_label: format!("{} of {}", e.spent.fmt_dollars(), e.limit.fmt_dollars()),
-            footnote: format!("{}% of monthly limit consumed", pct),
+            value_label,
+            footnote,
         });
     }
     v
@@ -759,8 +769,10 @@ mod tests {
             }),
             scoped: vec![],
             extra: Some(ExtraUsage {
-                limit: Cents(5000),
+                limit: Some(Cents(5000)),
                 spent: Cents(250),
+                currency: None,
+                decimal_places: 2,
             }),
         };
         let sections = sections_for(&ready(VendorSnapshot::Anthropic(snap)), now(), 5);
@@ -779,6 +791,56 @@ mod tests {
             .filter(|s| matches!(s, Section::Metric { .. }))
             .count();
         assert_eq!(metric_count, 4);
+    }
+
+    #[test]
+    fn anthropic_uncapped_extra_shows_spend_without_a_denominator() {
+        // The #30 shape: `monthly_limit: null` (Pro). The panel must show the
+        // spend alone — not "of $0.00", not an invented percentage.
+        let snap = AnthropicSnapshot {
+            plan: "Pro".into(),
+            session: UsageWindow {
+                utilization_pct: 10,
+                resets_at: None,
+                window_duration: chrono::Duration::hours(5),
+            },
+            weekly: UsageWindow {
+                utilization_pct: 20,
+                resets_at: None,
+                window_duration: chrono::Duration::days(7),
+            },
+            sonnet: None,
+            scoped: vec![],
+            extra: Some(ExtraUsage {
+                limit: None,
+                spent: Cents(14157),
+                currency: Some("BRL".into()),
+                decimal_places: 2,
+            }),
+        };
+        let sections = sections_for(&ready(VendorSnapshot::Anthropic(snap)), now(), 5);
+        let extra = sections
+            .iter()
+            .find_map(|s| match s {
+                Section::Metric {
+                    label,
+                    pct,
+                    value_label,
+                    footnote,
+                    ..
+                } if label == "Extra usage" => Some((*pct, value_label.clone(), footnote.clone())),
+                _ => None,
+            })
+            .expect("uncapped extra usage must still render a section");
+        assert_eq!(extra.0, 0);
+        // Non-vacuous currency pin: fmt_dollars would say "$141.57" here.
+        assert_eq!(extra.1, "R$141.57");
+        assert!(
+            !extra.1.contains(" of "),
+            "no denominator to show: {}",
+            extra.1
+        );
+        assert_eq!(extra.2, "no monthly limit reported");
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -117,8 +117,9 @@ pub struct ExtraUsage {
     /// the only behaviour before the field existed.
     pub currency: Option<String>,
     /// Minor-unit digits from the block's `decimal_places` (BRL/USD = 2,
-    /// JPY = 0). Both money values above are in this scale.
-    pub decimal_places: u32,
+    /// JPY/KRW = 0). `None` means the wire did not report the scale. We keep
+    /// that absence instead of guessing from an incomplete currency table.
+    pub decimal_places: Option<u32>,
 }
 
 impl ExtraUsage {
@@ -135,13 +136,31 @@ impl ExtraUsage {
     }
 
     pub fn fmt_spent(&self) -> String {
-        fmt_minor(self.spent.0, self.decimal_places, self.currency.as_deref())
+        self.fmt_amount(self.spent)
     }
 
     pub fn fmt_limit(&self) -> Option<String> {
-        self.limit
-            .map(|l| fmt_minor(l.0, self.decimal_places, self.currency.as_deref()))
+        self.limit.map(|l| self.fmt_amount(l))
     }
+
+    fn fmt_amount(&self, amount: Cents) -> String {
+        match (self.decimal_places, self.currency.as_deref()) {
+            (Some(decimal_places), currency) => fmt_minor(amount.0, decimal_places, currency),
+            // Legacy payloads predate both fields and were always cents/USD.
+            // Preserve that established behaviour only when neither field can
+            // tell us otherwise.
+            (None, None) => fmt_minor(amount.0, 2, None),
+            // A currency code alone does not determine its ISO minor-unit
+            // exponent. Keep the amount truthful instead of silently dividing
+            // zero-, three-, or four-decimal currencies by the wrong scale.
+            (None, Some(currency)) => fmt_minor_units(amount.0, currency),
+        }
+    }
+}
+
+fn fmt_minor_units(minor: i64, currency: &str) -> String {
+    let sign = if minor < 0 { "-" } else { "" };
+    format!("{sign}{} minor units {currency}", minor.unsigned_abs())
 }
 
 /// Format an amount in minor units with its own currency and scale. Rendering
@@ -172,17 +191,6 @@ pub fn fmt_minor(minor: i64, decimal_places: u32, currency: Option<&str>) -> Str
         Some("GBP") => format!("{sign}£{number}"),
         Some("JPY") | Some("CNY") => format!("{sign}¥{number}"),
         Some(other) => format!("{sign}{number} {other}"),
-    }
-}
-
-/// ISO 4217 minor-unit digits for a currency when the payload omits
-/// `decimal_places`. Defaulting JPY to the historical 2 would divide every
-/// amount by 100 (¥500 shown as ¥5.00); unknown codes keep 2, the scale every
-/// observed payload without the field has used.
-pub fn default_decimal_places(currency: Option<&str>) -> u32 {
-    match currency {
-        Some("JPY") => 0,
-        _ => 2,
     }
 }
 
@@ -481,7 +489,7 @@ mod tests {
                 limit: Some(Cents(limit)),
                 spent: Cents(spent),
                 currency: None,
-                decimal_places: 2,
+                decimal_places: Some(2),
             }),
         }
     }
@@ -507,7 +515,7 @@ mod tests {
             limit: None,
             spent: Cents(14157),
             currency: Some("BRL".into()),
-            decimal_places: 2,
+            decimal_places: Some(2),
         };
         assert_eq!(e.fmt_spent(), "R$141.57");
         assert_eq!(e.fmt_limit(), None);
@@ -516,7 +524,7 @@ mod tests {
             limit: Some(Cents(5000)),
             spent: Cents(250),
             currency: None,
-            decimal_places: 2,
+            decimal_places: Some(2),
         };
         assert_eq!(capped.fmt_spent(), "$2.50");
         assert_eq!(capped.fmt_limit().as_deref(), Some("$50.00"));
@@ -544,7 +552,7 @@ mod tests {
                 limit: Some(Cents(0)),
                 spent: Cents(100),
                 currency: None,
-                decimal_places: 2,
+                decimal_places: Some(2),
             }
             .percent(),
             0
@@ -559,7 +567,7 @@ mod tests {
                 limit: Some(Cents(10000)),
                 spent: Cents(3333),
                 currency: None,
-                decimal_places: 2,
+                decimal_places: Some(2),
             }
             .percent(),
             33

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -56,7 +56,8 @@ pub struct UsageWindow {
     pub window_duration: chrono::Duration,
 }
 
-/// Money expressed in cents to dodge float roundoff.
+/// Money in minor currency units (historically always cents; see
+/// `ExtraUsage::decimal_places` for the actual scale) to dodge float roundoff.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Cents(pub i64);
 
@@ -102,21 +103,86 @@ pub struct ScopedWindow {
 }
 
 /// "Extra usage" pay-as-you-go block (claudebar's `extra_usage`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExtraUsage {
-    pub limit: Cents,
+    /// `None` when the payload carries no usable `monthly_limit` — an
+    /// explicit null (observed for plans without a spending cap, e.g. Claude
+    /// Pro, #30) or an absent field. Either way the spend is real and stays
+    /// visible; only the limit is unreported, and the renderers say exactly
+    /// that rather than inferring a plan tier from it.
+    pub limit: Option<Cents>,
     pub spent: Cents,
+    /// ISO code from the block (`"BRL"`, `"USD"`, …). `None` on older payloads
+    /// that predate the field — formatted as `$` for back-compat, which was
+    /// the only behaviour before the field existed.
+    pub currency: Option<String>,
+    /// Minor-unit digits from the block's `decimal_places` (BRL/USD = 2,
+    /// JPY = 0). Both money values above are in this scale.
+    pub decimal_places: u32,
 }
 
 impl ExtraUsage {
     /// Integer percentage of the monthly limit consumed (0..=100, saturating
     /// at 0 when limit is non-positive — matches claudebar:540-542).
-    pub fn percent(self) -> i32 {
-        if self.limit.0 <= 0 {
-            0
-        } else {
-            ((self.spent.0 * 100) / self.limit.0) as i32
+    ///
+    /// With no cap there is no denominator, so no meaningful percentage
+    /// exists; 0 keeps the bar and severity calm rather than inventing one.
+    pub fn percent(&self) -> i32 {
+        match self.limit {
+            Some(l) if l.0 > 0 => ((self.spent.0 * 100) / l.0) as i32,
+            _ => 0,
         }
+    }
+
+    pub fn fmt_spent(&self) -> String {
+        fmt_minor(self.spent.0, self.decimal_places, self.currency.as_deref())
+    }
+
+    pub fn fmt_limit(&self) -> Option<String> {
+        self.limit
+            .map(|l| fmt_minor(l.0, self.decimal_places, self.currency.as_deref()))
+    }
+}
+
+/// Format an amount in minor units with its own currency and scale. Rendering
+/// R$ 141.57 as "$141.57" is a claim about the wrong currency — the same class
+/// of defect as a fabricated number. Known codes get their symbol (mirroring
+/// `deepseek::format_money`); anything else renders as `AMOUNT CODE`, which is
+/// still truthful.
+pub fn fmt_minor(minor: i64, decimal_places: u32, currency: Option<&str>) -> String {
+    let scale = 10_u64.pow(decimal_places);
+    // `unsigned_abs`, not negation: `-i64::MIN` overflows. Unreachable from
+    // the wire (the parse gate rejects negatives) but this is a pub fn.
+    let sign = if minor < 0 { "-" } else { "" };
+    let abs = minor.unsigned_abs();
+    let number = if decimal_places == 0 {
+        format!("{abs}")
+    } else {
+        format!(
+            "{}.{:0width$}",
+            abs / scale,
+            abs % scale,
+            width = decimal_places as usize
+        )
+    };
+    match currency {
+        None | Some("USD") => format!("{sign}${number}"),
+        Some("BRL") => format!("{sign}R${number}"),
+        Some("EUR") => format!("{sign}€{number}"),
+        Some("GBP") => format!("{sign}£{number}"),
+        Some("JPY") | Some("CNY") => format!("{sign}¥{number}"),
+        Some(other) => format!("{sign}{number} {other}"),
+    }
+}
+
+/// ISO 4217 minor-unit digits for a currency when the payload omits
+/// `decimal_places`. Defaulting JPY to the historical 2 would divide every
+/// amount by 100 (¥500 shown as ¥5.00); unknown codes keep 2, the scale every
+/// observed payload without the field has used.
+pub fn default_decimal_places(currency: Option<&str>) -> u32 {
+    match currency {
+        Some("JPY") => 0,
+        _ => 2,
     }
 }
 
@@ -381,7 +447,7 @@ pub fn anthropic_severity(snap: &AnthropicSnapshot) -> crate::pacing::PaceSeveri
             .as_ref()
             .is_some_and(|s| s.utilization_pct >= 100)
         || snap.scoped.iter().any(|s| s.window.utilization_pct >= 100);
-    if any_at_cap && let Some(extra) = snap.extra {
+    if any_at_cap && let Some(extra) = snap.extra.as_ref() {
         let p = extra.percent();
         if p > max {
             max = p;
@@ -412,10 +478,48 @@ mod tests {
             sonnet: sonnet.map(w),
             scoped: vec![],
             extra: extra.map(|(limit, spent)| ExtraUsage {
-                limit: Cents(limit),
+                limit: Some(Cents(limit)),
                 spent: Cents(spent),
+                currency: None,
+                decimal_places: 2,
             }),
         }
+    }
+
+    #[test]
+    fn fmt_minor_honors_currency_and_scale() {
+        // No currency (older payloads) keeps the historical `$`.
+        assert_eq!(fmt_minor(250, 2, None), "$2.50");
+        // The #30 reporter's actual figures: BRL must not be claimed as `$`.
+        assert_eq!(fmt_minor(14157, 2, Some("BRL")), "R$141.57");
+        assert_eq!(fmt_minor(14157, 2, Some("USD")), "$141.57");
+        // Zero-exponent currency: no decimal point, no /100.
+        assert_eq!(fmt_minor(500, 0, Some("JPY")), "¥500");
+        // Sign precedes the symbol, matching `fmt_dollars`.
+        assert_eq!(fmt_minor(-150, 2, Some("BRL")), "-R$1.50");
+        // Unknown code stays truthful as a suffix rather than guessing a symbol.
+        assert_eq!(fmt_minor(1234, 2, Some("CHF")), "12.34 CHF");
+    }
+
+    #[test]
+    fn extra_usage_formats_in_its_own_currency() {
+        let e = ExtraUsage {
+            limit: None,
+            spent: Cents(14157),
+            currency: Some("BRL".into()),
+            decimal_places: 2,
+        };
+        assert_eq!(e.fmt_spent(), "R$141.57");
+        assert_eq!(e.fmt_limit(), None);
+
+        let capped = ExtraUsage {
+            limit: Some(Cents(5000)),
+            spent: Cents(250),
+            currency: None,
+            decimal_places: 2,
+        };
+        assert_eq!(capped.fmt_spent(), "$2.50");
+        assert_eq!(capped.fmt_limit().as_deref(), Some("$50.00"));
     }
 
     #[test]
@@ -437,8 +541,10 @@ mod tests {
     fn extra_percent_with_zero_limit_is_zero() {
         assert_eq!(
             ExtraUsage {
-                limit: Cents(0),
-                spent: Cents(100)
+                limit: Some(Cents(0)),
+                spent: Cents(100),
+                currency: None,
+                decimal_places: 2,
             }
             .percent(),
             0
@@ -450,8 +556,10 @@ mod tests {
         // Bash integer division — 33/100 -> 33%, 50/100 -> 50%.
         assert_eq!(
             ExtraUsage {
-                limit: Cents(10000),
-                spent: Cents(3333)
+                limit: Some(Cents(10000)),
+                spent: Cents(3333),
+                currency: None,
+                decimal_places: 2,
             }
             .percent(),
             33

--- a/src/widget/render.rs
+++ b/src/widget/render.rs
@@ -618,7 +618,7 @@ mod tests {
                 limit: Some(Cents(5000)),
                 spent: Cents(250),
                 currency: None,
-                decimal_places: 2,
+                decimal_places: Some(2),
             }),
         };
         FetchOutcome {

--- a/src/widget/render.rs
+++ b/src/widget/render.rs
@@ -15,7 +15,7 @@ use crate::pacing;
 use crate::pango::{self, color_span, escape, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{self, Line};
-use crate::usage::anthropic_severity;
+use crate::usage::{ExtraUsage, anthropic_severity};
 use crate::waybar::{Class, WaybarOutput};
 
 /// Default format string when `--format` is omitted (claudebar:55).
@@ -234,18 +234,24 @@ fn build_placeholders(input: &RenderInput) -> HashMap<&'static str, String> {
         (
             "extra_spent",
             snap.extra
-                .map(|e| e.spent.fmt_dollars())
+                .as_ref()
+                .map(ExtraUsage::fmt_spent)
                 .unwrap_or_default(),
         ),
         (
             "extra_limit",
+            // "—" (not empty) for an uncapped plan: GNOME and the macOS menu
+            // bar hide the whole extra row when this field is empty, which
+            // would hide real spend — the exact symptom of #30.
             snap.extra
-                .map(|e| e.limit.fmt_dollars())
+                .as_ref()
+                .map(|e| e.fmt_limit().unwrap_or_else(|| "—".into()))
                 .unwrap_or_default(),
         ),
         (
             "extra_pct",
             snap.extra
+                .as_ref()
                 .map(|e| e.percent().to_string())
                 .unwrap_or_else(|| "0".into()),
         ),
@@ -487,7 +493,7 @@ fn render_default_tooltip(input: &RenderInput) -> String {
         )));
     }
 
-    if let Some(extra) = snap.extra {
+    if let Some(extra) = snap.extra.as_ref() {
         let extra_color = pango::severity_color(severity_for(extra.percent()), theme);
         let extra_bar = pango::progress_bar(extra.percent(), extra_color, theme, None);
         lines.push(Line::Body("".into()));
@@ -499,11 +505,19 @@ fn render_default_tooltip(input: &RenderInput) -> String {
             "   {bar}  <span font_weight='bold' foreground='{color}'>{spent}</span>",
             bar = extra_bar,
             color = extra_color,
-            spent = escape(&extra.spent.fmt_dollars())
+            spent = escape(&extra.fmt_spent())
         )));
+        let lim = match extra.fmt_limit() {
+            Some(l) => l,
+            // No usable `monthly_limit` in the payload (null — observed for
+            // uncapped plans — or absent). "none reported" states exactly
+            // that; inferring a plan tier from it would overclaim, and a
+            // $0.00 ceiling would be invented.
+            None => "none reported".into(),
+        };
         lines.push(Line::Body(format!(
             " <span foreground='{dim}'>  󰀓  Limit: {lim}</span>",
-            lim = escape(&extra.limit.fmt_dollars())
+            lim = escape(&lim)
         )));
     }
 
@@ -601,8 +615,10 @@ mod tests {
             sonnet: Some(sonnet),
             scoped: vec![],
             extra: Some(ExtraUsage {
-                limit: Cents(5000),
+                limit: Some(Cents(5000)),
                 spent: Cents(250),
+                currency: None,
+                decimal_places: 2,
             }),
         };
         FetchOutcome {
@@ -625,6 +641,58 @@ mod tests {
             tooltip_pace_pts: false,
             now: now(),
         }
+    }
+
+    #[test]
+    fn uncapped_extra_usage_renders_spend_with_dash_limit() {
+        // The #30 shape: real spend, `monthly_limit: null`. The spend must
+        // stay visible and `{extra_limit}` must be "—", NOT empty — GNOME and
+        // the macOS menu bar hide the whole extra row on an empty limit,
+        // which would re-hide the spend the fix is recovering.
+        let mut oc = sample_outcome();
+        if let Some(e) = oc.snapshot.extra.as_mut() {
+            e.limit = None;
+            e.spent = Cents(14157);
+        }
+        let theme = Theme::default();
+        let mut inp = input(&oc, &theme);
+        inp.format = "{extra_spent}|{extra_limit}|{extra_pct}";
+        let out = render_anthropic(&inp);
+        assert!(out.text.contains("$141.57|—|0"), "got: {}", out.text);
+
+        // Default tooltip: spend shown, the missing limit stated as exactly
+        // that, and no fabricated "$0.00" anywhere near the extra block.
+        let inp2 = input(&oc, &theme);
+        let out2 = render_anthropic(&inp2);
+        assert!(out2.tooltip.contains("$141.57"));
+        assert!(out2.tooltip.contains("none reported"));
+        assert!(!out2.tooltip.contains("Limit: $0.00"));
+    }
+
+    #[test]
+    fn extra_usage_placeholders_and_tooltip_use_the_blocks_currency() {
+        // Non-vacuous currency pin: with BRL in the snapshot, formatting
+        // through fmt_dollars again ("$141.57") must fail this test — that is
+        // the wrong-currency claim the wiring exists to prevent.
+        let mut oc = sample_outcome();
+        if let Some(e) = oc.snapshot.extra.as_mut() {
+            e.limit = None;
+            e.spent = Cents(14157);
+            e.currency = Some("BRL".into());
+        }
+        let theme = Theme::default();
+        let mut inp = input(&oc, &theme);
+        inp.format = "{extra_spent}";
+        let out = render_anthropic(&inp);
+        assert!(out.text.contains("R$141.57"), "got: {}", out.text);
+        assert!(!out.text.contains("$141.57|"), "got: {}", out.text);
+
+        let inp2 = input(&oc, &theme);
+        let out2 = render_anthropic(&inp2);
+        assert!(
+            out2.tooltip.contains("R$141.57"),
+            "tooltip must carry the block's currency"
+        );
     }
 
     #[test]

--- a/tests/fixtures/anthropic_usage_full.json
+++ b/tests/fixtures/anthropic_usage_full.json
@@ -17,6 +17,7 @@
     "is_enabled": true,
     "monthly_limit": 5000,
     "used_credits": 250.0,
-    "currency": "USD"
+    "currency": "USD",
+    "decimal_places": 2
   }
 }

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -107,8 +107,10 @@ async fn anthropic_live() {
     if let Some(s) = out.snapshot.sonnet.as_ref() {
         assert_pct("anthropic.sonnet", s.utilization_pct);
     }
-    if let Some(e) = out.snapshot.extra {
-        assert!(e.limit.0 >= 0, "anthropic extra.limit < 0");
+    if let Some(e) = out.snapshot.extra.as_ref() {
+        if let Some(l) = e.limit {
+            assert!(l.0 >= 0, "anthropic extra.limit < 0");
+        }
         // spent can equal or exceed limit briefly during reconciliation; just sanity-check.
         assert!(e.spent.0 >= 0, "anthropic extra.spent < 0");
     }
@@ -120,7 +122,8 @@ async fn anthropic_live() {
         out.snapshot.sonnet.as_ref().map(|s| s.utilization_pct),
         out.snapshot
             .extra
-            .map(|e| (e.spent.fmt_dollars(), e.limit.fmt_dollars())),
+            .as_ref()
+            .map(|e| (e.fmt_spent(), e.fmt_limit())),
     );
 }
 


### PR DESCRIPTION
Fixes #30.

## The bug

The usage endpoint now sends `extra_usage.monthly_limit: null` for plans with no spending cap (e.g. Claude Pro). The conversion did `Cents(e.monthly_limit?)` inside the `and_then`, so the `?` discarded the **entire block** — including a perfectly valid `used_credits`. The reporter's R$ 141.57 of real credit spend vanished from every surface.

## The semantic argument

The strictness that discards the block came from the `f783f99` re-audit, and its principle is right: an enabled-but-incomplete block must not manufacture $0.00. But it conflated two different inputs:

| Input | Meaning | Correct behaviour |
|---|---|---|
| `monthly_limit: null` + valid `used_credits` | **no spending cap** — semantic, observed on Pro (#30) | show the spend, no invented percentage |
| `used_credits` missing/null | no spend datum | drop the block (nothing truthful to show) — unchanged |

`ExtraUsage.limit` is now `Option<Cents>`. The block is only dropped when `used_credits` itself is unusable. Nothing is fabricated in either direction: the spend shown is exactly what the API sent, still gated by the strict `de_opt_cents`, and with no denominator there is no percentage — the bar and severity stay calm at 0 instead of inventing one.

One deliberate call-out: with `#[serde(default)]` an *absent* `monthly_limit` is indistinguishable from an explicit null at the struct level, so both render spend-only. Distinguishing them would take a double-option deserializer whose only effect is hiding real spend when a secondary field drifts — the exact failure mode of #30. The rendered wording (`Limit: none reported`) is precisely true of both cases and deliberately does **not** say "uncapped plan", which would infer a plan tier the payload doesn't state.

## Per surface

- **widget**: `{extra_spent}` unchanged; `{extra_pct}` → `0`; `{extra_limit}` → `—`, deliberately **non-empty** — GNOME (`extension.js` checks `d.extra.limit` truthiness) and the macOS menu bar (`limit.isEmpty` in `parse`) hide the whole extra row on an empty limit, which would re-hide the spend this fix recovers. No JS/Swift changes needed.
- **tooltip**: spend in bold as before; `Limit: none reported`.
- **TUI panel**: the amount alone (no "of $X.XX"), footnote "no monthly limit reported".

## Currency (the second half of the reporter's payload)

His block says `currency: "BRL"`, and both `currency` and `decimal_places` were ignored — every amount went through `fmt_dollars`, hard-coded `$` and cents. R$ 141.57 would have rendered as **"$141.57"**, a claim about the wrong currency — the same defect class as a fabricated number. Now:

- known codes get their symbol (`$`, `R$`, `€`, `£`, `¥`), mirroring the per-currency match `deepseek::format_money` already established; unknown codes render as `AMOUNT CODE`, still truthful;
- zero-exponent currencies (JPY) format without an invented decimal point — including when `decimal_places` is absent, where a flat default of 2 would show ¥500 as ¥5.00 (the fallback is per-currency);
- payloads without the fields keep the exact historical `$`/cents output, so nothing changes for accounts the old code rendered correctly.

Both new wire fields are gated at the parse boundary like everything else in this file:

- `decimal_places`: integer in 0..=6 (covers all of ISO 4217). **Integral floats are tolerated** for the same reason `de_opt_cents` tolerates them — this endpoint floats its numbers (`used_credits: 14157.0` in the reporter's own payload), and rejecting `2.0` would fail the whole response *after* the fetch has already cached it, evicting the last good payload and leaving a persistent ⚠.
- `currency`: three ASCII uppercase letters. The value is embedded verbatim in Pango bar markup and in the `;;`-delimited desktop FORMAT protocol, so an arbitrary string is an injection vector besides being drift.

## Tests

- The reporter's actual cached fixture (integral-float BRL cents) exercised at all three layers: wire→snapshot, placeholder/tooltip render, TUI panel.
- The BRL assertions live at the **surface** layer on purpose: reverting the currency wiring in `render.rs`/`panels.rs` fails the suite, not just the unit layer.
- `enabled_incomplete_extra_usage_does_not_invent_zero_money`'s third case pinned the null-limit discard — the behaviour #30 demonstrates is wrong — and was replaced; the no-spend cases keep their pin in `enabled_extra_usage_without_spend_is_dropped`.
- Drift gates covered: `decimal_places` 7/-1/100/2.5 rejected, 2.0 accepted; currency `"brl"`/`""`/`"R$"`/`"USD;;0"`/`"<b>"` rejected.

Not consumed here: the new top-level `spend` block from the issue (`amount_minor`/`currency`/`exponent`). It's the cleaner source long-term, but switching the source of truth deserves its own PR — happy to follow up.

**Gate:** 551 tests, `cargo clippy --all-targets --locked -- -D warnings`, `cargo fmt --all --check`, GNOME marker tests, Swift menu bar compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
