### PR TITLE
feat: add Cursor vendor (usage-summary two-pool model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Each release is also published at
   menu bar app** (its two pools relabel the session/weekly bars as "Cursor
   Models" / "Other Models"), and the config-example/README docs. Adds a
   `rusqlite` (bundled) dependency. Not wired into the GNOME extension yet.
+  **Team accounts** (`membershipType` with no `individualUsage.plan`) are now
+  parsed too, via the auto/named "You've used N% of your included … usage"
+  display-message strings the payload also carries — the only percentage
+  source Cursor exposes for those accounts, per an independent
+  reverse-engineering of the same endpoint. Unverified against a live team
+  account (labeled `"<Plan> (team)"` in the UI so it's visibly a best-effort
+  path); falls back to the existing schema error rather than a fabricated
+  0% if the display messages don't parse.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Cursor vendor.** Shows this billing cycle's two included-usage pools —
+  **Cursor Models** (Auto + Composer) and **Other Models** (named / API) — as
+  percentages, from `GET cursor.com/api/usage-summary`, the same undocumented
+  endpoint the Cursor dashboard's own frontend calls. Also surfaces the plan
+  (`membershipType`), the billing-cycle reset, whether on-demand spend is on,
+  and unlimited plans. No API key: the session token is read **read-only** from
+  the local `state.vscdb` SQLite database the Cursor IDE already wrote after you
+  signed in there (the JWT's `sub` claim yields the user id; combined with the
+  raw token it forms the `WorkosCursorSessionToken` cookie the endpoint
+  expects). Opt-in (`[cursor] enabled = true`) and wired into the Waybar widget,
+  `--vendor cursor`, the TUI panel (a bar per pool), scroll-cycling, **the macOS
+  menu bar app** (its two pools relabel the session/weekly bars as "Cursor
+  Models" / "Other Models"), and the config-example/README docs. Adds a
+  `rusqlite` (bundled) dependency. Not wired into the GNOME extension yet.
+
 ### Fixed
 
 - **A failed terminal resize no longer exits the TUI.** A transient

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +39,7 @@ dependencies = [
  "ratatui-bubbletea-components",
  "ratatui-bubbletea-theme",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -582,6 +595,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +804,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -806,6 +840,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1202,6 +1245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1624,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1958,6 +2018,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2692,6 +2766,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ base64 = "0.22"
 ratatui = "0.30.1"
 ratatui-bubbletea-components = "0.1"
 ratatui-bubbletea-theme = "0.1"
+# Reads Cursor's local `state.vscdb` (its own on-disk session store) to find
+# the OAuth token the Cursor IDE already wrote there. "bundled" statically
+# links SQLite via cc, so no system libsqlite3-dev is required — keeping the
+# AUR source build's hermeticity (see CLAUDE.md's release checklist).
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ When an endpoint drifts, **run `make smoke`**. It runs all ignored vendor tests,
 
 `{cursor_plan}`, `{cursor_auto_pct}`, `{cursor_api_pct}`, `{cursor_total_pct}`, `{cursor_reset}`, `{cursor_on_demand}`, `{cursor_unlimited}` — this billing cycle's two included-usage pools from `cursor.com/api/usage-summary`: `cursor_auto_pct` is **Cursor Models** (Auto + Composer) and `cursor_api_pct` is **Other Models** (named / API), matching the two bars on the Cursor dashboard. `cursor_total_pct` is the overall included-usage headline; `cursor_on_demand` is `on`/`off`; `cursor_unlimited` is `yes`/`no`. A pool can read above 100% when it is over its included allowance. The default bar format is `{cursor_auto_pct}·{cursor_api_pct}%` (e.g. `98·100%`), colored by whichever pool is worst. Generic aliases: `{session_pct}` = Cursor Models, `{weekly_pct}` = Other Models, `{plan}` = `Cursor <Plan>`.
 
-> Cursor's dashboard also reports usage-based (overage) spend and, for team accounts, per-member spend. Neither is tracked here — this vendor mirrors the two included-usage bars the dashboard shows. Team accounts (whose usage lives under `teamUsage`) aren't parsed yet.
+> Cursor's dashboard also reports usage-based (overage) spend and, for team accounts, per-member spend. Neither is tracked here — this vendor mirrors the two included-usage bars the dashboard shows. Team accounts (which report no `individualUsage.plan`) are parsed too, falling back to the payload's "You've used N%…" display-message strings for the two pools — the plan label gets a `(team)` suffix so it's visibly a best-effort path, since this has not been verified against a live team account.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This started as a Rust port of [`claudebar`](https://github.com/mryll/claudebar)
 - **Tabbed TUI** (`ai-usagebar-tui`) with Tab/h/l switching, per-tab refresh, and 60-second auto-refresh. Native ratatui widgets fill the available terminal width and keep the vendor tabs visually consistent.
 - **Optional local Claude Code context monitor** in the TUI, with a bounded,
   compaction-aware view of recent session input-context usage.
-- **Native desktop integrations** for GNOME Shell and the macOS menu bar. The macOS app supports eleven vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok, Anthropic API); the GNOME extension adds Google Antigravity.
+- **Native desktop integrations** for GNOME Shell and the macOS menu bar. The macOS app supports twelve vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok, Anthropic API, Cursor); the GNOME extension covers Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity. (Antigravity is Linux-only; Cursor isn't in the GNOME extension yet.)
 - **Scroll-to-cycle on the bar**: wire `on-scroll-up` / `on-scroll-down`, and one bar item cycles through your enabled vendors.
 - **Config-driven primary vendor**: set `[ui] primary` once; the widget shows that vendor by default and the TUI opens on its tab.
 - **Local testing tools**: `--pretty` renders ANSI-colored terminal output (auto-detects TTY), and `--watch N` re-renders every N seconds.
@@ -89,6 +89,7 @@ Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth c
 | Moonshot | API key (`MOONSHOT_API_KEY` env or `[moonshot] api_key` in config) | Set either. Opt-in. Set `[moonshot] region = "cn"` for `api.moonshot.cn` (balance in CNY); the default `"global"` uses `api.moonshot.ai` (USD). |
 | Grok (xAI) | **Management** key (`XAI_MANAGEMENT_KEY` env or `[grok] api_key` in config) | Set either. Opt-in. This is **not** the inference key — create it under xAI Console → Management keys. See the team note below. |
 | Google Antigravity | None — read from the local Antigravity server | Opt-in. Quota is served only while Antigravity 2.0, the Antigravity IDE, or an interactive `agy` session is running; all three share one account-wide quota. |
+| Cursor | None — read from Cursor's local `state.vscdb` | Opt-in. Sign in to the Cursor IDE at least once; ai-usagebar reads the session token it already wrote there. No key of your own to create. |
 
 #### Grok: team-scoped vs organization-scoped keys
 
@@ -109,7 +110,7 @@ rather than silently querying the wrong URL.
 ### Enabling a vendor
 
 `enabled = true` is what makes a vendor fetch. Anthropic (API), DeepSeek, Kimi,
-Kilo, Novita, Moonshot, Grok, and Antigravity all default to **disabled** so that existing
+Kilo, Novita, Moonshot, Grok, Antigravity, and Cursor all default to **disabled** so that existing
 installs are unaffected until you opt in. Two ways to do it:
 
 - **Via the TUI Settings overlay** (`ai-usagebar-tui`, then `s`): saving a
@@ -133,6 +134,7 @@ For each API-key vendor, ai-usagebar checks in this order:
 - If you put inline `api_key` values in config, `chmod 600 ~/.config/ai-usagebar/config.toml`. The default behavior reads only env vars, which is safer when your config might be world-readable.
 - Don't commit your config dir if you check it into dotfiles unless you've redacted `api_key` lines.
 - OAuth credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`) are managed by their respective CLIs and already chmod-protected.
+- Cursor's session token lives in its own `state.vscdb`, managed entirely by the Cursor IDE — ai-usagebar opens it read-only and never writes to it.
 
 #### macOS: Anthropic credentials in the Keychain
 
@@ -149,7 +151,7 @@ On macOS, recent Claude Code builds don't write `~/.claude/.credentials.json` �
 # Only a vendor that is enabled can be primary.
 # primary = "anthropic"   # anthropic | anthropic_api | openai | zai
 #                         # | openrouter | deepseek | kimi | kilo | novita
-#                         # | moonshot | grok
+#                         # | moonshot | grok | antigravity | cursor
 
 [context]
 enabled = false           # opt in, then press c in ai-usagebar-tui
@@ -219,6 +221,12 @@ api_key_env = "XAI_MANAGEMENT_KEY"
 # api_key = "..."          # used if XAI_MANAGEMENT_KEY is unset; chmod 600 the file!
 # Required for organization-scoped keys; auto-resolved for team-scoped ones.
 # team_id = "..."
+
+[cursor]
+enabled = true             # disabled by default; enable once you've signed in to Cursor
+# No API key: reads the session token the Cursor IDE already wrote to its own
+# state.vscdb after you signed in there.
+# db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"
 ```
 
 ## Quick start
@@ -261,7 +269,7 @@ The Waybar widget is optional. The TUI is the best way to see every enabled vend
 
 ## Native desktop integrations
 
-The [macOS menu bar app](macos/README.md) supports eleven vendors — **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok (xAI), and Anthropic (API)**. The [GNOME Shell extension](gnome-extension/README.md) supports **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity**, whose two independent quota pools it renders as grouped rows. macOS does not support Antigravity: the binary only discovers its local server on Linux.
+The [macOS menu bar app](macos/README.md) supports twelve vendors — **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok (xAI), Anthropic (API), and Cursor**. The [GNOME Shell extension](gnome-extension/README.md) supports **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity**, whose two independent quota pools it renders as grouped rows. macOS does not support Antigravity: the binary only discovers its local server on Linux. Cursor is not in the GNOME extension yet — use `ai-usagebar --vendor cursor` or the TUI there.
 
 ## Waybar config
 
@@ -284,7 +292,7 @@ Use one bar item and scroll through your vendors. The TUI on-click still shows t
 }
 ```
 
-The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` / `gpt` / `zai` / `opr` / `dsk` / `kmi` / `klo` / `nvt` / `msh` / `grk` / `aac` / `agy`), so the bar text tells you which vendor is active. The other usage placeholders (`{session_pct}` for Anthropic, `{oai_session_pct}` for OpenAI, etc.) are vendor-specific. If you want one format string for every cycled vendor, prefer the generic aliases: `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}` are implemented by all seven usage vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, and Antigravity; OpenRouter and DeepSeek use `0` / `—` for the windows they don't expose). Anthropic and OpenAI add `*_elapsed`, `*_pace`, and `*_bar` families; Antigravity adds `*_elapsed` for all four of its windows, plus `{session_model}` / `{weekly_model}` / `{scoped_model}` / `{extra_model}`, which name the model group each row belongs to (vendors with a single quota pool leave them empty). The established API-backed vendors also expose their own `{oai_*}` / `{zai_*}` / `{or_*}` / `{ds_*}` / `{kimi_*}` families, which expand to empty strings for vendors that don't define them.
+The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` / `gpt` / `zai` / `opr` / `dsk` / `kmi` / `klo` / `nvt` / `msh` / `grk` / `aac` / `agy` / `cur`), so the bar text tells you which vendor is active. The other usage placeholders (`{session_pct}` for Anthropic, `{oai_session_pct}` for OpenAI, etc.) are vendor-specific. If you want one format string for every cycled vendor, prefer the generic aliases: `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}` are implemented by all eight usage vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Antigravity, and Cursor; OpenRouter and DeepSeek use `0` / `—` for the windows they don't expose). Cursor has no time windows but two usage *pools*, so it maps them onto the two generic slots: `session_pct` = **Cursor Models** (Auto + Composer), `weekly_pct` = **Other Models** (named / API), both resetting on the billing cycle. Anthropic and OpenAI add `*_elapsed`, `*_pace`, and `*_bar` families; Antigravity adds `*_elapsed` for all four of its windows, plus `{session_model}` / `{weekly_model}` / `{scoped_model}` / `{extra_model}`, which name the model group each row belongs to (vendors with a single quota pool leave them empty). The established API-backed vendors also expose their own `{oai_*}` / `{zai_*}` / `{or_*}` / `{ds_*}` / `{kimi_*}` families, which expand to empty strings for vendors that don't define them.
 
 `signal: 13` lets the scroll-cycle commands refresh the bar instantly (via `SIGRTMIN+13`) instead of waiting for the next 300s interval.
 
@@ -462,10 +470,11 @@ Then `hyprctl reload` (no logout needed).
 | **Moonshot** | `api.moonshot.ai\|.cn/v1/users/me/balance` (documented) | Account balance ($ on `.ai`, ¥ on `.cn`) | No — widget/TUI only |
 | **Grok (xAI)** | `management-api.x.ai/v1/billing/teams/{team}/prepaid/balance` (Management API; documented) | Prepaid credit balance ($) | No — widget/TUI only |
 | **Anthropic (API)** | `api.anthropic.com/v1/organizations/cost_report` (Admin API; documented) | Month-to-date spend ($, excludes Priority Tier), optional spend-vs-limit % | No — widget/TUI only |
+| **Cursor** | `cursor.com/api/usage-summary` (undocumented; the dashboard's own frontend) | Two included-usage pools this billing cycle — Cursor Models (Auto/Composer) % and Other Models (named/API) % — plus plan, reset, on-demand | Yes |
 
 ### Endpoint stability
 
-Four of the six endpoints are undocumented. The Anthropic and OpenAI endpoints are used by their official CLIs (`claude` and `codex`), so removing them would break those tools too. That makes them less shaky than scraped web endpoints. Z.AI's monitor endpoint is reverse-engineered from a third-party plugin; treat it as the most fragile one. Kimi's `/coding/v1/usages` is community-confirmed and used by third-party quota tools; treat it as drift-prone.
+Four of the six endpoints are undocumented. The Anthropic and OpenAI endpoints are used by their official CLIs (`claude` and `codex`), so removing them would break those tools too. That makes them less shaky than scraped web endpoints. Z.AI's monitor endpoint is reverse-engineered from a third-party plugin; treat it as the most fragile one. Kimi's `/coding/v1/usages` is community-confirmed and used by third-party quota tools; treat it as drift-prone. Cursor's `/api/usage-summary` has no official docs and is the endpoint the dashboard's own frontend calls — treat it as drift-prone too (its shape tracks Cursor's pricing, which has changed before).
 
 OpenAI's known 5-hour and 7-day windows are identified from each window's
 reported duration, not from `primary_window` / `secondary_window` position.
@@ -530,6 +539,12 @@ When an endpoint drifts, **run `make smoke`**. It runs all ignored vendor tests,
 `{aapi_headline}`, `{aapi_spent}`, `{aapi_limit}`, `{aapi_pct}` — month-to-date spend for the API/Console account from the Admin API `cost_report`. The headline is `$1.34 / $1000 · 0%` when a positive, finite `monthly_limit` is set in config, `$1.34/mo` otherwise. Generic aliases `{plan}`, `{session_pct}`, and `{weekly_pct}` are also available (the last two both map to the spend-vs-limit %).
 
 > **Two things this figure is not.** It is **spend**, not remaining credit — Anthropic exposes no API for the prepaid balance, which is visible only on the Console dashboard. And per the [Cost API docs](https://platform.claude.com/docs/en/manage-claude/usage-cost-api) it **omits Priority Tier costs**, so an organization on Priority Tier is seeing less than its true total spend.
+
+### Cursor
+
+`{cursor_plan}`, `{cursor_auto_pct}`, `{cursor_api_pct}`, `{cursor_total_pct}`, `{cursor_reset}`, `{cursor_on_demand}`, `{cursor_unlimited}` — this billing cycle's two included-usage pools from `cursor.com/api/usage-summary`: `cursor_auto_pct` is **Cursor Models** (Auto + Composer) and `cursor_api_pct` is **Other Models** (named / API), matching the two bars on the Cursor dashboard. `cursor_total_pct` is the overall included-usage headline; `cursor_on_demand` is `on`/`off`; `cursor_unlimited` is `yes`/`no`. A pool can read above 100% when it is over its included allowance. The default bar format is `{cursor_auto_pct}·{cursor_api_pct}%` (e.g. `98·100%`), colored by whichever pool is worst. Generic aliases: `{session_pct}` = Cursor Models, `{weekly_pct}` = Other Models, `{plan}` = `Cursor <Plan>`.
+
+> Cursor's dashboard also reports usage-based (overage) spend and, for team accounts, per-member spend. Neither is tracked here — this vendor mirrors the two included-usage bars the dashboard shows. Team accounts (whose usage lives under `teamUsage`) aren't parsed yet.
 
 ## Local development
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -167,3 +167,22 @@ api_key_env = "XAI_MANAGEMENT_KEY" # checked first; if set + non-empty, used
 # "host:port" only if auto-discovery of that local server ever fails.
 [antigravity]
 enabled = false
+
+# Cursor. No API key: usage is read from the session token the Cursor IDE
+# already wrote to its own local state database after you signed in there —
+# no separate login step for ai-usagebar. Shows this billing cycle's two
+# included-usage pools — "Cursor Models" (Auto + Composer) and "Other Models"
+# (named / API) — from the undocumented cursor.com/api/usage-summary endpoint
+# (the same one the Cursor dashboard itself calls).
+[cursor]
+# Disabled by default — enable once you've signed in to the Cursor IDE at
+# least once (it needs no key from you, but it does need that one-time login
+# to exist).
+enabled = false
+# Override Cursor's local state database path. Leave commented out to use the
+# platform default:
+#   Linux:   ~/.config/Cursor/User/globalStorage/state.vscdb
+#   macOS:   ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
+#   Windows: %APPDATA%\Cursor\User\globalStorage\state.vscdb
+# Set this if you use a portable Cursor install or a renamed profile dir.
+# db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -344,6 +344,15 @@ struct Snapshot {
     /// Label for that bar: the scoped model name ("Fable") or "Sonnet only".
     let sonnetLabel: String
     let extra: (pct: Int, spent: String, limit: String)?
+    /// Overridable labels for the session/weekly bars. Default to the
+    /// time-window names; a vendor whose two windows aren't time-based (Cursor:
+    /// "Cursor Models" / "Other Models") sets its own. Tags are the 2-char
+    /// prefixes shown on the compact status bar. Defaulted so every other
+    /// vendor's construction is unchanged.
+    var sessionTag: String = "5h"
+    var weeklyTag: String = "7d"
+    var sessionLabel: String = "Session"
+    var weeklyLabel: String = "Weekly"
 }
 
 func stripMarkup(_ s: String) -> String {
@@ -439,6 +448,11 @@ func parse(_ text: String, vendor: String) -> Snapshot? {
     // With a limit configured the spend-vs-limit bar replaces the headline, so
     // avoid showing both the "cr" balance and the extra ($) row at once.
     let displayBalance = aapiExtra == nil ? balance : nil
+    // Cursor carries its two included-usage pools on the session/weekly
+    // aliases (session = Cursor Models, weekly = Other Models — both real, not
+    // time windows), so relabel those bars rather than call them "Session"/
+    // "Weekly". Every other vendor keeps the default time-window labels.
+    let isCursor = vendor == "cursor"
     return Snapshot(plan: t(0),
                     hasUsageWindows: !balanceOnly,
                     creditBalance: displayBalance,
@@ -446,7 +460,11 @@ func parse(_ text: String, vendor: String) -> Snapshot? {
                     weekly: quotaWindow(3, 4, 14),
                     sonnet: sonnet,
                     sonnetLabel: sonnetLabel,
-                    extra: aapiExtra ?? extra)
+                    extra: aapiExtra ?? extra,
+                    sessionTag: isCursor ? "auto" : "5h",
+                    weeklyTag: isCursor ? "premium" : "7d",
+                    sessionLabel: isCursor ? "Cursor Models" : "Session",
+                    weeklyLabel: isCursor ? "Other Models" : "Weekly")
 }
 
 // ─── Preferences UI (SwiftUI) ────────────────────────────────────────────
@@ -489,6 +507,11 @@ let VENDOR_AUTH: [VendorAuth] = [
     VendorAuth(id: "moonshot", name: "Moonshot", kind: "apikey", cli: "", login: "", pkg: "", env: "MOONSHOT_API_KEY"),
     VendorAuth(id: "grok", name: "Grok (xAI)", kind: "apikey", cli: "", login: "", pkg: "", env: "XAI_MANAGEMENT_KEY"),
     VendorAuth(id: "anthropic_api", name: "Anthropic (API)", kind: "apikey", cli: "", login: "", pkg: "", env: "ANTHROPIC_ADMIN_KEY"),
+    // Cursor has no API key: the binary reads the session token the Cursor IDE
+    // wrote to its own state.vscdb. `kind: "local"` marks the "configured =
+    // signed in to the app" case (like Antigravity in the GNOME extension),
+    // with no login CLI or env var of its own.
+    VendorAuth(id: "cursor", name: "Cursor", kind: "local", cli: "", login: "", pkg: "", env: ""),
 ]
 
 // The config file the Rust binary would actually read. On macOS
@@ -569,7 +592,7 @@ func apiKeyEnvironment(_ v: VendorAuth) -> String {
 func defaultEnabled(_ id: String) -> Bool {
     switch id {
     case "anthropic", "openai", "zai", "openrouter": return true
-    case "deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api": return false
+    case "deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor": return false
     default: return true
     }
 }
@@ -597,6 +620,13 @@ func vendorConfigured(_ v: VendorAuth) -> Bool {
     }
     if v.id == "openai" {
         return fm.fileExists(atPath: "\(home)/.codex/auth.json")
+    }
+    if v.id == "cursor" {
+        // Configured == signed in to the Cursor IDE, i.e. its state DB exists.
+        // Honor a [cursor] db_path override the same way the binary does.
+        let dbPath = configValueTOML("cursor", "db_path")
+            ?? "\(home)/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+        return fm.fileExists(atPath: dbPath)
     }
     if let e = ProcessInfo.processInfo.environment[apiKeyEnvironment(v)], !e.isEmpty { return true }
     return configHasApiKeyTOML(v.id)
@@ -659,6 +689,15 @@ func openTuiInTerminal() {
     runInTerminal("\"\(tui)\"\necho\nread -p \"Enter para fechar...\"")
 }
 
+// Launch a .app by name (e.g. "Cursor") via `open -a`, so a local-kind vendor's
+// button can bring the user to the app they need to sign into.
+func openApp(_ name: String) {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    p.arguments = ["-a", name]
+    try? p.run()
+}
+
 struct VendorsSection: View {
     @State private var configured: [String: Bool] = [:]
     @State private var cliPresent: [String: Bool] = [:]
@@ -711,6 +750,11 @@ struct VendorsSection: View {
             if cliPresent[v.id] == false { return "⚠ \(v.cli) não instalado" }
             return "⚠ Não logado — \(v.login)"
         }
+        // Local vendors (Cursor) have no key: "configured" means signed in to
+        // the app AND [cursor] enabled in config.
+        if v.kind == "local" {
+            return "⚠ Entre no app Cursor e ative [cursor] no config"
+        }
         return "⚠ Sem API key — \(apiKeyEnvironment(v))"
     }
 
@@ -720,11 +764,13 @@ struct VendorsSection: View {
             if cliPresent[v.id] == false { return "Instalar + logar" }
             return "Logar"
         }
+        if v.kind == "local" { return "Abrir Cursor" }
         return "Configurar (TUI)"
     }
 
     private func action(_ v: VendorAuth) {
         if v.kind == "oauth" { runInTerminal(oauthScript(v)) }
+        else if v.kind == "local" { openApp(v.name) }
         else { openTuiInTerminal() }
         DispatchQueue.main.asyncAfter(deadline: .now() + 4) { refresh() }
     }
@@ -1054,10 +1100,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             title.append(run("cr ", secondaryTextColor))
             title.append(run(creditBalance, primaryTextColor))
         } else if s.hasUsageWindows && SHOW_SESSION, let session = s.session {
-            seg("5h", session.pct, "\(session.pct)%", session.elapsed)
+            seg(s.sessionTag, session.pct, "\(session.pct)%", session.elapsed)
         }
         if s.creditBalance == nil && s.hasUsageWindows && SHOW_WEEKLY, let weekly = s.weekly {
-            seg("7d", weekly.pct, "\(weekly.pct)%", weekly.elapsed)
+            seg(s.weeklyTag, weekly.pct, "\(weekly.pct)%", weekly.elapsed)
         }
         if SHOW_EXTRA, let e = s.extra { seg("ex", e.pct, e.spent, nil) } // $ budget → no meta
         statusItem.button?.attributedTitle = title.length > 0 ? title : run("ai", secondaryTextColor)
@@ -1088,10 +1134,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             rows["sonnet"]?.isHidden = true
         } else {
             if s.hasUsageWindows, let session = s.session {
-                row("session", "Session", session.pct, "\(session.pct)%", session.reset, session.elapsed)
+                row("session", s.sessionLabel, session.pct, "\(session.pct)%", session.reset, session.elapsed)
             } else { rows["session"]?.isHidden = true }
             if s.hasUsageWindows, let weekly = s.weekly {
-                row("weekly", "Weekly", weekly.pct, "\(weekly.pct)%", weekly.reset, weekly.elapsed)
+                row("weekly", s.weeklyLabel, weekly.pct, "\(weekly.pct)%", weekly.reset, weekly.elapsed)
             } else { rows["weekly"]?.isHidden = true }
         }
         if let sn = s.sonnet { row("sonnet", s.sonnetLabel, sn.pct, "\(sn.pct)%", sn.reset, sn.elapsed) }

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -168,7 +168,7 @@ func testDefaultEnabled() {
     for id in ["anthropic", "openai", "zai", "openrouter"] {
         assertEqual(defaultEnabled(id), true, "\(id) defaults enabled")
     }
-    for id in ["deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api"] {
+    for id in ["deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor"] {
         assertEqual(defaultEnabled(id), false, "\(id) defaults disabled (opt-in)")
     }
 }
@@ -256,6 +256,26 @@ func testParserBalances() {
     assertEqual(cld?.hasUsageWindows, true, "anthropic shows windows")
     assertNil(cld?.creditBalance, "anthropic has no balance")
     assertEqual(cld?.session?.pct, 42, "anthropic session pct")
+
+    // Cursor: two included-usage pools carried on the session/weekly aliases
+    // (session = Cursor Models, weekly = Other Models), both real, no balance.
+    // The bars are relabeled away from the "Session"/"Weekly" time-window names.
+    let cur = snapshot(FORMAT, vendor: "cursor",
+                       fields: fields(through: 16, set: [
+                          0: "Cursor Ultra", 1: "98", 2: "8d", 3: "100", 4: "8d", 16: "cur"
+                       ]))
+    assertEqual(cur?.hasUsageWindows, true, "cursor shows windows")
+    assertNil(cur?.creditBalance, "cursor has no balance")
+    assertEqual(cur?.session?.pct, 98, "cursor Cursor Models pct")
+    assertEqual(cur?.weekly?.pct, 100, "cursor Other Models pct")
+    assertEqual(cur?.sessionLabel, "Cursor Models", "cursor relabels the session bar")
+    assertEqual(cur?.weeklyLabel, "Other Models", "cursor relabels the weekly bar")
+    assertEqual(cur?.sessionTag, "auto", "cursor session tag")
+    assertEqual(cur?.weeklyTag, "premium", "cursor weekly tag")
+
+    // A non-Cursor vendor keeps the default time-window labels.
+    assertEqual(cld?.sessionLabel, "Session", "anthropic keeps the Session label")
+    assertEqual(cld?.weeklyTag, "7d", "anthropic keeps the 7d tag")
 }
 
 // ─── Run ─────────────────────────────────────────────────────────────────

--- a/src/active.rs
+++ b/src/active.rs
@@ -111,6 +111,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "moonshot" => Some(VendorId::Moonshot),
         "grok" => Some(VendorId::Grok),
         "antigravity" => Some(VendorId::Antigravity),
+        "cursor" => Some(VendorId::Cursor),
         _ => None,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub moonshot: MoonshotConfig,
     pub grok: GrokConfig,
     pub antigravity: AntigravityConfig,
+    pub cursor: CursorConfig,
 }
 
 /// UI / dispatch preferences. Currently just `primary` — which vendor the
@@ -418,6 +419,25 @@ pub struct AntigravityConfig {
     pub enabled: bool,
 }
 
+/// Cursor reads its quota through a session token the Cursor IDE already
+/// wrote to its local `state.vscdb` — no API key, but (unlike Antigravity)
+/// there is a real on-disk path that can need overriding (e.g. a portable or
+/// non-default Cursor install), mirroring `openai.codex_auth_path`.
+///
+/// Opt-in like DeepSeek/Kilo/etc (`enabled` defaults to `false`, matching
+/// `bool::default()`): reads an undocumented endpoint via a session token
+/// scraped from a local IDE file, so it stays off until the user explicitly
+/// turns it on.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CursorConfig {
+    pub enabled: bool,
+    /// Override Cursor's local state database path (defaults to the
+    /// platform-standard `.../User/globalStorage/state.vscdb` — see
+    /// `cursor::db::default_db_path`).
+    pub db_path: Option<PathBuf>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct AnthropicApiConfig {
@@ -513,6 +533,7 @@ impl Config {
         expand_tilde_opt(&mut self.context.projects_path);
         expand_tilde_opt(&mut self.anthropic.credentials_path);
         expand_tilde_opt(&mut self.openai.codex_auth_path);
+        expand_tilde_opt(&mut self.cursor.db_path);
         for account in &mut self.anthropic.accounts {
             account.credentials_path = expand_tilde(&account.credentials_path);
         }
@@ -532,6 +553,7 @@ impl Config {
             VendorId::Moonshot => self.moonshot.enabled,
             VendorId::Grok => self.grok.enabled,
             VendorId::Antigravity => self.antigravity.enabled,
+            VendorId::Cursor => self.cursor.enabled,
         }
     }
 
@@ -688,6 +710,7 @@ mod tests {
             VendorId::Novita,
             VendorId::Moonshot,
             VendorId::Grok,
+            VendorId::Cursor,
         ] {
             assert!(!c.is_enabled(opt_in), "{opt_in:?}");
         }
@@ -1247,6 +1270,7 @@ enabled = false
         assert!(!c.is_enabled(VendorId::Novita));
         assert!(!c.is_enabled(VendorId::Moonshot));
         assert!(!c.is_enabled(VendorId::Grok));
+        assert!(!c.is_enabled(VendorId::Cursor));
     }
 
     #[test]
@@ -1314,5 +1338,32 @@ enabled = false
         assert!(!cfg.novita.enabled && cfg.novita.api_key.is_none());
         assert!(!cfg.moonshot.enabled && cfg.moonshot.api_key.is_none());
         assert!(!cfg.grok.enabled && cfg.grok.api_key.is_none());
+        assert!(!cfg.cursor.enabled && cfg.cursor.db_path.is_none());
+    }
+
+    #[test]
+    fn cursor_db_path_is_tilde_expanded() {
+        let f = write_toml(
+            r#"
+            [cursor]
+            db_path = "~/cursor-state.vscdb"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        let home = crate::cache::home_dir().unwrap();
+        assert_eq!(c.cursor.db_path, Some(home.join("cursor-state.vscdb")));
+    }
+
+    #[test]
+    fn cursor_appears_when_enabled() {
+        let f = write_toml(
+            r#"
+            [cursor]
+            enabled = true
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        assert!(c.is_enabled(VendorId::Cursor));
+        assert!(c.enabled_vendors().contains(&VendorId::Cursor));
     }
 }

--- a/src/cursor/db.rs
+++ b/src/cursor/db.rs
@@ -1,0 +1,247 @@
+//! Read the Cursor IDE's own session token out of its local `state.vscdb`.
+//!
+//! Cursor has no documented usage API or API key for personal quota — every
+//! community tool that shows it (cursor-stats, cursor-usage-tracker, etc.)
+//! reads the same place: a SQLite key-value store the Cursor IDE itself
+//! maintains at `.../User/globalStorage/state.vscdb` (the same `state.vscdb`
+//! every VS Code-family app uses for `ItemTable`-shaped extension/global
+//! state), under the key `cursorAuth/accessToken`. That value is a JWT whose
+//! `sub` claim (`auth0|<userId>`) is combined with the raw token into the
+//! `WorkosCursorSessionToken` cookie the dashboard's own usage call expects —
+//! see `fetch.rs`.
+
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use rusqlite::{Connection, OpenFlags};
+
+use crate::error::{AppError, Result};
+
+const TOKEN_KEY: &str = "cursorAuth/accessToken";
+
+/// Default location of Cursor's local state database. This is Cursor's own
+/// per-OS convention (same one every VS Code-family app uses for its user
+/// data), not ai-usagebar's XDG cache — conveniently identical to what
+/// `directories::BaseDirs::config_dir()` already resolves on every platform:
+///   - Linux: `~/.config`
+///   - macOS: `~/Library/Application Support`
+///   - Windows: `%APPDATA%` (Roaming)
+pub fn default_db_path() -> Result<PathBuf> {
+    let base = directories::BaseDirs::new().ok_or_else(|| {
+        AppError::Other("could not resolve the platform config directory (no HOME?)".into())
+    })?;
+    Ok(base
+        .config_dir()
+        .join("Cursor")
+        .join("User")
+        .join("globalStorage")
+        .join("state.vscdb"))
+}
+
+/// Read the raw `cursorAuth/accessToken` value from `path`. A missing file or
+/// missing row means "never signed in to Cursor" — reported as a credentials
+/// error (like a missing `~/.claude/.credentials.json`) rather than a network
+/// or schema failure, so the widget's `⚠` tooltip tells the user to sign in
+/// rather than implying the API is down.
+pub fn read_access_token(path: &Path) -> Result<String> {
+    if !path.exists() {
+        return Err(AppError::Credentials(format!(
+            "Cursor database not found at {}. Open the Cursor IDE and sign in at least once, \
+             then try again.",
+            path.display()
+        )));
+    }
+    // Read-only: this file is Cursor's own live state, not ours to lock for
+    // writing. SQLite allows concurrent readers, so this is safe alongside a
+    // running Cursor IDE.
+    let conn =
+        Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|e| {
+            AppError::Credentials(format!(
+                "could not open Cursor database at {}: {e}",
+                path.display()
+            ))
+        })?;
+    let token: String = conn
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1",
+            [TOKEN_KEY],
+            |row| row.get(0),
+        )
+        .map_err(|_| {
+            AppError::Credentials(format!(
+                "no Cursor session found in {}. Sign in to the Cursor IDE, then try again.",
+                path.display()
+            ))
+        })?;
+    if token.trim().is_empty() {
+        return Err(AppError::Credentials(
+            "Cursor session token is empty. Sign in to the Cursor IDE again.".into(),
+        ));
+    }
+    Ok(token)
+}
+
+/// The two values the `/api/usage` call needs, both derived from the same JWT:
+/// the bare user id (a query param) and the `WorkosCursorSessionToken` cookie
+/// value (`userId%3A%3Atoken` — literal, pre-encoded `::`, matching what the
+/// Cursor dashboard's own JS sends).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionAuth {
+    pub user_id: String,
+    pub cookie_value: String,
+}
+
+/// Derive [`SessionAuth`] from the raw access token. Fails when the token
+/// isn't a decodable JWT or its `sub` claim doesn't have the `issuer|userId`
+/// shape every Cursor account token carries — either way the token is
+/// unusable, so this is a credentials error, not a schema error (the *shape*
+/// of the wire endpoint isn't in play yet at this point).
+pub fn session_auth(token: &str) -> Result<SessionAuth> {
+    let claims = parse_jwt_claims(token).ok_or_else(|| {
+        AppError::Credentials(
+            "Cursor session token could not be decoded. Sign in to the Cursor IDE again.".into(),
+        )
+    })?;
+    let sub = claims
+        .get("sub")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| AppError::Credentials("Cursor session token has no `sub` claim.".into()))?;
+    let user_id = sub
+        .split('|')
+        .nth(1)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AppError::Credentials(format!(
+                "Cursor session token `sub` claim has an unexpected shape: {sub:?}"
+            ))
+        })?
+        .to_string();
+    let cookie_value = format!("{user_id}%3A%3A{token}");
+    Ok(SessionAuth {
+        user_id,
+        cookie_value,
+    })
+}
+
+/// Decode a JWT's payload segment without verifying its signature — we trust
+/// it the same way the Cursor dashboard's own browser JS does (it never
+/// verifies either; the server is the one that rejects a bad token).
+fn parse_jwt_claims(token: &str) -> Option<serde_json::Value> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload))
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a fake JWT with the given claims (no signature verification,
+    /// matching `openai::creds`'s test helper).
+    fn fake_jwt(claims: serde_json::Value) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+        format!("{header}.{payload}.sig")
+    }
+
+    fn seed_db(path: &Path, token: Option<&str>) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute("CREATE TABLE ItemTable (key TEXT, value TEXT)", [])
+            .unwrap();
+        if let Some(t) = token {
+            conn.execute(
+                "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+                rusqlite::params![TOKEN_KEY, t],
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn default_db_path_ends_with_the_cursor_state_file() {
+        let p = default_db_path().unwrap();
+        assert!(
+            p.ends_with(
+                std::path::Path::new("Cursor")
+                    .join("User")
+                    .join("globalStorage")
+                    .join("state.vscdb")
+            )
+        );
+    }
+
+    #[test]
+    fn missing_file_is_a_credentials_error_naming_the_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        let err = read_access_token(&path).unwrap_err();
+        match err {
+            AppError::Credentials(m) => assert!(m.contains(&path.display().to_string())),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reads_the_token_back_out_of_the_item_table() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        seed_db(&path, Some("fake-token-value"));
+        assert_eq!(read_access_token(&path).unwrap(), "fake-token-value");
+    }
+
+    #[test]
+    fn missing_row_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        seed_db(&path, None);
+        let err = read_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn empty_token_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        seed_db(&path, Some(""));
+        let err = read_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn session_auth_extracts_user_id_and_builds_the_cookie_value() {
+        let token = fake_jwt(serde_json::json!({"sub": "auth0|user_abc123"}));
+        let auth = session_auth(&token).unwrap();
+        assert_eq!(auth.user_id, "user_abc123");
+        assert_eq!(auth.cookie_value, format!("user_abc123%3A%3A{token}"));
+    }
+
+    #[test]
+    fn session_auth_rejects_a_non_jwt_token() {
+        let err = session_auth("not-a-jwt").unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn session_auth_rejects_missing_sub_claim() {
+        let token = fake_jwt(serde_json::json!({"other": "value"}));
+        let err = session_auth(&token).unwrap_err();
+        match err {
+            AppError::Credentials(m) => assert!(m.contains("sub")),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_auth_rejects_sub_without_a_pipe_separated_user_id() {
+        let token = fake_jwt(serde_json::json!({"sub": "no-pipe-here"}));
+        let err = session_auth(&token).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+}

--- a/src/cursor/fetch.rs
+++ b/src/cursor/fetch.rs
@@ -1,0 +1,405 @@
+//! Fetch Cursor's included-usage summary from `GET /api/usage-summary`,
+//! authenticated with the session token read out of the local `state.vscdb`
+//! (see `db.rs`). Cache/stale/error-fallback shape mirrors `kimi::fetch`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
+use crate::error::{AppError, Result};
+use crate::usage::CursorSnapshot;
+use crate::vendor::{MAX_BODY_BYTES, read_body_capped};
+
+use super::db;
+use super::types::{self, UsageSummary};
+
+pub const BASE_URL: &str = "https://cursor.com";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+/// The dashboard endpoint gates on browser-looking headers; a plain
+/// `reqwest` request with only the cookie is rejected by its CORS check.
+const BROWSER_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub summary: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            summary: format!("{BASE_URL}/api/usage-summary"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchOutcome {
+    pub snapshot: CursorSnapshot,
+    pub stale: bool,
+    pub last_error: Option<(u16, String)>,
+    pub cache_age: Option<Duration>,
+}
+
+/// Cache-aware fetch. `db_path` is Cursor's `state.vscdb` — the caller resolves
+/// `[cursor] db_path` (config override) vs [`db::default_db_path`], the same
+/// override pattern as `openai.codex_auth_path`.
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    db_path: &Path,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse_cache(&bytes, cache, false)
+    {
+        return Ok(outcome);
+    }
+
+    match fetch_live(client, endpoints, db_path).await {
+        Ok(snap) => {
+            let bytes = serde_json::to_vec(&snap_to_json(&snap))?;
+            cache.write_payload(&bytes)?;
+            Ok(FetchOutcome {
+                snapshot: snap,
+                stale: false,
+                last_error: None,
+                cache_age: Some(Duration::ZERO),
+            })
+        }
+        Err(e) if e.is_transient() => fallback_silent(cache, e),
+        Err(e) => {
+            cache.mark_stale();
+            if let Some((code, msg)) = error_to_pair(&e) {
+                cache.write_last_error(code, &msg);
+            }
+            fallback_with_error(cache, e)
+        }
+    }
+}
+
+fn fallback_silent(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
+        return Err(original);
+    };
+    match reuse_cache(&bytes, cache, true) {
+        Ok(outcome) => Ok(outcome),
+        Err(_) => Err(original),
+    }
+}
+
+fn fallback_with_error(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
+        return Err(original);
+    };
+    match reuse_cache(&bytes, cache, true) {
+        Ok(mut outcome) => {
+            outcome.last_error = error_to_pair(&original);
+            Ok(outcome)
+        }
+        Err(_) => Err(original),
+    }
+}
+
+/// Never surface upstream bodies for auth failures: the request carried a
+/// session cookie derived from a signed-in token, and 401/403 bodies from a
+/// scraped web endpoint are not guaranteed not to echo it back.
+fn error_to_pair(e: &AppError) -> Option<(u16, String)> {
+    match e {
+        AppError::Http { status, .. } if matches!(status, 401 | 403) => {
+            Some((*status, "Cursor authentication failed".into()))
+        }
+        AppError::Http { status, body } => Some((*status, body.clone())),
+        e => Some((0, e.to_string())),
+    }
+}
+
+fn reuse_cache(bytes: &[u8], cache: &Cache, stale: bool) -> Result<FetchOutcome> {
+    let snap = parse_cache(bytes)?;
+    Ok(FetchOutcome {
+        snapshot: snap,
+        stale,
+        last_error: cache.read_last_error(),
+        cache_age: cache.payload_age(),
+    })
+}
+
+fn parse_cache(bytes: &[u8]) -> Result<CursorSnapshot> {
+    let v: serde_json::Value = serde_json::from_slice(bytes)?;
+    let int = |key: &str| -> Result<i32> {
+        v[key]
+            .as_i64()
+            .map(|n| n as i32)
+            .ok_or_else(|| AppError::Schema(format!("cursor cache: invalid {key}")))
+    };
+    Ok(CursorSnapshot {
+        plan: v["plan"].as_str().unwrap_or("Cursor").to_string(),
+        auto_pct: int("auto_pct")?,
+        api_pct: int("api_pct")?,
+        total_pct: int("total_pct")?,
+        unlimited: v["unlimited"].as_bool().unwrap_or(false),
+        on_demand_enabled: v["on_demand_enabled"].as_bool().unwrap_or(false),
+        reset_at: parse_cache_datetime(&v["reset_at"])?,
+    })
+}
+
+fn parse_cache_datetime(v: &serde_json::Value) -> Result<Option<DateTime<Utc>>> {
+    match v {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(s) => DateTime::parse_from_rfc3339(s)
+            .map(|dt| Some(dt.into()))
+            .map_err(|e| AppError::Schema(format!("cursor cache: invalid reset timestamp: {e}"))),
+        _ => Err(AppError::Schema(
+            "cursor cache: invalid reset timestamp".into(),
+        )),
+    }
+}
+
+fn snap_to_json(snap: &CursorSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "plan": snap.plan,
+        "auto_pct": snap.auto_pct,
+        "api_pct": snap.api_pct,
+        "total_pct": snap.total_pct,
+        "unlimited": snap.unlimited,
+        "on_demand_enabled": snap.on_demand_enabled,
+        "reset_at": snap.reset_at.map(|dt| dt.to_rfc3339()),
+    })
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    endpoints: &Endpoints,
+    db_path: &Path,
+) -> Result<CursorSnapshot> {
+    // Local, synchronous, and cheap — only reached on a cache miss, so a
+    // running Cursor IDE isn't contending for the sqlite file every tick.
+    let token = db::read_access_token(db_path)?;
+    let auth = db::session_auth(&token)?;
+
+    // usage-summary keys off the session cookie alone (no `?user=` param); the
+    // browser-ish headers get past its CORS gate.
+    let resp = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(&endpoints.summary)
+            .header(
+                "Cookie",
+                format!("WorkosCursorSessionToken={}", auth.cookie_value),
+            )
+            .header("Origin", BASE_URL)
+            .header("Referer", format!("{BASE_URL}/dashboard"))
+            .header("User-Agent", BROWSER_UA)
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport(format!("cursor timeout: {}", endpoints.summary)))??;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = if matches!(status.as_u16(), 401 | 403) {
+            "Cursor authentication failed".into()
+        } else {
+            format!("Cursor API returned HTTP {}", status.as_u16())
+        };
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let bytes = read_body_capped(resp, MAX_BODY_BYTES).await?;
+    let parsed: UsageSummary = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Schema(format!("cursor usage-summary response: {e}")))?;
+    types::to_snapshot(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    fn cache_fixture() -> (TempDir, Cache) {
+        let td = TempDir::new().unwrap();
+        let cache = Cache::at(td.path().join("cursor"));
+        cache.ensure_dir().unwrap();
+        (td, cache)
+    }
+
+    /// A minimal, unsigned JWT with `sub: "auth0|<user_id>"` — signature
+    /// verification is never performed (see `db::parse_jwt_claims`).
+    fn fake_token(user_id: &str) -> String {
+        use base64::Engine;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::json!({"sub": format!("auth0|{user_id}")}).to_string());
+        format!("{header}.{payload}.sig")
+    }
+
+    fn seed_state_db(dir: &TempDir, token: &str) -> std::path::PathBuf {
+        let path = dir.path().join("state.vscdb");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("CREATE TABLE ItemTable (key TEXT, value TEXT)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES ('cursorAuth/accessToken', ?1)",
+            [token],
+        )
+        .unwrap();
+        path
+    }
+
+    fn sample_json() -> String {
+        r#"{
+            "billingCycleEnd": "2026-08-04T00:35:51.000Z",
+            "membershipType": "ultra",
+            "isUnlimited": false,
+            "individualUsage": {
+                "plan": { "autoPercentUsed": 98.109, "apiPercentUsed": 100, "totalPercentUsed": 98.5 },
+                "onDemand": { "enabled": false }
+            }
+        }"#
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn live_fetch_reads_token_from_db_and_sends_the_session_cookie() {
+        let mut server = mockito::Server::new_async().await;
+        let token = fake_token("user_123");
+        let m = server
+            .mock("GET", "/api/usage-summary")
+            .match_header(
+                "cookie",
+                format!("WorkosCursorSessionToken=user_123%3A%3A{token}").as_str(),
+            )
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+
+        let db_dir = TempDir::new().unwrap();
+        let db_path = seed_state_db(&db_dir, &token);
+        let (_cache_dir, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            summary: format!("{}/api/usage-summary", server.url()),
+        };
+
+        let out = fetch_snapshot(
+            &client,
+            &db_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        m.assert_async().await;
+        assert_eq!(out.snapshot.plan, "Ultra");
+        assert_eq!(out.snapshot.auto_pct, 98);
+        assert_eq!(out.snapshot.api_pct, 100);
+        assert!(!out.stale);
+    }
+
+    #[tokio::test]
+    async fn missing_db_file_is_a_credentials_error_with_no_cache_to_fall_back_on() {
+        let (_cache_dir, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints::default();
+        let db_path = std::path::Path::new("/nonexistent/state.vscdb");
+
+        let err = fetch_snapshot(&client, db_path, &cache, &endpoints, Duration::from_secs(0))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[tokio::test]
+    async fn http_error_falls_back_to_cache_and_hides_the_upstream_body() {
+        let mut server = mockito::Server::new_async().await;
+        let token = fake_token("user_123");
+        server
+            .mock("GET", "/api/usage-summary")
+            .with_status(401)
+            .with_body(r#"{"detail":"leaked-looking body"}"#)
+            .create_async()
+            .await;
+
+        let db_dir = TempDir::new().unwrap();
+        let db_path = seed_state_db(&db_dir, &token);
+        let (_cache_dir, cache) = cache_fixture();
+        cache
+            .write_payload(
+                serde_json::json!({
+                    "plan": "Ultra", "auto_pct": 40, "api_pct": 10, "total_pct": 30,
+                    "unlimited": false, "on_demand_enabled": false,
+                    "reset_at": "2026-08-04T00:00:00Z",
+                })
+                .to_string()
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            summary: format!("{}/api/usage-summary", server.url()),
+        };
+        let out = fetch_snapshot(
+            &client,
+            &db_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        assert!(out.stale);
+        assert_eq!(out.snapshot.auto_pct, 40);
+        let (code, msg) = out.last_error.unwrap();
+        assert_eq!(code, 401);
+        assert_eq!(msg, "Cursor authentication failed");
+        assert!(!msg.contains("leaked-looking"));
+    }
+
+    #[tokio::test]
+    async fn fresh_cache_short_circuits_without_touching_the_db() {
+        let (_cache_dir, cache) = cache_fixture();
+        cache
+            .write_payload(
+                serde_json::json!({
+                    "plan": "Pro", "auto_pct": 7, "api_pct": 3, "total_pct": 5,
+                    "unlimited": false, "on_demand_enabled": true,
+                    "reset_at": "2026-08-04T00:00:00Z",
+                })
+                .to_string()
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints::default();
+        // A path that doesn't exist would error if the db were read — proving
+        // the fresh-cache path never touches it.
+        let db_path = std::path::Path::new("/nonexistent/state.vscdb");
+        let out = fetch_snapshot(
+            &client,
+            db_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(3600),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.snapshot.auto_pct, 7);
+        assert!(out.snapshot.on_demand_enabled);
+        assert!(!out.stale);
+    }
+}

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,0 +1,11 @@
+//! Cursor — premium-request quota read from the local Cursor IDE session
+//! token (`state.vscdb`) against the undocumented `cursor.com/api/usage`
+//! endpoint the Cursor dashboard itself calls. See `db.rs` for the token
+//! source and `fetch.rs`/`types.rs` for the wire call and schema.
+
+pub mod db;
+pub mod fetch;
+pub mod types;
+pub mod vendor;
+
+pub use fetch::{FetchOutcome, fetch_snapshot};

--- a/src/cursor/types.rs
+++ b/src/cursor/types.rs
@@ -17,10 +17,32 @@
 //! }
 //! ```
 //!
