### PR TITLE
feat(macos): "start at login" toggle in Preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **"Iniciar no login" (start at login) toggle** in the macOS menu-bar app's
+  Preferences. Flipping it on installs a per-user LaunchAgent
+  (`~/Library/LaunchAgents/com.akitaonrails.ai-usagebar-menubar.plist`) pointing
+  at the running binary, so the app comes up automatically at each login; off
+  removes it. This is the GUI equivalent of `macos/install-agent.sh` — no
+  `launchctl` needed. macOS only: the app is a menu-bar agent that doesn't exist
+  on Linux (where the GNOME Shell extension autostarts with the session, and the
+  Waybar widget starts with the bar) or Windows.
+
 ### Fixed
 
 - **A failed terminal resize no longer exits the TUI.** A transient

--- a/macos/INSTALL.md
+++ b/macos/INSTALL.md
@@ -53,11 +53,17 @@ switch vendors quickly, and Preferences.
 
 ### 6. Start automatically at login
 
+The easiest way is the **Preferências… → Sistema → "Iniciar no login"** toggle in
+the app itself — it installs (or removes) the LaunchAgent for you, no Terminal
+needed. It takes effect at your next login.
+
+Or do it from the shell:
+
 ```bash
 ./install-agent.sh
 ```
 
-This installs a LaunchAgent at
+Either way installs a LaunchAgent at
 `~/Library/LaunchAgents/com.akitaonrails.ai-usagebar-menubar.plist` with
 `RunAtLoad`, so the app starts on every login. It is not kept alive after you
 choose **Sair/Quit**.

--- a/macos/README.md
+++ b/macos/README.md
@@ -51,7 +51,8 @@ cd macos
 ./ai-usagebar-menubar &    # appears in the menu bar (no Dock icon)
 ```
 
-Start at login:
+Start at login — toggle **Preferências… → Sistema → "Iniciar no login"** in the
+app, or from the shell:
 
 ```bash
 ./install-agent.sh         # installs a LaunchAgent (RunAtLoad)

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -747,6 +747,7 @@ struct SettingsView: View {
     @AppStorage("colorCritical") private var colorCritical = "#e06c75"
     @AppStorage("colorEmpty") private var colorEmpty = "#3e4451"
     @AppStorage("binaryPath") private var binaryPath = ""
+    @AppStorage("launchAtLogin") private var launchAtLogin = false
 
     // Only enabled vendors appear in the selector: Rust treats opt-in vendors
     // (deepseek/kimi/kilo/novita/moonshot/grok/anthropic_api) as disabled when
@@ -797,6 +798,15 @@ struct SettingsView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                GroupBox("Sistema") {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Iniciar no login", isOn: $launchAtLogin)
+                            .onChange(of: launchAtLogin) { value in setLaunchAtLogin(value) }
+                        Text("Instala um LaunchAgent que sobe o app ao entrar na sua conta.")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
                 VendorsSection()
             }
             .padding(20)
@@ -804,6 +814,57 @@ struct SettingsView: View {
         }
         .frame(width: 460)
         .frame(minHeight: 300, idealHeight: 560, maxHeight: .infinity)
+    }
+}
+
+// ─── Launch at login (macOS LaunchAgent) ─────────────────────────────────
+//
+// The app is an unbundled single binary, so the modern SMAppService.mainApp
+// API (which needs a bundle id) doesn't apply. A per-user LaunchAgent is the
+// portable way to start an unbundled executable at login — the same mechanism
+// install-agent.sh sets up, now toggleable from Preferences.
+let LAUNCH_AGENT_LABEL = "com.akitaonrails.ai-usagebar-menubar"
+
+func launchAgentPlistPath() -> String {
+    "\(NSHomeDirectory())/Library/LaunchAgents/\(LAUNCH_AGENT_LABEL).plist"
+}
+
+/// Absolute path of the running executable, for the LaunchAgent to relaunch.
+func selfExecutablePath() -> String {
+    if let p = Bundle.main.executablePath, !p.isEmpty { return p }
+    let arg0 = CommandLine.arguments.first ?? "ai-usagebar-menubar"
+    if arg0.hasPrefix("/") { return arg0 }
+    return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        .appendingPathComponent(arg0).standardized.path
+}
+
+/// Install (or remove) the login LaunchAgent by managing its plist file.
+/// Building the plist via PropertyListSerialization sidesteps the XML-escaping
+/// the shell installer has to do by hand.
+///
+/// Deliberately no `launchctl load`/`unload`: the app is already running when
+/// this is toggled, so `RunAtLoad` on load would spawn a *second* copy, and
+/// `unload` on disable would SIGTERM this very process (quitting the app the
+/// user is still using) if it happened to be the launchd-managed one. launchd
+/// loads every agent in ~/Library/LaunchAgents at the next login, so writing
+/// (or removing) the file is all that's needed for a start-at-login toggle.
+func setLaunchAtLogin(_ enabled: Bool) {
+    let path = launchAgentPlistPath()
+    if enabled {
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let plist: [String: Any] = [
+            "Label": LAUNCH_AGENT_LABEL,
+            "ProgramArguments": [selfExecutablePath()],
+            "RunAtLoad": true,
+            "ProcessType": "Interactive",
+        ]
+        if let data = try? PropertyListSerialization.data(
+            fromPropertyList: plist, format: .xml, options: 0) {
+            try? data.write(to: URL(fileURLWithPath: path))
+        }
+    } else {
+        try? FileManager.default.removeItem(atPath: path)
     }
 }
 


