### PR TITLE
fix(tooltip): count XML entities as one glyph; share the window block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Bordered tooltips no longer ragged-edge on rows containing an escaped
+  character: `visible_width` counted `&amp;` as five glyphs instead of one, so
+  every such row stopped short of the right border. Affects any vendor whose
+  API-supplied labels contain `&`, `<` or `>`.
+
 ### Added
 
 - The local Claude context monitor docks into the dashboard body instead of

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -8,9 +8,9 @@ use chrono::{DateTime, Utc};
 use crate::countdown;
 use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
-use crate::pango::{self, color_span, escape, severity_color, severity_for};
+use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
 use crate::usage::{OpenAiSnapshot, OpenAiSource};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -175,13 +175,27 @@ fn render_tooltip(
     lines.push(TooltipLine::Sep);
     lines.push(TooltipLine::Body("".into()));
 
-    push_window(&mut lines, "  󰔟  Codex 5h", &snap.session, theme, now);
+    push_window(&mut lines, "  󰔟  Codex 5h", &snap.session, theme, now, None);
     lines.push(TooltipLine::Body("".into()));
-    push_window(&mut lines, "  󰃰  Codex weekly", &snap.weekly, theme, now);
+    push_window(
+        &mut lines,
+        "  󰃰  Codex weekly",
+        &snap.weekly,
+        theme,
+        now,
+        None,
+    );
 
     if let Some(cr) = snap.code_review.as_ref() {
         lines.push(TooltipLine::Body("".into()));
-        push_window(&mut lines, "  󱦰  Code review (weekly)", cr, theme, now);
+        push_window(
+            &mut lines,
+            "  󱦰  Code review (weekly)",
+            cr,
+            theme,
+            now,
+            None,
+        );
     }
 
     if let Some(c) = snap.credits.as_ref() {
@@ -249,30 +263,6 @@ fn render_tooltip(
     )));
 
     render_bordered(&lines, theme)