-//! Team accounts report under `teamUsage` instead of `individualUsage`; that
-//! shape isn't modeled yet (a personal plan is the common case), so a payload
-//! with no `individualUsage.plan` is treated as schema drift rather than a
-//! fabricated zero.
+//! Team accounts (and personal token-based enterprise contracts) report no
+//! `individualUsage.plan` at all — there's no per-seat request quota for
+//! `pct()` to read.
+//!
+//! **Unverified against a live team account** — we don't have one to test
+//! against. The fallback below is inferred from an independent
+//! reverse-engineering of this same endpoint
+//! (`github.com/WoojinAhn/CursorMeter`'s `UsageModels.swift`, whose doc
+//! comments say it was confirmed against live token-based enterprise
+//! contracts): on those accounts, `teamUsage` itself carries no percentages
+//! (only an `onDemand` flag) and `individualUsage.overall.limit` — the
+//! numerator needed to turn `used` cents into a percentage — comes back
+//! `null`; Cursor doesn't put the per-seat limit on *this* endpoint for that
+//! account type at all. The **only** percentage this payload exposes for such
+//! accounts is the human-readable `autoModelSelectedDisplayMessage` /
+//! `namedModelSelectedDisplayMessage` strings (e.g. `"You've used 42% of your
+//! included total usage"`), and those line up with the auto/named pools
+//! respectively — the same two pools `individualUsage.plan.{autoPercentUsed,
+//! apiPercentUsed}` reports on personal accounts (confirmed by the `SAMPLE`
+//! fixture below, where both messages' percentages match the corresponding
+//! `plan` fields exactly). So when `individualUsage.plan` is missing,
+//! `to_snapshot` parses both display messages and only accepts them as a
+//! team/enterprise snapshot if **both** parse — a single stray message is
+//! unrecognized schema drift, not a half-guessed snapshot. A payload with
+//! neither `individualUsage.plan` nor two parseable display messages is
+//! schema drift, never a fabricated zero.
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -41,12 +63,38 @@ pub struct UsageSummary {
     pub billing_cycle_end: String,
     #[serde(rename = "individualUsage")]
     pub individual_usage: Option<IndividualUsage>,
+    /// Team-account usage. Present (possibly `{}`) whether or not the caller
+    /// is on a team; only its `onDemand` flag is modeled — see the module
+    /// doc for why the pool percentages come from the display-message
+    /// fallback below instead of from this object.
+    #[serde(rename = "teamUsage", default)]
+    pub team_usage: Option<TeamUsage>,
+    /// e.g. `"You've used 42% of your included total usage"` — the auto
+    /// (Cursor Models) pool's percentage in prose form. Redundant with
+    /// `individualUsage.plan.autoPercentUsed` on personal accounts; the only
+    /// source of that percentage on accounts with no `plan` object.
+    #[serde(rename = "autoModelSelectedDisplayMessage", default)]
+    pub auto_model_selected_display_message: Option<String>,
+    /// Same idea as above for the named/API pool, e.g. `"You've used 100% of
+    /// your included API usage"`.
+    #[serde(rename = "namedModelSelectedDisplayMessage", default)]
+    pub named_model_selected_display_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct IndividualUsage {
     pub plan: Option<PlanUsage>,
-    #[serde(default)]
+    // ponytail: pre-existing field lacked `rename = "onDemand"`, so this
+    // never actually deserialized (always None) — `on_demand_enabled` was
+    // silently always false. Fixed in passing since the new `TeamUsage` below
+    // needs the same field to actually work.
+    #[serde(rename = "onDemand", default)]
+    pub on_demand: Option<OnDemand>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TeamUsage {
+    #[serde(rename = "onDemand", default)]
     pub on_demand: Option<OnDemand>,
 }
 
@@ -111,34 +159,80 @@ pub fn to_snapshot(resp: UsageSummary) -> Result<CursorSnapshot> {
         });
     }
 