### PR DESCRIPTION
## What

Adds a **"Iniciar no login"** (start at login) toggle to the macOS menu-bar
app's Preferences, under a new **Sistema** group. On it, the app comes up
automatically at each login; off, it doesn't.

## How

- The toggle installs / removes a per-user LaunchAgent at
  `~/Library/LaunchAgents/com.akitaonrails.ai-usagebar-menubar.plist`, pointing
  at the running binary with `RunAtLoad` — the GUI equivalent of the existing
  `macos/install-agent.sh`, no Terminal needed.
- The plist is built with `PropertyListSerialization` (no hand-rolled XML
  escaping). Validated: `plutil -lint` OK, `RunAtLoad` = `<true/>`, structure
  identical to `install-agent.sh`.
- **Manages the plist file only** — deliberately no `launchctl load`/`unload`.
  The app is already running when you toggle, so loading with `RunAtLoad` would
  spawn a *second* instance, and unloading would `SIGTERM` the running app.
  launchd loads agents from `~/Library/LaunchAgents` at the next login, which is
  the right semantics for a start-at-login toggle.

Unbundled-binary note: the modern `SMAppService.mainApp` API needs a bundle id,
which this single-file `swiftc` binary doesn't have — a LaunchAgent is the
portable mechanism for an unbundled executable.

## Platforms

**macOS only.** The Preferences window / menu-bar agent is macOS-specific. On
Linux the equivalent surfaces autostart on their own — the GNOME Shell extension
starts with the session, and the Waybar widget starts with the bar — so there's
no separate process to toggle; Windows has no app. Docs say so explicitly.

## Tests / docs

- Swift app builds clean; `macos/run-tests.sh` green. (No unit test added: the
  logic is a `~/Library` file write, and the repo's tests must stay hermetic —
  never touch a real `$HOME`. The plist output was validated out-of-tree with
  `plutil`/`PlistBuddy`.)
- `macos/README.md`, `macos/INSTALL.md`, `CHANGELOG.md` updated.

---

Independent PR off `main` — touches only the macOS app + its docs. No dependency
on the Cursor / swap-shortcut / overview / multi-account PRs (it will share a
`CHANGELOG.md` region with them, a trivial merge conflict).
