### PR TITLE
feat(anthropic): multi-account auto-discovery via accounts_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,24 @@ Each release is also published at
 
 ### Fixed
 
+- **Named/`accounts_dir` Anthropic accounts now find macOS Keychain-backed
+  logins.** `CLAUDE_CONFIG_DIR=<accounts_dir>/<label> claude` was documented
+  to make `<label>` "just work", but on macOS Claude Code stores the login in
+  the Keychain (service `Claude Code-credentials-<hash>`, hashed from the
+  config dir's absolute path) and never writes `<label>/.credentials.json` —
+  so a named account could look logged in via `claude` yet ai-usagebar kept
+  reporting "no usable cache" / stale file errors. Named accounts now prefer
+  the Keychain item hashed from their own directory, falling back to the file
+  (the Linux layout). Keychain-first matters: a `.credentials.json` copied by
+  hand shares its refresh-token lineage with the original, and dies with a
+  401 as soon as the real holder rotates it — reading the file first kept
+  resurrecting those dead snapshots over the live login sitting in the
+  Keychain. Token refreshes write back to the same scoped item, so
+  ai-usagebar and Claude Code keep sharing one source of truth per account.
+  A different account's item can never match (the hash is per-directory), so
+  this doesn't reopen the cross-account ambiguity the original file-only
+  rule (#15) was written to avoid.
+
 - **A failed terminal resize no longer exits the TUI.** A transient
   `terminal.resize` error (e.g. an ioctl failure) now just skips that resize
   instead of tearing down the whole UI; the next resize or redraw recovers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-discovered Anthropic accounts (`[anthropic] accounts_dir`).** Point it
+  at a directory and ai-usagebar discovers each account under it automatically,
+  using Claude Code's own `CLAUDE_CONFIG_DIR` layout: every immediate
+  subdirectory holding a `.credentials.json` becomes an account labeled by the
+  subdirectory name — a TUI tab and `--account <label>`, refreshed
+  independently — with no per-account config entry. Populate it by running the
+  `claude` CLI with a per-account `CLAUDE_CONFIG_DIR`, the general way to keep
+  several Claude Code logins side by side. Discovered accounts merge with
+  explicit `[[anthropic.accounts]]` (explicit wins on a label clash); a missing
+  or unreadable directory is ignored. Because it keys only on the standard
+  Claude Code layout, any tool that manages multiple logins works with it, not
+  one specific account switcher.
+  - **`[anthropic] show_default_account`** (default `true`): set `false` to hide
+    the default (unnamed) Claude tab when every account is managed explicitly,
+    so you don't get a redundant tab for the ambient Keychain/`~/.claude` login.
+    Ignored when there are no named accounts.
+  - **Staggered multi-account refreshes.** The TUI previously refreshed every
+    tab at once; with several Anthropic accounts that burst the shared
+    `/api/oauth/usage` + token endpoints and tripped their rate limit (`429`).
+    Anthropic tabs now refresh spaced out (~0.8s apart) so each account fetches
+    politely; other vendors still start immediately.
+
 ### Fixed
 
 - **A failed terminal resize no longer exits the TUI.** A transient

--- a/README.md
+++ b/README.md
@@ -428,6 +428,39 @@ credentials_path = "~/.config/ai-usagebar/accounts/personal.json"
   tab per account (after the default Claude tab), so the config above wires up
   the widget and the TUI at once.
 
+#### Auto-discovered accounts (`accounts_dir`)
+
+Rather than list every account by hand, point `[anthropic] accounts_dir` at a
+directory and ai-usagebar discovers each account under it automatically — using
+**Claude Code's own [`CLAUDE_CONFIG_DIR`](https://docs.claude.com/en/docs/claude-code/settings)
+layout**: each immediate subdirectory that contains a `.credentials.json`
+becomes an account labeled by the subdirectory name. Drop one in (or log a new
+account in) and its tab / `--account <label>` appears with no config edit.
+
+```toml
+[anthropic]
+accounts_dir = "~/.config/ai-usagebar/accounts"
+```
+
+Populate it once per account by running the official `claude` CLI with a
+per-account config dir — this is the general, tool-agnostic way to keep several
+Claude Code logins side by side:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.config/ai-usagebar/accounts/personal claude   # sign in as personal
+CLAUDE_CONFIG_DIR=~/.config/ai-usagebar/accounts/work     claude   # sign in as work
+```
+
+Each login writes that dir's own `.credentials.json`; ai-usagebar then reads and
+**refreshes each independently** (writing the refreshed token back to that dir),
+so all your accounts stay live at once. Discovered accounts are merged with any
+explicit `[[anthropic.accounts]]` entries — an explicit entry wins on a label
+clash — and a missing or unreadable `accounts_dir` is simply ignored. Because
+discovery keys only on the standard Claude Code layout, *any* tool or script
+that manages multiple Claude Code logins (not just one specific account
+switcher) works with it; a rotating account manager just needs to drop or
+refresh each login under this directory.
+
 ## Hyprland: float the TUI window
 
 By default Hyprland tiles the TUI. To make `ai-usagebar-tui` open as a centered floating window, the same way Omarchy floats its own settings TUIs (Wi-Fi/`impala`, audio/`wiremix`, Bluetooth/`bluetui`), add this to `~/.config/hypr/hyprland.conf` or any sourced `.conf`, such as `looknfeel.conf`:

--- a/config.example.toml
+++ b/config.example.toml
@@ -34,6 +34,21 @@ enabled = true
 # Path to the Claude CLI OAuth credentials. Leave commented out to use
 # the default ~/.claude/.credentials.json.
 # credentials_path = "/home/you/.claude/.credentials.json"
+# Auto-discover extra accounts from a directory, in Claude Code's own
+# CLAUDE_CONFIG_DIR layout: each subdir holding a .credentials.json becomes an
+# account labeled by the subdir name (shown as a TUI tab and selectable with
+# --account <label>), refreshed independently. Populate it with, e.g.:
+#   CLAUDE_CONFIG_DIR=~/.config/ai-usagebar/accounts/work claude   # sign in
+# Merged with the explicit [[anthropic.accounts]] entries below (explicit wins).
+# accounts_dir = "~/.config/ai-usagebar/accounts"
+# Hide the default (unnamed) Claude tab when you manage every account explicitly
+# above — otherwise you get an extra tab for the ambient ~/.claude / Keychain
+# login. Default true; ignored when there are no named accounts.
+# show_default_account = false
+# Or list accounts explicitly:
+# [[anthropic.accounts]]
+# label = "work"
+# credentials_path = "~/.config/ai-usagebar/accounts/work/.credentials.json"
 
 # Anthropic (API) — unlike the balance vendors above (which show your REMAINING
 # credit), Anthropic does not expose the prepaid credit balance over any API

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -131,15 +131,25 @@ pub enum CredsTarget {
     /// `~/.claude/.credentials.json` (or the Windows equivalent) — falls back
     /// to the macOS Keychain when the file is missing *or unusable* (#15).
     Default(PathBuf),
-    /// `--creds-path`, config `credentials_path`, or a named account's file —
-    /// never consults the Keychain.
+    /// `--creds-path` or config `credentials_path` with no `CLAUDE_CONFIG_DIR`
+    /// of its own — never consults the Keychain.
     Explicit(PathBuf),
+    /// A named account (`[[anthropic.accounts]]` or `accounts_dir`): prefers
+    /// the macOS Keychain item scoped to `config_dir` (`path`'s parent, the
+    /// account's own `CLAUDE_CONFIG_DIR`) because that is where
+    /// `CLAUDE_CONFIG_DIR=<dir> claude` actually writes on macOS; `path` is
+    /// the fallback for the Linux layout and hand-managed files (see
+    /// [`read_named_with`] for the full decision table). Safe unlike a shared
+    /// fallback would be: the Keychain item is hashed from `config_dir`, so
+    /// it can never resolve to a *different* account's credentials.
+    Named { path: PathBuf, config_dir: PathBuf },
 }
 
 impl CredsTarget {
     pub fn path(&self) -> &Path {
         match self {
             CredsTarget::Default(p) | CredsTarget::Explicit(p) => p,
+            CredsTarget::Named { path, .. } => path,
         }
     }
 }
@@ -153,6 +163,11 @@ pub enum CredsSource {
     /// Only produced on macOS in production (the login Keychain item
     /// `Claude Code-credentials`).
     Keychain,
+    /// Only produced on macOS in production: a named account's
+    /// `CLAUDE_CONFIG_DIR`-scoped Keychain item (`Claude
+    /// Code-credentials-<hash>`), keyed by the account's config dir so
+    /// write-backs land in the same per-account item they were read from.
+    NamedKeychain(PathBuf),
 }
 
 /// Credentials that can't possibly authenticate anything: no access token, no
@@ -176,6 +191,12 @@ pub fn resolve(target: &CredsTarget) -> Result<(CredentialsFile, CredsSource)> {
             return read_default_with(p, keychain::read_raw);
             #[cfg(not(target_os = "macos"))]
             read_default_with(p, || Ok(None))
+        }
+        CredsTarget::Named { path, config_dir } => {
+            #[cfg(target_os = "macos")]
+            return read_named_with(path, config_dir, keychain::read_raw_for);
+            #[cfg(not(target_os = "macos"))]
+            read_named_with(path, config_dir, |_| Ok(None))
         }
     }
 }
