### PR TITLE
fix(tui): redraw on terminal resize (maximize/restore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUI redraws on terminal resize.** The crossterm reader thread discarded
+  `Event::Resize`, so maximizing or restoring the terminal left the UI painted
+  in a corner of the alternate screen until a manual `R`. Resize events are now
+  forwarded to the main loop, which resizes the viewport and redraws.
+
 ## [0.17.1] — 2026-07-24
 
 ### Added

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -22,6 +22,7 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
 };
+use ratatui::layout::Rect;
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -127,15 +128,24 @@ where
     // raced each other on `event::read()`, so keypresses could be consumed by
     // an orphan and lost. A dedicated thread also means a slow branch can never
     // delay input.
-    let (key_tx, mut key_rx) = mpsc::unbounded_channel::<event::KeyEvent>();
+    //
+    // Resize must wake the loop too: discarding `Event::Resize` left the
+    // alternate screen at the previous paint size (UI stuck in a corner after
+    // maximize, or ghost cells after shrink) until a keypress forced a draw.
+    let (input_tx, mut input_rx) = mpsc::unbounded_channel::<InputEvent>();
     std::thread::spawn(move || {
         loop {
             // A blocking read is fine here: this thread does nothing else, and
             // the channel send wakes the runtime.
             match event::read() {
                 Ok(Event::Key(k)) => {
-                    if key_tx.send(k).is_err() {
+                    if input_tx.send(InputEvent::Key(k)).is_err() {
                         return; // receiver gone: the TUI is shutting down.
+                    }
+                }
+                Ok(Event::Resize(cols, rows)) => {
+                    if input_tx.send(InputEvent::Resize { cols, rows }).is_err() {
+                        return;
                     }
                 }
                 Ok(_) => {}
@@ -167,10 +177,22 @@ where
             _ = tick.tick() => {
                 spawn_all(app, client, config, &tx);
             }
-            // Keyboard events, delivered by the single reader thread.
-            maybe_key = key_rx.recv() => {
-                let Some(k) = maybe_key else {
+            // Keyboard + resize, delivered by the single reader thread.
+            maybe_input = input_rx.recv() => {
+                let Some(input) = maybe_input else {
                     return Ok(()); // reader thread ended: stdin closed.
+                };
+                let k = match input {
+                    InputEvent::Resize { cols, rows } => {
+                        // Prefer resize() over clear(): clear() snapshots the
+                        // cursor via DSR (\x1b[6n) and can hang/fail when the
+                        // terminal doesn't answer. resize() for Fullscreen
+                        // clears the viewport + resets the diff buffer without
+                        // that round-trip; the next draw fills the new area.
+                        terminal.resize(Rect::new(0, 0, cols, rows))?;
+                        continue;
+                    }
+                    InputEvent::Key(k) => k,
                 };
                 {
                     // On Windows Terminal (and terminals advertising the
@@ -276,6 +298,12 @@ where
             return Ok(());
         }
     }
+}
+
+/// Crossterm events the dedicated reader thread forwards into the async loop.
+enum InputEvent {
+    Key(event::KeyEvent),
+    Resize { cols: u16, rows: u16 },
 }
 
 fn spawn_context_scan(

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -22,11 +22,11 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::event::{
     self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind, KeyModifiers,
 };
-use ratatui::layout::Rect;
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
+use ratatui::layout::Rect;
 use reqwest::Client;
 use tokio::sync::mpsc;
 


### PR DESCRIPTION
## Symptom

Resizing the terminal (fullscreen → restore → maximize again) leaves the TUI painted in a corner of the alternate screen. Pressing `R` redraws correctly; maximize alone does not.

## Root cause

The dedicated crossterm reader thread only forwarded `Event::Key`. `Event::Resize` was discarded (`Ok(_) => {}`), so the `select!` loop never woke and `terminal.draw` never ran after a size change. This gap dates from the reader-thread refactor in #26 — even before that, the poll path only accepted `Event::Key`.

## Fix

- Forward `Event::Resize { cols, rows }` over the same channel as keys.
- On resize, call `terminal.resize(Rect::…)` so Fullscreen clears the viewport and resets the diff buffer; the next loop iteration draws into the new area.
- Prefer `resize()` over `clear()`: `clear()` snapshots the cursor via DSR (`\x1b[6n`) and can hang/fail when the terminal does not answer.

Surgical change only (`+33/−5` in `src/bin/ai-usagebar-tui.rs`); key-handling paths untouched.

## Test plan

- [x] A/B: build without the patch → maximize/restore sticks in the corner until `R`
- [x] Build with the patch → maximize/restore redraws without `R`
- [x] PTY smoke: grow 80×24→160×40 and shrink back; process stays alive, redraw bytes emitted, clean quit
- [x] `cargo test` / `cargo clippy --all-targets -- -D warnings` (local gate green)