-}
-
-fn push_window(
-    lines: &mut Vec<TooltipLine>,
-    label: &str,
-    w: &crate::usage::UsageWindow,
-    theme: &Theme,
-    now: DateTime<Utc>,
-) {
-    let color = severity_color(severity_for(w.utilization_pct), theme);
-    let bar = pango::progress_bar(w.utilization_pct, color, theme, None);
-    let fg = &theme.fg;
-    let dim = &theme.dim;
-    lines.push(TooltipLine::Body(format!(
-        " <span foreground='{fg}'>{label}</span>"
-    )));
-    lines.push(TooltipLine::Body(format!(
-        "   {bar}  <span font_weight='bold' foreground='{color}'>{pct}%</span>",
-        pct = w.utilization_pct
-    )));
-    lines.push(TooltipLine::Body(format!(
-        " <span foreground='{dim}'>  ⏱  Resets in {cd}</span>",
-        cd = escape(&countdown::format(w.resets_at, now))
-    )));
 }
 
 impl From<FetchOutcome> for VendorOutcome {

--- a/src/pango.rs
+++ b/src/pango.rs
@@ -136,15 +136,49 @@ fn repeat_char(c: char, n: u32) -> String {
 pub fn visible_width(s: &str) -> usize {
     let mut depth = 0usize;
     let mut count = 0usize;
-    for ch in s.chars() {
-        match ch {
-            '<' => depth += 1,
-            '>' if depth > 0 => depth = depth.saturating_sub(1),
-            _ if depth == 0 => count += 1,
-            _ => {}
-        }
+    let mut rest = s;
+    while let Some(ch) = rest.chars().next() {
+        let step = match ch {
+            '<' => {
+                depth += 1;
+                ch.len_utf8()
+            }
+            '>' if depth > 0 => {
+                depth -= 1;
+                ch.len_utf8()
+            }
+            // An entity such as "&amp;" is five bytes but one glyph; measuring
+            // it as five over-counts the line and ragged-edges the tooltip box.
+            '&' if depth == 0 => {
+                count += 1;
+                entity_len(rest).unwrap_or(ch.len_utf8())
+            }
+            _ => {
+                if depth == 0 {
+                    count += 1;
+                }
+                ch.len_utf8()
+            }
+        };
+        rest = &rest[step..];
     }
     count
+}
+
+/// Byte length of the XML entity starting at `s` (which begins with `&`), or
+/// `None` when this is a bare ampersand rather than an entity.
+fn entity_len(s: &str) -> Option<usize> {
+    let body = s.strip_prefix('&')?;
+    let end = body.find(';')?;
+    if end == 0 || end > 8 {
+        return None;
+    }
+    let name = &body[..end];
+    let named = name.chars().all(|c| c.is_ascii_alphanumeric());
+    let numeric = name
+        .strip_prefix('#')
+        .is_some_and(|d| !d.is_empty() && d.chars().all(|c| c.is_ascii_alphanumeric()));
+    (named || numeric).then_some(1 + end + 1)
 }
 
 #[cfg(test)]
@@ -248,5 +282,37 @@ mod tests {
     #[test]
     fn visible_width_handles_nested_tags() {
         assert_eq!(visible_width("<a><b>xy</b></a>"), 2);
+    }
+
+    /// An escaped character occupies one cell on screen. Counting its source
+    /// bytes instead left every tooltip row containing one short on padding.
+    #[test]
+    fn visible_width_counts_an_entity_as_one_glyph() {
+        assert_eq!(visible_width("&amp;"), 1);
+        assert_eq!(visible_width("Claude &amp; GPT"), 12);
+        assert_eq!(visible_width(escape("Claude & GPT").as_str()), 12);
+        assert_eq!(visible_width("&lt;&gt;&quot;&apos;"), 4);
+        assert_eq!(visible_width("&#38;"), 1);
+        assert_eq!(visible_width("<span>a &amp; b</span>"), 5);
+    }
+
+    #[test]
+    fn visible_width_treats_a_bare_ampersand_as_one_glyph() {
+        assert_eq!(visible_width("a & b"), 5);
+        assert_eq!(visible_width("&"), 1);
+        assert_eq!(visible_width("&;"), 2);
+        // Too long to be an entity, so every character counts.
+        assert_eq!(visible_width("&notanentityatall;"), 18);
+    }
+
+    #[test]
+    fn escaped_and_plain_labels_measure_the_same() {
+        for label in ["Claude & GPT (weekly)", "a<b>c", "quote\"d", "plain"] {
+            assert_eq!(
+                visible_width(escape(label).as_str()),
+                label.chars().count(),
+                "{label}"
+            );
+        }
     }
 }

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -8,8 +8,12 @@
 //! Mirrors the visual style of `claudebar`'s `${B}╭${border_h}╮${E}` block
 //! (claudebar:843-859).
 
-use crate::pango::visible_width;
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::pango::{self, escape, severity_color, severity_for, visible_width};
 use crate::theme::Theme;
+use crate::usage::UsageWindow;
 
 /// One row of the bordered tooltip box.
 pub enum Line {
@@ -19,6 +23,35 @@ pub enum Line {
     Body(String),
     /// A horizontal separator drawn with `─` characters.
     Sep,
+}
+
+/// Append the standard three-line block every vendor uses for a usage window:
+/// icon + label, progress bar + bold percentage, then the dim reset countdown.
+///
+/// `elapsed` draws the pace marker inside the bar; pass `None` for a plain bar.
+pub fn push_window(
+    lines: &mut Vec<Line>,
+    label: &str,
+    w: &UsageWindow,
+    theme: &Theme,
+    now: DateTime<Utc>,
+    elapsed: Option<i32>,
+) {
+    let color = severity_color(severity_for(w.utilization_pct), theme);
+    let bar = pango::progress_bar(w.utilization_pct, color, theme, elapsed);
+    let fg = &theme.fg;
+    let dim = &theme.dim;
+    lines.push(Line::Body(format!(
+        " <span foreground='{fg}'>{label}</span>"
+    )));
+    lines.push(Line::Body(format!(
+        "   {bar}  <span font_weight='bold' foreground='{color}'>{pct}%</span>",
+        pct = w.utilization_pct
+    )));
+    lines.push(Line::Body(format!(
+        " <span foreground='{dim}'>  ⏱  Resets in {cd}</span>",
+        cd = escape(&countdown::format(w.resets_at, now))
+    )));
 }
 
 /// Render the bordered tooltip. Width is computed from the widest body/center
@@ -93,6 +126,22 @@ mod tests {
         assert!(out.contains("╰"));
         assert!(out.contains("╯"));
         assert!(out.contains("Hi"));
+    }
+
+    /// Escaped characters are one glyph wide; if the box measured them by
+    /// source length, rows containing one would stop short of the right border.
+    #[test]
+    fn rows_with_escaped_characters_keep_the_border_flush() {
+        let lines = vec![
+            Line::Body(crate::pango::escape("Claude & GPT (weekly)")),
+            Line::Body("Gemini (weekly)".into()),
+        ];
+        let out = render_bordered(&lines, &theme());
+        let right_edges: Vec<usize> = out.lines().map(crate::pango::visible_width).collect();
+        assert!(
+            right_edges.windows(2).all(|w| w[0] == w[1]),
+            "ragged box: {right_edges:?}\n{out}"
+        );
     }
 
     #[test]

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -7,9 +7,9 @@ use chrono::{DateTime, Utc};
 use crate::countdown;
 use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::PaceSeverity;
-use crate::pango::{self, color_span, escape, severity_color, severity_for};
+use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
 use crate::usage::{UsageWindow, ZaiSnapshot};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -130,18 +130,18 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     if let Some(w) = snap.session.as_ref() {
-        push_window(&mut lines, "  󰔟  Session (5h)", w, theme, now);
+        push_window(&mut lines, "  󰔟  Session (5h)", w, theme, now, None);
     }
     if let Some(w) = snap.weekly.as_ref() {
         if snap.session.is_some() {
             lines.push(TooltipLine::Body("".into()));
         }
-        push_window(&mut lines, "  󰃰  Weekly", w, theme, now);
+        push_window(&mut lines, "  󰃰  Weekly", w, theme, now, None);
     }
     if let Some(w) = snap.mcp.as_ref() {
         lines.push(TooltipLine::Body("".into()));
         lines.push(TooltipLine::Sep);
-        push_window(&mut lines, "  󰓹  MCP tools (monthly)", w, theme, now);
+        push_window(&mut lines, "  󰓹  MCP tools (monthly)", w, theme, now, None);
     }
     if snap.session.is_none() && snap.weekly.is_none() && snap.mcp.is_none() {
         lines.push(TooltipLine::Body(format!(
@@ -176,30 +176,6 @@ fn render_tooltip(
     )));
 
     render_bordered(&lines, theme)
-}
-
-fn push_window(
-    lines: &mut Vec<TooltipLine>,
-    label: &str,
-    w: &UsageWindow,
-    theme: &Theme,
-    now: DateTime<Utc>,
-) {
-    let color = severity_color(severity_for(w.utilization_pct), theme);
-    let bar = pango::progress_bar(w.utilization_pct, color, theme, None);
-    let fg = &theme.fg;
-    let dim = &theme.dim;
-    lines.push(TooltipLine::Body(format!(
-        " <span foreground='{fg}'>{label}</span>"
-    )));
-    lines.push(TooltipLine::Body(format!(
-        "   {bar}  <span font_weight='bold' foreground='{color}'>{pct}%</span>",
-        pct = w.utilization_pct
-    )));
-    lines.push(TooltipLine::Body(format!(
-        " <span foreground='{dim}'>  ⏱  Resets in {cd}</span>",
-        cd = escape(&countdown::format(w.resets_at, now))
-    )));
 }
 
 impl From<FetchOutcome> for VendorOutcome {


### PR DESCRIPTION
Two changes to the shared tooltip primitives, independent of any vendor. First of a three-PR stack; the other two build on it.

## Scope

- `visible_width` measured markup by source characters, so an escaped character inflated the count: `&amp;` scored 5 instead of 1. Every bordered-tooltip row containing one was under-padded and stopped short of the right border, leaving a ragged box. Any vendor whose API-supplied labels can contain `&`, `<` or `>` is affected, since the label is escaped for Pango before the box is measured.
- A named or numeric entity now counts as one glyph. A bare `&` still counts as one character, as before.
- Extract the three-line usage-window block (icon + label, bar + percentage, dim reset countdown) that `zai/vendor.rs` and `openai/vendor.rs` had duplicated byte-for-byte into `tooltip::push_window`, with a new `elapsed` argument feeding the existing `pango::progress_bar` pace marker. Both existing callers pass `None`, so their rendered output is unchanged.

## Verification

Local gate:

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 550 tests passed (546 on `main`), 5 live tests ignored by design
- `cargo machete` passed
- `git diff --check` passed
- GNOME marker tests passed

New coverage: entity widths (`&amp;`, `&lt;`, `&quot;`, numeric `&#38;`), a bare ampersand and a non-entity `&…;` run, `escape(label)` measuring equal to the raw label for every label shape, and a `render_bordered` regression asserting every line of the box has the same visible width when one row contains an escaped character.

## Limitations

- The extraction is behaviour-preserving for `zai` and `openai` by construction (both pass `None`), so nothing pins their tooltips against a future change to `push_window` beyond their existing tests.
- CI on a fork PR needs maintainer approval to run.