@@ -222,6 +243,42 @@ fn read_default_with(
     }
 }
 
+/// Named-account read: the account's `CLAUDE_CONFIG_DIR`-scoped Keychain item
+/// wins over the file. On macOS the `claude` CLI *always* writes logins to the
+/// Keychain — `CLAUDE_CONFIG_DIR=<dir> claude` lands in the dir-scoped item,
+/// never in `<dir>/.credentials.json` — so a file there is at best a hand-made
+/// snapshot. Snapshots die: their refresh-token lineage rotates away the next
+/// time the *real* holder refreshes, and the copy 401s within hours (observed
+/// in production; that failure is what motivated this order). Decision table:
+///
+/// | keychain item              | file             | outcome            |
+/// |----------------------------|------------------|--------------------|
+/// | usable                     | (not consulted)  | keychain           |
+/// | absent/unusable/unparsable | readable         | file               |
+/// | absent/unusable/unparsable | missing/broken   | the file's error   |
+/// | **unreadable** (locked/ACL)| any              | the Keychain error |
+///
+/// The unreadable row follows [`read_default_with`]'s reasoning: a locked
+/// Keychain is not "no credentials", and silently dropping to a stale file
+/// snapshot would produce exactly the confusing half-dead state this order
+/// exists to prevent. On non-macOS the injected reader returns `None`, so the
+/// file is simply read strictly — the Linux layout is file-only.
+fn read_named_with(
+    path: &Path,
+    config_dir: &Path,
+    keychain_read: impl Fn(&Path) -> Result<Option<String>>,
+) -> Result<(CredentialsFile, CredsSource)> {
+    // A present-but-unparsable/unusable item is no better than the file, so
+    // the whole chain failing falls through to the strict file read.
+    if let Some(raw) = keychain_read(config_dir)?
+        && let Ok(kc) = parse(&raw, "macOS Keychain (named account)")
+        && !is_unusable(&kc.claude_ai_oauth)
+    {
+        return Ok((kc, CredsSource::NamedKeychain(config_dir.to_path_buf())));
+    }
+    Ok((read_from(path)?, CredsSource::File(path.to_path_buf())))
+}
+
 /// Parse a credentials JSON blob from any source (`source` only labels errors).
 fn parse(raw: &str, source: &str) -> Result<CredentialsFile> {
     serde_json::from_str(raw).map_err(|e| {
@@ -266,6 +323,17 @@ pub fn write_back_to(source: &CredsSource, new_oauth: &OauthCreds) -> Result<()>
         }
         #[cfg(not(target_os = "macos"))]
         CredsSource::Keychain => Err(AppError::Other(
+            "Keychain credentials source is macOS-only".into(),
+        )),
+        #[cfg(target_os = "macos")]
+        CredsSource::NamedKeychain(config_dir) => {
+            let existing = keychain::read_raw_for(config_dir)?;
+            let doc = merge_oauth(existing.as_deref(), new_oauth)?;
+            let json = serde_json::to_string(&doc).map_err(AppError::Json)?;
+            keychain::write_raw_for(config_dir, &json)
+        }
+        #[cfg(not(target_os = "macos"))]
+        CredsSource::NamedKeychain(_) => Err(AppError::Other(
             "Keychain credentials source is macOS-only".into(),
         )),
     }
@@ -489,6 +557,68 @@ mod tests {
         // Without a keychain rescue, the original parse error surfaces.
         let err = read_default_with(&path, || Ok(None)).unwrap_err();
         assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    // --- named accounts: config-dir-scoped Keychain wins over the file ------
+    // `read_named_with` takes the keychain reader as a closure, so these run
+    // hermetically on any platform — no real Keychain, no real $HOME.
+
+    #[test]
+    fn named_read_prefers_keychain_over_a_live_looking_file() {
+        // The production failure this order exists for: the file is a stale
+        // hand-made snapshot that still *looks* usable (tokens present) but
+        // whose refresh lineage has rotated away; the scoped Keychain item is
+        // what `claude` actually keeps alive.
+        let (_dir, path) = write_creds_closed(USABLE);
+        let cfg_dir = path.parent().unwrap().to_path_buf();
+        let (creds, source) =
+            read_named_with(&path, &cfg_dir, |_| Ok(Some(KEYCHAIN_USABLE.into()))).unwrap();
+        assert_eq!(creds.claude_ai_oauth.access_token, "kc-token");
+        assert_eq!(source, CredsSource::NamedKeychain(cfg_dir));
+    }
+
+    #[test]
+    fn named_read_falls_back_to_file_when_keychain_absent() {
+        // Linux layout / hand-managed file: no scoped Keychain item exists.
+        let (_dir, path) = write_creds_closed(USABLE);
+        let cfg_dir = path.parent().unwrap().to_path_buf();
+        let (creds, source) = read_named_with(&path, &cfg_dir, |_| Ok(None)).unwrap();
+        assert_eq!(creds.claude_ai_oauth.access_token, "live-token");
+        assert_eq!(source, CredsSource::File(path));
+    }
+
+    #[test]
+    fn named_read_unusable_keychain_falls_back_to_file() {
+        let (_dir, path) = write_creds_closed(USABLE);
+        let cfg_dir = path.parent().unwrap().to_path_buf();
+        let (_, source) = read_named_with(&path, &cfg_dir, |_| Ok(Some(UNUSABLE.into()))).unwrap();
+        assert_eq!(source, CredsSource::File(path.clone()));
+        // Unparsable Keychain blob — same fallback.
+        let (_, source) =
+            read_named_with(&path, &cfg_dir, |_| Ok(Some("not json".into()))).unwrap();
+        assert_eq!(source, CredsSource::File(path));
+    }
+
+    #[test]
+    fn named_read_both_missing_surfaces_the_file_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("missing.json");
+        let err = read_named_with(&path, dir.path(), |_| Ok(None)).unwrap_err();
+        assert!(matches!(err, AppError::Io { .. }));
+    }
+
+    #[test]
+    fn named_read_locked_keychain_error_surfaces_not_the_stale_file() {
+        // Same reasoning as the default account: a locked Keychain is not
+        // "no credentials", and silently reading a stale snapshot instead
+        // recreates exactly the half-dead fork this order prevents.
+        let (_dir, path) = write_creds_closed(USABLE);
+        let cfg_dir = path.parent().unwrap();
+        let err = read_named_with(&path, cfg_dir, |_| {
+            Err(AppError::Credentials("the Keychain is locked".into()))
+        })
+        .unwrap_err();
+        assert!(matches!(err, AppError::Credentials(ref m) if m.contains("locked")));
     }
 
     #[test]

--- a/src/anthropic/keychain.rs
+++ b/src/anthropic/keychain.rs
@@ -10,13 +10,54 @@
 //! macOS-only crate (`security-framework`) — it keeps the dependency tree and
 //! the Linux build untouched, and mirrors the project's "read what the CLI
 //! already wrote" philosophy.
+//!
+//! A `CLAUDE_CONFIG_DIR`-scoped login (`CLAUDE_CONFIG_DIR=<dir> claude`, the
+//! mechanism `accounts_dir` documents) also lands in the Keychain rather than
+//! `<dir>/.credentials.json` — under a *different* service name, `Claude
+//! Code-credentials-<hash>`, where `<hash>` is the first 8 hex chars of the
+//! SHA-256 of the config dir's absolute path (verified empirically against a
+//! real install). [`read_raw_for`]/[`write_raw_for`] target that per-account
+//! item so named accounts can find it without ever reading the *default*
+//! item — a hash tied to the account's own directory can't collide with a
+//! different account's, which is what issue #15 needed the strict
+//! `Explicit`-only rule to avoid in the first place.
 
-use std::process::Command;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
 
 use crate::error::{AppError, Result};
 
 /// Generic-password *service* name Claude Code uses for the credentials blob.
 const SERVICE: &str = "Claude Code-credentials";
+
+/// The per-account service name for a `CLAUDE_CONFIG_DIR`-scoped login. Shells
+/// out to `shasum(1)` rather than pulling in a `sha2` crate — same rationale
+/// as the rest of this module.
+fn service_name_for(config_dir: &Path) -> Result<String> {
+    let mut child = Command::new("/usr/bin/shasum")
+        .args(["-a", "256"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+        .map_err(|e| AppError::Other(format!("could not run `shasum`: {e}")))?;
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped")
+        .write_all(config_dir.display().to_string().as_bytes())
+        .map_err(|e| AppError::Other(format!("could not run `shasum`: {e}")))?;
+    let out = child
+        .wait_with_output()
+        .map_err(|e| AppError::Other(format!("could not run `shasum`: {e}")))?;
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let hash = stdout
+        .split_whitespace()
+        .next()
+        .and_then(|h| h.get(..8))
+        .ok_or_else(|| AppError::Other("shasum produced unexpected output".into()))?;
+    Ok(format!("{SERVICE}-{hash}"))
+}
 
 /// The Keychain item's *account* is the macOS short username. We match on it
 /// when updating so we touch exactly the item Claude Code created.
@@ -40,8 +81,18 @@ const ERR_SEC_ITEM_NOT_FOUND: i32 = 44;
 /// same as "you are not logged in", and reporting it as such sent users off to
 /// re-authenticate when the credentials were there all along.
 pub fn read_raw() -> Result<Option<String>> {
+    read_raw_service(SERVICE)
+}
+
+/// Same as [`read_raw`], but for a named account's `CLAUDE_CONFIG_DIR`-scoped
+/// Keychain item instead of the default one.
+pub fn read_raw_for(config_dir: &Path) -> Result<Option<String>> {
+    read_raw_service(&service_name_for(config_dir)?)
+}
+
+fn read_raw_service(service: &str) -> Result<Option<String>> {
     let mut cmd = Command::new("/usr/bin/security");
-    cmd.args(["find-generic-password", "-s", SERVICE, "-w"]);
+    cmd.args(["find-generic-password", "-s", service, "-w"]);
     if let Some(acct) = account() {
         cmd.args(["-a", &acct]);
     }
@@ -89,8 +140,18 @@ pub fn read_raw() -> Result<Option<String>> {
 /// rare proactive token refresh, so we accept the local-only exposure of a
 /// secret that already lives in this user's Keychain.
 pub fn write_raw(json: &str) -> Result<()> {
+    write_raw_service(SERVICE, json)
+}
+
+/// Same as [`write_raw`], but for a named account's `CLAUDE_CONFIG_DIR`-scoped
+/// Keychain item instead of the default one.
+pub fn write_raw_for(config_dir: &Path, json: &str) -> Result<()> {
+    write_raw_service(&service_name_for(config_dir)?, json)
+}
+
+fn write_raw_service(service: &str, json: &str) -> Result<()> {
     let mut cmd = Command::new("/usr/bin/security");
-    cmd.args(["add-generic-password", "-U", "-s", SERVICE]);
+    cmd.args(["add-generic-password", "-U", "-s", service]);
     // Must mirror `read_raw`'s selection exactly, or an update can create a
     // second item the read will never find.
     if let Some(acct) = account() {

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -11,9 +11,12 @@
 
 use std::io;
 
+use std::time::Duration;
+
 use ai_usagebar::config::Config;
 use ai_usagebar::tui::app::{
-    App, REFRESH_INTERVAL, TabId, TabState, refresh_one, tabs_from_config,
+    ANTHROPIC_REFRESH_STAGGER, App, REFRESH_INTERVAL, TabId, TabState, refresh_one,
+    refresh_stagger, tabs_from_config,
 };
 use ai_usagebar::tui::view::draw;
 use ai_usagebar::vendor::HTTP_CLIENT_TIMEOUT;
@@ -288,7 +291,8 @@ where
                     if matches!(k.code, KeyCode::Char('r'))
                         && let Some(tab) = app.active_tab_id().cloned()
                     {
-                        spawn_one(app, tab, client, config, &tx);
+                        // A manual single-tab refresh isn't a burst — no stagger.
+                        spawn_one(app, tab, client, config, &tx, Duration::ZERO);
                     }
                     if matches!(k.code, KeyCode::Char('R')) {
                         spawn_all(app, client, config, &tx);
@@ -344,8 +348,12 @@ fn spawn_all(
     config: &Config,
     tx: &mpsc::UnboundedSender<(u64, TabId, TabState)>,
 ) {
-    for tab in app.tabs_meta.clone() {
-        spawn_one(app, tab, client, config, tx);
+    let tabs = app.tabs_meta.clone();
+    // Space out the Anthropic tabs so several accounts don't burst the shared
+    // usage/token endpoint and trip its rate limit (429).
+    let delays = refresh_stagger(&tabs, ANTHROPIC_REFRESH_STAGGER);
+    for (tab, delay) in tabs.into_iter().zip(delays) {
+        spawn_one(app, tab, client, config, tx, delay);
     }
 }
 
@@ -355,6 +363,7 @@ fn spawn_one(
     client: &Client,
     config: &Config,
     tx: &mpsc::UnboundedSender<(u64, TabId, TabState)>,
+    delay: Duration,
 ) {
     let tx = tx.clone();
     let client = client.clone();
@@ -364,6 +373,9 @@ fn spawn_one(
         app.tabs[index] = TabState::Loading;
     }
     tokio::spawn(async move {
+        if !delay.is_zero() {
+            tokio::time::sleep(delay).await;
+        }
         let state = refresh_one(&client, &cfg, &tab).await;
         let _ = tx.send((generation, tab, state));
     });

--- a/src/config.rs
+++ b/src/config.rs
@@ -215,15 +215,27 @@ impl AnthropicConfig {
     }
 
     /// Resolve a named account to the credentials target + isolated cache it
-    /// fetches through: a strict [`CredsTarget::Explicit`] on the account's file
-    /// (never the Keychain — issue #15) and an `anthropic/<label>` cache subdir.
-    /// Shared by the widget (`--account`) and the TUI's per-account tab (#14,
-    /// #17) so both resolve accounts identically; the widget layers its
-    /// `--cache-dir` override on top of the cache returned here.
+    /// fetches through: [`CredsTarget::Named`], which on macOS prefers the
+    /// Keychain item scoped to the file's own directory (that is where
+    /// `CLAUDE_CONFIG_DIR=<dir> claude` actually writes) and falls back to
+    /// the file elsewhere — never a *different* account's item, since the
+    /// hash is per-directory, so issue #15's cross-account concern doesn't
+    /// apply. Plus an `anthropic/<label>` cache subdir. Shared by the widget
+    /// (`--account`) and the TUI's per-account tab (#14, #17) so both resolve
+    /// accounts identically; the widget layers its `--cache-dir` override on
+    /// top of the cache returned here.
     pub fn account_target(&self, label: &str) -> Result<(CredsTarget, Cache)> {
         let account = self.account(label)?;
+        let config_dir = account
+            .credentials_path
+            .parent()
+            .map(std::path::Path::to_path_buf)
+            .unwrap_or_else(|| account.credentials_path.clone());
         Ok((
-            CredsTarget::Explicit(account.credentials_path),
+            CredsTarget::Named {
+                path: account.credentials_path,
+                config_dir,
+            },
             Cache::for_vendor_account("anthropic", label)?,
         ))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,19 @@ pub struct AnthropicConfig {
     /// with `--account <label>` (issue #14). Empty by default, so existing
     /// single-account configs are byte-for-byte unchanged.
     pub accounts: Vec<AnthropicAccount>,
+    /// Directory to auto-discover extra accounts from, in Claude Code's own
+    /// `CLAUDE_CONFIG_DIR` layout: each immediate subdirectory holding a
+    /// `.credentials.json` becomes an account labeled by the subdirectory name,
+    /// so `CLAUDE_CONFIG_DIR=<accounts_dir>/<label> claude` makes `<label>`
+    /// appear with no config edit. Merged with `accounts` (explicit wins on a
+    /// label clash); each is refreshed independently.
+    pub accounts_dir: Option<PathBuf>,
+    /// Whether the default (unnamed) Claude account gets its own tab. Defaults
+    /// to `true` for back-compat. Set `false` when every account is managed
+    /// explicitly (via `accounts`/`accounts_dir`) so the ambient
+    /// Keychain/`~/.claude` login doesn't add a redundant "Claude" tab. Ignored
+    /// when there are no named accounts, so Anthropic never loses its only tab.
+    pub show_default_account: bool,
 }
 
 impl Default for AnthropicConfig {
@@ -141,6 +154,8 @@ impl Default for AnthropicConfig {
             enabled: true,
             credentials_path: None,
             accounts: Vec::new(),
+            accounts_dir: None,
+            show_default_account: true,
         }
     }
 }
@@ -166,20 +181,37 @@ pub struct AnthropicAccount {
 }
 
 impl AnthropicConfig {
-    /// Find a configured extra account by label, or error listing the known
-    /// labels so a typo fails loudly instead of silently hitting the default.
-    pub fn account(&self, label: &str) -> Result<&AnthropicAccount> {
+    /// Every extra account: the explicit `[[anthropic.accounts]]` entries plus
+    /// any auto-discovered under [`accounts_dir`](AnthropicConfig::accounts_dir).
+    /// Explicit entries take precedence on a label clash. This is what tabs and
+    /// `--account` enumerate, so a discovered account behaves exactly like a
+    /// hand-written one (own cache subdir, independent refresh).
+    pub fn all_accounts(&self) -> Vec<AnthropicAccount> {
+        let mut out = self.accounts.clone();
+        if let Some(dir) = &self.accounts_dir {
+            for acct in discover_accounts(dir) {
+                if !out.iter().any(|a| a.label == acct.label) {
+                    out.push(acct);
+                }
+            }
+        }
+        out
+    }
+
+    /// Find an extra account by label (explicit or discovered), or error listing
+    /// the known labels so a typo fails loudly instead of silently hitting the
+    /// default. Returns an owned account because discovered entries are
+    /// synthesized, not stored.
+    pub fn account(&self, label: &str) -> Result<AnthropicAccount> {
         validate_account_label(label)?;
-        self.accounts
-            .iter()
-            .find(|a| a.label == label)
-            .ok_or_else(|| {
-                let known: Vec<&str> = self.accounts.iter().map(|a| a.label.as_str()).collect();
-                AppError::Credentials(format!(
-                    "anthropic account {label:?} not found in [[anthropic.accounts]]; \
-                     known labels: {known:?}"
-                ))
-            })
+        let all = self.all_accounts();
+        all.iter().find(|a| a.label == label).cloned().ok_or_else(|| {
+            let known: Vec<&str> = all.iter().map(|a| a.label.as_str()).collect();
+            AppError::Credentials(format!(
+                "anthropic account {label:?} not found in [[anthropic.accounts]] or accounts_dir; \
+                 known labels: {known:?}"
+            ))
+        })
     }
 
     /// Resolve a named account to the credentials target + isolated cache it
@@ -191,7 +223,7 @@ impl AnthropicConfig {
     pub fn account_target(&self, label: &str) -> Result<(CredsTarget, Cache)> {
         let account = self.account(label)?;
         Ok((
-            CredsTarget::Explicit(account.credentials_path.clone()),
+            CredsTarget::Explicit(account.credentials_path),
             Cache::for_vendor_account("anthropic", label)?,
         ))
     }
@@ -215,6 +247,40 @@ fn validate_account_label(label: &str) -> Result<()> {
         )));
     }
     Ok(())
+}
+
+/// Discover accounts under `accounts_dir` in the `CLAUDE_CONFIG_DIR` layout:
+/// each immediate subdirectory holding a `.credentials.json` becomes an account
+/// labeled by the subdirectory name. Best-effort: an unreadable directory, a
+/// subdir without the credentials file, or an unusable label is skipped
+/// silently rather than failing the whole config — discovery is convenience,
+/// while an explicit `[[anthropic.accounts]]` entry stays authoritative. Sorted
+/// by label so the tab order is stable across runs.
+fn discover_accounts(accounts_dir: &std::path::Path) -> Vec<AnthropicAccount> {
+    let Ok(entries) = std::fs::read_dir(accounts_dir) else {
+        return Vec::new();
+    };
+    let mut found: Vec<AnthropicAccount> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if !path.is_dir() {
+                return None;
+            }
+            let creds = path.join(".credentials.json");
+            if !creds.is_file() {
+                return None;
+            }
+            let label = path.file_name()?.to_str()?.to_string();
+            validate_account_label(&label).ok()?;
+            Some(AnthropicAccount {
+                label,
+                credentials_path: creds,
+            })
+        })
+        .collect();
+    found.sort_by(|a, b| a.label.cmp(&b.label));
+    found
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -512,6 +578,7 @@ impl Config {
     fn expand_paths(&mut self) {
         expand_tilde_opt(&mut self.context.projects_path);
         expand_tilde_opt(&mut self.anthropic.credentials_path);
+        expand_tilde_opt(&mut self.anthropic.accounts_dir);
         expand_tilde_opt(&mut self.openai.codex_auth_path);
         for account in &mut self.anthropic.accounts {
             account.credentials_path = expand_tilde(&account.credentials_path);
@@ -1221,6 +1288,91 @@ enabled = false
         // No [[anthropic.accounts]] → the single default account, empty list,
         // nothing to migrate (issue #14, back-compat rule 1).
         assert!(Config::default().anthropic.accounts.is_empty());
+        assert!(Config::default().anthropic.accounts_dir.is_none());
+    }
+
+    // --- accounts_dir: CLAUDE_CONFIG_DIR-style auto-discovery ----------------
+    // All hermetic: discovery reads a TempDir, never the user's real config.
+
+    /// Create `<root>/<label>/.credentials.json` (contents irrelevant here —
+    /// discovery keys on the file existing, the fetch path parses it).
+    fn seed_account_dir(root: &std::path::Path, label: &str) {
+        let dir = root.join(label);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(".credentials.json"), "{}").unwrap();
+    }
+
+    #[test]
+    fn discovers_credential_dirs_in_claude_config_dir_layout() {
+        let td = tempfile::tempdir().unwrap();
+        seed_account_dir(td.path(), "work");
+        seed_account_dir(td.path(), "personal");
+        // A subdir with no .credentials.json is ignored.
+        std::fs::create_dir_all(td.path().join("empty")).unwrap();
+        // A loose file (not a dir) is ignored.
+        std::fs::write(td.path().join("stray.json"), "{}").unwrap();
+
+        let cfg = AnthropicConfig {
+            accounts_dir: Some(td.path().to_path_buf()),
+            ..Default::default()
+        };
+        let all = cfg.all_accounts();
+        let labels: Vec<&str> = all.iter().map(|a| a.label.as_str()).collect();
+        // Sorted, and only the two real credential dirs.
+        assert_eq!(labels, vec!["personal", "work"]);
+        assert_eq!(
+            all[1].credentials_path,
+            td.path().join("work").join(".credentials.json")
+        );
+    }
+
+    #[test]
+    fn explicit_account_wins_over_a_discovered_one_with_the_same_label() {
+        let td = tempfile::tempdir().unwrap();
+        seed_account_dir(td.path(), "work");
+        let cfg = AnthropicConfig {
+            accounts: vec![AnthropicAccount {
+                label: "work".into(),
+                credentials_path: "/explicit/work.json".into(),
+            }],
+            accounts_dir: Some(td.path().to_path_buf()),
+            ..Default::default()
+        };
+        let all = cfg.all_accounts();
+        assert_eq!(all.len(), 1, "no duplicate label");
+        assert_eq!(
+            all[0].credentials_path,
+            std::path::Path::new("/explicit/work.json"),
+            "explicit entry wins"
+        );
+        // A discovered account is still reachable through `account()`.
+        seed_account_dir(td.path(), "other");
+        assert_eq!(cfg.account("other").unwrap().label, "other");
+    }
+
+    #[test]
+    fn missing_accounts_dir_is_silently_empty_not_an_error() {
+        let cfg = AnthropicConfig {
+            accounts_dir: Some("/nonexistent/ai-usagebar-accounts".into()),
+            ..Default::default()
+        };
+        assert!(cfg.all_accounts().is_empty());
+    }
+
+    #[test]
+    fn accounts_dir_is_tilde_expanded_on_load() {
+        let f = write_toml(
+            r#"
+            [anthropic]
+            accounts_dir = "~/.config/ai-usagebar/accounts"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        let home = crate::cache::home_dir().unwrap();
+        assert_eq!(
+            c.anthropic.accounts_dir,
+            Some(home.join(".config/ai-usagebar/accounts"))
+        );
     }
 
     /// The shipped example, which `make install` puts in

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -70,11 +70,19 @@ impl TabId {
 pub fn tabs_from_config(config: &Config) -> Vec<TabId> {
     let mut tabs = Vec::new();
     for vendor in config.enabled_vendors() {
-        tabs.push(TabId::vendor(vendor));
         if vendor == VendorId::Anthropic {
-            for acct in &config.anthropic.accounts {
-                tabs.push(TabId::account(acct.label.clone()));
+            let accounts = config.anthropic.all_accounts();
+            // The default (unnamed) Claude tab is suppressible once every
+            // account is named — but never when it would leave Anthropic with
+            // no tab at all.
+            if config.anthropic.show_default_account || accounts.is_empty() {
+                tabs.push(TabId::vendor(vendor));
             }
+            for acct in accounts {
+                tabs.push(TabId::account(acct.label));
+            }
+        } else {
+            tabs.push(TabId::vendor(vendor));
         }
     }
     tabs
@@ -436,6 +444,34 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
 /// automatic refreshes.
 pub const REFRESH_INTERVAL: Duration = Duration::from_secs(60);
 
+/// Gap between successive Anthropic fetches at refresh time. Every Anthropic
+/// tab (the default account and each named/discovered account) hits the same
+/// `/api/oauth/usage` + token-refresh endpoints, which rate-limit a burst of
+/// simultaneous requests from one client — so with several accounts the TUI
+/// would fire them all at once and some would come back `429`. Spacing them
+/// out keeps every account refreshing politely.
+pub const ANTHROPIC_REFRESH_STAGGER: Duration = Duration::from_millis(800);
+
+/// Per-tab startup delay for one `spawn_all` pass. Only Anthropic tabs are
+/// staggered (they share the rate-limited endpoint and multiply with accounts);
+/// every other vendor hits its own endpoint and starts immediately. The first
+/// Anthropic tab also starts immediately; each subsequent one waits one more
+/// `step`. Pure and position-based so it is unit-testable.
+pub fn refresh_stagger(tabs: &[TabId], step: Duration) -> Vec<Duration> {
+    let mut anthropic_seen: u32 = 0;
+    tabs.iter()
+        .map(|tab| {
+            if tab.vendor == VendorId::Anthropic {
+                let delay = step * anthropic_seen;
+                anthropic_seen += 1;
+                delay
+            } else {
+                Duration::ZERO
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -444,6 +480,43 @@ mod tests {
     // Use `App::with_theme(.., Theme::default())` rather than `App::new`, which
     // would read the real Omarchy theme file + `$HOME`. The tab-selection logic
     // under test is theme-agnostic.
+    #[test]
+    fn refresh_stagger_spaces_out_anthropic_tabs_only() {
+        let step = Duration::from_millis(800);
+        let tabs = vec![
+            TabId::vendor(VendorId::Anthropic), // default account
+            TabId::account("work"),
+            TabId::account("personal"),
+            TabId::vendor(VendorId::Openai),
+            TabId::vendor(VendorId::Zai),
+        ];
+        let delays = refresh_stagger(&tabs, step);
+        assert_eq!(
+            delays,
+            vec![
+                Duration::ZERO, // 1st anthropic — immediate
+                step,           // 2nd anthropic
+                step * 2,       // 3rd anthropic
+                Duration::ZERO, // openai — own endpoint, immediate
+                Duration::ZERO, // zai — own endpoint, immediate
+            ]
+        );
+    }
+
+    #[test]
+    fn refresh_stagger_is_a_noop_without_anthropic_accounts() {
+        // A single Anthropic tab (or none) never waits.
+        let tabs = vec![
+            TabId::vendor(VendorId::Anthropic),
+            TabId::vendor(VendorId::Openrouter),
+        ];
+        assert!(
+            refresh_stagger(&tabs, Duration::from_millis(800))
+                .iter()
+                .all(|d| d.is_zero())
+        );
+    }
+
     #[test]
     fn select_primary_moves_to_enabled_vendor() {
         let mut app = App::with_theme(
@@ -482,6 +555,30 @@ mod tests {
     }
 
     #[test]
+    fn show_default_account_false_hides_the_unnamed_claude_tab() {
+        // With named accounts and show_default_account=false, only the named
+        // tabs appear — no redundant default "Claude" tab.
+        let mut config = config_with_accounts(&["work", "personal"]);
+        config.anthropic.show_default_account = false;
+        assert_eq!(
+            tabs_from_config(&config),
+            vec![TabId::account("work"), TabId::account("personal")]
+        );
+
+        // But with no named accounts it is kept, so Anthropic never loses its
+        // only tab.
+        let mut empty = Config::default();
+        empty.openai.enabled = false;
+        empty.zai.enabled = false;
+        empty.openrouter.enabled = false;
+        empty.anthropic.show_default_account = false;
+        assert_eq!(
+            tabs_from_config(&empty),
+            vec![TabId::vendor(VendorId::Anthropic)]
+        );
+    }
+
+    #[test]
     fn tabs_expand_anthropic_accounts_after_default() {
         // Default Claude tab first, then each account in config order.
         let tabs = tabs_from_config(&config_with_accounts(&["work", "personal"]));
@@ -503,6 +600,33 @@ mod tests {
         let vendors: Vec<VendorId> = tabs.iter().map(|t| t.vendor).collect();
         assert_eq!(vendors, config.enabled_vendors());
         assert!(tabs.iter().all(|t| t.account.is_none()));
+    }
+
+    #[test]
+    fn tabs_include_accounts_auto_discovered_from_accounts_dir() {
+        // A CLAUDE_CONFIG_DIR-style directory becomes account tabs with no
+        // explicit [[anthropic.accounts]] entry. Hermetic: real TempDir.
+        let td = tempfile::tempdir().unwrap();
+        for label in ["work", "personal"] {
+            let dir = td.path().join(label);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join(".credentials.json"), "{}").unwrap();
+        }
+        let mut config = Config::default();
+        config.openai.enabled = false;
+        config.zai.enabled = false;
+        config.openrouter.enabled = false;
+        config.anthropic.accounts_dir = Some(td.path().to_path_buf());
+
+        let tabs = tabs_from_config(&config);
+        assert_eq!(
+            tabs,
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::account("personal"), // sorted by label
+                TabId::account("work"),
+            ]
+        );
     }
 
     #[test]

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -823,14 +823,18 @@ mod tests {
 
     #[test]
     fn named_account_uses_its_creds_and_label_subdir() {
-        // A named account's file is Explicit: a missing/broken path must fail
-        // loudly, never silently read another account's Keychain item (#15).
+        // A named account's file is read strictly first; the Keychain fallback
+        // (if the file is missing/unusable) is scoped to its own directory, so
+        // it can never silently read a *different* account's item (#15).
         let config = config_with_account("work", "/creds/work.json");
         let cli = cli_with(Some("work"), None, Some("/tmp/cache"));
         let (creds, cache) = anthropic_target(&cli, &config).unwrap();
         assert_eq!(
             creds,
-            CredsTarget::Explicit(PathBuf::from("/creds/work.json"))
+            CredsTarget::Named {
+                path: PathBuf::from("/creds/work.json"),
+                config_dir: PathBuf::from("/creds"),
+            }
         );
         assert_eq!(
             cache.dir(),


### PR DESCRIPTION
## What

Adds **`[anthropic] accounts_dir`** — point it at a directory and each immediate
subdirectory containing a `.credentials.json` becomes an Anthropic account,
labeled by the subdirectory name. This is exactly the layout Claude Code's own
`CLAUDE_CONFIG_DIR` produces, so:

```
CLAUDE_CONFIG_DIR=<dir>/<label> claude   # log in once per account
```

makes `<label>` show up as a TUI tab / `--account <label>` with **no config
edit**, each refreshed independently.

## How

- New `accounts_dir` key on `[anthropic]`; each `<label>/.credentials.json`
  under it is discovered at load time and merged with any explicit
  `[[anthropic.accounts]]` (explicit wins on a label clash). A missing or
  unreadable directory is ignored (never fatal).
- Reuses the existing per-account cache + refresh + TUI-tab machinery — no new
  fetch path.
- **General by design:** it keys only on the standard Claude Code directory
  layout, so any tool that manages multiple logins works with it — not tied to
  one specific account switcher.

## Tests / docs

- Hermetic tests (temp dirs only — no real `$HOME`/creds).
- `config.example.toml`, `README.md`, `CHANGELOG.md` updated.

---

Independent of the Cursor / swap-shortcut / overview PRs — branches off `main`,
touches only Anthropic account discovery. (It does share `config.rs` /
`tui/app.rs` / `CHANGELOG.md` regions with the Cursor PR, so whichever merges
second will need a trivial conflict resolution.)


## Update: macOS Keychain-scoped logins now resolve

On macOS, `CLAUDE_CONFIG_DIR=<dir> claude` stores the login in the Keychain under `Claude Code-credentials-<hash>` (first 8 hex chars of sha256 of the config dir's absolute path) and never writes `<dir>/.credentials.json` — so a discovered/named account could look logged-in via `claude` yet error here. Named accounts now resolve **keychain-first**: the item hashed from their own config dir wins, with the file as fallback (the Linux layout). Keychain-first matters because hand-copied credential files share their refresh-token lineage with the original and die with a 401 as soon as the real holder rotates it. Refresh write-backs follow the read source, so each account keeps one source of truth shared with Claude Code. The per-directory hash can never match a different account's item, so #15's cross-account concern doesn't reapply.

Known limitation (follow-up candidate): *discovery* via `accounts_dir` still keys on `<dir>/<label>/.credentials.json` existing, so a keychain-only login dir isn't auto-discovered yet — declare it in `[[anthropic.accounts]]` and resolution finds the Keychain item.