-    let plan_usage = resp
-        .individual_usage
-        .as_ref()
-        .and_then(|u| u.plan.as_ref())
-        .ok_or_else(|| {
-            AppError::Schema(
-                "cursor: response has no `individualUsage.plan` (team accounts are not \
-                 supported yet)"
-                    .into(),
-            )
-        })?;
-
+    // `onDemand` can live under either `individualUsage` (personal accounts)
+    // or `teamUsage` (per CursorMeter's `TeamUsage`, which models nothing
+    // else there) — check both rather than assuming one.
     let on_demand_enabled = resp
         .individual_usage
         .as_ref()
         .and_then(|u| u.on_demand.as_ref())
+        .or_else(|| resp.team_usage.as_ref().and_then(|t| t.on_demand.as_ref()))
         .map(|o| o.enabled)
         .unwrap_or(false);
 
-    Ok(CursorSnapshot {
-        plan,
-        auto_pct: pct("autoPercentUsed", plan_usage.auto_percent_used)?,
-        api_pct: pct("apiPercentUsed", plan_usage.api_percent_used)?,
-        total_pct: pct("totalPercentUsed", plan_usage.total_percent_used)?,
-        unlimited: false,
-        on_demand_enabled,
-        reset_at: Some(reset_at),
-    })
+    if let Some(plan_usage) = resp.individual_usage.as_ref().and_then(|u| u.plan.as_ref()) {
+        return Ok(CursorSnapshot {
+            plan,
+            auto_pct: pct("autoPercentUsed", plan_usage.auto_percent_used)?,
+            api_pct: pct("apiPercentUsed", plan_usage.api_percent_used)?,
+            total_pct: pct("totalPercentUsed", plan_usage.total_percent_used)?,
+            unlimited: false,
+            on_demand_enabled,
+            reset_at: Some(reset_at),
+        });
+    }
+
+    // No numeric `plan` object — the team/enterprise fallback described in
+    // the module doc. Both display messages must parse or this isn't the
+    // shape we think it is; see the module doc for why "both or neither".
+    let team_pcts = resp
+        .auto_model_selected_display_message
+        .as_deref()
+        .and_then(parse_percent_from_message)
+        .zip(
+            resp.named_model_selected_display_message
+                .as_deref()
+                .and_then(parse_percent_from_message),
+        );
+    if let Some((auto_raw, api_raw)) = team_pcts {
+        let auto_pct = pct("autoModelSelectedDisplayMessage", auto_raw)?;
+        let api_pct = pct("namedModelSelectedDisplayMessage", api_raw)?;
+        return Ok(CursorSnapshot {
+            // Flag this as the best-effort team path — distinct from the
+            // membership label alone, since the number came from prose, not
+            // the numeric `plan` object.
+            plan: format!("{plan} (team)"),
+            auto_pct,
+            api_pct,
+            // No distinct blended-total signal exists on this path (no
+            // `totalPercentUsed` equivalent message); the worse of the two
+            // pools is the best-effort stand-in.
+            total_pct: auto_pct.max(api_pct),
+            unlimited: false,
+            on_demand_enabled,
+            reset_at: Some(reset_at),
+        });
+    }
+
+    Err(AppError::Schema(
+        "cursor: response has no `individualUsage.plan` and no parseable team-usage \
+         display message (unrecognized team-account shape)"
+            .into(),
+    ))
+}
+
+/// Pulls the leading `N` or `N.N` out of a `"…N%…"` prose string, e.g.
+/// `"You've used 98% of your included total usage"` -> `Some(98.0)`. Returns
+/// `None` if there's no `%` or nothing number-shaped precedes it, so callers
+/// treat a reworded message as unparseable rather than misreading it.
+fn parse_percent_from_message(msg: &str) -> Option<f64> {
+    let pct_idx = msg.find('%')?;
+    let before = &msg[..pct_idx];
+    let start = before
+        .rfind(|c: char| !c.is_ascii_digit() && c != '.')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    before[start..].parse::<f64>().ok()
 }
 
 /// "ultra" -> "Ultra". Cursor's `membershipType` is lowercase; the dashboard
@@ -253,7 +347,69 @@ mod tests {
                 }),
                 on_demand: None,
             }),
+            team_usage: None,
+            auto_model_selected_display_message: None,
+            named_model_selected_display_message: None,
         };
         assert!(matches!(to_snapshot(resp), Err(AppError::Schema(_))));
+    }
+
+    /// The fixture backing the team-account fallback. **Unverified against a
+    /// live team account** — see the module doc for the reasoning: no
+    /// `individualUsage.plan`, `teamUsage` carries only `onDemand`, and the
+    /// two pool percentages come from the display-message strings instead.
+    const TEAM_SAMPLE: &str = r#"{
+        "billingCycleEnd": "2026-08-04T00:35:51.000Z",
+        "membershipType": "team",
+        "isUnlimited": false,
+        "autoModelSelectedDisplayMessage": "You've used 42% of your included total usage",
+        "namedModelSelectedDisplayMessage": "You've used 15% of your included API usage",
+        "teamUsage": { "onDemand": { "enabled": true } }
+    }"#;
+
+    #[test]
+    fn team_account_falls_back_to_display_message_percentages() {
+        let resp: UsageSummary = serde_json::from_str(TEAM_SAMPLE).unwrap();
+        let snap = to_snapshot(resp).unwrap();
+        assert_eq!(snap.plan, "Team (team)");
+        assert_eq!(snap.auto_pct, 42);
+        assert_eq!(snap.api_pct, 15);
+        assert_eq!(
+            snap.total_pct, 42,
+            "no blended-total signal exists; worst pool stands in"
+        );
+        assert!(!snap.unlimited);
+        assert!(
+            snap.on_demand_enabled,
+            "onDemand lives under teamUsage for a team account, not individualUsage"
+        );
+        assert_eq!(snap.worst_pct(), 42);
+    }
+
+    #[test]
+    fn team_account_with_only_one_parseable_message_is_still_schema_drift() {
+        // Guards the "both or neither" rule: a half-recognized shape must not
+        // silently render one real pool and one fabricated zero.
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "team",
+            "autoModelSelectedDisplayMessage": "You've used 42% of your included total usage",
+            "namedModelSelectedDisplayMessage": "unavailable"
+        }"#;
+        let err = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap_err();
+        assert!(matches!(err, AppError::Schema(_)));
+    }
+
+    #[test]
+    fn parse_percent_from_message_reads_leading_number_before_percent_sign() {
+        assert_eq!(
+            parse_percent_from_message("You've used 98% of your included total usage"),
+            Some(98.0)
+        );
+        assert_eq!(
+            parse_percent_from_message("You've used 100% of your included API usage"),
+            Some(100.0)
+        );
+        assert_eq!(parse_percent_from_message("no percent here"), None);
+        assert_eq!(parse_percent_from_message("unavailable"), None);
     }
 }

--- a/src/cursor/types.rs
+++ b/src/cursor/types.rs
@@ -1,0 +1,259 @@
+//! Wire types for `GET cursor.com/api/usage-summary`.
+//!
+//! **Undocumented** — the endpoint the Cursor dashboard's own frontend calls
+//! to draw the "Cursor Models" / "Other Models" usage bars. Confirmed against a
+//! live Ultra account:
+//!
+//! ```json
+//! {
+//!   "billingCycleStart": "2026-07-04T00:35:51.000Z",
+//!   "billingCycleEnd":   "2026-08-04T00:35:51.000Z",
+//!   "membershipType": "ultra",
+//!   "isUnlimited": false,
+//!   "individualUsage": {
+//!     "plan": { "autoPercentUsed": 98.1, "apiPercentUsed": 100, "totalPercentUsed": 98.5 },
+//!     "onDemand": { "enabled": false }
+//!   }
+//! }
+//! ```
+//!
+//! Team accounts report under `teamUsage` instead of `individualUsage`; that
+//! shape isn't modeled yet (a personal plan is the common case), so a payload
+//! with no `individualUsage.plan` is treated as schema drift rather than a
+//! fabricated zero.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::{AppError, Result};
+use crate::usage::CursorSnapshot;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageSummary {
+    #[serde(rename = "membershipType", default)]
+    pub membership_type: String,
+    #[serde(rename = "isUnlimited", default)]
+    pub is_unlimited: bool,
+    /// RFC3339 end of the current billing cycle — when the pools reset.
+    /// Required: without it there is no reset to show, so its absence is
+    /// schema drift, not a "no reset" state.
+    #[serde(rename = "billingCycleEnd")]
+    pub billing_cycle_end: String,
+    #[serde(rename = "individualUsage")]
+    pub individual_usage: Option<IndividualUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IndividualUsage {
+    pub plan: Option<PlanUsage>,
+    #[serde(default)]
+    pub on_demand: Option<OnDemand>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanUsage {
+    /// "Cursor Models" pool (Auto + Composer).
+    #[serde(rename = "autoPercentUsed")]
+    pub auto_percent_used: f64,
+    /// "Other Models" pool (named / third-party).
+    #[serde(rename = "apiPercentUsed")]
+    pub api_percent_used: f64,
+    /// Overall included usage — the dashboard headline percentage.
+    #[serde(rename = "totalPercentUsed", default)]
+    pub total_percent_used: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OnDemand {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+/// Round a wire percentage to an integer, matching the dashboard's whole-number
+/// display and the integer-percent convention used across every vendor here. A
+/// non-finite value (NaN/inf) means the payload wasn't what we think it is —
+/// surfaced as schema drift rather than silently rendered.
+fn pct(field: &str, v: f64) -> Result<i32> {
+    if !v.is_finite() {
+        return Err(AppError::Schema(format!(
+            "cursor: `{field}` is not a finite number"
+        )));
+    }
+    // Clamp only the low end: a pool can legitimately exceed 100% when it is
+    // over its included allowance, and callers clamp for bar width themselves.
+    Ok(v.round().max(0.0) as i32)
+}
+
+pub fn to_snapshot(resp: UsageSummary) -> Result<CursorSnapshot> {
+    let reset_at = DateTime::parse_from_rfc3339(&resp.billing_cycle_end)
+        .map_err(|e| {
+            AppError::Schema(format!(
+                "cursor: `billingCycleEnd` is not RFC3339 ({:?}): {e}",
+                resp.billing_cycle_end
+            ))
+        })?
+        .with_timezone(&Utc);
+
+    let plan = title_case(&resp.membership_type);
+
+    // Unlimited plans report no meaningful pool percentages; represent them as
+    // zeros with the `unlimited` flag so renderers say "unlimited" rather than
+    // painting a bogus bar.
+    if resp.is_unlimited {
+        return Ok(CursorSnapshot {
+            plan,
+            auto_pct: 0,
+            api_pct: 0,
+            total_pct: 0,
+            unlimited: true,
+            on_demand_enabled: false,
+            reset_at: Some(reset_at),
+        });
+    }
+
+    let plan_usage = resp
+        .individual_usage
+        .as_ref()
+        .and_then(|u| u.plan.as_ref())
+        .ok_or_else(|| {
+            AppError::Schema(
+                "cursor: response has no `individualUsage.plan` (team accounts are not \
+                 supported yet)"
+                    .into(),
+            )
+        })?;
+
+    let on_demand_enabled = resp
+        .individual_usage
+        .as_ref()
+        .and_then(|u| u.on_demand.as_ref())
+        .map(|o| o.enabled)
+        .unwrap_or(false);
+
+    Ok(CursorSnapshot {
+        plan,
+        auto_pct: pct("autoPercentUsed", plan_usage.auto_percent_used)?,
+        api_pct: pct("apiPercentUsed", plan_usage.api_percent_used)?,
+        total_pct: pct("totalPercentUsed", plan_usage.total_percent_used)?,
+        unlimited: false,
+        on_demand_enabled,
+        reset_at: Some(reset_at),
+    })
+}
+
+/// "ultra" -> "Ultra". Cursor's `membershipType` is lowercase; the dashboard
+/// shows it title-cased.
+fn title_case(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Cursor".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    const SAMPLE: &str = r#"{
+        "billingCycleStart": "2026-07-04T00:35:51.000Z",
+        "billingCycleEnd": "2026-08-04T00:35:51.000Z",
+        "membershipType": "ultra",
+        "limitType": "user",
+        "isUnlimited": false,
+        "autoModelSelectedDisplayMessage": "You've used 98% of your included total usage",
+        "namedModelSelectedDisplayMessage": "You've used 100% of your included API usage",
+        "individualUsage": {
+            "plan": {
+                "enabled": true, "used": 40000, "limit": 40000, "remaining": 0,
+                "autoPercentUsed": 98.109, "apiPercentUsed": 100, "totalPercentUsed": 98.5128
+            },
+            "onDemand": { "enabled": false, "used": 0, "limit": null, "remaining": null }
+        },
+        "teamUsage": {}
+    }"#;
+
+    #[test]
+    fn parses_the_live_ultra_shape() {
+        let resp: UsageSummary = serde_json::from_str(SAMPLE).unwrap();
+        let snap = to_snapshot(resp).unwrap();
+        assert_eq!(snap.plan, "Ultra");
+        assert_eq!(snap.auto_pct, 98); // 98.109 rounds to 98 (matches the dashboard bar)
+        assert_eq!(snap.api_pct, 100);
+        assert_eq!(snap.total_pct, 99); // 98.5128 rounds to 99
+        assert!(!snap.unlimited);
+        assert!(!snap.on_demand_enabled);
+        assert_eq!(
+            snap.reset_at,
+            Some(Utc.with_ymd_and_hms(2026, 8, 4, 0, 35, 51).unwrap())
+        );
+        assert_eq!(snap.worst_pct(), 100);
+    }
+
+    #[test]
+    fn over_allowance_percentage_is_kept_above_100() {
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "pro",
+            "individualUsage": { "plan": { "autoPercentUsed": 142.7, "apiPercentUsed": 5, "totalPercentUsed": 80 } }
+        }"#;
+        let snap = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap();
+        assert_eq!(
+            snap.auto_pct, 143,
+            "an over-quota pool must not clamp to 100"
+        );
+        assert_eq!(snap.worst_pct(), 143);
+    }
+
+    #[test]
+    fn unlimited_plan_reports_no_pool_percentages() {
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "enterprise",
+            "isUnlimited": true
+        }"#;
+        let snap = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap();
+        assert!(snap.unlimited);
+        assert_eq!(snap.worst_pct(), 0);
+        assert_eq!(snap.plan, "Enterprise");
+    }
+
+    #[test]
+    fn missing_individual_plan_is_schema_drift_not_zero() {
+        // A team-only or unexpected shape must not read as "0% used".
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "team",
+            "teamUsage": {}
+        }"#;
+        let err = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap_err();
+        assert!(matches!(err, AppError::Schema(_)));
+    }
+
+    #[test]
+    fn missing_billing_cycle_end_is_a_parse_error() {
+        let raw = r#"{ "membershipType": "pro",
+            "individualUsage": { "plan": { "autoPercentUsed": 1, "apiPercentUsed": 2, "totalPercentUsed": 1 } } }"#;
+        // `billingCycleEnd` is required by serde → a missing field fails to parse.
+        assert!(serde_json::from_str::<UsageSummary>(raw).is_err());
+    }
+
+    #[test]
+    fn non_finite_percentage_is_rejected() {
+        // serde rejects a non-finite JSON literal at parse time, so exercise the
+        // guard directly: a NaN reaching a percentage field must be a schema
+        // error, never rendered as a bar.
+        let resp = UsageSummary {
+            membership_type: "pro".into(),
+            is_unlimited: false,
+            billing_cycle_end: "2026-08-04T00:00:00Z".into(),
+            individual_usage: Some(IndividualUsage {
+                plan: Some(PlanUsage {
+                    auto_percent_used: f64::NAN,
+                    api_percent_used: 2.0,
+                    total_percent_used: 1.0,
+                }),
+                on_demand: None,
+            }),
+        };
+        assert!(matches!(to_snapshot(resp), Err(AppError::Schema(_))));
+    }
+}

--- a/src/cursor/vendor.rs
+++ b/src/cursor/vendor.rs
@@ -1,0 +1,373 @@
+//! Cursor renderer — bar text + bordered Pango tooltip. Two included-usage
+//! pools (Cursor Models / Other Models), like Kimi's two windows but keyed on
+//! model category rather than a time window.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::pacing::PaceSeverity;
+use crate::pango::{color_span, escape, severity_color, severity_for};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::usage::CursorSnapshot;
+use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+
+pub const DEFAULT_FORMAT: &str = "{cursor_auto_pct}·{cursor_api_pct}%";
+
+/// No confirmed Cursor glyph in the common Nerd Font sets, so a plain caret.
+/// Override with `--icon`.
+const DEFAULT_ICON: &str = "❯";
+
+pub fn build_placeholders(
+    snap: &CursorSnapshot,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
+    let reset = countdown::format(snap.reset_at, now);
+    placeholders(vec![
+        ("icon", DEFAULT_ICON.to_string()),
+        ("vendor_short", "cur".to_string()),
+        // Cross-vendor aliases: the two pools map onto the two generic windows
+        // (session = Cursor Models, weekly = Other Models) so a shared format
+        // and the macOS menu bar show both. Severity still keys on the worst.
+        ("plan", format!("Cursor {}", snap.plan)),
+        ("session_pct", snap.auto_pct.to_string()),
+        ("session_reset", reset.clone()),
+        ("weekly_pct", snap.api_pct.to_string()),
+        ("weekly_reset", reset.clone()),
+        // Cursor-specific placeholders.
+        ("cursor_plan", snap.plan.clone()),
+        ("cursor_auto_pct", snap.auto_pct.to_string()),
+        ("cursor_api_pct", snap.api_pct.to_string()),
+        ("cursor_total_pct", snap.total_pct.to_string()),
+        ("cursor_reset", reset),
+        (
+            "cursor_on_demand",
+            if snap.on_demand_enabled { "on" } else { "off" }.to_string(),
+        ),
+        (
+            "cursor_unlimited",
+            if snap.unlimited { "yes" } else { "no" }.to_string(),
+        ),
+    ])
+}
+
+/// Severity keys on the binding pool. An unlimited plan has no cap, so it stays
+/// calm regardless of the (meaningless) percentages.
+pub fn severity(snap: &CursorSnapshot) -> PaceSeverity {
+    if snap.unlimited {
+        PaceSeverity::Low
+    } else {
+        severity_for(snap.worst_pct())
+    }
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &CursorSnapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let class = Class::from(severity(snap));
+    let format = opts
+        .format
+        .clone()
+        .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
+    let values = build_placeholders(snap, now);
+
+    let mut text = if snap.unlimited && opts.format.is_none() {
+        "unlimited".to_string()
+    } else {
+        substitute(&format, &values)
+    };
+    if outcome.stale {
+        text.push_str(" ⏸");
+    }
+
+    let wrapper_color = severity_color(severity(snap), theme).to_string();
+    let icon_prefix = match opts.icon.as_deref() {
+        Some(ic) if !ic.is_empty() => format!("{ic} "),
+        _ => String::new(),
+    };
+    let bar_text = color_span(&wrapper_color, &format!("{icon_prefix}{text}"));
+
+    let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
+        substitute(fmt, &values)
+    } else {
+        render_tooltip(outcome, snap, theme, now)
+    };
+
+    WaybarOutput {
+        text: bar_text,
+        tooltip,
+        class,
+    }
+}
+
+fn pool_line(lines: &mut Vec<TooltipLine>, theme: &Theme, label: &str, pct: i32) {
+    let fg = &theme.fg;
+    let color = severity_color(severity_for(pct), theme);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{fg}'>  󰢻  {label}</span>"
+    )));
+    lines.push(TooltipLine::Body(format!(
+        "   <span font_weight='bold' foreground='{color}'>{pct}%</span> used"
+    )));
+}
+
+fn render_tooltip(
+    outcome: &VendorOutcome,
+    snap: &CursorSnapshot,
+    theme: &Theme,
+    now: DateTime<Utc>,
+) -> String {
+    let blue = &theme.blue;
+    let dim = &theme.dim;
+    let fg = &theme.fg;
+
+    let mut lines: Vec<TooltipLine> = Vec::new();
+    lines.push(TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{blue}'>Cursor {}</span>",
+        escape(&snap.plan)
+    )));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body("".into()));
+
+    if snap.unlimited {
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{fg}'>  󰐾  Unlimited plan</span>"
+        )));
+    } else {
+        pool_line(&mut lines, theme, "Cursor Models", snap.auto_pct);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{dim}'>     Auto + Composer</span>"
+        )));
+        lines.push(TooltipLine::Body("".into()));
+        pool_line(&mut lines, theme, "Other Models", snap.api_pct);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{dim}'>     Named / API models · on-demand {}</span>",
+            if snap.on_demand_enabled { "on" } else { "off" }
+        )));
+    }
+
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰃰  Resets {}</span>",
+        escape(&countdown::format(snap.reset_at, now))
+    )));
+
+    if let Some((code, msg)) = outcome.last_error.as_ref()
+        && *code != 0
+    {
+        let (icon, ecolor) = if *code >= 500 {
+            ("󰅚", theme.red.as_str())
+        } else {
+            ("󰀪", theme.orange.as_str())
+        };
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{ecolor}'>  {icon}  HTTP {code}</span>"
+        )));
+        lines.push(TooltipLine::Body(format!(
+            "     <span foreground='{dim}'>{}</span>",
+            escape(msg)
+        )));
+    }
+
+    let updated = updated_at_hm(now, outcome.cache_age);
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰅐  Updated {updated}</span>"
+    )));
+
+    render_bordered(&lines, theme)
+}
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(o: FetchOutcome) -> Self {
+        Self {
+            snapshot: crate::usage::VendorSnapshot::Cursor(o.snapshot),
+            stale: o.stale,
+            last_error: o.last_error,
+            cache_age: o.cache_age,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 26, 12, 0, 0).unwrap()
+    }
+
+    fn sample_snap() -> CursorSnapshot {
+        CursorSnapshot {
+            plan: "Ultra".into(),
+            auto_pct: 98,
+            api_pct: 100,
+            total_pct: 99,
+            unlimited: false,
+            on_demand_enabled: false,
+            reset_at: Some(now() + chrono::Duration::days(9)),
+        }
+    }
+
+    fn sample_outcome(snap: CursorSnapshot) -> VendorOutcome {
+        VendorOutcome {
+            snapshot: crate::usage::VendorSnapshot::Cursor(snap),
+            stale: false,
+            last_error: None,
+            cache_age: Some(std::time::Duration::from_secs(10)),
+        }
+    }
+
+    fn opts() -> RenderOpts {
+        RenderOpts {
+            format: None,
+            tooltip_format: None,
+            icon: None,
+            pace_tolerance: 5,
+            format_pace_color: false,
+            tooltip_pace_pts: false,
+        }
+    }
+
+    #[test]
+    fn default_bar_shows_both_pools() {
+        let snap = sample_snap();
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert!(out.text.contains("98·100%"), "text: {}", out.text);
+    }
+
+    #[test]
+    fn tooltip_breaks_out_both_pools_and_reset() {
+        let snap = sample_snap();
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert!(out.tooltip.contains("Cursor Ultra"));
+        assert!(out.tooltip.contains("Cursor Models"));
+        assert!(out.tooltip.contains("98%"));
+        assert!(out.tooltip.contains("Other Models"));
+        assert!(out.tooltip.contains("100%"));
+        assert!(out.tooltip.contains("9d"));
+    }
+
+    #[test]
+    fn severity_keys_on_the_worst_pool() {
+        let mut snap = sample_snap();
+        snap.auto_pct = 10;
+        snap.api_pct = 95;
+        // Other Models at 95% must drive severity Critical even though Cursor
+        // Models is calm.
+        assert_eq!(severity(&snap), PaceSeverity::Critical);
+    }
+
+    #[test]
+    fn unlimited_plan_is_calm_and_labeled() {
+        let mut snap = sample_snap();
+        snap.unlimited = true;
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert_eq!(severity(&snap), PaceSeverity::Low);
+        assert!(out.text.contains("unlimited"));
+        assert!(out.tooltip.contains("Unlimited plan"));
+    }
+
+    #[test]
+    fn stale_appends_pause() {
+        let snap = sample_snap();
+        let mut outcome = sample_outcome(snap.clone());
+        outcome.stale = true;
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        assert!(out.text.contains("⏸"));
+    }
+
+    #[test]
+    fn custom_tooltip_uses_placeholders() {
+        let snap = sample_snap();
+        let mut o = opts();
+        o.tooltip_format = Some("auto {cursor_auto_pct} api {cursor_api_pct} {cursor_plan}".into());
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &o,
+            now(),
+        );
+        assert_eq!(out.tooltip, "auto 98 api 100 Ultra");
+    }
+
+    #[test]
+    fn generic_windows_map_to_the_two_pools() {
+        let values = build_placeholders(&sample_snap(), now());
+        assert_eq!(values["session_pct"], "98"); // Cursor Models (auto)
+        assert_eq!(values["weekly_pct"], "100"); // Other Models (api)
+        assert_eq!(values["plan"], "Cursor Ultra");
+    }
+
+    #[test]
+    fn placeholder_set_contains_all_keys() {
+        let values = build_placeholders(&sample_snap(), now());
+        for key in [
+            "icon",
+            "vendor_short",
+            "plan",
+            "session_pct",
+            "session_reset",
+            "weekly_pct",
+            "weekly_reset",
+            "cursor_plan",
+            "cursor_auto_pct",
+            "cursor_api_pct",
+            "cursor_total_pct",
+            "cursor_reset",
+            "cursor_on_demand",
+            "cursor_unlimited",
+        ] {
+            assert!(values.contains_key(key), "missing placeholder {key}");
+        }
+    }
+
+    #[test]
+    fn fetch_outcome_conversion_preserves_metadata() {
+        let fetch = FetchOutcome {
+            snapshot: sample_snap(),
+            stale: true,
+            last_error: Some((401, "bad".into())),
+            cache_age: Some(std::time::Duration::from_secs(42)),
+        };
+        let vendor: VendorOutcome = fetch.into();
+        assert!(matches!(
+            vendor.snapshot,
+            crate::usage::VendorSnapshot::Cursor(_)
+        ));
+        assert!(vendor.stale);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cache;
 pub mod config;
 pub mod context;
 pub mod countdown;
+pub mod cursor;
 pub mod deepseek;
 pub mod error;
 pub mod format;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -429,6 +429,20 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             let outcome = crate::antigravity::fetch_snapshot(client, &cache, DEFAULT_TTL).await?;
             Ok(outcome.into())
         }
+        VendorId::Cursor => {
+            let cache = crate::cache::Cache::for_vendor("cursor")?;
+            let db_path = config
+                .cursor
+                .db_path
+                .clone()
+                .map(Ok)
+                .unwrap_or_else(crate::cursor::db::default_db_path)?;
+            let endpoints = crate::cursor::fetch::Endpoints::default();
+            let outcome =
+                crate::cursor::fetch_snapshot(client, &db_path, &cache, &endpoints, DEFAULT_TTL)
+                    .await?;
+            Ok(outcome.into())
+        }
     }
 }
 

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -89,6 +89,7 @@ pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> 
                 VendorSnapshot::Moonshot(s) => moonshot_sections(s),
                 VendorSnapshot::Grok(s) => grok_sections(s),
                 VendorSnapshot::Antigravity(s) => antigravity_sections(s, now),
+                VendorSnapshot::Cursor(s) => cursor_sections(s, now),
             };
             // Inject the (already-absolute) fetched-at instant into the title
             // row, right-aligned. Pre-snapshotted in app::refresh_one so it
@@ -366,6 +367,47 @@ fn antigravity_sections(s: &crate::usage::AntigravitySnapshot, now: DateTime<Utc
             push_window(&mut v, GROUP_THIRD_PARTY, w, now, 5, false);
         }
     }
+    v
+}
+
+fn cursor_sections(s: &crate::usage::CursorSnapshot, now: DateTime<Utc>) -> Vec<Section> {
+    let mut v = vec![Section::Title {
+        left: format!("Cursor {}", s.plan),
+        right: None,
+    }];
+    if s.unlimited {
+        v.push(Section::Spacer);
+        v.push(Section::Text {
+            label: "Plan".into(),
+            value: "Unlimited — pools don't cap".into(),
+        });
+    } else {
+        // Two included-usage pools, mirroring the dashboard's two bars.
+        v.push(Section::Spacer);
+        v.push(Section::Metric {
+            label: "Cursor Models".into(),
+            pct: s.auto_pct.clamp(0, 100) as u16,
+            severity: severity_for(s.auto_pct),
+            value_label: format!("{}%", s.auto_pct),
+            footnote: "Auto + Composer".into(),
+        });
+        v.push(Section::Spacer);
+        v.push(Section::Metric {
+            label: "Other Models".into(),
+            pct: s.api_pct.clamp(0, 100) as u16,
+            severity: severity_for(s.api_pct),
+            value_label: format!("{}%", s.api_pct),
+            footnote: format!(
+                "Named / API models · on-demand {}",
+                if s.on_demand_enabled { "on" } else { "off" }
+            ),
+        });
+    }
+    v.push(Section::Spacer);
+    v.push(Section::Text {
+        label: "Resets".into(),
+        value: countdown::format(s.reset_at, now),
+    });
     v
 }
 
@@ -1128,6 +1170,63 @@ mod tests {
             .filter(|s| matches!(s, Section::Metric { .. }))
             .count();
         assert_eq!(metric_count, 1);
+    }
+
+    fn cursor_snap() -> crate::usage::CursorSnapshot {
+        crate::usage::CursorSnapshot {
+            plan: "Ultra".into(),
+            auto_pct: 98,
+            api_pct: 100,
+            total_pct: 99,
+            unlimited: false,
+            on_demand_enabled: false,
+            reset_at: Some(now() + chrono::Duration::days(9)),
+        }
+    }
+
+    #[test]
+    fn cursor_sections_show_both_pools_and_reset() {
+        let sections = sections_for(&ready(VendorSnapshot::Cursor(cursor_snap())), now(), 5);
+        let metrics: Vec<_> = sections
+            .iter()
+            .filter_map(|s| match s {
+                Section::Metric {
+                    label, value_label, ..
+                } => Some((label.clone(), value_label.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(metrics.len(), 2, "two pools");
+        assert!(
+            metrics
+                .iter()
+                .any(|(l, v)| l == "Cursor Models" && v == "98%")
+        );
+        assert!(
+            metrics
+                .iter()
+                .any(|(l, v)| l == "Other Models" && v == "100%")
+        );
+        assert!(sections.iter().any(|s| matches!(
+            s,
+            Section::Text { label, value } if label == "Resets" && value.contains("9d")
+        )));
+    }
+
+    #[test]
+    fn cursor_unlimited_plan_shows_no_pool_bars() {
+        let mut snap = cursor_snap();
+        snap.unlimited = true;
+        let sections = sections_for(&ready(VendorSnapshot::Cursor(snap)), now(), 5);
+        let metric_count = sections
+            .iter()
+            .filter(|s| matches!(s, Section::Metric { .. }))
+            .count();
+        assert_eq!(metric_count, 0);
+        assert!(sections.iter().any(|s| matches!(
+            s,
+            Section::Text { value, .. } if value.contains("Unlimited")
+        )));
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -744,6 +744,7 @@ fn vendor_label(v: VendorId) -> &'static str {
         VendorId::Moonshot => "Moonshot",
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
+        VendorId::Cursor => "Cursor",
     }
 }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -82,6 +82,7 @@ fn vendor_label(id: VendorId) -> &'static str {
         VendorId::Moonshot => "Moonshot",
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
+        VendorId::Cursor => "Cursor",
     }
 }
 
@@ -99,6 +100,7 @@ fn compact_vendor_label(id: VendorId) -> &'static str {
         VendorId::Moonshot => "Moonshot",
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
+        VendorId::Cursor => "Cursor",
     }
 }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -222,6 +222,47 @@ impl Default for DeepseekSnapshot {
     }
 }
 
+/// Cursor — the two included-usage pools the dashboard shows, from the
+/// undocumented `cursor.com/api/usage-summary` endpoint (the same one the
+/// dashboard's own frontend calls), authenticated with the session token the
+/// Cursor IDE wrote to its local `state.vscdb`.
+///
+/// Since Cursor's mid-2026 pricing, a plan's included compute is split into two
+/// quota pools, each shown as a percentage: **Cursor Models** (Auto + Composer,
+/// `autoPercentUsed`) and **Other Models** (named / third-party, `apiPercentUsed`).
+/// Overflow past either pool falls to on-demand spend. Percentages are integers
+/// (rounded from the wire floats) to match the dashboard and every other
+/// vendor's integer-percent convention; they can exceed 100 when a pool is over
+/// its included allowance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CursorSnapshot {
+    /// Membership label, title-cased from `membershipType` (e.g. "Ultra").
+    pub plan: String,
+    /// "Cursor Models" pool — Auto + Composer (`autoPercentUsed`, rounded).
+    pub auto_pct: i32,
+    /// "Other Models" pool — named / third-party (`apiPercentUsed`, rounded).
+    pub api_pct: i32,
+    /// Overall included usage (`totalPercentUsed`, rounded) — the dashboard's
+    /// "you've used N% of your included total usage" headline.
+    pub total_pct: i32,
+    /// `true` when the plan reports `isUnlimited` — the pools don't cap and the
+    /// percentages are not meaningful.
+    pub unlimited: bool,
+    /// Whether on-demand (overage) spend is turned on (`onDemand.enabled`).
+    pub on_demand_enabled: bool,
+    /// End of the current billing cycle (`billingCycleEnd`) — when the pools
+    /// reset.
+    pub reset_at: Option<DateTime<Utc>>,
+}
+
+impl CursorSnapshot {
+    /// The binding pool — whichever is closest to (or furthest past) its cap.
+    /// Drives the bar color and the single generic `session_pct` alias.
+    pub fn worst_pct(&self) -> i32 {
+        self.auto_pct.max(self.api_pct)
+    }
+}
+
 /// Kimi Code — weekly subscription quota plus a 5h rolling rate-limit window.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KimiSnapshot {
@@ -276,6 +317,7 @@ pub enum VendorSnapshot {
     Grok(GrokSnapshot),
     AnthropicApi(AnthropicApiSnapshot),
     Antigravity(AntigravitySnapshot),
+    Cursor(CursorSnapshot),
 }
 
 /// Google Antigravity 2.0 / CLI snapshot. The API groups models into Gemini

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -70,6 +70,7 @@ pub enum VendorId {
     Moonshot,
     Grok,
     Antigravity,
+    Cursor,
 }
 
 impl VendorId {
@@ -87,6 +88,7 @@ impl VendorId {
             VendorId::Moonshot => "moonshot",
             VendorId::Grok => "grok",
             VendorId::Antigravity => "antigravity",
+            VendorId::Cursor => "cursor",
         }
     }
 
@@ -104,6 +106,7 @@ impl VendorId {
             VendorId::Moonshot,
             VendorId::Grok,
             VendorId::Antigravity,
+            VendorId::Cursor,
         ]
     }
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -138,6 +138,7 @@ pub enum Vendor {
     Moonshot,
     Grok,
     Antigravity,
+    Cursor,
 }
 
 impl Vendor {
@@ -155,6 +156,7 @@ impl Vendor {
             Vendor::Moonshot => crate::vendor::VendorId::Moonshot,
             Vendor::Grok => crate::vendor::VendorId::Grok,
             Vendor::Antigravity => crate::vendor::VendorId::Antigravity,
+            Vendor::Cursor => crate::vendor::VendorId::Cursor,
         }
     }
 }
@@ -239,6 +241,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::Moonshot => Vendor::Moonshot,
         crate::vendor::VendorId::Grok => Vendor::Grok,
         crate::vendor::VendorId::Antigravity => Vendor::Antigravity,
+        crate::vendor::VendorId::Cursor => Vendor::Cursor,
     }
 }
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -13,6 +13,7 @@ use crate::anthropic_api;
 use crate::antigravity;
 use crate::cache::{Cache, DEFAULT_TTL};
 use crate::config::Config;
+use crate::cursor;
 use crate::deepseek;
 use crate::error::{AppError, Result};
 use crate::grok;
@@ -149,6 +150,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::Moonshot => moonshot_output(cli, &config).await,
         Vendor::Grok => grok_output(cli, &config).await,
         Vendor::Antigravity => antigravity_output(cli, &config).await,
+        Vendor::Cursor => cursor_output(cli, &config).await,
     }
 }
 
@@ -175,6 +177,38 @@ async fn antigravity_output(cli: &Cli, _config: &Config) -> Result<WaybarOutput>
     let vendor_outcome: VendorOutcome = outcome.into();
     let opts = RenderOpts::from_cli(cli);
     Ok(antigravity::vendor::render(
+        &vendor_outcome,
+        &snap,
+        &theme,
+        &opts,
+        chrono::Utc::now(),
+    ))
+}
+
+/// Cursor authenticates via a session token the Cursor IDE already wrote to
+/// its local `state.vscdb` — no API key to resolve, but (unlike Antigravity)
+/// a real on-disk path that can be overridden, mirroring OpenAI's
+/// `codex_auth_path`.
+async fn cursor_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "cursor")?;
+    let db_path = match config.cursor.db_path.as_deref() {
+        Some(p) => p.to_path_buf(),
+        None => cursor::db::default_db_path()?,
+    };
+    let endpoints = cursor::fetch::Endpoints::default();
+    let outcome =
+        match cursor::fetch_snapshot(&client, &db_path, &cache, &endpoints, DEFAULT_TTL).await {
+            Ok(o) => o,
+            Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
+            Err(e) => return Err(e),
+        };
+
+    let theme = theme_from_cli(cli);
+    let snap = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    let opts = RenderOpts::from_cli(cli);
+    Ok(cursor::vendor::render(
         &vendor_outcome,
         &snap,
         &theme,

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -39,11 +39,16 @@
 //!   window are optional, so the smoke test validates their public fields only
 //!   when present; the snapshot does not expose raw wire duration/unit.
 //!   `kimi_live` skips when optional `KIMI_API_KEY` is unset.
+//! - **Cursor**: reads the session token from the local `state.vscdb`, then
+//!   asserts `premium_pct` is 0..=100 and a future `premium_reset_at` was
+//!   derived from `startOfMonth`. `cursor_live` skips when there is no Cursor
+//!   install (no state DB and no `CURSOR_DB_PATH`).
 
 use std::time::Duration;
 
 use ai_usagebar::anthropic;
 use ai_usagebar::cache::Cache;
+use ai_usagebar::cursor;
 use ai_usagebar::error::AppError;
 use ai_usagebar::kimi;
 use ai_usagebar::openai;
@@ -308,5 +313,69 @@ async fn kimi_live() {
         out.snapshot.window_limit,
         out.snapshot.window_remaining,
         out.snapshot.window_reset_at,
+    );
+}
+
+#[tokio::test]
+#[ignore = "live API; run with --ignored"]
+async fn cursor_live() {
+    // Cursor has no API key — the credential is the session token the Cursor
+    // IDE wrote to its local state DB. So this test needs a real Cursor install
+    // (or `CURSOR_DB_PATH` pointing at a copied `state.vscdb`) and skips
+    // otherwise, the same way `kimi_live` skips without a key. Nothing to fetch
+    // on a CI box with no Cursor.
+    let db_path = match std::env::var("CURSOR_DB_PATH") {
+        Ok(p) if !p.trim().is_empty() => std::path::PathBuf::from(p),
+        _ => cursor::db::default_db_path().expect("resolve platform config dir"),
+    };
+    if !db_path.exists() {
+        eprintln!(
+            "cursor_live: no Cursor state DB at {} — skipping (sign in to the Cursor IDE, or set CURSOR_DB_PATH)",
+            db_path.display()
+        );
+        return;
+    }
+
+    let cache = xdg_cache_for("cursor");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let endpoints = cursor::fetch::Endpoints::default();
+    let out = cursor::fetch_snapshot(
+        &client,
+        &db_path,
+        &cache,
+        &endpoints,
+        Duration::from_secs(0),
+    )
+    .await
+    .expect("cursor fetch should succeed against the real API");
+
+    // The fields the widget depends on: two pool percentages (>= 0; a pool can
+    // exceed 100 when over its included allowance, so only the low bound is
+    // asserted) and a future billing-cycle reset.
+    assert!(
+        out.snapshot.auto_pct >= 0 && out.snapshot.api_pct >= 0,
+        "cursor: negative pool percentage — shape changed? auto={} api={}",
+        out.snapshot.auto_pct,
+        out.snapshot.api_pct
+    );
+    assert!(!out.snapshot.plan.is_empty(), "cursor plan label empty");
+    assert!(
+        out.snapshot
+            .reset_at
+            .is_some_and(|r| r > chrono::Utc::now()),
+        "cursor: reset_at should be a future instant, got {:?}",
+        out.snapshot.reset_at
+    );
+    println!(
+        "✅ cursor — plan={}, Cursor Models {}%, Other Models {}%, total {}%, on-demand={}, reset {:?}",
+        out.snapshot.plan,
+        out.snapshot.auto_pct,
+        out.snapshot.api_pct,
+        out.snapshot.total_pct,
+        out.snapshot.on_demand_enabled,
+        out.snapshot.reset_at,
     );
 }


### PR DESCRIPTION
## Screenshot


<img width="836" height="676" alt="Screenshot 2026-07-26 at 15 46 08" src="https://github.com/user-attachments/assets/89f85a1b-8cc4-48dc-b9c4-defe547c7190" />

<img width="423" height="254" alt="image" src="https://github.com/user-attachments/assets/b6806249-736b-4a78-9d62-732c5a2177fc" />




*`ai-usagebar-tui` showing the Cursor tab live — **Cursor Ultra**, with the **Cursor Models** (Auto + Composer) and **Other Models** (named / API) pools and the billing-cycle reset.*

---

## What

Adds a **Cursor** vendor that shows this billing cycle's two included-usage pools — **Cursor Models** (Auto + Composer) and **Other Models** (named / API) — as percentages, matching the two bars on the Cursor dashboard:

```
❯ 98·100%          # bar (colored by the worst pool)

  Cursor Ultra
  ──────────────
    Cursor Models   98% used   (Auto + Composer)
    Other Models   100% used   (Named / API models · on-demand off)
    Resets 8d 7h
```

Also surfaces the plan (`membershipType`), the billing-cycle reset, whether on-demand spend is enabled, and unlimited plans.

## How it authenticates (no API key)

Cursor exposes no documented usage API or personal API key, so — like the community extensions (`Dwtexe/cursor-stats` et al.) — this reads the session token the Cursor IDE already wrote to its local `state.vscdb` (SQLite, key `cursorAuth/accessToken`), **read-only**. The JWT's `sub` claim yields the user id; combined with the raw token it forms the `WorkosCursorSessionToken` cookie the endpoint expects. No login step of the user's own — signing into the Cursor IDE once is enough.

Endpoint: `GET cursor.com/api/usage-summary` (undocumented; the one the dashboard's own frontend calls). Verified live against an Ultra account; a `#[ignore]`d smoke test (`cursor_live`) exercises it under `make smoke`.

## Wiring

Opt-in (`[cursor] enabled = true`, defaults off like the other reverse-engineered vendors). Follows the existing vendor module shape (`types`/`fetch`/`vendor` + a small `db` for the token read) and the shared cache/flock/staleness machinery. Wired into:

- the Waybar widget (`--vendor cursor`) and scroll-cycling,
- the TUI panel (a gauge per pool),
- the **macOS menu bar app** (the two pools relabel the session/weekly bars as "Cursor Models" / "Other Models"; other vendors keep their time-window labels),
- `config.example.toml`, README (auth table, vendor matrix, placeholders, endpoint-stability note), and `CHANGELOG.md`.

New placeholders: `{cursor_auto_pct}`, `{cursor_api_pct}`, `{cursor_total_pct}`, `{cursor_plan}`, `{cursor_reset}`, `{cursor_on_demand}`, `{cursor_unlimited}`; generic aliases `{session_pct}` = Cursor Models, `{weekly_pct}` = Other Models.

## Dependency

Adds `rusqlite` with the **bundled** feature (statically links SQLite via `cc`), so no system `libsqlite3` is required and the AUR source build stays hermetic.

## Tests

`cargo test` green (642), `cargo fmt --check` clean, `cargo clippy --all-targets -D warnings` clean for the new code, and the macOS Swift harness (`macos/run-tests.sh`) passes with new Cursor cases. Unit tests cover the SQLite token read, JWT/cookie derivation, `usage-summary` parsing (including over-100% pools, unlimited plans, and schema-drift guards), the cache round-trip, and rendering.

## Team accounts (best-effort)

Team / token-based enterprise accounts report **no** `individualUsage.plan` — Cursor doesn't expose the per-seat request limit on this endpoint for them. Their only percentage source is the prose `autoModelSelectedDisplayMessage` / `namedModelSelectedDisplayMessage` strings the payload also carries (e.g. *"You've used 42% of your included total usage"*), which map to the same two pools. `to_snapshot` now parses those when `plan` is absent, accepting a team snapshot only if **both** messages parse (a single stray message stays schema drift, never a fabricated 0%), and labels it `"<Plan> (team)"`. **Unverified against a live team account** — inferred from an independent reverse-engineering of the same endpoint; a payload that matches neither shape still falls through to the existing schema error. Also fixes a latent bug found along the way: `individualUsage.onDemand` lacked its serde rename, so `on_demand_enabled` was silently always `false`.

## Not included

- **GNOME extension** — not wired yet (CLI/TUI/macOS only for now).

