### PR TITLE
feat(macos): Claude multi-account in the menu bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Each release is also published at
   menu bar app** (its two pools relabel the session/weekly bars as "Cursor
   Models" / "Other Models"), and the config-example/README docs. Adds a
   `rusqlite` (bundled) dependency. Not wired into the GNOME extension yet.
+  **Team accounts** (`membershipType` with no `individualUsage.plan`) are now
+  parsed too, via the auto/named "You've used N% of your included … usage"
+  display-message strings the payload also carries — the only percentage
+  source Cursor exposes for those accounts, per an independent
+  reverse-engineering of the same endpoint. Unverified against a live team
+  account (labeled `"<Plan> (team)"` in the UI so it's visibly a best-effort
+  path); falls back to the existing schema error rather than a fabricated
+  0% if the display messages don't parse.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Cursor vendor.** Shows this billing cycle's two included-usage pools —
+  **Cursor Models** (Auto + Composer) and **Other Models** (named / API) — as
+  percentages, from `GET cursor.com/api/usage-summary`, the same undocumented
+  endpoint the Cursor dashboard's own frontend calls. Also surfaces the plan
+  (`membershipType`), the billing-cycle reset, whether on-demand spend is on,
+  and unlimited plans. No API key: the session token is read **read-only** from
+  the local `state.vscdb` SQLite database the Cursor IDE already wrote after you
+  signed in there (the JWT's `sub` claim yields the user id; combined with the
+  raw token it forms the `WorkosCursorSessionToken` cookie the endpoint
+  expects). Opt-in (`[cursor] enabled = true`) and wired into the Waybar widget,
+  `--vendor cursor`, the TUI panel (a bar per pool), scroll-cycling, **the macOS
+  menu bar app** (its two pools relabel the session/weekly bars as "Cursor
+  Models" / "Other Models"), and the config-example/README docs. Adds a
+  `rusqlite` (bundled) dependency. Not wired into the GNOME extension yet.
+
 ### Fixed
 
 - **A failed terminal resize no longer exits the TUI.** A transient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Each release is also published at
 
 ### Added
 
+- **Claude multi-account in the macOS menu bar.** Every named Anthropic account
+  — explicit `[[anthropic.accounts]]` entries and `[anthropic] accounts_dir`
+  discoveries, the same config the binary and TUI already read — now appears as
+  its own entry ("Claude · work") in the *Trocar vendor* submenu, the **⌥⌘\\**
+  swap ring, the Preferences vendor selector, and the **Overview** (its own
+  dropdown row and status-bar segment, labeled by account). Fetches run as
+  `--vendor anthropic --account <label>`, so each account keeps its own cache
+  and refresh, and the dropdown header shows which account is active
+  ("Claude Max 20x · work"). `[anthropic] show_default_account = false` hides
+  the default (unnamed) Claude entry, mirroring the TUI.
+
 - **Overview across the TUI and the macOS menu bar.** A single view summarizing
   every vendor at once — one compact row each (key metric, colored by severity)
   — so all your limits are visible without switching tabs. In the **TUI** it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,18 @@ Each release is also published at
   `[ui] overview_vendors = [...]` picks and orders which vendors it lists. In the
   **macOS menu-bar app** it is a target in the vendor submenu and in the global
   **⌥⌘\\** swap ring (which now cycles all providers *and* the overview); its
-  dropdown lists every configured vendor and the bar shows the single most-
-  exhausted quota.
+  dropdown lists every configured vendor — each row **clickable** to jump to that
+  vendor — and the bar shows every vendor at once (a mini bar each when few, or
+  worst-first numbers past `[ui] overview_menubar_bars_max`, capped at
+  `overview_menubar_max`). Each vendor's headline is the metric that matters:
+  **Cursor** shows its combined *included total usage*; **Anthropic** the biggest
+  of 5h / weekly / the scoped-model (Fable) window.
+
+- **Instant "Loading…" feedback on a vendor swap** (menu bar). Switching vendor —
+  by ⌥⌘\\, the submenu, or an overview row — immediately replaces the view with a
+  placeholder naming the target, instead of leaving the previous vendor's data up
+  (which read as a freeze). The **⌥⌘\\ shortcut is also hinted** on the *Trocar
+  vendor* menu item.
 
 - **Cursor vendor.** Shows this billing cycle's two included-usage pools —
   **Cursor Models** (Auto + Composer) and **Other Models** (named / API) — as
@@ -46,6 +56,14 @@ Each release is also published at
   0% if the display messages don't parse.
 
 ### Fixed
+
+- **Menu-bar app no longer freezes in Overview mode.** The appearance observer
+  fired on every layout pass (not just real light↔dark flips), and in Overview
+  each fire rebuilt the vendor submenu — which relaid out the button, re-firing
+  the observer: a main-thread loop that also spawned a keychain subprocess each
+  iteration, so the menu stopped responding to clicks. The observer now reacts
+  only to actual theme changes, appearance repaints skip the submenu rebuild, and
+  the keychain check is cached.
 
 - **A failed terminal resize no longer exits the TUI.** A transient
   `terminal.resize` error (e.g. an ioctl failure) now just skips that resize

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,10 @@ Each release is also published at
   toggleable in Preferências → Atalho next to the ⌥⌘\\ swap toggle; overview
   mode only). Each vendor's headline is the metric that matters:
   **Cursor** shows its combined *included total usage*; **Anthropic** the biggest
-  of 5h / weekly / the scoped-model (Fable) window.
+  of 5h / weekly / the scoped-model (Fable) window. The menu-bar title now also
+  shows each vendor's **time to reset**, squeezed to its leading unit ("4d",
+  "2h", "5m") to fit both bar and %-text modes — same countdown the dropdown
+  and the per-vendor detail view already show, just shortened for the bar.
 
 - **Instant "Loading…" feedback on a vendor swap** (menu bar). Switching vendor —
   by ⌥⌘\\, the submenu, or an overview row — immediately replaces the view with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,11 @@ Each release is also published at
   vendor — and the bar shows every vendor at once (a mini bar each when few, or
   compact %-text past `[ui] overview_menubar_bars_max` (default 4), capped at
   `overview_menubar_max`, in stable provider-grouped entry order). A
-  **Compactar** item (⌘E) right under the usage rows forces the compact %-text
+  **Compactar** item right under the usage rows forces the compact %-text
   mode even under the threshold; while compact it reads **Expandir** and turns
-  it back off. Each vendor's headline is the metric that matters:
+  it back off. It also has a **global ⌥⌘E shortcut** (hinted on the item,
+  toggleable in Preferências → Atalho next to the ⌥⌘\\ swap toggle; overview
+  mode only). Each vendor's headline is the metric that matters:
   **Cursor** shows its combined *included total usage*; **Anthropic** the biggest
   of 5h / weekly / the scoped-model (Fable) window.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ Each release is also published at
 
 ### Added
 
-- **Overview tab in the TUI.** A virtual first tab summarizing every vendor at
-  once — one compact row each (name + plan + key metric cells, colored by
-  severity) — so all your limits are visible on one screen. `Tab`/`h`/`l` wrap
-  through it at both ends, and it is the default landing view unless `[ui]
-  primary` opens on a specific vendor. `[ui] overview_vendors = [...]` picks and
-  orders which vendors it lists (default: all enabled).
+- **Overview across the TUI and the macOS menu bar.** A single view summarizing
+  every vendor at once — one compact row each (key metric, colored by severity)
+  — so all your limits are visible without switching tabs. In the **TUI** it is
+  a virtual first tab that `Tab`/`h`/`l` wrap through at both ends and the
+  default landing view (unless `[ui] primary` opens on a specific vendor);
+  `[ui] overview_vendors = [...]` picks and orders which vendors it lists. In the
+  **macOS menu-bar app** it is a target in the vendor submenu and in the global
+  **⌥⌘\\** swap ring (which now cycles all providers *and* the overview); its
+  dropdown lists every configured vendor and the bar shows the single most-
+  exhausted quota.
 
 - **Cursor vendor.** Shows this billing cycle's two included-usage pools —
   **Cursor Models** (Auto + Composer) and **Other Models** (named / API) — as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ Each release is also published at
   **⌥⌘\\** swap ring (which now cycles all providers *and* the overview); its
   dropdown lists every configured vendor — each row **clickable** to jump to that
   vendor — and the bar shows every vendor at once (a mini bar each when few, or
-  worst-first numbers past `[ui] overview_menubar_bars_max`, capped at
-  `overview_menubar_max`). Each vendor's headline is the metric that matters:
+  compact %-text past `[ui] overview_menubar_bars_max` (default 4), capped at
+  `overview_menubar_max`, in stable provider-grouped entry order). A
+  **Compactar** item (⌘E) right under the usage rows forces the compact %-text
+  mode even under the threshold; while compact it reads **Expandir** and turns
+  it back off. Each vendor's headline is the metric that matters:
   **Cursor** shows its combined *included total usage*; **Anthropic** the biggest
   of 5h / weekly / the scoped-model (Fable) window.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Each release is also published at
 
 ### Added
 
+- **Overview tab in the TUI.** A virtual first tab summarizing every vendor at
+  once — one compact row each (name + plan + key metric cells, colored by
+  severity) — so all your limits are visible on one screen. `Tab`/`h`/`l` wrap
+  through it at both ends, and it is the default landing view unless `[ui]
+  primary` opens on a specific vendor. `[ui] overview_vendors = [...]` picks and
+  orders which vendors it lists (default: all enabled).
+
 - **Cursor vendor.** Shows this billing cycle's two included-usage pools —
   **Cursor Models** (Auto + Composer) and **Other Models** (named / API) — as
   percentages, from `GET cursor.com/api/usage-summary`, the same undocumented

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +39,7 @@ dependencies = [
  "ratatui-bubbletea-components",
  "ratatui-bubbletea-theme",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -582,6 +595,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,6 +804,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -806,6 +840,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1202,6 +1245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1570,6 +1624,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1958,6 +2018,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2692,6 +2766,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,11 @@ base64 = "0.22"
 ratatui = "0.30.1"
 ratatui-bubbletea-components = "0.1"
 ratatui-bubbletea-theme = "0.1"
+# Reads Cursor's local `state.vscdb` (its own on-disk session store) to find
+# the OAuth token the Cursor IDE already wrote there. "bundled" statically
+# links SQLite via cc, so no system libsqlite3-dev is required — keeping the
+# AUR source build's hermeticity (see CLAUDE.md's release checklist).
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [dev-dependencies]
 mockito = "1"

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ When an endpoint drifts, **run `make smoke`**. It runs all ignored vendor tests,
 
 `{cursor_plan}`, `{cursor_auto_pct}`, `{cursor_api_pct}`, `{cursor_total_pct}`, `{cursor_reset}`, `{cursor_on_demand}`, `{cursor_unlimited}` — this billing cycle's two included-usage pools from `cursor.com/api/usage-summary`: `cursor_auto_pct` is **Cursor Models** (Auto + Composer) and `cursor_api_pct` is **Other Models** (named / API), matching the two bars on the Cursor dashboard. `cursor_total_pct` is the overall included-usage headline; `cursor_on_demand` is `on`/`off`; `cursor_unlimited` is `yes`/`no`. A pool can read above 100% when it is over its included allowance. The default bar format is `{cursor_auto_pct}·{cursor_api_pct}%` (e.g. `98·100%`), colored by whichever pool is worst. Generic aliases: `{session_pct}` = Cursor Models, `{weekly_pct}` = Other Models, `{plan}` = `Cursor <Plan>`.
 
-> Cursor's dashboard also reports usage-based (overage) spend and, for team accounts, per-member spend. Neither is tracked here — this vendor mirrors the two included-usage bars the dashboard shows. Team accounts (whose usage lives under `teamUsage`) aren't parsed yet.
+> Cursor's dashboard also reports usage-based (overage) spend and, for team accounts, per-member spend. Neither is tracked here — this vendor mirrors the two included-usage bars the dashboard shows. Team accounts (which report no `individualUsage.plan`) are parsed too, falling back to the payload's "You've used N%…" display-message strings for the two pools — the plan label gets a `(team)` suffix so it's visibly a best-effort path, since this has not been verified against a live team account.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This started as a Rust port of [`claudebar`](https://github.com/mryll/claudebar)
 - **Tabbed TUI** (`ai-usagebar-tui`) with Tab/h/l switching, per-tab refresh, and 60-second auto-refresh. Native ratatui widgets fill the available terminal width and keep the vendor tabs visually consistent.
 - **Optional local Claude Code context monitor** in the TUI, with a bounded,
   compaction-aware view of recent session input-context usage.
-- **Native desktop integrations** for GNOME Shell and the macOS menu bar. The macOS app supports eleven vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok, Anthropic API); the GNOME extension adds Google Antigravity.
+- **Native desktop integrations** for GNOME Shell and the macOS menu bar. The macOS app supports twelve vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok, Anthropic API, Cursor); the GNOME extension covers Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity. (Antigravity is Linux-only; Cursor isn't in the GNOME extension yet.)
 - **Scroll-to-cycle on the bar**: wire `on-scroll-up` / `on-scroll-down`, and one bar item cycles through your enabled vendors.
 - **Config-driven primary vendor**: set `[ui] primary` once; the widget shows that vendor by default and the TUI opens on its tab.
 - **Local testing tools**: `--pretty` renders ANSI-colored terminal output (auto-detects TTY), and `--watch N` re-renders every N seconds.
@@ -89,6 +89,7 @@ Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth c
 | Moonshot | API key (`MOONSHOT_API_KEY` env or `[moonshot] api_key` in config) | Set either. Opt-in. Set `[moonshot] region = "cn"` for `api.moonshot.cn` (balance in CNY); the default `"global"` uses `api.moonshot.ai` (USD). |
 | Grok (xAI) | **Management** key (`XAI_MANAGEMENT_KEY` env or `[grok] api_key` in config) | Set either. Opt-in. This is **not** the inference key — create it under xAI Console → Management keys. See the team note below. |
 | Google Antigravity | None — read from the local Antigravity server | Opt-in. Quota is served only while Antigravity 2.0, the Antigravity IDE, or an interactive `agy` session is running; all three share one account-wide quota. |
+| Cursor | None — read from Cursor's local `state.vscdb` | Opt-in. Sign in to the Cursor IDE at least once; ai-usagebar reads the session token it already wrote there. No key of your own to create. |
 
 #### Grok: team-scoped vs organization-scoped keys
 
@@ -109,7 +110,7 @@ rather than silently querying the wrong URL.
 ### Enabling a vendor
 
 `enabled = true` is what makes a vendor fetch. Anthropic (API), DeepSeek, Kimi,
-Kilo, Novita, Moonshot, Grok, and Antigravity all default to **disabled** so that existing
+Kilo, Novita, Moonshot, Grok, Antigravity, and Cursor all default to **disabled** so that existing
 installs are unaffected until you opt in. Two ways to do it:
 
 - **Via the TUI Settings overlay** (`ai-usagebar-tui`, then `s`): saving a
@@ -133,6 +134,7 @@ For each API-key vendor, ai-usagebar checks in this order:
 - If you put inline `api_key` values in config, `chmod 600 ~/.config/ai-usagebar/config.toml`. The default behavior reads only env vars, which is safer when your config might be world-readable.
 - Don't commit your config dir if you check it into dotfiles unless you've redacted `api_key` lines.
 - OAuth credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`) are managed by their respective CLIs and already chmod-protected.
+- Cursor's session token lives in its own `state.vscdb`, managed entirely by the Cursor IDE — ai-usagebar opens it read-only and never writes to it.
 
 #### macOS: Anthropic credentials in the Keychain
 
@@ -149,7 +151,7 @@ On macOS, recent Claude Code builds don't write `~/.claude/.credentials.json` �
 # Only a vendor that is enabled can be primary.
 # primary = "anthropic"   # anthropic | anthropic_api | openai | zai
 #                         # | openrouter | deepseek | kimi | kilo | novita
-#                         # | moonshot | grok
+#                         # | moonshot | grok | antigravity | cursor
 
 [context]
 enabled = false           # opt in, then press c in ai-usagebar-tui
@@ -219,6 +221,12 @@ api_key_env = "XAI_MANAGEMENT_KEY"
 # api_key = "..."          # used if XAI_MANAGEMENT_KEY is unset; chmod 600 the file!
 # Required for organization-scoped keys; auto-resolved for team-scoped ones.
 # team_id = "..."
+
+[cursor]
+enabled = true             # disabled by default; enable once you've signed in to Cursor
+# No API key: reads the session token the Cursor IDE already wrote to its own
+# state.vscdb after you signed in there.
+# db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"
 ```
 
 ## Quick start
@@ -261,7 +269,7 @@ The Waybar widget is optional. The TUI is the best way to see every enabled vend
 
 ## Native desktop integrations
 
-The [macOS menu bar app](macos/README.md) supports eleven vendors — **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok (xAI), and Anthropic (API)**. The [GNOME Shell extension](gnome-extension/README.md) supports **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity**, whose two independent quota pools it renders as grouped rows. macOS does not support Antigravity: the binary only discovers its local server on Linux.
+The [macOS menu bar app](macos/README.md) supports twelve vendors — **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok (xAI), Anthropic (API), and Cursor**. The [GNOME Shell extension](gnome-extension/README.md) supports **Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity**, whose two independent quota pools it renders as grouped rows. macOS does not support Antigravity: the binary only discovers its local server on Linux. Cursor is not in the GNOME extension yet — use `ai-usagebar --vendor cursor` or the TUI there.
 
 ## Waybar config
 
@@ -284,7 +292,7 @@ Use one bar item and scroll through your vendors. The TUI on-click still shows t
 }
 ```
 
-The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` / `gpt` / `zai` / `opr` / `dsk` / `kmi` / `klo` / `nvt` / `msh` / `grk` / `aac` / `agy`), so the bar text tells you which vendor is active. The other usage placeholders (`{session_pct}` for Anthropic, `{oai_session_pct}` for OpenAI, etc.) are vendor-specific. If you want one format string for every cycled vendor, prefer the generic aliases: `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}` are implemented by all seven usage vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, and Antigravity; OpenRouter and DeepSeek use `0` / `—` for the windows they don't expose). Anthropic and OpenAI add `*_elapsed`, `*_pace`, and `*_bar` families; Antigravity adds `*_elapsed` for all four of its windows, plus `{session_model}` / `{weekly_model}` / `{scoped_model}` / `{extra_model}`, which name the model group each row belongs to (vendors with a single quota pool leave them empty). The established API-backed vendors also expose their own `{oai_*}` / `{zai_*}` / `{or_*}` / `{ds_*}` / `{kimi_*}` families, which expand to empty strings for vendors that don't define them.
+The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` / `gpt` / `zai` / `opr` / `dsk` / `kmi` / `klo` / `nvt` / `msh` / `grk` / `aac` / `agy` / `cur`), so the bar text tells you which vendor is active. The other usage placeholders (`{session_pct}` for Anthropic, `{oai_session_pct}` for OpenAI, etc.) are vendor-specific. If you want one format string for every cycled vendor, prefer the generic aliases: `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}` are implemented by all eight usage vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Antigravity, and Cursor; OpenRouter and DeepSeek use `0` / `—` for the windows they don't expose). Cursor has no time windows but two usage *pools*, so it maps them onto the two generic slots: `session_pct` = **Cursor Models** (Auto + Composer), `weekly_pct` = **Other Models** (named / API), both resetting on the billing cycle. Anthropic and OpenAI add `*_elapsed`, `*_pace`, and `*_bar` families; Antigravity adds `*_elapsed` for all four of its windows, plus `{session_model}` / `{weekly_model}` / `{scoped_model}` / `{extra_model}`, which name the model group each row belongs to (vendors with a single quota pool leave them empty). The established API-backed vendors also expose their own `{oai_*}` / `{zai_*}` / `{or_*}` / `{ds_*}` / `{kimi_*}` families, which expand to empty strings for vendors that don't define them.
 
 `signal: 13` lets the scroll-cycle commands refresh the bar instantly (via `SIGRTMIN+13`) instead of waiting for the next 300s interval.
 
@@ -462,10 +470,11 @@ Then `hyprctl reload` (no logout needed).
 | **Moonshot** | `api.moonshot.ai\|.cn/v1/users/me/balance` (documented) | Account balance ($ on `.ai`, ¥ on `.cn`) | No — widget/TUI only |
 | **Grok (xAI)** | `management-api.x.ai/v1/billing/teams/{team}/prepaid/balance` (Management API; documented) | Prepaid credit balance ($) | No — widget/TUI only |
 | **Anthropic (API)** | `api.anthropic.com/v1/organizations/cost_report` (Admin API; documented) | Month-to-date spend ($, excludes Priority Tier), optional spend-vs-limit % | No — widget/TUI only |
+| **Cursor** | `cursor.com/api/usage-summary` (undocumented; the dashboard's own frontend) | Two included-usage pools this billing cycle — Cursor Models (Auto/Composer) % and Other Models (named/API) % — plus plan, reset, on-demand | Yes |
 
 ### Endpoint stability
 
-Four of the six endpoints are undocumented. The Anthropic and OpenAI endpoints are used by their official CLIs (`claude` and `codex`), so removing them would break those tools too. That makes them less shaky than scraped web endpoints. Z.AI's monitor endpoint is reverse-engineered from a third-party plugin; treat it as the most fragile one. Kimi's `/coding/v1/usages` is community-confirmed and used by third-party quota tools; treat it as drift-prone.
+Four of the six endpoints are undocumented. The Anthropic and OpenAI endpoints are used by their official CLIs (`claude` and `codex`), so removing them would break those tools too. That makes them less shaky than scraped web endpoints. Z.AI's monitor endpoint is reverse-engineered from a third-party plugin; treat it as the most fragile one. Kimi's `/coding/v1/usages` is community-confirmed and used by third-party quota tools; treat it as drift-prone. Cursor's `/api/usage-summary` has no official docs and is the endpoint the dashboard's own frontend calls — treat it as drift-prone too (its shape tracks Cursor's pricing, which has changed before).
 
 OpenAI's known 5-hour and 7-day windows are identified from each window's
 reported duration, not from `primary_window` / `secondary_window` position.
@@ -530,6 +539,12 @@ When an endpoint drifts, **run `make smoke`**. It runs all ignored vendor tests,
 `{aapi_headline}`, `{aapi_spent}`, `{aapi_limit}`, `{aapi_pct}` — month-to-date spend for the API/Console account from the Admin API `cost_report`. The headline is `$1.34 / $1000 · 0%` when a positive, finite `monthly_limit` is set in config, `$1.34/mo` otherwise. Generic aliases `{plan}`, `{session_pct}`, and `{weekly_pct}` are also available (the last two both map to the spend-vs-limit %).
 
 > **Two things this figure is not.** It is **spend**, not remaining credit — Anthropic exposes no API for the prepaid balance, which is visible only on the Console dashboard. And per the [Cost API docs](https://platform.claude.com/docs/en/manage-claude/usage-cost-api) it **omits Priority Tier costs**, so an organization on Priority Tier is seeing less than its true total spend.
+
+### Cursor
+
+`{cursor_plan}`, `{cursor_auto_pct}`, `{cursor_api_pct}`, `{cursor_total_pct}`, `{cursor_reset}`, `{cursor_on_demand}`, `{cursor_unlimited}` — this billing cycle's two included-usage pools from `cursor.com/api/usage-summary`: `cursor_auto_pct` is **Cursor Models** (Auto + Composer) and `cursor_api_pct` is **Other Models** (named / API), matching the two bars on the Cursor dashboard. `cursor_total_pct` is the overall included-usage headline; `cursor_on_demand` is `on`/`off`; `cursor_unlimited` is `yes`/`no`. A pool can read above 100% when it is over its included allowance. The default bar format is `{cursor_auto_pct}·{cursor_api_pct}%` (e.g. `98·100%`), colored by whichever pool is worst. Generic aliases: `{session_pct}` = Cursor Models, `{weekly_pct}` = Other Models, `{plan}` = `Cursor <Plan>`.
+
+> Cursor's dashboard also reports usage-based (overage) spend and, for team accounts, per-member spend. Neither is tracked here — this vendor mirrors the two included-usage bars the dashboard shows. Team accounts (whose usage lives under `teamUsage`) aren't parsed yet.
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This started as a Rust port of [`claudebar`](https://github.com/mryll/claudebar)
 ## Features
 
 - **Per-vendor Waybar modules** with the same JSON shape as claudebar.
-- **Tabbed TUI** (`ai-usagebar-tui`) with Tab/h/l switching, per-tab refresh, and 60-second auto-refresh. Native ratatui widgets fill the available terminal width and keep the vendor tabs visually consistent.
+- **Tabbed TUI** (`ai-usagebar-tui`) with Tab/h/l switching, per-tab refresh, and 60-second auto-refresh. Native ratatui widgets fill the available terminal width and keep the vendor tabs visually consistent. Opens on an **Overview** tab summarizing every vendor at once (one compact row each); `[ui] overview_vendors` picks which vendors it lists.
 - **Optional local Claude Code context monitor** in the TUI, with a bounded,
   compaction-aware view of recent session input-context usage.
 - **Native desktop integrations** for GNOME Shell and the macOS menu bar. The macOS app supports twelve vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok, Anthropic API, Cursor); the GNOME extension covers Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, and Google Antigravity. (Antigravity is Linux-only; Cursor isn't in the GNOME extension yet.)

--- a/config.example.toml
+++ b/config.example.toml
@@ -167,3 +167,22 @@ api_key_env = "XAI_MANAGEMENT_KEY" # checked first; if set + non-empty, used
 # "host:port" only if auto-discovery of that local server ever fails.
 [antigravity]
 enabled = false
+
+# Cursor. No API key: usage is read from the session token the Cursor IDE
+# already wrote to its own local state database after you signed in there —
+# no separate login step for ai-usagebar. Shows this billing cycle's two
+# included-usage pools — "Cursor Models" (Auto + Composer) and "Other Models"
+# (named / API) — from the undocumented cursor.com/api/usage-summary endpoint
+# (the same one the Cursor dashboard itself calls).
+[cursor]
+# Disabled by default — enable once you've signed in to the Cursor IDE at
+# least once (it needs no key from you, but it does need that one-time login
+# to exist).
+enabled = false
+# Override Cursor's local state database path. Leave commented out to use the
+# platform default:
+#   Linux:   ~/.config/Cursor/User/globalStorage/state.vscdb
+#   macOS:   ~/Library/Application Support/Cursor/User/globalStorage/state.vscdb
+#   Windows: %APPDATA%\Cursor\User\globalStorage\state.vscdb
+# Set this if you use a portable Cursor install or a renamed profile dir.
+# db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,7 +9,12 @@
 # Which vendor the widget shows when `--vendor` is omitted, AND which tab
 # is selected when the TUI opens. Comment out to default to Anthropic.
 # Valid: anthropic | openai | zai | openrouter | deepseek | kimi
+# When unset, the TUI opens on the Overview (all vendors at once); set this to
+# open directly on a vendor's tab instead.
 # primary = "anthropic"
+# Which vendors the Overview lists (the TUI's first tab / the macOS menu-bar's
+# top section), in this order. Omit for every enabled vendor.
+# overview_vendors = ["anthropic", "cursor", "openai"]
 
 # Optional, TUI-only monitor for local Claude Code session context. When
 # enabled, press `c` in ai-usagebar-tui. The scanner reads only bounded tails

--- a/macos/README.md
+++ b/macos/README.md
@@ -111,6 +111,17 @@ A **"Trocar vendor"** submenu in the dropdown (between "Atualizar agora" /
 checkmark on the active one.
 Selecting one switches immediately, without opening Preferences.
 
+## Multiple Claude accounts
+
+Named Anthropic accounts from the binary's config
+(`[[anthropic.accounts]]` entries and `[anthropic] accounts_dir`
+auto-discovery — see the main README's "Multiple accounts") each get their own
+entry, "Claude · label", in the vendor submenu, the ⌥⌘\ swap ring, the
+Preferences selector, and the Overview. Each is fetched as
+`--vendor anthropic --account <label>`, so caches and token refreshes stay
+per-account. Set `[anthropic] show_default_account = false` to hide the
+default (unnamed) Claude entry when every account is managed explicitly.
+
 ## How it works
 
 Runs `ai-usagebar --vendor <v> --format '{plan};;{session_pct};;…'`, parses the

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -801,6 +801,7 @@ struct SettingsView: View {
     @AppStorage("showMeta") private var showMeta = true
     @AppStorage("barStyle") private var barStyle = "block"
     @AppStorage("swapShortcutEnabled") private var swapShortcutEnabled = true
+    @AppStorage("compactShortcutEnabled") private var compactShortcutEnabled = true
     @AppStorage("colorLow") private var colorLow = "#98c379"
     @AppStorage("colorMid") private var colorMid = "#e5c07b"
     @AppStorage("colorHigh") private var colorHigh = "#d19a66"
@@ -841,6 +842,9 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Toggle("Trocar vendor com ⌥⌘\\ (atalho global)", isOn: $swapShortcutEnabled)
                         Text("Alterna o vendor ativo a partir de qualquer app.")
+                            .font(.caption).foregroundColor(.secondary)
+                        Toggle("Compactar/Expandir com ⌥⌘E (atalho global)", isOn: $compactShortcutEnabled)
+                        Text("Alterna a Visão geral entre barras e modo compacto.")
                             .font(.caption).foregroundColor(.secondary)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -885,22 +889,33 @@ struct SettingsView: View {
 // posts a notification the delegate observes.
 
 let swapHotKeyNotification = Notification.Name("aiusagebar.swapHotKey")
+let compactHotKeyNotification = Notification.Name("aiusagebar.compactHotKey")
 
-/// Default shortcut: `\` (kVK_ANSI_Backslash) with Command+Option. `[ui]` on
-/// Linux has no equivalent; this is macOS-only.
+/// Default shortcuts: `\` (kVK_ANSI_Backslash) with Command+Option swaps the
+/// vendor; `E` with Command+Option toggles the overview's Compactar/Expandir.
+/// `[ui]` on Linux has no equivalent; this is macOS-only.
 let SWAP_HOTKEY_KEYCODE = UInt32(kVK_ANSI_Backslash)
+let COMPACT_HOTKEY_KEYCODE = UInt32(kVK_ANSI_E)
 let SWAP_HOTKEY_MODIFIERS = UInt32(cmdKey | optionKey)
+
+/// Registered hot-key ids, carried back to us in the event so one shared C
+/// callback can tell which shortcut fired.
+let SWAP_HOTKEY_ID = UInt32(1)
+let COMPACT_HOTKEY_ID = UInt32(2)
 
 private func swapHotKeyCallback(
     _ next: EventHandlerCallRef?, _ event: EventRef?, _ userData: UnsafeMutableRawPointer?
 ) -> OSStatus {
-    NotificationCenter.default.post(name: swapHotKeyNotification, object: nil)
+    var hk = EventHotKeyID()
+    GetEventParameter(event, EventParamName(kEventParamDirectObject),
+                      EventParamType(typeEventHotKeyID), nil,
+                      MemoryLayout<EventHotKeyID>.size, nil, &hk)
+    NotificationCenter.default.post(
+        name: hk.id == COMPACT_HOTKEY_ID ? compactHotKeyNotification : swapHotKeyNotification,
+        object: nil)
     return noErr
 }
 
-/// The next id in the cycle, wrapping. `current` absent from `ids` (e.g. the
-/// selected vendor was disabled) starts at the first (or last, backward).
-/// Pure + testable — the hot-key handler is not.
 /// Whether the overview status-bar title draws mini bars (vs. the compact
 /// %-text mode). "Compactar" forces the text mode even under the bars-count
 /// threshold. Pure + testable — the render path is not.
@@ -908,6 +923,9 @@ func overviewUsesBars(count: Int, barsMax: Int, compact: Bool) -> Bool {
     !compact && count <= barsMax
 }
 
+/// The next id in the cycle, wrapping. `current` absent from `ids` (e.g. the
+/// selected vendor was disabled) starts at the first (or last, backward).
+/// Pure + testable — the hot-key handler is not.
 func nextVendorId(current: String, in ids: [String], forward: Bool = true) -> String? {
     guard !ids.isEmpty else { return nil }
     let n = ids.count
@@ -919,6 +937,7 @@ func nextVendorId(current: String, in ids: [String], forward: Bool = true) -> St
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
     var swapHotKeyRef: EventHotKeyRef?
+    var compactHotKeyRef: EventHotKeyRef?
     var swapHotKeyHandlerInstalled = false
     var timer: Timer?
     var prefsWindow: NSWindow?
@@ -956,10 +975,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let vendorSubmenuItem = NSMenuItem(title: "Trocar vendor", action: nil, keyEquivalent: "")
     /// Overview-only: forces the status-bar title into the compact %-text mode
     /// ("Compactar"); while compact it reads "Expandir" and turns it back off.
-    let compactItem = NSMenuItem(title: "Compactar", action: nil, keyEquivalent: "e")
+    let compactItem = NSMenuItem(title: "Compactar", action: nil, keyEquivalent: "")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        DEF.register(defaults: ["swapShortcutEnabled": true])
+        DEF.register(defaults: ["swapShortcutEnabled": true, "compactShortcutEnabled": true])
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.title = "5h …"
         buildMenu()
@@ -974,7 +993,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NotificationCenter.default.addObserver(
             self, selector: #selector(handleSwapHotKey),
             name: swapHotKeyNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleCompactHotKey),
+            name: compactHotKeyNotification, object: nil)
         installSwapHotKey()
+        installCompactHotKey()
     }
 
     /// (Re)register the global ⌥⌘\ hot key to match the `swapShortcutEnabled`
@@ -1001,16 +1024,56 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             vendorSubmenuItem.attributedTitle = NSAttributedString(string: "Trocar vendor")
         }
         guard enabled else { return }
-        if !swapHotKeyHandlerInstalled {
-            var spec = EventTypeSpec(
-                eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
-            InstallEventHandler(GetApplicationEventTarget(), swapHotKeyCallback, 1, &spec, nil, nil)
-            swapHotKeyHandlerInstalled = true
-        }
-        let id = EventHotKeyID(signature: OSType(0x4149_4242), id: 1)  // 'AIBB'
+        installHotKeyHandlerOnce()
+        let id = EventHotKeyID(signature: OSType(0x4149_4242), id: SWAP_HOTKEY_ID)  // 'AIBB'
         RegisterEventHotKey(
             SWAP_HOTKEY_KEYCODE, SWAP_HOTKEY_MODIFIERS, id, GetApplicationEventTarget(), 0,
             &swapHotKeyRef)
+    }
+
+    /// (Re)register the global ⌥⌘E Compactar/Expandir hot key to match the
+    /// `compactShortcutEnabled` preference. Idempotent, mirroring
+    /// `installSwapHotKey` — including the painted-in hint (a native
+    /// keyEquivalent would fire a second time while the menu is open, double-
+    /// toggling on one press).
+    func installCompactHotKey() {
+        if let ref = compactHotKeyRef {
+            UnregisterEventHotKey(ref)
+            compactHotKeyRef = nil
+        }
+        updateCompactItemTitle()
+        guard DEF.bool(forKey: "compactShortcutEnabled") else { return }
+        installHotKeyHandlerOnce()
+        let id = EventHotKeyID(signature: OSType(0x4149_4242), id: COMPACT_HOTKEY_ID)
+        RegisterEventHotKey(
+            COMPACT_HOTKEY_KEYCODE, SWAP_HOTKEY_MODIFIERS, id, GetApplicationEventTarget(), 0,
+            &compactHotKeyRef)
+    }
+
+    /// Compactar ↔ Expandir label plus the dimmed ⌥⌘E hint when the global
+    /// shortcut is on. Shared by the overview render and the hot-key installer.
+    func updateCompactItemTitle() {
+        let label = DEF.bool(forKey: "overviewCompact") ? "Expandir" : "Compactar"
+        guard DEF.bool(forKey: "compactShortcutEnabled") else {
+            compactItem.attributedTitle = NSAttributedString(string: label)
+            return
+        }
+        let font = NSFont.menuFont(ofSize: 0)
+        let s = NSMutableAttributedString(string: "\(label)  ", attributes: [.font: font])
+        s.append(NSAttributedString(string: "⌥⌘E", attributes: [
+            .font: font, .foregroundColor: NSColor.tertiaryLabelColor,
+        ]))
+        compactItem.attributedTitle = s
+    }
+
+    /// One Carbon handler serves every hot key; the event's EventHotKeyID
+    /// says which one fired.
+    private func installHotKeyHandlerOnce() {
+        guard !swapHotKeyHandlerInstalled else { return }
+        var spec = EventTypeSpec(
+            eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(GetApplicationEventTarget(), swapHotKeyCallback, 1, &spec, nil, nil)
+        swapHotKeyHandlerInstalled = true
     }
 
     func removeSwapHotKey() {
@@ -1027,6 +1090,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if let next = nextVendorId(current: VENDOR, in: swapCycleIds()) {
             DEF.set(next, forKey: "vendor")
         }
+    }
+
+    /// ⌥⌘E: toggle Compactar/Expandir. Overview-only — flipping a hidden
+    /// preference from another view would be invisible and confusing.
+    @objc func handleCompactHotKey() {
+        guard VENDOR == "overview" else { return }
+        toggleCompact()
     }
 
     /// The swap-shortcut ring: every configured vendor plus the synthetic
@@ -1133,6 +1203,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // vendor switch, which itself writes defaults).
         if DEF.bool(forKey: "swapShortcutEnabled") != (swapHotKeyRef != nil) {
             installSwapHotKey()
+        }
+        if DEF.bool(forKey: "compactShortcutEnabled") != (compactHotKeyRef != nil) {
+            installCompactHotKey()
         }
         // A vendor swap re-fetches, which takes a moment; keeping the previous
         // vendor's view up reads as a freeze. Show a Loading placeholder at once.
@@ -1453,7 +1526,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // many). The dropdown always holds the full per-vendor list.
         statusItem.button?.attributedTitle = overviewBarTitle(items, appearance)
         compactItem.isHidden = false
-        compactItem.title = DEF.bool(forKey: "overviewCompact") ? "Expandir" : "Compactar"
+        updateCompactItemTitle()
         if rebuildSubmenu { rebuildVendorSubmenu() }
     }
 

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -919,6 +919,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var refreshQueued = false
     let headerItem = NSMenuItem()
     var rows: [String: NSMenuItem] = [:]
+    // Overview mode fills these (one per vendor); hidden in single-vendor mode.
+    // A fixed pool avoids rebuilding the menu (which would disrupt an open menu).
+    var overviewRows: [NSMenuItem] = []
+    /// Last overview fetch, so a settings/appearance change re-renders it without
+    /// flashing the stale single-vendor snapshot.
+    var lastOverview: [(name: String, snap: Snapshot?)]?
     // Rebuilt on every render so only configured vendors show, and the active
     // one is checked. Kept as a field so the menu owns it for its lifetime.
     let vendorSubmenu = NSMenu()
@@ -970,12 +976,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// the global hot key; sets `vendor` in defaults, which drives the usual
     /// re-render via `settingsChanged`.
     @objc func handleSwapHotKey() {
-        let ids = VENDOR_AUTH
-            .filter { vendorEnabled($0) && ($0.id == VENDOR || vendorConfigured($0)) }
-            .map { $0.id }
-        if let next = nextVendorId(current: VENDOR, in: ids) {
+        if let next = nextVendorId(current: VENDOR, in: swapCycleIds()) {
             DEF.set(next, forKey: "vendor")
         }
+    }
+
+    /// The swap-shortcut ring: every configured vendor plus the synthetic
+    /// "overview" target, so ⌥⌘\ cycles all providers *and* the overview.
+    func swapCycleIds() -> [String] {
+        var ids = VENDOR_AUTH
+            .filter { vendorEnabled($0) && ($0.id == VENDOR || vendorConfigured($0)) }
+            .map { $0.id }
+        ids.append("overview")
+        return ids
     }
 
     func buildMenu() {
@@ -983,6 +996,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.autoenablesItems = false
 
         menu.addItem(headerItem)
+        // One hidden slot per possible vendor for Overview mode. ponytail: 12 ≥
+        // the vendor count; bump if VENDOR_AUTH ever grows past it.
+        for _ in 0..<12 {
+            let it = NSMenuItem()
+            it.isHidden = true
+            overviewRows.append(it)
+            menu.addItem(it)
+        }
         for key in ["session", "weekly", "sonnet", "extra"] {
             let it = NSMenuItem()
             rows[key] = it
@@ -1054,7 +1075,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if DEF.bool(forKey: "swapShortcutEnabled") != (swapHotKeyRef != nil) {
             installSwapHotKey()
         }
-        if let s = lastSnapshot { renderPanel(s); renderMenu(s) }
+        if VENDOR == "overview" {
+            if let ov = lastOverview { renderOverview(ov) }
+        } else if let s = lastSnapshot {
+            renderPanel(s); renderMenu(s)
+        }
         restartTimer()
         pendingRefresh?.cancel()
         let work = DispatchWorkItem { [weak self] in self?.refresh() }
@@ -1078,6 +1103,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func rerenderAppearance() {
+        if VENDOR == "overview", let ov = lastOverview { renderOverview(ov); return }
         guard let snapshot = lastSnapshot else { return }
         renderPanel(snapshot)
     }
@@ -1099,6 +1125,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Captured for THIS attempt: reading `VENDOR` again on completion would
         // label a late result with whatever is selected by then.
         let vendor = VENDOR
+
+        if vendor == "overview" {
+            refreshOverview(bin: bin, generation: generation)
+            return
+        }
 
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let p = Process()
@@ -1158,6 +1189,111 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Overview mode: fetch every configured vendor and render one compact row
+    /// each. Sequential on purpose — reads are cache-first, and serializing
+    /// respects the per-vendor cache flock and avoids an OAuth-refresh 429 burst.
+    /// ponytail: parallelize only if it ever feels slow.
+    func refreshOverview(bin: String, generation: Int) {
+        let vendors = VENDOR_AUTH.filter { vendorEnabled($0) && vendorConfigured($0) }
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            var results: [(name: String, snap: Snapshot?)] = []
+            for v in vendors {
+                let p = Process()
+                p.executableURL = URL(fileURLWithPath: bin)
+                p.arguments = ["--vendor", v.id, "--format", FORMAT_WITH_SENTINEL]
+                let pipe = Pipe()
+                p.standardOutput = pipe
+                p.standardError = FileHandle.nullDevice
+                let watchdog = DispatchWorkItem { if p.isRunning { p.terminate() } }
+                DispatchQueue.global(qos: .utility)
+                    .asyncAfter(deadline: .now() + REFRESH_TIMEOUT, execute: watchdog)
+                var out = ""
+                do {
+                    try p.run()
+                    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                    p.waitUntilExit()
+                    out = String(data: data, encoding: .utf8) ?? ""
+                } catch { out = "" }
+                watchdog.cancel()
+                var snap: Snapshot?
+                if let data = out.data(using: .utf8),
+                   let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let text = obj["text"] as? String {
+                    snap = parse(text, vendor: v.id)
+                }
+                results.append((name: v.name, snap: snap))
+            }
+            DispatchQueue.main.async {
+                self?.finishRefresh(generation) { me in
+                    guard VENDOR == "overview" else { return }
+                    me.renderOverview(results)
+                }
+            }
+        }
+    }
+
+    /// The single most-relevant number for a vendor in the overview: the worse of
+    /// its two windows, or its $ budget when it has no time windows.
+    func overviewHeadline(_ s: Snapshot) -> (pct: Int, value: String, reset: String?, elapsed: Int?) {
+        if let a = s.session, let b = s.weekly {
+            return a.pct >= b.pct
+                ? (a.pct, "\(a.pct)%", a.reset, a.elapsed)
+                : (b.pct, "\(b.pct)%", b.reset, b.elapsed)
+        }
+        if let a = s.session ?? s.weekly { return (a.pct, "\(a.pct)%", a.reset, a.elapsed) }
+        if let e = s.extra { return (e.pct, "\(e.spent) / \(e.limit)", nil, nil) }
+        return (0, "—", nil, nil)
+    }
+
+    func renderOverview(_ items: [(name: String, snap: Snapshot?)]) {
+        lastSnapshot = nil
+        lastOverview = items
+        let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
+        headerItem.attributedTitle = run("Visão geral", .labelColor, NSFont.boldSystemFont(ofSize: 13))
+        for key in ["session", "weekly", "sonnet", "extra"] { rows[key]?.isHidden = true }
+
+        var worstPct = -1
+        var worstName = ""
+        for (i, item) in items.enumerated() where i < overviewRows.count {
+            let it = overviewRows[i]
+            it.isHidden = false
+            let a = NSMutableAttributedString()
+            let label = item.name.count < 16
+                ? item.name.padding(toLength: 16, withPad: " ", startingAt: 0)
+                : item.name
+            a.append(run(label, .labelColor))
+            if let s = item.snap {
+                if let cb = s.creditBalance {
+                    a.append(run("cr \(cb)", .labelColor))
+                } else {
+                    let h = overviewHeadline(s)
+                    a.append(progressAttr(pct: h.pct, width: MENU_BAR_W, elapsed: h.elapsed,
+                                          menu: true, appearance: appearance))
+                    a.append(run("  \(h.value)", colorForPct(h.pct)))
+                    if let r = h.reset, !r.isEmpty { a.append(run("   ↺ \(r)", .secondaryLabelColor)) }
+                    if h.pct > worstPct { worstPct = h.pct; worstName = item.name }
+                }
+            } else {
+                a.append(run("—", .secondaryLabelColor))
+            }
+            it.attributedTitle = a
+        }
+        for i in items.count..<overviewRows.count { overviewRows[i].isHidden = true }
+
+        // Menu-bar title: the single most-exhausted quota — the one glanceable
+        // fact a tiny bar can carry. The dropdown holds the full list.
+        let secondary = menuBarTextColor(appearance, secondary: true)
+        if worstPct >= 0 {
+            let t = NSMutableAttributedString()
+            t.append(run("\(worstPct)% ", colorForPct(worstPct)))
+            t.append(run(String(worstName.split(separator: " ").first ?? Substring(worstName)), secondary))
+            statusItem.button?.attributedTitle = t
+        } else {
+            statusItem.button?.attributedTitle = run("ovr", secondary)
+        }
+        rebuildVendorSubmenu()
+    }
+
     func consume(_ output: String) {
         guard let data = output.data(using: .utf8),
               let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1203,6 +1339,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func renderMenu(_ s: Snapshot) {
         let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
+        for it in overviewRows { it.isHidden = true }
         headerItem.attributedTitle = run(s.plan.isEmpty ? "AI Usage" : s.plan,
                                          .labelColor, NSFont.boldSystemFont(ofSize: 13))
 
@@ -1260,6 +1397,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             it.state = (v.id == active) ? .on : .off
             vendorSubmenu.addItem(it)
         }
+        // Synthetic overview target — same one the ⌥⌘\ ring ends on.
+        vendorSubmenu.addItem(.separator())
+        let ov = NSMenuItem(title: "Visão geral", action: #selector(switchVendor(_:)), keyEquivalent: "")
+        ov.target = self
+        ov.representedObject = "overview"
+        ov.state = (active == "overview") ? .on : .off
+        vendorSubmenu.addItem(ov)
         vendorSubmenuItem.isHidden = false
     }
 
@@ -1274,6 +1418,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
         headerItem.attributedTitle = run(msg, menuBarTextColor(appearance))
         for (_, it) in rows { it.isHidden = true }
+        for it in overviewRows { it.isHidden = true }
     }
 }
 

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -591,6 +591,141 @@ func apiKeyEnvironment(_ v: VendorAuth) -> String {
     configValueTOML(v.id, "api_key_env") ?? v.env
 }
 
+// ── Anthropic multi-account ────────────────────────────────────────────────
+// Mirrors the Rust side (`src/config.rs`): explicit `[[anthropic.accounts]]`
+// entries plus subdirectories of `[anthropic] accounts_dir` holding a
+// `.credentials.json`, explicit labels winning on a clash. Each account is a
+// selectable entry with the pseudo-id `anthropic@<label>`, fetched by the
+// binary as `--vendor anthropic --account <label>` — the binary resolves the
+// account's credentials itself (file or its own Keychain item), so the app
+// never needs to know where they live.
+
+/// `[[anthropic.accounts]]` labels, in file order. Pure text scan, like the
+/// rest of this app's TOML reading: a `[[anthropic.accounts]]` header opens a
+/// block, the first `label = "…"` inside it counts.
+func anthropicAccountLabels(inTOML text: String) -> [String] {
+    var labels: [String] = []
+    var inBlock = false
+    for rawLine in text.components(separatedBy: .newlines) {
+        let line = rawLine.trimmingCharacters(in: .whitespaces)
+        if line.hasPrefix("[") {
+            inBlock = line == "[[anthropic.accounts]]"
+            continue
+        }
+        guard inBlock, line.hasPrefix("label") else { continue }
+        let parts = line.split(separator: "=", maxSplits: 1)
+        guard parts.count == 2,
+              parts[0].trimmingCharacters(in: .whitespaces) == "label" else { continue }
+        var value = parts[1].trimmingCharacters(in: .whitespaces)
+        if let quote = value.first, quote == "\"" || quote == "'" {
+            let content = value.dropFirst()
+            guard let end = content.firstIndex(of: quote) else { continue }
+            value = String(content[..<end])
+        }
+        if !value.isEmpty {
+            labels.append(value)
+            inBlock = false  // one label per block
+        }
+    }
+    return labels
+}
+
+/// Subdirectories of `dir` holding a `.credentials.json`, sorted — the same
+/// discovery rule as the Rust `accounts_dir` scan.
+func discoverAccountLabels(inDir dir: String) -> [String] {
+    let fm = FileManager.default
+    guard let names = try? fm.contentsOfDirectory(atPath: dir) else { return [] }
+    return names.filter { name in
+        var isDir: ObjCBool = false
+        let sub = "\(dir)/\(name)"
+        return fm.fileExists(atPath: sub, isDirectory: &isDir) && isDir.boolValue
+            && fm.fileExists(atPath: "\(sub)/.credentials.json")
+    }.sorted()
+}
+
+/// Explicit labels first (file order), then discovered ones that don't clash.
+func mergedAccountLabels(explicit: [String], discovered: [String]) -> [String] {
+    explicit + discovered.filter { !explicit.contains($0) }
+}
+
+/// All configured Claude account labels, from the same config the binary reads.
+func claudeAccountLabels() -> [String] {
+    guard let text = try? String(contentsOfFile: configPathTOML(), encoding: .utf8) else {
+        return []
+    }
+    let explicit = anthropicAccountLabels(inTOML: text)
+    var discovered: [String] = []
+    if let dir = tomlValueInText(text, section: "anthropic", key: "accounts_dir"), !dir.isEmpty {
+        discovered = discoverAccountLabels(inDir: NSString(string: dir).expandingTildeInPath)
+    }
+    return mergedAccountLabels(explicit: explicit, discovered: discovered)
+}
+
+/// Rust semantics (`show_default_account`): `false` hides the default
+/// (unnamed) Claude entry, but is ignored when there are no named accounts,
+/// so Anthropic never loses its only entry.
+func showDefaultClaudeAccount(configValue: String?, hasAccounts: Bool) -> Bool {
+    guard hasAccounts else { return true }
+    return configValue != "false"
+}
+
+/// Pseudo-id mapping: `anthropic@<label>` selects a named account.
+let ACCOUNT_ID_PREFIX = "anthropic@"
+
+func accountLabel(of id: String) -> String? {
+    id.hasPrefix(ACCOUNT_ID_PREFIX) ? String(id.dropFirst(ACCOUNT_ID_PREFIX.count)) : nil
+}
+
+func baseVendorId(_ id: String) -> String {
+    accountLabel(of: id) != nil ? "anthropic" : id
+}
+
+/// The subprocess arguments that select `id` (base vendor or named account).
+func vendorArgs(for id: String) -> [String] {
+    if let label = accountLabel(of: id) {
+        return ["--vendor", "anthropic", "--account", label]
+    }
+    return ["--vendor", id]
+}
+
+/// One selectable entry: a base vendor or one Claude account.
+struct MenuEntry {
+    let id: String    // "cursor", "anthropic", or "anthropic@<label>"
+    let name: String  // display: "Cursor", "Claude · <label>"
+}
+
+/// The selectable entries, in menu order: every enabled+configured vendor,
+/// with Anthropic expanded into its named accounts (the default entry kept
+/// only per `show_default_account`). `active` stays listed even when
+/// unconfigured — same rule the per-vendor list always had.
+func vendorEntries(active: String) -> [MenuEntry] {
+    var out: [MenuEntry] = []
+    for v in VENDOR_AUTH where vendorEnabled(v) {
+        if v.id == "anthropic" {
+            let labels = claudeAccountLabels()
+            let showDefault = showDefaultClaudeAccount(
+                configValue: configValueTOML("anthropic", "show_default_account"),
+                hasAccounts: !labels.isEmpty)
+            if showDefault && (v.id == active || vendorConfigured(v)) {
+                out.append(MenuEntry(id: v.id, name: v.name))
+            }
+            for label in labels {
+                out.append(MenuEntry(id: ACCOUNT_ID_PREFIX + label, name: "Claude · \(label)"))
+            }
+        } else if v.id == active || vendorConfigured(v) {
+            out.append(MenuEntry(id: v.id, name: v.name))
+        }
+    }
+    return out
+}
+
+/// Display name for any selectable id (base vendor, account, or overview).
+func entryDisplayName(_ id: String) -> String {
+    if id == "overview" { return "Visão geral" }
+    if let label = accountLabel(of: id) { return "Claude · \(label)" }
+    return VENDOR_AUTH.first { $0.id == id }?.name ?? id
+}
+
 /// Rust defaults (`src/config.rs`): the OAuth/api-key vendors that ship enabled,
 /// versus the opt-in balance vendors that default to disabled. An omitted
 /// `[vendor].enabled` must reproduce these, not silently enable everything.
@@ -810,9 +945,16 @@ struct SettingsView: View {
 
     // Only enabled vendors appear in the selector: Rust treats opt-in vendors
     // (deepseek/kimi/kilo/novita/moonshot/grok/anthropic_api) as disabled when
-    // their `[vendor].enabled` is omitted, and so must this picker.
+    // their `[vendor].enabled` is omitted, and so must this picker. Claude
+    // accounts appear as their `anthropic@<label>` pseudo-ids, same as the
+    // "Trocar vendor" submenu.
     private var vendors: [String] {
-        VENDOR_AUTH.filter { vendorEnabled($0) }.map { $0.id }
+        var ids = VENDOR_AUTH.filter { vendorEnabled($0) }.map { $0.id }
+        let labels = claudeAccountLabels()
+        if let at = ids.firstIndex(of: "anthropic") {
+            ids.insert(contentsOf: labels.map { ACCOUNT_ID_PREFIX + $0 }, at: at + 1)
+        }
+        return ids
     }
 
     var body: some View {
@@ -1019,12 +1161,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// The swap-shortcut ring: every configured vendor plus the synthetic
-    /// "overview" target, so ⌥⌘\ cycles all providers *and* the overview.
+    /// The swap-shortcut ring: every configured entry (vendors *and* Claude
+    /// accounts) plus the synthetic "overview" target, so ⌥⌘\ cycles them all.
     func swapCycleIds() -> [String] {
-        var ids = VENDOR_AUTH
-            .filter { vendorEnabled($0) && ($0.id == VENDOR || vendorConfigured($0)) }
-            .map { $0.id }
+        var ids = vendorEntries(active: VENDOR).map { $0.id }
         ids.append("overview")
         return ids
     }
@@ -1137,9 +1277,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         lastSnapshot = nil
         lastOverview = nil
         let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
-        let name = VENDOR == "overview"
-            ? "Visão geral"
-            : (VENDOR_AUTH.first { $0.id == VENDOR }?.name ?? VENDOR)
+        let name = entryDisplayName(VENDOR)
         statusItem.button?.attributedTitle = run("\(name) …", menuBarTextColor(appearance))
         headerItem.attributedTitle = run("\(name) · carregando…", .labelColor,
                                          NSFont.boldSystemFont(ofSize: 13))
@@ -1206,7 +1344,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let p = Process()
             p.executableURL = URL(fileURLWithPath: bin)
-            p.arguments = ["--vendor", vendor, "--format", FORMAT_WITH_SENTINEL]
+            p.arguments = vendorArgs(for: vendor) + ["--format", FORMAT_WITH_SENTINEL]
             let pipe = Pipe()
             p.standardOutput = pipe
             p.standardError = FileHandle.nullDevice
@@ -1266,13 +1404,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// respects the per-vendor cache flock and avoids an OAuth-refresh 429 burst.
     /// ponytail: parallelize only if it ever feels slow.
     func refreshOverview(bin: String, generation: Int) {
-        let vendors = VENDOR_AUTH.filter { vendorEnabled($0) && vendorConfigured($0) }
+        // vendorEntries(active: "") keeps only configured entries — the
+        // active-vendor courtesy slot has no place in an all-vendors sweep.
+        let entries = vendorEntries(active: "")
         DispatchQueue.global(qos: .utility).async { [weak self] in
             var results: [(name: String, id: String, snap: Snapshot?)] = []
-            for v in vendors {
+            for v in entries {
                 let p = Process()
                 p.executableURL = URL(fileURLWithPath: bin)
-                p.arguments = ["--vendor", v.id, "--format", FORMAT_WITH_SENTINEL]
+                p.arguments = vendorArgs(for: v.id) + ["--format", FORMAT_WITH_SENTINEL]
                 let pipe = Pipe()
                 p.standardOutput = pipe
                 p.standardError = FileHandle.nullDevice
@@ -1291,7 +1431,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if let data = out.data(using: .utf8),
                    let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let text = obj["text"] as? String {
-                    snap = parse(text, vendor: v.id)
+                    snap = parse(text, vendor: baseVendorId(v.id))
                 }
                 results.append((name: v.name, id: v.id, snap: snap))
             }
@@ -1321,10 +1461,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return (0, "—", nil, nil)
     }
 
-    /// First word of a vendor name, clipped to `maxLen` — a compact bar label.
+    /// Compact bar label for a vendor name. Usually the first word; for a
+    /// Claude account ("Claude · gmail") the account label is the part that
+    /// distinguishes entries, so use it instead of the shared "Claude".
     func ovLabel(_ name: String, _ maxLen: Int) -> String {
-        let first = String(name.split(separator: " ").first ?? Substring(name))
-        return first.count <= maxLen ? first : String(first.prefix(maxLen))
+        let base = name.range(of: " · ").map { String(name[$0.upperBound...]) }
+            ?? String(name.split(separator: " ").first ?? Substring(name))
+        return base.count <= maxLen ? base : String(base.prefix(maxLen))
     }
 
     /// Status-bar summary for overview mode: every vendor at once. Mini bar per
@@ -1436,7 +1579,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             setError("saída inválida")
             return
         }
-        guard let snap = parse(text, vendor: VENDOR) else {
+        guard let snap = parse(text, vendor: baseVendorId(VENDOR)) else {
             lastSnapshot = nil
             let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
             statusItem.button?.attributedTitle = run(stripMarkup(text), menuBarTextColor(appearance))  // Loading… / ⚠
@@ -1475,8 +1618,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func renderMenu(_ s: Snapshot) {
         let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
         for it in overviewRows { it.isHidden = true }
-        headerItem.attributedTitle = run(s.plan.isEmpty ? "AI Usage" : s.plan,
-                                         .labelColor, NSFont.boldSystemFont(ofSize: 13))
+        // With several Claude accounts the plan alone ("Claude Max 20x") no
+        // longer says WHICH account this is — suffix the label.
+        let plan = s.plan.isEmpty ? "AI Usage" : s.plan
+        let header = accountLabel(of: VENDOR).map { "\(plan) · \($0)" } ?? plan
+        headerItem.attributedTitle = run(header, .labelColor, NSFont.boldSystemFont(ofSize: 13))
 
         func row(_ key: String, _ name: String, _ pct: Int, _ value: String, _ reset: String?, _ elapsed: Int?) {
             guard let item = rows[key] else { return }
@@ -1517,15 +1663,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func rebuildVendorSubmenu() {
         vendorSubmenu.removeAllItems()
         let active = VENDOR
-        let configured = VENDOR_AUTH.filter { vendorEnabled($0) && ($0.id == active || vendorConfigured($0)) }
-        if configured.isEmpty {
+        let entries = vendorEntries(active: active)
+        if entries.isEmpty {
             let none = NSMenuItem(title: "Nenhum configurado", action: nil, keyEquivalent: "")
             none.isEnabled = false
             vendorSubmenu.addItem(none)
             vendorSubmenuItem.isHidden = false
             return
         }
-        for v in configured {
+        for v in entries {
             let it = NSMenuItem(title: v.name, action: #selector(switchVendor(_:)), keyEquivalent: "")
             it.target = self
             it.representedObject = v.id

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -86,7 +86,7 @@ let FORMAT = "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_rese
              "{scoped_model};;{scoped_pct};;{scoped_reset};;" +
              "{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;{vendor_short};;{or_balance};;" +
              "{ds_balance};;{kilo_balance};;{nv_balance};;{km_balance};;{grok_balance};;" +
-             "{aapi_headline};;{aapi_pct};;{aapi_spent};;{aapi_limit}"
+             "{aapi_headline};;{aapi_pct};;{aapi_spent};;{aapi_limit};;{cursor_total_pct}"
 
 let FORMAT_WITH_SENTINEL = FORMAT + ";;__aiub_end__"
 
@@ -354,6 +354,9 @@ struct Snapshot {
     var weeklyTag: String = "7d"
     var sessionLabel: String = "Session"
     var weeklyLabel: String = "Weekly"
+    /// Cursor's combined "included total usage" headline (`totalPercentUsed`),
+    /// the single number its dashboard shows across both pools. nil for others.
+    var cursorTotalPct: Int? = nil
 }
 
 func stripMarkup(_ s: String) -> String {
@@ -465,7 +468,8 @@ func parse(_ text: String, vendor: String) -> Snapshot? {
                     sessionTag: isCursor ? "auto" : "5h",
                     weeklyTag: isCursor ? "premium" : "7d",
                     sessionLabel: isCursor ? "Cursor Models" : "Session",
-                    weeklyLabel: isCursor ? "Other Models" : "Weekly")
+                    weeklyLabel: isCursor ? "Other Models" : "Weekly",
+                    cursorTotalPct: isCursor ? n(27) : nil)
 }
 
 // ─── Preferences UI (SwiftUI) ────────────────────────────────────────────
@@ -603,13 +607,21 @@ func vendorEnabled(_ v: VendorAuth) -> Bool {
     return defaultEnabled(v.id)
 }
 
+// Cached: the check spawns a `security` subprocess, and it is consulted from the
+// menu-rebuild path (main thread). Signed-in state doesn't change within a run,
+// so compute it at most once — a restart picks up a fresh login.
+var keychainClaudeCache: Bool?
 func keychainHasClaude() -> Bool {
+    if let cached = keychainClaudeCache { return cached }
     let p = Process()
     p.executableURL = URL(fileURLWithPath: "/usr/bin/security")
     p.arguments = ["find-generic-password", "-s", "Claude Code-credentials"]
     p.standardOutput = FileHandle.nullDevice
     p.standardError = FileHandle.nullDevice
-    do { try p.run(); p.waitUntilExit(); return p.terminationStatus == 0 } catch { return false }
+    let result: Bool
+    do { try p.run(); p.waitUntilExit(); result = p.terminationStatus == 0 } catch { result = false }
+    keychainClaudeCache = result
+    return result
 }
 
 func vendorConfigured(_ v: VendorAuth) -> Bool {
@@ -904,6 +916,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var timer: Timer?
     var prefsWindow: NSWindow?
     var appearanceObservation: NSKeyValueObservation?
+    /// Last resolved light/dark name, so the appearance observer ignores the
+    /// layout-driven KVO fires that don't actually change the theme.
+    var lastAppearanceName: NSAppearance.Name?
+    /// Tracks the active vendor so `settingsChanged` can tell a vendor swap (show
+    /// Loading) apart from an unrelated preference change (repaint from cache).
+    var lastVendor = ""
     var lastSnapshot: Snapshot?
     var pendingRefresh: DispatchWorkItem?
     /// Bumped on every refresh attempt. A result whose generation is no longer
@@ -924,7 +942,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var overviewRows: [NSMenuItem] = []
     /// Last overview fetch, so a settings/appearance change re-renders it without
     /// flashing the stale single-vendor snapshot.
-    var lastOverview: [(name: String, snap: Snapshot?)]?
+    var lastOverview: [(name: String, id: String, snap: Snapshot?)]?
     // Rebuilt on every render so only configured vendors show, and the active
     // one is checked. Kept as a field so the menu owns it for its lifetime.
     let vendorSubmenu = NSMenu()
@@ -937,6 +955,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         buildMenu()
         rebuildVendorSubmenu()
         observeAppearanceChanges()
+        lastVendor = VENDOR  // so the first settingsChanged isn't mistaken for a swap
         refresh()
         restartTimer()
         NotificationCenter.default.addObserver(
@@ -952,7 +971,26 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// preference. Idempotent: always unregisters first.
     func installSwapHotKey() {
         removeSwapHotKey()
-        guard DEF.bool(forKey: "swapShortcutEnabled") else { return }
+        let enabled = DEF.bool(forKey: "swapShortcutEnabled")
+        // Mirror the swap shortcut as a hint on the "Trocar vendor" item. A native
+        // keyEquivalent is suppressed by the submenu's disclosure arrow, so paint
+        // the hint into the title instead (right-aligned, dimmed). Cleared when off.
+        if enabled {
+            // Inline, dimmed hint right after the label. A right-aligned column
+            // (like the other items' ⌘R) isn't possible here: the submenu arrow
+            // takes the trailing slot, and a fixed tab stop would over-widen the
+            // menu whenever the wide overview rows are hidden.
+            let font = NSFont.menuFont(ofSize: 0)
+            let s = NSMutableAttributedString(
+                string: "Trocar vendor  ", attributes: [.font: font])
+            s.append(NSAttributedString(string: "⌥⌘\\", attributes: [
+                .font: font, .foregroundColor: NSColor.tertiaryLabelColor,
+            ]))
+            vendorSubmenuItem.attributedTitle = s
+        } else {
+            vendorSubmenuItem.attributedTitle = NSAttributedString(string: "Trocar vendor")
+        }
+        guard enabled else { return }
         if !swapHotKeyHandlerInstalled {
             var spec = EventTypeSpec(
                 eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
@@ -1075,7 +1113,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if DEF.bool(forKey: "swapShortcutEnabled") != (swapHotKeyRef != nil) {
             installSwapHotKey()
         }
-        if VENDOR == "overview" {
+        // A vendor swap re-fetches, which takes a moment; keeping the previous
+        // vendor's view up reads as a freeze. Show a Loading placeholder at once.
+        let vendorChanged = VENDOR != lastVendor
+        lastVendor = VENDOR
+        if vendorChanged {
+            showLoading()
+        } else if VENDOR == "overview" {
             if let ov = lastOverview { renderOverview(ov) }
         } else if let s = lastSnapshot {
             renderPanel(s); renderMenu(s)
@@ -1087,6 +1131,23 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: work)
     }
 
+    /// Instant feedback for a vendor swap: replace the whole view with a Loading
+    /// placeholder naming the target, until its data arrives.
+    func showLoading() {
+        lastSnapshot = nil
+        lastOverview = nil
+        let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
+        let name = VENDOR == "overview"
+            ? "Visão geral"
+            : (VENDOR_AUTH.first { $0.id == VENDOR }?.name ?? VENDOR)
+        statusItem.button?.attributedTitle = run("\(name) …", menuBarTextColor(appearance))
+        headerItem.attributedTitle = run("\(name) · carregando…", .labelColor,
+                                         NSFont.boldSystemFont(ofSize: 13))
+        for (_, it) in rows { it.isHidden = true }
+        for it in overviewRows { it.isHidden = true }
+        rebuildVendorSubmenu()
+    }
+
     func restartTimer() {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: INTERVAL, repeats: true) { [weak self] _ in
@@ -1096,14 +1157,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func observeAppearanceChanges() {
         guard let button = statusItem.button else { return }
+        lastAppearanceName = button.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
         appearanceObservation = button.observe(\NSStatusBarButton.effectiveAppearance,
-                                               options: [.new]) { [weak self] _, _ in
-            DispatchQueue.main.async { self?.rerenderAppearance() }
+                                               options: [.new]) { [weak self] btn, _ in
+            // The KVO fires on every layout pass, not only on a real light↔dark
+            // flip — and rendering (which relays out the button) would retrigger
+            // it, spinning the main thread. Act only when the theme truly changes.
+            let name = btn.effectiveAppearance.bestMatch(from: [.aqua, .darkAqua])
+            DispatchQueue.main.async {
+                guard let self, self.lastAppearanceName != name else { return }
+                self.lastAppearanceName = name
+                self.rerenderAppearance()
+            }
         }
     }
 
     func rerenderAppearance() {
-        if VENDOR == "overview", let ov = lastOverview { renderOverview(ov); return }
+        // Appearance only changes colors; the configured-vendor set is unchanged,
+        // so repaint without rebuilding the (subprocess-touching) submenu.
+        if VENDOR == "overview", let ov = lastOverview { renderOverview(ov, rebuildSubmenu: false); return }
         guard let snapshot = lastSnapshot else { return }
         renderPanel(snapshot)
     }
@@ -1196,7 +1268,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func refreshOverview(bin: String, generation: Int) {
         let vendors = VENDOR_AUTH.filter { vendorEnabled($0) && vendorConfigured($0) }
         DispatchQueue.global(qos: .utility).async { [weak self] in
-            var results: [(name: String, snap: Snapshot?)] = []
+            var results: [(name: String, id: String, snap: Snapshot?)] = []
             for v in vendors {
                 let p = Process()
                 p.executableURL = URL(fileURLWithPath: bin)
@@ -1221,7 +1293,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                    let text = obj["text"] as? String {
                     snap = parse(text, vendor: v.id)
                 }
-                results.append((name: v.name, snap: snap))
+                results.append((name: v.name, id: v.id, snap: snap))
             }
             DispatchQueue.main.async {
                 self?.finishRefresh(generation) { me in
@@ -1232,36 +1304,106 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    /// The single most-relevant number for a vendor in the overview: the worse of
-    /// its two windows, or its $ budget when it has no time windows.
+    /// The single most-relevant number for a vendor in the overview.
+    /// Cursor: the combined "included total usage" headline (both pools as one).
+    /// Everyone else: the most-exhausted of its windows — for Anthropic that is
+    /// the biggest of 5h, weekly, and the scoped model bar (Fable). Falls back to
+    /// the $ budget when a vendor has no time windows.
     func overviewHeadline(_ s: Snapshot) -> (pct: Int, value: String, reset: String?, elapsed: Int?) {
-        if let a = s.session, let b = s.weekly {
-            return a.pct >= b.pct
-                ? (a.pct, "\(a.pct)%", a.reset, a.elapsed)
-                : (b.pct, "\(b.pct)%", b.reset, b.elapsed)
+        if let t = s.cursorTotalPct {
+            return (t, "\(t)%", s.weekly?.reset ?? s.session?.reset, nil)
         }
-        if let a = s.session ?? s.weekly { return (a.pct, "\(a.pct)%", a.reset, a.elapsed) }
+        let windows = [s.session, s.weekly, s.sonnet].compactMap { $0 }
+        if let w = windows.max(by: { $0.pct < $1.pct }) {
+            return (w.pct, "\(w.pct)%", w.reset, w.elapsed)
+        }
         if let e = s.extra { return (e.pct, "\(e.spent) / \(e.limit)", nil, nil) }
         return (0, "—", nil, nil)
     }
 
-    func renderOverview(_ items: [(name: String, snap: Snapshot?)]) {
+    /// First word of a vendor name, clipped to `maxLen` — a compact bar label.
+    func ovLabel(_ name: String, _ maxLen: Int) -> String {
+        let first = String(name.split(separator: " ").first ?? Substring(name))
+        return first.count <= maxLen ? first : String(first.prefix(maxLen))
+    }
+
+    /// Status-bar summary for overview mode: every vendor at once. Mini bar per
+    /// vendor when few; worst-first numbers (capped, with `+K` overflow) when
+    /// many. Tunable via `[ui] overview_menubar_bars_max` (bar↔number threshold,
+    /// default 2) and `overview_menubar_max` (how many numbers fit, default 4).
+    func overviewBarTitle(_ items: [(name: String, id: String, snap: Snapshot?)],
+                          _ appearance: NSAppearance) -> NSAttributedString {
+        let secondary = menuBarTextColor(appearance, secondary: true)
+        let heads: [(name: String, pct: Int, elapsed: Int?, value: String)] = items.compactMap {
+            guard let s = $0.snap else { return nil }
+            if let cb = s.creditBalance { return ($0.name, -1, nil, "cr \(cb)") }
+            let h = overviewHeadline(s)
+            return ($0.name, h.pct, h.elapsed, "\(h.pct)%")
+        }
+        guard !heads.isEmpty else { return run("ovr", secondary) }
+
+        let barsMax = Int(configValueTOML("ui", "overview_menubar_bars_max") ?? "") ?? 2
+        let t = NSMutableAttributedString()
+        if heads.count <= barsMax {
+            for (i, e) in heads.enumerated() {
+                if i > 0 { t.append(run("   ", secondary)) }
+                t.append(run("\(ovLabel(e.name, 6)) ", secondary))
+                if e.pct >= 0 {
+                    t.append(run("\(e.pct)% ", colorForPct(e.pct)))
+                    t.append(progressAttr(pct: e.pct, width: BAR_WIDTH, elapsed: e.elapsed,
+                                          appearance: appearance))
+                } else {
+                    t.append(run(e.value, .labelColor))  // credit balance
+                }
+            }
+        } else {
+            let maxN = Int(configValueTOML("ui", "overview_menubar_max") ?? "") ?? 4
+            let sorted = heads.sorted { $0.pct > $1.pct }
+            for (i, e) in sorted.prefix(maxN).enumerated() {
+                if i > 0 { t.append(run("  ", secondary)) }
+                t.append(run("\(ovLabel(e.name, 3)) ", secondary))
+                t.append(run(e.value, e.pct >= 0 ? colorForPct(e.pct) : .labelColor))
+            }
+            if sorted.count > maxN { t.append(run("  +\(sorted.count - maxN)", secondary)) }
+        }
+        return t
+    }
+
+    func renderOverview(_ items: [(name: String, id: String, snap: Snapshot?)],
+                        rebuildSubmenu: Bool = true) {
         lastSnapshot = nil
         lastOverview = items
         let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
         headerItem.attributedTitle = run("Visão geral", .labelColor, NSFont.boldSystemFont(ofSize: 13))
         for key in ["session", "weekly", "sonnet", "extra"] { rows[key]?.isHidden = true }
 
-        var worstPct = -1
-        var worstName = ""
+        // Rows render in a monospaced font, so fixed character widths line the
+        // columns up. Pre-compute the widest headline pct and reset so both can be
+        // right-aligned — the reset then ends flush at the line's right edge.
+        let nameW = 14
+        var pctW = 0, resetW = 0
+        for item in items.prefix(overviewRows.count) {
+            guard let s = item.snap, s.creditBalance == nil else { continue }
+            let h = overviewHeadline(s)
+            pctW = max(pctW, h.value.count)
+            if let r = h.reset, !r.isEmpty { resetW = max(resetW, r.count) }
+        }
+        func rpad(_ s: String, _ w: Int) -> String {
+            String(repeating: " ", count: max(0, w - s.count)) + s
+        }
+
         for (i, item) in items.enumerated() where i < overviewRows.count {
             let it = overviewRows[i]
             it.isHidden = false
+            // Click a row to jump straight to that vendor's detail view.
+            it.representedObject = item.id
+            it.target = self
+            it.action = #selector(switchVendor(_:))
             let a = NSMutableAttributedString()
-            let label = item.name.count < 16
-                ? item.name.padding(toLength: 16, withPad: " ", startingAt: 0)
-                : item.name
-            a.append(run(label, .labelColor))
+            let fitted = item.name.count > nameW
+                ? String(item.name.prefix(nameW - 1)) + "…"
+                : item.name.padding(toLength: nameW, withPad: " ", startingAt: 0)
+            a.append(run(fitted + " ", .labelColor))
             if let s = item.snap {
                 if let cb = s.creditBalance {
                     a.append(run("cr \(cb)", .labelColor))
@@ -1269,9 +1411,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     let h = overviewHeadline(s)
                     a.append(progressAttr(pct: h.pct, width: MENU_BAR_W, elapsed: h.elapsed,
                                           menu: true, appearance: appearance))
-                    a.append(run("  \(h.value)", colorForPct(h.pct)))
-                    if let r = h.reset, !r.isEmpty { a.append(run("   ↺ \(r)", .secondaryLabelColor)) }
-                    if h.pct > worstPct { worstPct = h.pct; worstName = item.name }
+                    a.append(run("  \(rpad(h.value, pctW))", colorForPct(h.pct)))
+                    if let r = h.reset, !r.isEmpty {
+                        a.append(run("   ↺ \(rpad(r, resetW))", .secondaryLabelColor))
+                    }
                 }
             } else {
                 a.append(run("—", .secondaryLabelColor))
@@ -1280,18 +1423,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         for i in items.count..<overviewRows.count { overviewRows[i].isHidden = true }
 
-        // Menu-bar title: the single most-exhausted quota — the one glanceable
-        // fact a tiny bar can carry. The dropdown holds the full list.
-        let secondary = menuBarTextColor(appearance, secondary: true)
-        if worstPct >= 0 {
-            let t = NSMutableAttributedString()
-            t.append(run("\(worstPct)% ", colorForPct(worstPct)))
-            t.append(run(String(worstName.split(separator: " ").first ?? Substring(worstName)), secondary))
-            statusItem.button?.attributedTitle = t
-        } else {
-            statusItem.button?.attributedTitle = run("ovr", secondary)
-        }
-        rebuildVendorSubmenu()
+        // Menu-bar title: every vendor at once (mini bars when few, numbers when
+        // many). The dropdown always holds the full per-vendor list.
+        statusItem.button?.attributedTitle = overviewBarTitle(items, appearance)
+        if rebuildSubmenu { rebuildVendorSubmenu() }
     }
 
     func consume(_ output: String) {

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -345,6 +345,15 @@ struct Snapshot {
     /// Label for that bar: the scoped model name ("Fable") or "Sonnet only".
     let sonnetLabel: String
     let extra: (pct: Int, spent: String, limit: String)?
+    /// Overridable labels for the session/weekly bars. Default to the
+    /// time-window names; a vendor whose two windows aren't time-based (Cursor:
+    /// "Cursor Models" / "Other Models") sets its own. Tags are the 2-char
+    /// prefixes shown on the compact status bar. Defaulted so every other
+    /// vendor's construction is unchanged.
+    var sessionTag: String = "5h"
+    var weeklyTag: String = "7d"
+    var sessionLabel: String = "Session"
+    var weeklyLabel: String = "Weekly"
 }
 
 func stripMarkup(_ s: String) -> String {
@@ -440,6 +449,11 @@ func parse(_ text: String, vendor: String) -> Snapshot? {
     // With a limit configured the spend-vs-limit bar replaces the headline, so
     // avoid showing both the "cr" balance and the extra ($) row at once.
     let displayBalance = aapiExtra == nil ? balance : nil
+    // Cursor carries its two included-usage pools on the session/weekly
+    // aliases (session = Cursor Models, weekly = Other Models — both real, not
+    // time windows), so relabel those bars rather than call them "Session"/
+    // "Weekly". Every other vendor keeps the default time-window labels.
+    let isCursor = vendor == "cursor"
     return Snapshot(plan: t(0),
                     hasUsageWindows: !balanceOnly,
                     creditBalance: displayBalance,
@@ -447,7 +461,11 @@ func parse(_ text: String, vendor: String) -> Snapshot? {
                     weekly: quotaWindow(3, 4, 14),
                     sonnet: sonnet,
                     sonnetLabel: sonnetLabel,
-                    extra: aapiExtra ?? extra)
+                    extra: aapiExtra ?? extra,
+                    sessionTag: isCursor ? "auto" : "5h",
+                    weeklyTag: isCursor ? "premium" : "7d",
+                    sessionLabel: isCursor ? "Cursor Models" : "Session",
+                    weeklyLabel: isCursor ? "Other Models" : "Weekly")
 }
 
 // ─── Preferences UI (SwiftUI) ────────────────────────────────────────────
@@ -490,6 +508,11 @@ let VENDOR_AUTH: [VendorAuth] = [
     VendorAuth(id: "moonshot", name: "Moonshot", kind: "apikey", cli: "", login: "", pkg: "", env: "MOONSHOT_API_KEY"),
     VendorAuth(id: "grok", name: "Grok (xAI)", kind: "apikey", cli: "", login: "", pkg: "", env: "XAI_MANAGEMENT_KEY"),
     VendorAuth(id: "anthropic_api", name: "Anthropic (API)", kind: "apikey", cli: "", login: "", pkg: "", env: "ANTHROPIC_ADMIN_KEY"),
+    // Cursor has no API key: the binary reads the session token the Cursor IDE
+    // wrote to its own state.vscdb. `kind: "local"` marks the "configured =
+    // signed in to the app" case (like Antigravity in the GNOME extension),
+    // with no login CLI or env var of its own.
+    VendorAuth(id: "cursor", name: "Cursor", kind: "local", cli: "", login: "", pkg: "", env: ""),
 ]
 
 // The config file the Rust binary would actually read. On macOS
@@ -570,7 +593,7 @@ func apiKeyEnvironment(_ v: VendorAuth) -> String {
 func defaultEnabled(_ id: String) -> Bool {
     switch id {
     case "anthropic", "openai", "zai", "openrouter": return true
-    case "deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api": return false
+    case "deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor": return false
     default: return true
     }
 }
@@ -598,6 +621,13 @@ func vendorConfigured(_ v: VendorAuth) -> Bool {
     }
     if v.id == "openai" {
         return fm.fileExists(atPath: "\(home)/.codex/auth.json")
+    }
+    if v.id == "cursor" {
+        // Configured == signed in to the Cursor IDE, i.e. its state DB exists.
+        // Honor a [cursor] db_path override the same way the binary does.
+        let dbPath = configValueTOML("cursor", "db_path")
+            ?? "\(home)/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+        return fm.fileExists(atPath: dbPath)
     }
     if let e = ProcessInfo.processInfo.environment[apiKeyEnvironment(v)], !e.isEmpty { return true }
     return configHasApiKeyTOML(v.id)
@@ -660,6 +690,15 @@ func openTuiInTerminal() {
     runInTerminal("\"\(tui)\"\necho\nread -p \"Enter para fechar...\"")
 }
 
+// Launch a .app by name (e.g. "Cursor") via `open -a`, so a local-kind vendor's
+// button can bring the user to the app they need to sign into.
+func openApp(_ name: String) {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    p.arguments = ["-a", name]
+    try? p.run()
+}
+
 struct VendorsSection: View {
     @State private var configured: [String: Bool] = [:]
     @State private var cliPresent: [String: Bool] = [:]
@@ -712,6 +751,11 @@ struct VendorsSection: View {
             if cliPresent[v.id] == false { return "⚠ \(v.cli) não instalado" }
             return "⚠ Não logado — \(v.login)"
         }
+        // Local vendors (Cursor) have no key: "configured" means signed in to
+        // the app AND [cursor] enabled in config.
+        if v.kind == "local" {
+            return "⚠ Entre no app Cursor e ative [cursor] no config"
+        }
         return "⚠ Sem API key — \(apiKeyEnvironment(v))"
     }
 
@@ -721,11 +765,13 @@ struct VendorsSection: View {
             if cliPresent[v.id] == false { return "Instalar + logar" }
             return "Logar"
         }
+        if v.kind == "local" { return "Abrir Cursor" }
         return "Configurar (TUI)"
     }
 
     private func action(_ v: VendorAuth) {
         if v.kind == "oauth" { runInTerminal(oauthScript(v)) }
+        else if v.kind == "local" { openApp(v.name) }
         else { openTuiInTerminal() }
         DispatchQueue.main.asyncAfter(deadline: .now() + 4) { refresh() }
     }
@@ -1146,10 +1192,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             title.append(run("cr ", secondaryTextColor))
             title.append(run(creditBalance, primaryTextColor))
         } else if s.hasUsageWindows && SHOW_SESSION, let session = s.session {
-            seg("5h", session.pct, "\(session.pct)%", session.elapsed)
+            seg(s.sessionTag, session.pct, "\(session.pct)%", session.elapsed)
         }
         if s.creditBalance == nil && s.hasUsageWindows && SHOW_WEEKLY, let weekly = s.weekly {
-            seg("7d", weekly.pct, "\(weekly.pct)%", weekly.elapsed)
+            seg(s.weeklyTag, weekly.pct, "\(weekly.pct)%", weekly.elapsed)
         }
         if SHOW_EXTRA, let e = s.extra { seg("ex", e.pct, e.spent, nil) } // $ budget → no meta
         statusItem.button?.attributedTitle = title.length > 0 ? title : run("ai", secondaryTextColor)
@@ -1180,10 +1226,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             rows["sonnet"]?.isHidden = true
         } else {
             if s.hasUsageWindows, let session = s.session {
-                row("session", "Session", session.pct, "\(session.pct)%", session.reset, session.elapsed)
+                row("session", s.sessionLabel, session.pct, "\(session.pct)%", session.reset, session.elapsed)
             } else { rows["session"]?.isHidden = true }
             if s.hasUsageWindows, let weekly = s.weekly {
-                row("weekly", "Weekly", weekly.pct, "\(weekly.pct)%", weekly.reset, weekly.elapsed)
+                row("weekly", s.weeklyLabel, weekly.pct, "\(weekly.pct)%", weekly.reset, weekly.elapsed)
             } else { rows["weekly"]?.isHidden = true }
         }
         if let sn = s.sonnet { row("sonnet", s.sonnetLabel, sn.pct, "\(sn.pct)%", sn.reset, sn.elapsed) }

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -17,6 +17,7 @@
 
 import Cocoa
 import SwiftUI
+import Carbon.HIToolbox  // RegisterEventHotKey for the global vendor-swap shortcut
 
 // ─── Settings (persisted in UserDefaults; edit in Preferences) ───────────
 let DEF = UserDefaults.standard
@@ -741,6 +742,7 @@ struct SettingsView: View {
     @AppStorage("showBars") private var showBars = true
     @AppStorage("showMeta") private var showMeta = true
     @AppStorage("barStyle") private var barStyle = "block"
+    @AppStorage("swapShortcutEnabled") private var swapShortcutEnabled = true
     @AppStorage("colorLow") private var colorLow = "#98c379"
     @AppStorage("colorMid") private var colorMid = "#e5c07b"
     @AppStorage("colorHigh") private var colorHigh = "#d19a66"
@@ -777,6 +779,14 @@ struct SettingsView: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
+                GroupBox("Atalho") {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Trocar vendor com ⌥⌘\\ (atalho global)", isOn: $swapShortcutEnabled)
+                        Text("Alterna o vendor ativo a partir de qualquer app.")
+                            .font(.caption).foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
                 GroupBox("Cores") {
                     VStack(alignment: .leading, spacing: 8) {
                         HexColorPicker(title: "Baixo (<50%)", hex: $colorLow)
@@ -808,8 +818,43 @@ struct SettingsView: View {
 }
 
 // ─── App ─────────────────────────────────────────────────────────────────
+// ─── Global vendor-swap shortcut (⌥⌘\) ───────────────────────────────────
+//
+// A menu-bar app has no focused window, so a system-wide shortcut needs a
+// Carbon hot key (RegisterEventHotKey), which fires regardless of focus and —
+// unlike an NSEvent global monitor — needs no Accessibility permission. The
+// Carbon handler is a C callback that can't capture Swift state, so it just
+// posts a notification the delegate observes.
+
+let swapHotKeyNotification = Notification.Name("aiusagebar.swapHotKey")
+
+/// Default shortcut: `\` (kVK_ANSI_Backslash) with Command+Option. `[ui]` on
+/// Linux has no equivalent; this is macOS-only.
+let SWAP_HOTKEY_KEYCODE = UInt32(kVK_ANSI_Backslash)
+let SWAP_HOTKEY_MODIFIERS = UInt32(cmdKey | optionKey)
+
+private func swapHotKeyCallback(
+    _ next: EventHandlerCallRef?, _ event: EventRef?, _ userData: UnsafeMutableRawPointer?
+) -> OSStatus {
+    NotificationCenter.default.post(name: swapHotKeyNotification, object: nil)
+    return noErr
+}
+
+/// The next id in the cycle, wrapping. `current` absent from `ids` (e.g. the
+/// selected vendor was disabled) starts at the first (or last, backward).
+/// Pure + testable — the hot-key handler is not.
+func nextVendorId(current: String, in ids: [String], forward: Bool = true) -> String? {
+    guard !ids.isEmpty else { return nil }
+    let n = ids.count
+    let i = ids.firstIndex(of: current) ?? (forward ? -1 : 0)
+    let j = forward ? (i + 1) % n : (i - 1 + n) % n
+    return ids[j]
+}
+
 class AppDelegate: NSObject, NSApplicationDelegate {
     var statusItem: NSStatusItem!
+    var swapHotKeyRef: EventHotKeyRef?
+    var swapHotKeyHandlerInstalled = false
     var timer: Timer?
     var prefsWindow: NSWindow?
     var appearanceObservation: NSKeyValueObservation?
@@ -834,6 +879,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let vendorSubmenuItem = NSMenuItem(title: "Trocar vendor", action: nil, keyEquivalent: "")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        DEF.register(defaults: ["swapShortcutEnabled": true])
         statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         statusItem.button?.title = "5h …"
         buildMenu()
@@ -844,6 +890,46 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         NotificationCenter.default.addObserver(
             self, selector: #selector(settingsChanged),
             name: UserDefaults.didChangeNotification, object: nil)
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(handleSwapHotKey),
+            name: swapHotKeyNotification, object: nil)
+        installSwapHotKey()
+    }
+
+    /// (Re)register the global ⌥⌘\ hot key to match the `swapShortcutEnabled`
+    /// preference. Idempotent: always unregisters first.
+    func installSwapHotKey() {
+        removeSwapHotKey()
+        guard DEF.bool(forKey: "swapShortcutEnabled") else { return }
+        if !swapHotKeyHandlerInstalled {
+            var spec = EventTypeSpec(
+                eventClass: OSType(kEventClassKeyboard), eventKind: UInt32(kEventHotKeyPressed))
+            InstallEventHandler(GetApplicationEventTarget(), swapHotKeyCallback, 1, &spec, nil, nil)
+            swapHotKeyHandlerInstalled = true
+        }
+        let id = EventHotKeyID(signature: OSType(0x4149_4242), id: 1)  // 'AIBB'
+        RegisterEventHotKey(
+            SWAP_HOTKEY_KEYCODE, SWAP_HOTKEY_MODIFIERS, id, GetApplicationEventTarget(), 0,
+            &swapHotKeyRef)
+    }
+
+    func removeSwapHotKey() {
+        if let ref = swapHotKeyRef {
+            UnregisterEventHotKey(ref)
+            swapHotKeyRef = nil
+        }
+    }
+
+    /// Advance the active vendor to the next configured one, wrapping. Fired by
+    /// the global hot key; sets `vendor` in defaults, which drives the usual
+    /// re-render via `settingsChanged`.
+    @objc func handleSwapHotKey() {
+        let ids = VENDOR_AUTH
+            .filter { vendorEnabled($0) && ($0.id == VENDOR || vendorConfigured($0)) }
+            .map { $0.id }
+        if let next = nextVendorId(current: VENDOR, in: ids) {
+            DEF.set(next, forKey: "vendor")
+        }
     }
 
     func buildMenu() {
@@ -916,6 +1002,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Settings changed in Preferences: re-render instantly from cache, re-arm
     // the timer, and re-fetch (debounced) in case vendor/binary changed.
     @objc func settingsChanged() {
+        // The swap-shortcut toggle lives in defaults too; re-register only when
+        // its state and the live registration disagree (avoids churn on every
+        // vendor switch, which itself writes defaults).
+        if DEF.bool(forKey: "swapShortcutEnabled") != (swapHotKeyRef != nil) {
+            installSwapHotKey()
+        }
         if let s = lastSnapshot { renderPanel(s); renderMenu(s) }
         restartTimer()
         pendingRefresh?.cancel()

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -901,6 +901,13 @@ private func swapHotKeyCallback(
 /// The next id in the cycle, wrapping. `current` absent from `ids` (e.g. the
 /// selected vendor was disabled) starts at the first (or last, backward).
 /// Pure + testable — the hot-key handler is not.
+/// Whether the overview status-bar title draws mini bars (vs. the compact
+/// %-text mode). "Compactar" forces the text mode even under the bars-count
+/// threshold. Pure + testable — the render path is not.
+func overviewUsesBars(count: Int, barsMax: Int, compact: Bool) -> Bool {
+    !compact && count <= barsMax
+}
+
 func nextVendorId(current: String, in ids: [String], forward: Bool = true) -> String? {
     guard !ids.isEmpty else { return nil }
     let n = ids.count
@@ -947,6 +954,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // one is checked. Kept as a field so the menu owns it for its lifetime.
     let vendorSubmenu = NSMenu()
     let vendorSubmenuItem = NSMenuItem(title: "Trocar vendor", action: nil, keyEquivalent: "")
+    /// Overview-only: forces the status-bar title into the compact %-text mode
+    /// ("Compactar"); while compact it reads "Expandir" and turns it back off.
+    let compactItem = NSMenuItem(title: "Compactar", action: nil, keyEquivalent: "e")
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         DEF.register(defaults: ["swapShortcutEnabled": true])
@@ -1047,6 +1057,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             rows[key] = it
             menu.addItem(it)
         }
+        // First item after the usage rows, Overview-only (hidden elsewhere).
+        compactItem.action = #selector(toggleCompact)
+        compactItem.target = self
+        compactItem.isHidden = true
+        menu.addItem(compactItem)
 
         menu.addItem(.separator())
         addAction(menu, "Atualizar agora", #selector(refreshAction), "r")
@@ -1068,6 +1083,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func refreshAction() { refresh() }
     @objc func quit() { NSApp.terminate(nil) }
+
+    /// Flip the overview's compact mode; the UserDefaults observer re-renders,
+    /// which also relabels the item (Compactar ↔ Expandir).
+    @objc func toggleCompact() {
+        DEF.set(!DEF.bool(forKey: "overviewCompact"), forKey: "overviewCompact")
+    }
 
     @objc func openPrefs() {
         if prefsWindow == nil {
@@ -1145,6 +1166,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                                          NSFont.boldSystemFont(ofSize: 13))
         for (_, it) in rows { it.isHidden = true }
         for it in overviewRows { it.isHidden = true }
+        compactItem.isHidden = true
         rebuildVendorSubmenu()
     }
 
@@ -1343,8 +1365,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard !heads.isEmpty else { return run("ovr", secondary) }
 
         let barsMax = Int(configValueTOML("ui", "overview_menubar_bars_max") ?? "") ?? 4
+        let compact = DEF.bool(forKey: "overviewCompact")
         let t = NSMutableAttributedString()
-        if heads.count <= barsMax {
+        if overviewUsesBars(count: heads.count, barsMax: barsMax, compact: compact) {
             for (i, e) in heads.enumerated() {
                 if i > 0 { t.append(run("   ", secondary)) }
                 t.append(run("\(ovLabel(e.name, 6)) ", secondary))
@@ -1429,6 +1452,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Menu-bar title: every vendor at once (mini bars when few, numbers when
         // many). The dropdown always holds the full per-vendor list.
         statusItem.button?.attributedTitle = overviewBarTitle(items, appearance)
+        compactItem.isHidden = false
+        compactItem.title = DEF.bool(forKey: "overviewCompact") ? "Expandir" : "Compactar"
         if rebuildSubmenu { rebuildVendorSubmenu() }
     }
 
@@ -1478,6 +1503,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func renderMenu(_ s: Snapshot) {
         let appearance = statusItem.button?.effectiveAppearance ?? NSApp.effectiveAppearance
         for it in overviewRows { it.isHidden = true }
+        compactItem.isHidden = true
         headerItem.attributedTitle = run(s.plan.isEmpty ? "AI Usage" : s.plan,
                                          .labelColor, NSFont.boldSystemFont(ofSize: 13))
 
@@ -1557,6 +1583,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         headerItem.attributedTitle = run(msg, menuBarTextColor(appearance))
         for (_, it) in rows { it.isHidden = true }
         for it in overviewRows { it.isHidden = true }
+        compactItem.isHidden = true
     }
 }
 

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1330,7 +1330,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Status-bar summary for overview mode: every vendor at once. Mini bar per
     /// vendor when few; worst-first numbers (capped, with `+K` overflow) when
     /// many. Tunable via `[ui] overview_menubar_bars_max` (bar↔number threshold,
-    /// default 2) and `overview_menubar_max` (how many numbers fit, default 4).
+    /// default 4) and `overview_menubar_max` (how many numbers fit, default 4).
     func overviewBarTitle(_ items: [(name: String, id: String, snap: Snapshot?)],
                           _ appearance: NSAppearance) -> NSAttributedString {
         let secondary = menuBarTextColor(appearance, secondary: true)
@@ -1342,7 +1342,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
         guard !heads.isEmpty else { return run("ovr", secondary) }
 
-        let barsMax = Int(configValueTOML("ui", "overview_menubar_bars_max") ?? "") ?? 2
+        let barsMax = Int(configValueTOML("ui", "overview_menubar_bars_max") ?? "") ?? 4
         let t = NSMutableAttributedString()
         if heads.count <= barsMax {
             for (i, e) in heads.enumerated() {
@@ -1358,13 +1358,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
         } else {
             let maxN = Int(configValueTOML("ui", "overview_menubar_max") ?? "") ?? 4
-            let sorted = heads.sorted { $0.pct > $1.pct }
-            for (i, e) in sorted.prefix(maxN).enumerated() {
+            // Entry order, not worst-first: entries are provider-grouped
+            // (standard Claude, then its accounts, then the other vendors), and
+            // stable positions beat a pct sort that reshuffles labels on every
+            // refresh.
+            for (i, e) in heads.prefix(maxN).enumerated() {
                 if i > 0 { t.append(run("  ", secondary)) }
                 t.append(run("\(ovLabel(e.name, 3)) ", secondary))
                 t.append(run(e.value, e.pct >= 0 ? colorForPct(e.pct) : .labelColor))
             }
-            if sorted.count > maxN { t.append(run("  +\(sorted.count - maxN)", secondary)) }
+            if heads.count > maxN { t.append(run("  +\(heads.count - maxN)", secondary)) }
         }
         return t
     }

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -139,6 +139,20 @@ func markerElapsed(reset: String, elapsed: Int?) -> Int? {
     return elapsed
 }
 
+/// Squeeze a countdown ("4d 1h", "2h 05m", "now") down to its leading unit for
+/// the overview status-bar title, where every character fights for space:
+/// "4d 1h" → "4d", "2h 05m" → "2h", "0h 05m" → "5m". Missing/em-dash → nil.
+func shortReset(_ r: String) -> String? {
+    guard !r.isEmpty, r != "—" else { return nil }
+    let parts = r.split(separator: " ")
+    guard let first = parts.first else { return nil }
+    if first == "0h", parts.count > 1 {
+        let m = parts[1].drop(while: { $0 == "0" })
+        return m == "m" ? "0m" : String(m)
+    }
+    return String(first)
+}
+
 let barFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
 
 func run(_ s: String, _ color: NSColor, _ font: NSFont = barFont) -> NSAttributedString {
@@ -1429,12 +1443,13 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func overviewBarTitle(_ items: [(name: String, id: String, snap: Snapshot?)],
                           _ appearance: NSAppearance) -> NSAttributedString {
         let secondary = menuBarTextColor(appearance, secondary: true)
-        let heads: [(name: String, pct: Int, elapsed: Int?, value: String)] = items.compactMap {
-            guard let s = $0.snap else { return nil }
-            if let cb = s.creditBalance { return ($0.name, -1, nil, "cr \(cb)") }
-            let h = overviewHeadline(s)
-            return ($0.name, h.pct, h.elapsed, "\(h.pct)%")
-        }
+        let heads: [(name: String, pct: Int, elapsed: Int?, value: String, reset: String?)] =
+            items.compactMap {
+                guard let s = $0.snap else { return nil }
+                if let cb = s.creditBalance { return ($0.name, -1, nil, "cr \(cb)", nil) }
+                let h = overviewHeadline(s)
+                return ($0.name, h.pct, h.elapsed, "\(h.pct)%", h.reset.flatMap(shortReset))
+            }
         guard !heads.isEmpty else { return run("ovr", secondary) }
 
         let barsMax = Int(configValueTOML("ui", "overview_menubar_bars_max") ?? "") ?? 4
@@ -1448,6 +1463,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                     t.append(run("\(e.pct)% ", colorForPct(e.pct)))
                     t.append(progressAttr(pct: e.pct, width: BAR_WIDTH, elapsed: e.elapsed,
                                           appearance: appearance))
+                    if let r = e.reset { t.append(run(" \(r)", secondary)) }
                 } else {
                     t.append(run(e.value, .labelColor))  // credit balance
                 }
@@ -1462,6 +1478,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 if i > 0 { t.append(run("  ", secondary)) }
                 t.append(run("\(ovLabel(e.name, 3)) ", secondary))
                 t.append(run(e.value, e.pct >= 0 ? colorForPct(e.pct) : .labelColor))
+                if let r = e.reset { t.append(run(" \(r)", secondary)) }
             }
             if heads.count > maxN { t.append(run("  +\(heads.count - maxN)", secondary)) }
         }

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -168,7 +168,7 @@ func testDefaultEnabled() {
     for id in ["anthropic", "openai", "zai", "openrouter"] {
         assertEqual(defaultEnabled(id), true, "\(id) defaults enabled")
     }
-    for id in ["deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api"] {
+    for id in ["deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor"] {
         assertEqual(defaultEnabled(id), false, "\(id) defaults disabled (opt-in)")
     }
 }
@@ -256,6 +256,26 @@ func testParserBalances() {
     assertEqual(cld?.hasUsageWindows, true, "anthropic shows windows")
     assertNil(cld?.creditBalance, "anthropic has no balance")
     assertEqual(cld?.session?.pct, 42, "anthropic session pct")
+
+    // Cursor: two included-usage pools carried on the session/weekly aliases
+    // (session = Cursor Models, weekly = Other Models), both real, no balance.
+    // The bars are relabeled away from the "Session"/"Weekly" time-window names.
+    let cur = snapshot(FORMAT, vendor: "cursor",
+                       fields: fields(through: 16, set: [
+                          0: "Cursor Ultra", 1: "98", 2: "8d", 3: "100", 4: "8d", 16: "cur"
+                       ]))
+    assertEqual(cur?.hasUsageWindows, true, "cursor shows windows")
+    assertNil(cur?.creditBalance, "cursor has no balance")
+    assertEqual(cur?.session?.pct, 98, "cursor Cursor Models pct")
+    assertEqual(cur?.weekly?.pct, 100, "cursor Other Models pct")
+    assertEqual(cur?.sessionLabel, "Cursor Models", "cursor relabels the session bar")
+    assertEqual(cur?.weeklyLabel, "Other Models", "cursor relabels the weekly bar")
+    assertEqual(cur?.sessionTag, "auto", "cursor session tag")
+    assertEqual(cur?.weeklyTag, "premium", "cursor weekly tag")
+
+    // A non-Cursor vendor keeps the default time-window labels.
+    assertEqual(cld?.sessionLabel, "Session", "anthropic keeps the Session label")
+    assertEqual(cld?.weeklyTag, "7d", "anthropic keeps the 7d tag")
 }
 
 // ─── Run ─────────────────────────────────────────────────────────────────

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -293,6 +293,10 @@ func testVendorCycle() {
         nextVendorId(current: "gone", in: ids) ?? "?", "anthropic",
         "an absent current starts at the first")
     assertEqual(nextVendorId(current: "x", in: []) == nil, true, "empty list yields nil")
+    // The ring ends on the synthetic "overview" target, then wraps to the first.
+    let ring = ["anthropic", "cursor", "overview"]
+    assertEqual(nextVendorId(current: "cursor", in: ring) ?? "?", "overview", "last vendor → overview")
+    assertEqual(nextVendorId(current: "overview", in: ring) ?? "?", "anthropic", "overview wraps to first")
 }
 
 @main

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -279,6 +279,25 @@ func testParserBalances() {
 }
 
 // ─── Run ─────────────────────────────────────────────────────────────────
+func testOverviewHeadline() {
+    print("overview headline (cursor combined, anthropic biggest-of-three)")
+    let app = AppDelegate()  // overviewHeadline reads only the snapshot
+    // Anthropic-style: biggest of 5h / weekly / scoped model (Fable), not the first.
+    let anthropic = Snapshot(
+        plan: "Max", hasUsageWindows: true, creditBalance: nil,
+        session: Window(pct: 30, reset: "3h", elapsed: nil),
+        weekly: Window(pct: 55, reset: "5d", elapsed: nil),
+        sonnet: Window(pct: 80, reset: "5d", elapsed: nil), sonnetLabel: "Fable", extra: nil)
+    assertEqual(app.overviewHeadline(anthropic).pct, 80, "anthropic = biggest of 5h/weekly/Fable")
+    // Cursor: the combined total, not the worse of the two pools.
+    let cursor = Snapshot(
+        plan: "Cursor Ultra", hasUsageWindows: true, creditBalance: nil,
+        session: Window(pct: 98, reset: "12d", elapsed: nil),
+        weekly: Window(pct: 100, reset: "12d", elapsed: nil),
+        sonnet: nil, sonnetLabel: "", extra: nil, cursorTotalPct: 62)
+    assertEqual(app.overviewHeadline(cursor).pct, 62, "cursor = combined total (not max pool)")
+}
+
 func testVendorCycle() {
     print("vendor swap cycle (⌥⌘\\)")
     let ids = ["anthropic", "cursor", "zai"]
@@ -306,6 +325,7 @@ struct TestRunner {
         testTomlParsing()
         testDefaultEnabled()
         testParserBalances()
+        testOverviewHeadline()
         testVendorCycle()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -259,6 +259,22 @@ func testParserBalances() {
 }
 
 // ─── Run ─────────────────────────────────────────────────────────────────
+func testVendorCycle() {
+    print("vendor swap cycle (⌥⌘\\)")
+    let ids = ["anthropic", "cursor", "zai"]
+    assertEqual(nextVendorId(current: "anthropic", in: ids) ?? "?", "cursor", "forward from first")
+    assertEqual(nextVendorId(current: "zai", in: ids) ?? "?", "anthropic", "forward wraps to first")
+    assertEqual(
+        nextVendorId(current: "cursor", in: ids, forward: false) ?? "?", "anthropic", "backward")
+    assertEqual(
+        nextVendorId(current: "anthropic", in: ids, forward: false) ?? "?", "zai",
+        "backward wraps to last")
+    assertEqual(
+        nextVendorId(current: "gone", in: ids) ?? "?", "anthropic",
+        "an absent current starts at the first")
+    assertEqual(nextVendorId(current: "x", in: []) == nil, true, "empty list yields nil")
+}
+
 @main
 struct TestRunner {
     static func main() {
@@ -266,6 +282,7 @@ struct TestRunner {
         testTomlParsing()
         testDefaultEnabled()
         testParserBalances()
+        testVendorCycle()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")
             exit(1)

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -330,6 +330,16 @@ func testCompactToggle() {
                 "boundary: exactly barsMax still draws bars")
 }
 
+func testShortReset() {
+    assertEqual(shortReset("4d 1h"), "4d", "days+hours → leading days")
+    assertEqual(shortReset("2h 05m"), "2h", "hours+minutes → leading hours")
+    assertEqual(shortReset("0h 05m"), "5m", "under an hour → minutes, no leading zero")
+    assertEqual(shortReset("0h 00m"), "0m", "zero minutes stays 0m")
+    assertEqual(shortReset("now"), "now", "already reset")
+    assertEqual(shortReset("—"), nil, "em-dash → nil")
+    assertEqual(shortReset(""), nil, "empty → nil")
+}
+
 @main
 struct TestRunner {
     static func main() {
@@ -340,6 +350,7 @@ struct TestRunner {
         testOverviewHeadline()
         testVendorCycle()
         testCompactToggle()
+        testShortReset()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")
             exit(1)

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -318,6 +318,83 @@ func testVendorCycle() {
     assertEqual(nextVendorId(current: "overview", in: ring) ?? "?", "anthropic", "overview wraps to first")
 }
 
+func testClaudeAccounts() {
+    // [[anthropic.accounts]] label extraction, in file order, ignoring other
+    // sections/keys and both quote styles.
+    let toml = """
+    [ui]
+    primary = "cursor"
+
+    [anthropic]
+    enabled = true
+    show_default_account = false
+
+    [[anthropic.accounts]]
+    label = "struct"
+    credentials_path = "~/x/struct/.credentials.json"
+
+    [[anthropic.accounts]]
+    label = 'gmail'
+    credentials_path = "~/x/gmail/.credentials.json"
+
+    [cursor]
+    enabled = true
+    """
+    assertEqual(anthropicAccountLabels(inTOML: toml).joined(separator: ","),
+                "struct,gmail", "labels in file order")
+    assertEqual(anthropicAccountLabels(inTOML: "[anthropic]\nenabled = true").isEmpty, true,
+                "no account blocks → no labels")
+    // A `label` key outside an accounts block must not count.
+    assertEqual(anthropicAccountLabels(inTOML: "[ui]\nlabel = \"nope\"").isEmpty, true,
+                "label outside [[anthropic.accounts]] ignored")
+
+    // Explicit wins over discovered on a clash; discovered appended sorted.
+    assertEqual(mergedAccountLabels(explicit: ["b"], discovered: ["a", "b", "c"])
+                    .joined(separator: ","),
+                "b,a,c", "explicit first, clash dropped")
+
+    // show_default_account semantics mirror Rust: ignored without accounts.
+    assertEqual(showDefaultClaudeAccount(configValue: "false", hasAccounts: false), true,
+                "no accounts → default always shown")
+    assertEqual(showDefaultClaudeAccount(configValue: "false", hasAccounts: true), false,
+                "false hides the default")
+    assertEqual(showDefaultClaudeAccount(configValue: nil, hasAccounts: true), true,
+                "omitted → shown")
+
+    // accounts_dir discovery: only subdirs holding .credentials.json, sorted.
+    let fm = FileManager.default
+    let dir = NSTemporaryDirectory() + "aiusagebar-tests-\(ProcessInfo.processInfo.processIdentifier)"
+    defer { try? fm.removeItem(atPath: dir) }
+    for sub in ["zeta", "alpha", "nofile"] {
+        try? fm.createDirectory(atPath: "\(dir)/\(sub)", withIntermediateDirectories: true)
+    }
+    fm.createFile(atPath: "\(dir)/zeta/.credentials.json", contents: Data("{}".utf8))
+    fm.createFile(atPath: "\(dir)/alpha/.credentials.json", contents: Data("{}".utf8))
+    fm.createFile(atPath: "\(dir)/stray.json", contents: Data("{}".utf8))
+    assertEqual(discoverAccountLabels(inDir: dir).joined(separator: ","),
+                "alpha,zeta", "subdirs with .credentials.json, sorted")
+    assertEqual(discoverAccountLabels(inDir: dir + "/missing").isEmpty, true,
+                "missing dir → empty")
+
+    // Pseudo-id mapping round-trip.
+    assertEqual(accountLabel(of: "anthropic@gmail") ?? "?", "gmail", "label extracted")
+    assertEqual(accountLabel(of: "anthropic") == nil, true, "base id has no label")
+    assertEqual(baseVendorId("anthropic@gmail"), "anthropic", "account → base vendor")
+    assertEqual(baseVendorId("cursor"), "cursor", "base id unchanged")
+    assertEqual(vendorArgs(for: "anthropic@gmail").joined(separator: " "),
+                "--vendor anthropic --account gmail", "account fetch args")
+    assertEqual(vendorArgs(for: "zai").joined(separator: " "), "--vendor zai", "vendor fetch args")
+    assertEqual(entryDisplayName("anthropic@gmail"), "Claude · gmail", "account display name")
+    assertEqual(entryDisplayName("overview"), "Visão geral", "overview display name")
+
+    // The swap ring cycles across accounts like any other entry.
+    let ring = ["anthropic@struct", "anthropic@gmail", "cursor", "overview"]
+    assertEqual(nextVendorId(current: "anthropic@struct", in: ring) ?? "?",
+                "anthropic@gmail", "ring steps between accounts")
+    assertEqual(nextVendorId(current: "overview", in: ring) ?? "?",
+                "anthropic@struct", "ring wraps to the first account")
+}
+
 @main
 struct TestRunner {
     static func main() {
@@ -327,6 +404,7 @@ struct TestRunner {
         testParserBalances()
         testOverviewHeadline()
         testVendorCycle()
+        testClaudeAccounts()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")
             exit(1)

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -318,6 +318,18 @@ func testVendorCycle() {
     assertEqual(nextVendorId(current: "overview", in: ring) ?? "?", "anthropic", "overview wraps to first")
 }
 
+func testCompactToggle() {
+    // Under the threshold → bars, unless Compactar forces the text mode.
+    assertEqual(overviewUsesBars(count: 3, barsMax: 4, compact: false), true,
+                "≤ barsMax without compact → bars")
+    assertEqual(overviewUsesBars(count: 3, barsMax: 4, compact: true), false,
+                "Compactar forces %-text even under the threshold")
+    assertEqual(overviewUsesBars(count: 5, barsMax: 4, compact: false), false,
+                "past the threshold → %-text regardless")
+    assertEqual(overviewUsesBars(count: 4, barsMax: 4, compact: false), true,
+                "boundary: exactly barsMax still draws bars")
+}
+
 @main
 struct TestRunner {
     static func main() {
@@ -327,6 +339,7 @@ struct TestRunner {
         testParserBalances()
         testOverviewHeadline()
         testVendorCycle()
+        testCompactToggle()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")
             exit(1)

--- a/src/active.rs
+++ b/src/active.rs
@@ -111,6 +111,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "moonshot" => Some(VendorId::Moonshot),
         "grok" => Some(VendorId::Grok),
         "antigravity" => Some(VendorId::Antigravity),
+        "cursor" => Some(VendorId::Cursor),
         _ => None,
     }
 }

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -64,6 +64,7 @@ async fn run() -> io::Result<()> {
 
     let mut app = App::new_with_primary(tabs, config.ui.primary);
     app.context_enabled = config.context.enabled;
+    app.overview_vendors = config.ui.overview_vendors.clone();
 
     // RAII: restoring the terminal must survive an error or a panic in the
     // loop below. Doing it inline left the user in raw mode on the alternate
@@ -285,10 +286,13 @@ where
                         return Ok(());
                     }
                     // Refresh-on-key handling.
-                    if matches!(k.code, KeyCode::Char('r'))
-                        && let Some(tab) = app.active_tab_id().cloned()
-                    {
-                        spawn_one(app, tab, client, config, &tx);
+                    if matches!(k.code, KeyCode::Char('r')) {
+                        if app.overview {
+                            // No single active tab on the Overview — refresh all.
+                            spawn_all(app, client, config, &tx);
+                        } else if let Some(tab) = app.active_tab_id().cloned() {
+                            spawn_one(app, tab, client, config, &tx);
+                        }
                     }
                     if matches!(k.code, KeyCode::Char('R')) {
                         spawn_all(app, client, config, &tx);

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub moonshot: MoonshotConfig,
     pub grok: GrokConfig,
     pub antigravity: AntigravityConfig,
+    pub cursor: CursorConfig,
 }
 
 /// UI / dispatch preferences. Currently just `primary` — which vendor the
@@ -418,6 +419,25 @@ pub struct AntigravityConfig {
     pub enabled: bool,
 }
 
+/// Cursor reads its quota through a session token the Cursor IDE already
+/// wrote to its local `state.vscdb` — no API key, but (unlike Antigravity)
+/// there is a real on-disk path that can need overriding (e.g. a portable or
+/// non-default Cursor install), mirroring `openai.codex_auth_path`.
+///
+/// Opt-in like DeepSeek/Kilo/etc (`enabled` defaults to `false`, matching
+/// `bool::default()`): reads an undocumented endpoint via a session token
+/// scraped from a local IDE file, so it stays off until the user explicitly
+/// turns it on.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CursorConfig {
+    pub enabled: bool,
+    /// Override Cursor's local state database path (defaults to the
+    /// platform-standard `.../User/globalStorage/state.vscdb` — see
+    /// `cursor::db::default_db_path`).
+    pub db_path: Option<PathBuf>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct AnthropicApiConfig {
@@ -513,6 +533,7 @@ impl Config {
         expand_tilde_opt(&mut self.context.projects_path);
         expand_tilde_opt(&mut self.anthropic.credentials_path);
         expand_tilde_opt(&mut self.openai.codex_auth_path);
+        expand_tilde_opt(&mut self.cursor.db_path);
         for account in &mut self.anthropic.accounts {
             account.credentials_path = expand_tilde(&account.credentials_path);
         }
@@ -532,6 +553,7 @@ impl Config {
             VendorId::Moonshot => self.moonshot.enabled,
             VendorId::Grok => self.grok.enabled,
             VendorId::Antigravity => self.antigravity.enabled,
+            VendorId::Cursor => self.cursor.enabled,
         }
     }
 
@@ -688,6 +710,7 @@ mod tests {
             VendorId::Novita,
             VendorId::Moonshot,
             VendorId::Grok,
+            VendorId::Cursor,
         ] {
             assert!(!c.is_enabled(opt_in), "{opt_in:?}");
         }
@@ -1247,6 +1270,7 @@ enabled = false
         assert!(!c.is_enabled(VendorId::Novita));
         assert!(!c.is_enabled(VendorId::Moonshot));
         assert!(!c.is_enabled(VendorId::Grok));
+        assert!(!c.is_enabled(VendorId::Cursor));
     }
 
     #[test]
@@ -1314,5 +1338,32 @@ enabled = false
         assert!(!cfg.novita.enabled && cfg.novita.api_key.is_none());
         assert!(!cfg.moonshot.enabled && cfg.moonshot.api_key.is_none());
         assert!(!cfg.grok.enabled && cfg.grok.api_key.is_none());
+        assert!(!cfg.cursor.enabled && cfg.cursor.db_path.is_none());
+    }
+
+    #[test]
+    fn cursor_db_path_is_tilde_expanded() {
+        let f = write_toml(
+            r#"
+            [cursor]
+            db_path = "~/cursor-state.vscdb"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        let home = crate::cache::home_dir().unwrap();
+        assert_eq!(c.cursor.db_path, Some(home.join("cursor-state.vscdb")));
+    }
+
+    #[test]
+    fn cursor_appears_when_enabled() {
+        let f = write_toml(
+            r#"
+            [cursor]
+            enabled = true
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        assert!(c.is_enabled(VendorId::Cursor));
+        assert!(c.enabled_vendors().contains(&VendorId::Cursor));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,10 @@ pub struct Config {
 pub struct UiConfig {
     /// `None` → fall back to anthropic for backward compatibility.
     pub primary: Option<VendorId>,
+    /// Which vendors the Overview shows (the TUI's first tab and the macOS
+    /// menu-bar's top section), in this order. `None` → every enabled vendor,
+    /// in the canonical order.
+    pub overview_vendors: Option<Vec<VendorId>>,
 }
 
 /// Where the context view docks in the dashboard body. `v` cycles it while the

--- a/src/cursor/db.rs
+++ b/src/cursor/db.rs
@@ -1,0 +1,247 @@
+//! Read the Cursor IDE's own session token out of its local `state.vscdb`.
+//!
+//! Cursor has no documented usage API or API key for personal quota — every
+//! community tool that shows it (cursor-stats, cursor-usage-tracker, etc.)
+//! reads the same place: a SQLite key-value store the Cursor IDE itself
+//! maintains at `.../User/globalStorage/state.vscdb` (the same `state.vscdb`
+//! every VS Code-family app uses for `ItemTable`-shaped extension/global
+//! state), under the key `cursorAuth/accessToken`. That value is a JWT whose
+//! `sub` claim (`auth0|<userId>`) is combined with the raw token into the
+//! `WorkosCursorSessionToken` cookie the dashboard's own usage call expects —
+//! see `fetch.rs`.
+
+use std::path::{Path, PathBuf};
+
+use base64::Engine;
+use rusqlite::{Connection, OpenFlags};
+
+use crate::error::{AppError, Result};
+
+const TOKEN_KEY: &str = "cursorAuth/accessToken";
+
+/// Default location of Cursor's local state database. This is Cursor's own
+/// per-OS convention (same one every VS Code-family app uses for its user
+/// data), not ai-usagebar's XDG cache — conveniently identical to what
+/// `directories::BaseDirs::config_dir()` already resolves on every platform:
+///   - Linux: `~/.config`
+///   - macOS: `~/Library/Application Support`
+///   - Windows: `%APPDATA%` (Roaming)
+pub fn default_db_path() -> Result<PathBuf> {
+    let base = directories::BaseDirs::new().ok_or_else(|| {
+        AppError::Other("could not resolve the platform config directory (no HOME?)".into())
+    })?;
+    Ok(base
+        .config_dir()
+        .join("Cursor")
+        .join("User")
+        .join("globalStorage")
+        .join("state.vscdb"))
+}
+
+/// Read the raw `cursorAuth/accessToken` value from `path`. A missing file or
+/// missing row means "never signed in to Cursor" — reported as a credentials
+/// error (like a missing `~/.claude/.credentials.json`) rather than a network
+/// or schema failure, so the widget's `⚠` tooltip tells the user to sign in
+/// rather than implying the API is down.
+pub fn read_access_token(path: &Path) -> Result<String> {
+    if !path.exists() {
+        return Err(AppError::Credentials(format!(
+            "Cursor database not found at {}. Open the Cursor IDE and sign in at least once, \
+             then try again.",
+            path.display()
+        )));
+    }
+    // Read-only: this file is Cursor's own live state, not ours to lock for
+    // writing. SQLite allows concurrent readers, so this is safe alongside a
+    // running Cursor IDE.
+    let conn =
+        Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|e| {
+            AppError::Credentials(format!(
+                "could not open Cursor database at {}: {e}",
+                path.display()
+            ))
+        })?;
+    let token: String = conn
+        .query_row(
+            "SELECT value FROM ItemTable WHERE key = ?1",
+            [TOKEN_KEY],
+            |row| row.get(0),
+        )
+        .map_err(|_| {
+            AppError::Credentials(format!(
+                "no Cursor session found in {}. Sign in to the Cursor IDE, then try again.",
+                path.display()
+            ))
+        })?;
+    if token.trim().is_empty() {
+        return Err(AppError::Credentials(
+            "Cursor session token is empty. Sign in to the Cursor IDE again.".into(),
+        ));
+    }
+    Ok(token)
+}
+
+/// The two values the `/api/usage` call needs, both derived from the same JWT:
+/// the bare user id (a query param) and the `WorkosCursorSessionToken` cookie
+/// value (`userId%3A%3Atoken` — literal, pre-encoded `::`, matching what the
+/// Cursor dashboard's own JS sends).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionAuth {
+    pub user_id: String,
+    pub cookie_value: String,
+}
+
+/// Derive [`SessionAuth`] from the raw access token. Fails when the token
+/// isn't a decodable JWT or its `sub` claim doesn't have the `issuer|userId`
+/// shape every Cursor account token carries — either way the token is
+/// unusable, so this is a credentials error, not a schema error (the *shape*
+/// of the wire endpoint isn't in play yet at this point).
+pub fn session_auth(token: &str) -> Result<SessionAuth> {
+    let claims = parse_jwt_claims(token).ok_or_else(|| {
+        AppError::Credentials(
+            "Cursor session token could not be decoded. Sign in to the Cursor IDE again.".into(),
+        )
+    })?;
+    let sub = claims
+        .get("sub")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| AppError::Credentials("Cursor session token has no `sub` claim.".into()))?;
+    let user_id = sub
+        .split('|')
+        .nth(1)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| {
+            AppError::Credentials(format!(
+                "Cursor session token `sub` claim has an unexpected shape: {sub:?}"
+            ))
+        })?
+        .to_string();
+    let cookie_value = format!("{user_id}%3A%3A{token}");
+    Ok(SessionAuth {
+        user_id,
+        cookie_value,
+    })
+}
+
+/// Decode a JWT's payload segment without verifying its signature — we trust
+/// it the same way the Cursor dashboard's own browser JS does (it never
+/// verifies either; the server is the one that rejects a bad token).
+fn parse_jwt_claims(token: &str) -> Option<serde_json::Value> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload))
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    /// Build a fake JWT with the given claims (no signature verification,
+    /// matching `openai::creds`'s test helper).
+    fn fake_jwt(claims: serde_json::Value) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+        format!("{header}.{payload}.sig")
+    }
+
+    fn seed_db(path: &Path, token: Option<&str>) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute("CREATE TABLE ItemTable (key TEXT, value TEXT)", [])
+            .unwrap();
+        if let Some(t) = token {
+            conn.execute(
+                "INSERT INTO ItemTable (key, value) VALUES (?1, ?2)",
+                rusqlite::params![TOKEN_KEY, t],
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn default_db_path_ends_with_the_cursor_state_file() {
+        let p = default_db_path().unwrap();
+        assert!(
+            p.ends_with(
+                std::path::Path::new("Cursor")
+                    .join("User")
+                    .join("globalStorage")
+                    .join("state.vscdb")
+            )
+        );
+    }
+
+    #[test]
+    fn missing_file_is_a_credentials_error_naming_the_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        let err = read_access_token(&path).unwrap_err();
+        match err {
+            AppError::Credentials(m) => assert!(m.contains(&path.display().to_string())),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reads_the_token_back_out_of_the_item_table() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        seed_db(&path, Some("fake-token-value"));
+        assert_eq!(read_access_token(&path).unwrap(), "fake-token-value");
+    }
+
+    #[test]
+    fn missing_row_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        seed_db(&path, None);
+        let err = read_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn empty_token_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("state.vscdb");
+        seed_db(&path, Some(""));
+        let err = read_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn session_auth_extracts_user_id_and_builds_the_cookie_value() {
+        let token = fake_jwt(serde_json::json!({"sub": "auth0|user_abc123"}));
+        let auth = session_auth(&token).unwrap();
+        assert_eq!(auth.user_id, "user_abc123");
+        assert_eq!(auth.cookie_value, format!("user_abc123%3A%3A{token}"));
+    }
+
+    #[test]
+    fn session_auth_rejects_a_non_jwt_token() {
+        let err = session_auth("not-a-jwt").unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn session_auth_rejects_missing_sub_claim() {
+        let token = fake_jwt(serde_json::json!({"other": "value"}));
+        let err = session_auth(&token).unwrap_err();
+        match err {
+            AppError::Credentials(m) => assert!(m.contains("sub")),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn session_auth_rejects_sub_without_a_pipe_separated_user_id() {
+        let token = fake_jwt(serde_json::json!({"sub": "no-pipe-here"}));
+        let err = session_auth(&token).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+}

--- a/src/cursor/fetch.rs
+++ b/src/cursor/fetch.rs
@@ -1,0 +1,405 @@
+//! Fetch Cursor's included-usage summary from `GET /api/usage-summary`,
+//! authenticated with the session token read out of the local `state.vscdb`
+//! (see `db.rs`). Cache/stale/error-fallback shape mirrors `kimi::fetch`.
+
+use std::path::Path;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
+use crate::error::{AppError, Result};
+use crate::usage::CursorSnapshot;
+use crate::vendor::{MAX_BODY_BYTES, read_body_capped};
+
+use super::db;
+use super::types::{self, UsageSummary};
+
+pub const BASE_URL: &str = "https://cursor.com";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+/// The dashboard endpoint gates on browser-looking headers; a plain
+/// `reqwest` request with only the cookie is rejected by its CORS check.
+const BROWSER_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub summary: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            summary: format!("{BASE_URL}/api/usage-summary"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchOutcome {
+    pub snapshot: CursorSnapshot,
+    pub stale: bool,
+    pub last_error: Option<(u16, String)>,
+    pub cache_age: Option<Duration>,
+}
+
+/// Cache-aware fetch. `db_path` is Cursor's `state.vscdb` — the caller resolves
+/// `[cursor] db_path` (config override) vs [`db::default_db_path`], the same
+/// override pattern as `openai.codex_auth_path`.
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    db_path: &Path,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse_cache(&bytes, cache, false)
+    {
+        return Ok(outcome);
+    }
+
+    match fetch_live(client, endpoints, db_path).await {
+        Ok(snap) => {
+            let bytes = serde_json::to_vec(&snap_to_json(&snap))?;
+            cache.write_payload(&bytes)?;
+            Ok(FetchOutcome {
+                snapshot: snap,
+                stale: false,
+                last_error: None,
+                cache_age: Some(Duration::ZERO),
+            })
+        }
+        Err(e) if e.is_transient() => fallback_silent(cache, e),
+        Err(e) => {
+            cache.mark_stale();
+            if let Some((code, msg)) = error_to_pair(&e) {
+                cache.write_last_error(code, &msg);
+            }
+            fallback_with_error(cache, e)
+        }
+    }
+}
+
+fn fallback_silent(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
+        return Err(original);
+    };
+    match reuse_cache(&bytes, cache, true) {
+        Ok(outcome) => Ok(outcome),
+        Err(_) => Err(original),
+    }
+}
+
+fn fallback_with_error(cache: &Cache, original: AppError) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
+        return Err(original);
+    };
+    match reuse_cache(&bytes, cache, true) {
+        Ok(mut outcome) => {
+            outcome.last_error = error_to_pair(&original);
+            Ok(outcome)
+        }
+        Err(_) => Err(original),
+    }
+}
+
+/// Never surface upstream bodies for auth failures: the request carried a
+/// session cookie derived from a signed-in token, and 401/403 bodies from a
+/// scraped web endpoint are not guaranteed not to echo it back.
+fn error_to_pair(e: &AppError) -> Option<(u16, String)> {
+    match e {
+        AppError::Http { status, .. } if matches!(status, 401 | 403) => {
+            Some((*status, "Cursor authentication failed".into()))
+        }
+        AppError::Http { status, body } => Some((*status, body.clone())),
+        e => Some((0, e.to_string())),
+    }
+}
+
+fn reuse_cache(bytes: &[u8], cache: &Cache, stale: bool) -> Result<FetchOutcome> {
+    let snap = parse_cache(bytes)?;
+    Ok(FetchOutcome {
+        snapshot: snap,
+        stale,
+        last_error: cache.read_last_error(),
+        cache_age: cache.payload_age(),
+    })
+}
+
+fn parse_cache(bytes: &[u8]) -> Result<CursorSnapshot> {
+    let v: serde_json::Value = serde_json::from_slice(bytes)?;
+    let int = |key: &str| -> Result<i32> {
+        v[key]
+            .as_i64()
+            .map(|n| n as i32)
+            .ok_or_else(|| AppError::Schema(format!("cursor cache: invalid {key}")))
+    };
+    Ok(CursorSnapshot {
+        plan: v["plan"].as_str().unwrap_or("Cursor").to_string(),
+        auto_pct: int("auto_pct")?,
+        api_pct: int("api_pct")?,
+        total_pct: int("total_pct")?,
+        unlimited: v["unlimited"].as_bool().unwrap_or(false),
+        on_demand_enabled: v["on_demand_enabled"].as_bool().unwrap_or(false),
+        reset_at: parse_cache_datetime(&v["reset_at"])?,
+    })
+}
+
+fn parse_cache_datetime(v: &serde_json::Value) -> Result<Option<DateTime<Utc>>> {
+    match v {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(s) => DateTime::parse_from_rfc3339(s)
+            .map(|dt| Some(dt.into()))
+            .map_err(|e| AppError::Schema(format!("cursor cache: invalid reset timestamp: {e}"))),
+        _ => Err(AppError::Schema(
+            "cursor cache: invalid reset timestamp".into(),
+        )),
+    }
+}
+
+fn snap_to_json(snap: &CursorSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "plan": snap.plan,
+        "auto_pct": snap.auto_pct,
+        "api_pct": snap.api_pct,
+        "total_pct": snap.total_pct,
+        "unlimited": snap.unlimited,
+        "on_demand_enabled": snap.on_demand_enabled,
+        "reset_at": snap.reset_at.map(|dt| dt.to_rfc3339()),
+    })
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    endpoints: &Endpoints,
+    db_path: &Path,
+) -> Result<CursorSnapshot> {
+    // Local, synchronous, and cheap — only reached on a cache miss, so a
+    // running Cursor IDE isn't contending for the sqlite file every tick.
+    let token = db::read_access_token(db_path)?;
+    let auth = db::session_auth(&token)?;
+
+    // usage-summary keys off the session cookie alone (no `?user=` param); the
+    // browser-ish headers get past its CORS gate.
+    let resp = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(&endpoints.summary)
+            .header(
+                "Cookie",
+                format!("WorkosCursorSessionToken={}", auth.cookie_value),
+            )
+            .header("Origin", BASE_URL)
+            .header("Referer", format!("{BASE_URL}/dashboard"))
+            .header("User-Agent", BROWSER_UA)
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport(format!("cursor timeout: {}", endpoints.summary)))??;
+
+    let status = resp.status();
+    if !status.is_success() {
+        let body = if matches!(status.as_u16(), 401 | 403) {
+            "Cursor authentication failed".into()
+        } else {
+            format!("Cursor API returned HTTP {}", status.as_u16())
+        };
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let bytes = read_body_capped(resp, MAX_BODY_BYTES).await?;
+    let parsed: UsageSummary = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Schema(format!("cursor usage-summary response: {e}")))?;
+    types::to_snapshot(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use tempfile::TempDir;
+
+    fn cache_fixture() -> (TempDir, Cache) {
+        let td = TempDir::new().unwrap();
+        let cache = Cache::at(td.path().join("cursor"));
+        cache.ensure_dir().unwrap();
+        (td, cache)
+    }
+
+    /// A minimal, unsigned JWT with `sub: "auth0|<user_id>"` — signature
+    /// verification is never performed (see `db::parse_jwt_claims`).
+    fn fake_token(user_id: &str) -> String {
+        use base64::Engine;
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(br#"{"alg":"none"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::json!({"sub": format!("auth0|{user_id}")}).to_string());
+        format!("{header}.{payload}.sig")
+    }
+
+    fn seed_state_db(dir: &TempDir, token: &str) -> std::path::PathBuf {
+        let path = dir.path().join("state.vscdb");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute("CREATE TABLE ItemTable (key TEXT, value TEXT)", [])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO ItemTable (key, value) VALUES ('cursorAuth/accessToken', ?1)",
+            [token],
+        )
+        .unwrap();
+        path
+    }
+
+    fn sample_json() -> String {
+        r#"{
+            "billingCycleEnd": "2026-08-04T00:35:51.000Z",
+            "membershipType": "ultra",
+            "isUnlimited": false,
+            "individualUsage": {
+                "plan": { "autoPercentUsed": 98.109, "apiPercentUsed": 100, "totalPercentUsed": 98.5 },
+                "onDemand": { "enabled": false }
+            }
+        }"#
+        .to_string()
+    }
+
+    #[tokio::test]
+    async fn live_fetch_reads_token_from_db_and_sends_the_session_cookie() {
+        let mut server = mockito::Server::new_async().await;
+        let token = fake_token("user_123");
+        let m = server
+            .mock("GET", "/api/usage-summary")
+            .match_header(
+                "cookie",
+                format!("WorkosCursorSessionToken=user_123%3A%3A{token}").as_str(),
+            )
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+
+        let db_dir = TempDir::new().unwrap();
+        let db_path = seed_state_db(&db_dir, &token);
+        let (_cache_dir, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            summary: format!("{}/api/usage-summary", server.url()),
+        };
+
+        let out = fetch_snapshot(
+            &client,
+            &db_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        m.assert_async().await;
+        assert_eq!(out.snapshot.plan, "Ultra");
+        assert_eq!(out.snapshot.auto_pct, 98);
+        assert_eq!(out.snapshot.api_pct, 100);
+        assert!(!out.stale);
+    }
+
+    #[tokio::test]
+    async fn missing_db_file_is_a_credentials_error_with_no_cache_to_fall_back_on() {
+        let (_cache_dir, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints::default();
+        let db_path = std::path::Path::new("/nonexistent/state.vscdb");
+
+        let err = fetch_snapshot(&client, db_path, &cache, &endpoints, Duration::from_secs(0))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[tokio::test]
+    async fn http_error_falls_back_to_cache_and_hides_the_upstream_body() {
+        let mut server = mockito::Server::new_async().await;
+        let token = fake_token("user_123");
+        server
+            .mock("GET", "/api/usage-summary")
+            .with_status(401)
+            .with_body(r#"{"detail":"leaked-looking body"}"#)
+            .create_async()
+            .await;
+
+        let db_dir = TempDir::new().unwrap();
+        let db_path = seed_state_db(&db_dir, &token);
+        let (_cache_dir, cache) = cache_fixture();
+        cache
+            .write_payload(
+                serde_json::json!({
+                    "plan": "Ultra", "auto_pct": 40, "api_pct": 10, "total_pct": 30,
+                    "unlimited": false, "on_demand_enabled": false,
+                    "reset_at": "2026-08-04T00:00:00Z",
+                })
+                .to_string()
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            summary: format!("{}/api/usage-summary", server.url()),
+        };
+        let out = fetch_snapshot(
+            &client,
+            &db_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        assert!(out.stale);
+        assert_eq!(out.snapshot.auto_pct, 40);
+        let (code, msg) = out.last_error.unwrap();
+        assert_eq!(code, 401);
+        assert_eq!(msg, "Cursor authentication failed");
+        assert!(!msg.contains("leaked-looking"));
+    }
+
+    #[tokio::test]
+    async fn fresh_cache_short_circuits_without_touching_the_db() {
+        let (_cache_dir, cache) = cache_fixture();
+        cache
+            .write_payload(
+                serde_json::json!({
+                    "plan": "Pro", "auto_pct": 7, "api_pct": 3, "total_pct": 5,
+                    "unlimited": false, "on_demand_enabled": true,
+                    "reset_at": "2026-08-04T00:00:00Z",
+                })
+                .to_string()
+                .as_bytes(),
+            )
+            .unwrap();
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints::default();
+        // A path that doesn't exist would error if the db were read — proving
+        // the fresh-cache path never touches it.
+        let db_path = std::path::Path::new("/nonexistent/state.vscdb");
+        let out = fetch_snapshot(
+            &client,
+            db_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(3600),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.snapshot.auto_pct, 7);
+        assert!(out.snapshot.on_demand_enabled);
+        assert!(!out.stale);
+    }
+}

--- a/src/cursor/mod.rs
+++ b/src/cursor/mod.rs
@@ -1,0 +1,11 @@
+//! Cursor — premium-request quota read from the local Cursor IDE session
+//! token (`state.vscdb`) against the undocumented `cursor.com/api/usage`
+//! endpoint the Cursor dashboard itself calls. See `db.rs` for the token
+//! source and `fetch.rs`/`types.rs` for the wire call and schema.
+
+pub mod db;
+pub mod fetch;
+pub mod types;
+pub mod vendor;
+
+pub use fetch::{FetchOutcome, fetch_snapshot};

--- a/src/cursor/types.rs
+++ b/src/cursor/types.rs
@@ -17,10 +17,32 @@
 //! }
 //! ```
 //!
-//! Team accounts report under `teamUsage` instead of `individualUsage`; that
-//! shape isn't modeled yet (a personal plan is the common case), so a payload
-//! with no `individualUsage.plan` is treated as schema drift rather than a
-//! fabricated zero.
+//! Team accounts (and personal token-based enterprise contracts) report no
+//! `individualUsage.plan` at all — there's no per-seat request quota for
+//! `pct()` to read.
+//!
+//! **Unverified against a live team account** — we don't have one to test
+//! against. The fallback below is inferred from an independent
+//! reverse-engineering of this same endpoint
+//! (`github.com/WoojinAhn/CursorMeter`'s `UsageModels.swift`, whose doc
+//! comments say it was confirmed against live token-based enterprise
+//! contracts): on those accounts, `teamUsage` itself carries no percentages
+//! (only an `onDemand` flag) and `individualUsage.overall.limit` — the
+//! numerator needed to turn `used` cents into a percentage — comes back
+//! `null`; Cursor doesn't put the per-seat limit on *this* endpoint for that
+//! account type at all. The **only** percentage this payload exposes for such
+//! accounts is the human-readable `autoModelSelectedDisplayMessage` /
+//! `namedModelSelectedDisplayMessage` strings (e.g. `"You've used 42% of your
+//! included total usage"`), and those line up with the auto/named pools
+//! respectively — the same two pools `individualUsage.plan.{autoPercentUsed,
+//! apiPercentUsed}` reports on personal accounts (confirmed by the `SAMPLE`
+//! fixture below, where both messages' percentages match the corresponding
+//! `plan` fields exactly). So when `individualUsage.plan` is missing,
+//! `to_snapshot` parses both display messages and only accepts them as a
+//! team/enterprise snapshot if **both** parse — a single stray message is
+//! unrecognized schema drift, not a half-guessed snapshot. A payload with
+//! neither `individualUsage.plan` nor two parseable display messages is
+//! schema drift, never a fabricated zero.
 
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -41,12 +63,38 @@ pub struct UsageSummary {
     pub billing_cycle_end: String,
     #[serde(rename = "individualUsage")]
     pub individual_usage: Option<IndividualUsage>,
+    /// Team-account usage. Present (possibly `{}`) whether or not the caller
+    /// is on a team; only its `onDemand` flag is modeled — see the module
+    /// doc for why the pool percentages come from the display-message
+    /// fallback below instead of from this object.
+    #[serde(rename = "teamUsage", default)]
+    pub team_usage: Option<TeamUsage>,
+    /// e.g. `"You've used 42% of your included total usage"` — the auto
+    /// (Cursor Models) pool's percentage in prose form. Redundant with
+    /// `individualUsage.plan.autoPercentUsed` on personal accounts; the only
+    /// source of that percentage on accounts with no `plan` object.
+    #[serde(rename = "autoModelSelectedDisplayMessage", default)]
+    pub auto_model_selected_display_message: Option<String>,
+    /// Same idea as above for the named/API pool, e.g. `"You've used 100% of
+    /// your included API usage"`.
+    #[serde(rename = "namedModelSelectedDisplayMessage", default)]
+    pub named_model_selected_display_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct IndividualUsage {
     pub plan: Option<PlanUsage>,
-    #[serde(default)]
+    // ponytail: pre-existing field lacked `rename = "onDemand"`, so this
+    // never actually deserialized (always None) — `on_demand_enabled` was
+    // silently always false. Fixed in passing since the new `TeamUsage` below
+    // needs the same field to actually work.
+    #[serde(rename = "onDemand", default)]
+    pub on_demand: Option<OnDemand>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct TeamUsage {
+    #[serde(rename = "onDemand", default)]
     pub on_demand: Option<OnDemand>,
 }
 
@@ -111,34 +159,80 @@ pub fn to_snapshot(resp: UsageSummary) -> Result<CursorSnapshot> {
         });
     }
 
-    let plan_usage = resp
-        .individual_usage
-        .as_ref()
-        .and_then(|u| u.plan.as_ref())
-        .ok_or_else(|| {
-            AppError::Schema(
-                "cursor: response has no `individualUsage.plan` (team accounts are not \
-                 supported yet)"
-                    .into(),
-            )
-        })?;
-
+    // `onDemand` can live under either `individualUsage` (personal accounts)
+    // or `teamUsage` (per CursorMeter's `TeamUsage`, which models nothing
+    // else there) — check both rather than assuming one.
     let on_demand_enabled = resp
         .individual_usage
         .as_ref()
         .and_then(|u| u.on_demand.as_ref())
+        .or_else(|| resp.team_usage.as_ref().and_then(|t| t.on_demand.as_ref()))
         .map(|o| o.enabled)
         .unwrap_or(false);
 
-    Ok(CursorSnapshot {
-        plan,
-        auto_pct: pct("autoPercentUsed", plan_usage.auto_percent_used)?,
-        api_pct: pct("apiPercentUsed", plan_usage.api_percent_used)?,
-        total_pct: pct("totalPercentUsed", plan_usage.total_percent_used)?,
-        unlimited: false,
-        on_demand_enabled,
-        reset_at: Some(reset_at),
-    })
+    if let Some(plan_usage) = resp.individual_usage.as_ref().and_then(|u| u.plan.as_ref()) {
+        return Ok(CursorSnapshot {
+            plan,
+            auto_pct: pct("autoPercentUsed", plan_usage.auto_percent_used)?,
+            api_pct: pct("apiPercentUsed", plan_usage.api_percent_used)?,
+            total_pct: pct("totalPercentUsed", plan_usage.total_percent_used)?,
+            unlimited: false,
+            on_demand_enabled,
+            reset_at: Some(reset_at),
+        });
+    }
+
+    // No numeric `plan` object — the team/enterprise fallback described in
+    // the module doc. Both display messages must parse or this isn't the
+    // shape we think it is; see the module doc for why "both or neither".
+    let team_pcts = resp
+        .auto_model_selected_display_message
+        .as_deref()
+        .and_then(parse_percent_from_message)
+        .zip(
+            resp.named_model_selected_display_message
+                .as_deref()
+                .and_then(parse_percent_from_message),
+        );
+    if let Some((auto_raw, api_raw)) = team_pcts {
+        let auto_pct = pct("autoModelSelectedDisplayMessage", auto_raw)?;
+        let api_pct = pct("namedModelSelectedDisplayMessage", api_raw)?;
+        return Ok(CursorSnapshot {
+            // Flag this as the best-effort team path — distinct from the
+            // membership label alone, since the number came from prose, not
+            // the numeric `plan` object.
+            plan: format!("{plan} (team)"),
+            auto_pct,
+            api_pct,
+            // No distinct blended-total signal exists on this path (no
+            // `totalPercentUsed` equivalent message); the worse of the two
+            // pools is the best-effort stand-in.
+            total_pct: auto_pct.max(api_pct),
+            unlimited: false,
+            on_demand_enabled,
+            reset_at: Some(reset_at),
+        });
+    }
+
+    Err(AppError::Schema(
+        "cursor: response has no `individualUsage.plan` and no parseable team-usage \
+         display message (unrecognized team-account shape)"
+            .into(),
+    ))
+}
+
+/// Pulls the leading `N` or `N.N` out of a `"…N%…"` prose string, e.g.
+/// `"You've used 98% of your included total usage"` -> `Some(98.0)`. Returns
+/// `None` if there's no `%` or nothing number-shaped precedes it, so callers
+/// treat a reworded message as unparseable rather than misreading it.
+fn parse_percent_from_message(msg: &str) -> Option<f64> {
+    let pct_idx = msg.find('%')?;
+    let before = &msg[..pct_idx];
+    let start = before
+        .rfind(|c: char| !c.is_ascii_digit() && c != '.')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    before[start..].parse::<f64>().ok()
 }
 
 /// "ultra" -> "Ultra". Cursor's `membershipType` is lowercase; the dashboard
@@ -253,7 +347,69 @@ mod tests {
                 }),
                 on_demand: None,
             }),
+            team_usage: None,
+            auto_model_selected_display_message: None,
+            named_model_selected_display_message: None,
         };
         assert!(matches!(to_snapshot(resp), Err(AppError::Schema(_))));
+    }
+
+    /// The fixture backing the team-account fallback. **Unverified against a
+    /// live team account** — see the module doc for the reasoning: no
+    /// `individualUsage.plan`, `teamUsage` carries only `onDemand`, and the
+    /// two pool percentages come from the display-message strings instead.
+    const TEAM_SAMPLE: &str = r#"{
+        "billingCycleEnd": "2026-08-04T00:35:51.000Z",
+        "membershipType": "team",
+        "isUnlimited": false,
+        "autoModelSelectedDisplayMessage": "You've used 42% of your included total usage",
+        "namedModelSelectedDisplayMessage": "You've used 15% of your included API usage",
+        "teamUsage": { "onDemand": { "enabled": true } }
+    }"#;
+
+    #[test]
+    fn team_account_falls_back_to_display_message_percentages() {
+        let resp: UsageSummary = serde_json::from_str(TEAM_SAMPLE).unwrap();
+        let snap = to_snapshot(resp).unwrap();
+        assert_eq!(snap.plan, "Team (team)");
+        assert_eq!(snap.auto_pct, 42);
+        assert_eq!(snap.api_pct, 15);
+        assert_eq!(
+            snap.total_pct, 42,
+            "no blended-total signal exists; worst pool stands in"
+        );
+        assert!(!snap.unlimited);
+        assert!(
+            snap.on_demand_enabled,
+            "onDemand lives under teamUsage for a team account, not individualUsage"
+        );
+        assert_eq!(snap.worst_pct(), 42);
+    }
+
+    #[test]
+    fn team_account_with_only_one_parseable_message_is_still_schema_drift() {
+        // Guards the "both or neither" rule: a half-recognized shape must not
+        // silently render one real pool and one fabricated zero.
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "team",
+            "autoModelSelectedDisplayMessage": "You've used 42% of your included total usage",
+            "namedModelSelectedDisplayMessage": "unavailable"
+        }"#;
+        let err = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap_err();
+        assert!(matches!(err, AppError::Schema(_)));
+    }
+
+    #[test]
+    fn parse_percent_from_message_reads_leading_number_before_percent_sign() {
+        assert_eq!(
+            parse_percent_from_message("You've used 98% of your included total usage"),
+            Some(98.0)
+        );
+        assert_eq!(
+            parse_percent_from_message("You've used 100% of your included API usage"),
+            Some(100.0)
+        );
+        assert_eq!(parse_percent_from_message("no percent here"), None);
+        assert_eq!(parse_percent_from_message("unavailable"), None);
     }
 }

--- a/src/cursor/types.rs
+++ b/src/cursor/types.rs
@@ -1,0 +1,259 @@
+//! Wire types for `GET cursor.com/api/usage-summary`.
+//!
+//! **Undocumented** — the endpoint the Cursor dashboard's own frontend calls
+//! to draw the "Cursor Models" / "Other Models" usage bars. Confirmed against a
+//! live Ultra account:
+//!
+//! ```json
+//! {
+//!   "billingCycleStart": "2026-07-04T00:35:51.000Z",
+//!   "billingCycleEnd":   "2026-08-04T00:35:51.000Z",
+//!   "membershipType": "ultra",
+//!   "isUnlimited": false,
+//!   "individualUsage": {
+//!     "plan": { "autoPercentUsed": 98.1, "apiPercentUsed": 100, "totalPercentUsed": 98.5 },
+//!     "onDemand": { "enabled": false }
+//!   }
+//! }
+//! ```
+//!
+//! Team accounts report under `teamUsage` instead of `individualUsage`; that
+//! shape isn't modeled yet (a personal plan is the common case), so a payload
+//! with no `individualUsage.plan` is treated as schema drift rather than a
+//! fabricated zero.
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+use crate::error::{AppError, Result};
+use crate::usage::CursorSnapshot;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UsageSummary {
+    #[serde(rename = "membershipType", default)]
+    pub membership_type: String,
+    #[serde(rename = "isUnlimited", default)]
+    pub is_unlimited: bool,
+    /// RFC3339 end of the current billing cycle — when the pools reset.
+    /// Required: without it there is no reset to show, so its absence is
+    /// schema drift, not a "no reset" state.
+    #[serde(rename = "billingCycleEnd")]
+    pub billing_cycle_end: String,
+    #[serde(rename = "individualUsage")]
+    pub individual_usage: Option<IndividualUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct IndividualUsage {
+    pub plan: Option<PlanUsage>,
+    #[serde(default)]
+    pub on_demand: Option<OnDemand>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PlanUsage {
+    /// "Cursor Models" pool (Auto + Composer).
+    #[serde(rename = "autoPercentUsed")]
+    pub auto_percent_used: f64,
+    /// "Other Models" pool (named / third-party).
+    #[serde(rename = "apiPercentUsed")]
+    pub api_percent_used: f64,
+    /// Overall included usage — the dashboard headline percentage.
+    #[serde(rename = "totalPercentUsed", default)]
+    pub total_percent_used: f64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OnDemand {
+    #[serde(default)]
+    pub enabled: bool,
+}
+
+/// Round a wire percentage to an integer, matching the dashboard's whole-number
+/// display and the integer-percent convention used across every vendor here. A
+/// non-finite value (NaN/inf) means the payload wasn't what we think it is —
+/// surfaced as schema drift rather than silently rendered.
+fn pct(field: &str, v: f64) -> Result<i32> {
+    if !v.is_finite() {
+        return Err(AppError::Schema(format!(
+            "cursor: `{field}` is not a finite number"
+        )));
+    }
+    // Clamp only the low end: a pool can legitimately exceed 100% when it is
+    // over its included allowance, and callers clamp for bar width themselves.
+    Ok(v.round().max(0.0) as i32)
+}
+
+pub fn to_snapshot(resp: UsageSummary) -> Result<CursorSnapshot> {
+    let reset_at = DateTime::parse_from_rfc3339(&resp.billing_cycle_end)
+        .map_err(|e| {
+            AppError::Schema(format!(
+                "cursor: `billingCycleEnd` is not RFC3339 ({:?}): {e}",
+                resp.billing_cycle_end
+            ))
+        })?
+        .with_timezone(&Utc);
+
+    let plan = title_case(&resp.membership_type);
+
+    // Unlimited plans report no meaningful pool percentages; represent them as
+    // zeros with the `unlimited` flag so renderers say "unlimited" rather than
+    // painting a bogus bar.
+    if resp.is_unlimited {
+        return Ok(CursorSnapshot {
+            plan,
+            auto_pct: 0,
+            api_pct: 0,
+            total_pct: 0,
+            unlimited: true,
+            on_demand_enabled: false,
+            reset_at: Some(reset_at),
+        });
+    }
+
+    let plan_usage = resp
+        .individual_usage
+        .as_ref()
+        .and_then(|u| u.plan.as_ref())
+        .ok_or_else(|| {
+            AppError::Schema(
+                "cursor: response has no `individualUsage.plan` (team accounts are not \
+                 supported yet)"
+                    .into(),
+            )
+        })?;
+
+    let on_demand_enabled = resp
+        .individual_usage
+        .as_ref()
+        .and_then(|u| u.on_demand.as_ref())
+        .map(|o| o.enabled)
+        .unwrap_or(false);
+
+    Ok(CursorSnapshot {
+        plan,
+        auto_pct: pct("autoPercentUsed", plan_usage.auto_percent_used)?,
+        api_pct: pct("apiPercentUsed", plan_usage.api_percent_used)?,
+        total_pct: pct("totalPercentUsed", plan_usage.total_percent_used)?,
+        unlimited: false,
+        on_demand_enabled,
+        reset_at: Some(reset_at),
+    })
+}
+
+/// "ultra" -> "Ultra". Cursor's `membershipType` is lowercase; the dashboard
+/// shows it title-cased.
+fn title_case(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => "Cursor".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    const SAMPLE: &str = r#"{
+        "billingCycleStart": "2026-07-04T00:35:51.000Z",
+        "billingCycleEnd": "2026-08-04T00:35:51.000Z",
+        "membershipType": "ultra",
+        "limitType": "user",
+        "isUnlimited": false,
+        "autoModelSelectedDisplayMessage": "You've used 98% of your included total usage",
+        "namedModelSelectedDisplayMessage": "You've used 100% of your included API usage",
+        "individualUsage": {
+            "plan": {
+                "enabled": true, "used": 40000, "limit": 40000, "remaining": 0,
+                "autoPercentUsed": 98.109, "apiPercentUsed": 100, "totalPercentUsed": 98.5128
+            },
+            "onDemand": { "enabled": false, "used": 0, "limit": null, "remaining": null }
+        },
+        "teamUsage": {}
+    }"#;
+
+    #[test]
+    fn parses_the_live_ultra_shape() {
+        let resp: UsageSummary = serde_json::from_str(SAMPLE).unwrap();
+        let snap = to_snapshot(resp).unwrap();
+        assert_eq!(snap.plan, "Ultra");
+        assert_eq!(snap.auto_pct, 98); // 98.109 rounds to 98 (matches the dashboard bar)
+        assert_eq!(snap.api_pct, 100);
+        assert_eq!(snap.total_pct, 99); // 98.5128 rounds to 99
+        assert!(!snap.unlimited);
+        assert!(!snap.on_demand_enabled);
+        assert_eq!(
+            snap.reset_at,
+            Some(Utc.with_ymd_and_hms(2026, 8, 4, 0, 35, 51).unwrap())
+        );
+        assert_eq!(snap.worst_pct(), 100);
+    }
+
+    #[test]
+    fn over_allowance_percentage_is_kept_above_100() {
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "pro",
+            "individualUsage": { "plan": { "autoPercentUsed": 142.7, "apiPercentUsed": 5, "totalPercentUsed": 80 } }
+        }"#;
+        let snap = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap();
+        assert_eq!(
+            snap.auto_pct, 143,
+            "an over-quota pool must not clamp to 100"
+        );
+        assert_eq!(snap.worst_pct(), 143);
+    }
+
+    #[test]
+    fn unlimited_plan_reports_no_pool_percentages() {
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "enterprise",
+            "isUnlimited": true
+        }"#;
+        let snap = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap();
+        assert!(snap.unlimited);
+        assert_eq!(snap.worst_pct(), 0);
+        assert_eq!(snap.plan, "Enterprise");
+    }
+
+    #[test]
+    fn missing_individual_plan_is_schema_drift_not_zero() {
+        // A team-only or unexpected shape must not read as "0% used".
+        let raw = r#"{
+            "billingCycleEnd": "2026-08-04T00:00:00Z", "membershipType": "team",
+            "teamUsage": {}
+        }"#;
+        let err = to_snapshot(serde_json::from_str(raw).unwrap()).unwrap_err();
+        assert!(matches!(err, AppError::Schema(_)));
+    }
+
+    #[test]
+    fn missing_billing_cycle_end_is_a_parse_error() {
+        let raw = r#"{ "membershipType": "pro",
+            "individualUsage": { "plan": { "autoPercentUsed": 1, "apiPercentUsed": 2, "totalPercentUsed": 1 } } }"#;
+        // `billingCycleEnd` is required by serde → a missing field fails to parse.
+        assert!(serde_json::from_str::<UsageSummary>(raw).is_err());
+    }
+
+    #[test]
+    fn non_finite_percentage_is_rejected() {
+        // serde rejects a non-finite JSON literal at parse time, so exercise the
+        // guard directly: a NaN reaching a percentage field must be a schema
+        // error, never rendered as a bar.
+        let resp = UsageSummary {
+            membership_type: "pro".into(),
+            is_unlimited: false,
+            billing_cycle_end: "2026-08-04T00:00:00Z".into(),
+            individual_usage: Some(IndividualUsage {
+                plan: Some(PlanUsage {
+                    auto_percent_used: f64::NAN,
+                    api_percent_used: 2.0,
+                    total_percent_used: 1.0,
+                }),
+                on_demand: None,
+            }),
+        };
+        assert!(matches!(to_snapshot(resp), Err(AppError::Schema(_))));
+    }
+}

--- a/src/cursor/vendor.rs
+++ b/src/cursor/vendor.rs
@@ -1,0 +1,373 @@
+//! Cursor renderer — bar text + bordered Pango tooltip. Two included-usage
+//! pools (Cursor Models / Other Models), like Kimi's two windows but keyed on
+//! model category rather than a time window.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::pacing::PaceSeverity;
+use crate::pango::{color_span, escape, severity_color, severity_for};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::usage::CursorSnapshot;
+use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+
+pub const DEFAULT_FORMAT: &str = "{cursor_auto_pct}·{cursor_api_pct}%";
+
+/// No confirmed Cursor glyph in the common Nerd Font sets, so a plain caret.
+/// Override with `--icon`.
+const DEFAULT_ICON: &str = "❯";
+
+pub fn build_placeholders(
+    snap: &CursorSnapshot,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
+    let reset = countdown::format(snap.reset_at, now);
+    placeholders(vec![
+        ("icon", DEFAULT_ICON.to_string()),
+        ("vendor_short", "cur".to_string()),
+        // Cross-vendor aliases: the two pools map onto the two generic windows
+        // (session = Cursor Models, weekly = Other Models) so a shared format
+        // and the macOS menu bar show both. Severity still keys on the worst.
+        ("plan", format!("Cursor {}", snap.plan)),
+        ("session_pct", snap.auto_pct.to_string()),
+        ("session_reset", reset.clone()),
+        ("weekly_pct", snap.api_pct.to_string()),
+        ("weekly_reset", reset.clone()),
+        // Cursor-specific placeholders.
+        ("cursor_plan", snap.plan.clone()),
+        ("cursor_auto_pct", snap.auto_pct.to_string()),
+        ("cursor_api_pct", snap.api_pct.to_string()),
+        ("cursor_total_pct", snap.total_pct.to_string()),
+        ("cursor_reset", reset),
+        (
+            "cursor_on_demand",
+            if snap.on_demand_enabled { "on" } else { "off" }.to_string(),
+        ),
+        (
+            "cursor_unlimited",
+            if snap.unlimited { "yes" } else { "no" }.to_string(),
+        ),
+    ])
+}
+
+/// Severity keys on the binding pool. An unlimited plan has no cap, so it stays
+/// calm regardless of the (meaningless) percentages.
+pub fn severity(snap: &CursorSnapshot) -> PaceSeverity {
+    if snap.unlimited {
+        PaceSeverity::Low
+    } else {
+        severity_for(snap.worst_pct())
+    }
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &CursorSnapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let class = Class::from(severity(snap));
+    let format = opts
+        .format
+        .clone()
+        .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
+    let values = build_placeholders(snap, now);
+
+    let mut text = if snap.unlimited && opts.format.is_none() {
+        "unlimited".to_string()
+    } else {
+        substitute(&format, &values)
+    };
+    if outcome.stale {
+        text.push_str(" ⏸");
+    }
+
+    let wrapper_color = severity_color(severity(snap), theme).to_string();
+    let icon_prefix = match opts.icon.as_deref() {
+        Some(ic) if !ic.is_empty() => format!("{ic} "),
+        _ => String::new(),
+    };
+    let bar_text = color_span(&wrapper_color, &format!("{icon_prefix}{text}"));
+
+    let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
+        substitute(fmt, &values)
+    } else {
+        render_tooltip(outcome, snap, theme, now)
+    };
+
+    WaybarOutput {
+        text: bar_text,
+        tooltip,
+        class,
+    }
+}
+
+fn pool_line(lines: &mut Vec<TooltipLine>, theme: &Theme, label: &str, pct: i32) {
+    let fg = &theme.fg;
+    let color = severity_color(severity_for(pct), theme);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{fg}'>  󰢻  {label}</span>"
+    )));
+    lines.push(TooltipLine::Body(format!(
+        "   <span font_weight='bold' foreground='{color}'>{pct}%</span> used"
+    )));
+}
+
+fn render_tooltip(
+    outcome: &VendorOutcome,
+    snap: &CursorSnapshot,
+    theme: &Theme,
+    now: DateTime<Utc>,
+) -> String {
+    let blue = &theme.blue;
+    let dim = &theme.dim;
+    let fg = &theme.fg;
+
+    let mut lines: Vec<TooltipLine> = Vec::new();
+    lines.push(TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{blue}'>Cursor {}</span>",
+        escape(&snap.plan)
+    )));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body("".into()));
+
+    if snap.unlimited {
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{fg}'>  󰐾  Unlimited plan</span>"
+        )));
+    } else {
+        pool_line(&mut lines, theme, "Cursor Models", snap.auto_pct);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{dim}'>     Auto + Composer</span>"
+        )));
+        lines.push(TooltipLine::Body("".into()));
+        pool_line(&mut lines, theme, "Other Models", snap.api_pct);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{dim}'>     Named / API models · on-demand {}</span>",
+            if snap.on_demand_enabled { "on" } else { "off" }
+        )));
+    }
+
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰃰  Resets {}</span>",
+        escape(&countdown::format(snap.reset_at, now))
+    )));
+
+    if let Some((code, msg)) = outcome.last_error.as_ref()
+        && *code != 0
+    {
+        let (icon, ecolor) = if *code >= 500 {
+            ("󰅚", theme.red.as_str())
+        } else {
+            ("󰀪", theme.orange.as_str())
+        };
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{ecolor}'>  {icon}  HTTP {code}</span>"
+        )));
+        lines.push(TooltipLine::Body(format!(
+            "     <span foreground='{dim}'>{}</span>",
+            escape(msg)
+        )));
+    }
+
+    let updated = updated_at_hm(now, outcome.cache_age);
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰅐  Updated {updated}</span>"
+    )));
+
+    render_bordered(&lines, theme)
+}
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(o: FetchOutcome) -> Self {
+        Self {
+            snapshot: crate::usage::VendorSnapshot::Cursor(o.snapshot),
+            stale: o.stale,
+            last_error: o.last_error,
+            cache_age: o.cache_age,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 26, 12, 0, 0).unwrap()
+    }
+
+    fn sample_snap() -> CursorSnapshot {
+        CursorSnapshot {
+            plan: "Ultra".into(),
+            auto_pct: 98,
+            api_pct: 100,
+            total_pct: 99,
+            unlimited: false,
+            on_demand_enabled: false,
+            reset_at: Some(now() + chrono::Duration::days(9)),
+        }
+    }
+
+    fn sample_outcome(snap: CursorSnapshot) -> VendorOutcome {
+        VendorOutcome {
+            snapshot: crate::usage::VendorSnapshot::Cursor(snap),
+            stale: false,
+            last_error: None,
+            cache_age: Some(std::time::Duration::from_secs(10)),
+        }
+    }
+
+    fn opts() -> RenderOpts {
+        RenderOpts {
+            format: None,
+            tooltip_format: None,
+            icon: None,
+            pace_tolerance: 5,
+            format_pace_color: false,
+            tooltip_pace_pts: false,
+        }
+    }
+
+    #[test]
+    fn default_bar_shows_both_pools() {
+        let snap = sample_snap();
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert!(out.text.contains("98·100%"), "text: {}", out.text);
+    }
+
+    #[test]
+    fn tooltip_breaks_out_both_pools_and_reset() {
+        let snap = sample_snap();
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert!(out.tooltip.contains("Cursor Ultra"));
+        assert!(out.tooltip.contains("Cursor Models"));
+        assert!(out.tooltip.contains("98%"));
+        assert!(out.tooltip.contains("Other Models"));
+        assert!(out.tooltip.contains("100%"));
+        assert!(out.tooltip.contains("9d"));
+    }
+
+    #[test]
+    fn severity_keys_on_the_worst_pool() {
+        let mut snap = sample_snap();
+        snap.auto_pct = 10;
+        snap.api_pct = 95;
+        // Other Models at 95% must drive severity Critical even though Cursor
+        // Models is calm.
+        assert_eq!(severity(&snap), PaceSeverity::Critical);
+    }
+
+    #[test]
+    fn unlimited_plan_is_calm_and_labeled() {
+        let mut snap = sample_snap();
+        snap.unlimited = true;
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert_eq!(severity(&snap), PaceSeverity::Low);
+        assert!(out.text.contains("unlimited"));
+        assert!(out.tooltip.contains("Unlimited plan"));
+    }
+
+    #[test]
+    fn stale_appends_pause() {
+        let snap = sample_snap();
+        let mut outcome = sample_outcome(snap.clone());
+        outcome.stale = true;
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        assert!(out.text.contains("⏸"));
+    }
+
+    #[test]
+    fn custom_tooltip_uses_placeholders() {
+        let snap = sample_snap();
+        let mut o = opts();
+        o.tooltip_format = Some("auto {cursor_auto_pct} api {cursor_api_pct} {cursor_plan}".into());
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &o,
+            now(),
+        );
+        assert_eq!(out.tooltip, "auto 98 api 100 Ultra");
+    }
+
+    #[test]
+    fn generic_windows_map_to_the_two_pools() {
+        let values = build_placeholders(&sample_snap(), now());
+        assert_eq!(values["session_pct"], "98"); // Cursor Models (auto)
+        assert_eq!(values["weekly_pct"], "100"); // Other Models (api)
+        assert_eq!(values["plan"], "Cursor Ultra");
+    }
+
+    #[test]
+    fn placeholder_set_contains_all_keys() {
+        let values = build_placeholders(&sample_snap(), now());
+        for key in [
+            "icon",
+            "vendor_short",
+            "plan",
+            "session_pct",
+            "session_reset",
+            "weekly_pct",
+            "weekly_reset",
+            "cursor_plan",
+            "cursor_auto_pct",
+            "cursor_api_pct",
+            "cursor_total_pct",
+            "cursor_reset",
+            "cursor_on_demand",
+            "cursor_unlimited",
+        ] {
+            assert!(values.contains_key(key), "missing placeholder {key}");
+        }
+    }
+
+    #[test]
+    fn fetch_outcome_conversion_preserves_metadata() {
+        let fetch = FetchOutcome {
+            snapshot: sample_snap(),
+            stale: true,
+            last_error: Some((401, "bad".into())),
+            cache_age: Some(std::time::Duration::from_secs(42)),
+        };
+        let vendor: VendorOutcome = fetch.into();
+        assert!(matches!(
+            vendor.snapshot,
+            crate::usage::VendorSnapshot::Cursor(_)
+        ));
+        assert!(vendor.stale);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cache;
 pub mod config;
 pub mod context;
 pub mod countdown;
+pub mod cursor;
 pub mod deepseek;
 pub mod error;
 pub mod format;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -429,6 +429,20 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             let outcome = crate::antigravity::fetch_snapshot(client, &cache, DEFAULT_TTL).await?;
             Ok(outcome.into())
         }
+        VendorId::Cursor => {
+            let cache = crate::cache::Cache::for_vendor("cursor")?;
+            let db_path = config
+                .cursor
+                .db_path
+                .clone()
+                .map(Ok)
+                .unwrap_or_else(crate::cursor::db::default_db_path)?;
+            let endpoints = crate::cursor::fetch::Endpoints::default();
+            let outcome =
+                crate::cursor::fetch_snapshot(client, &db_path, &cache, &endpoints, DEFAULT_TTL)
+                    .await?;
+            Ok(outcome.into())
+        }
     }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -89,6 +89,11 @@ pub struct App {
     /// Background fetches carry this with their tab identity so results from a
     /// previous Settings reload cannot land in a new tab at the old index.
     pub tab_generation: u64,
+    /// When `true`, the Overview pane is selected (the virtual first tab that
+    /// summarizes every vendor at once) instead of a per-vendor detail tab.
+    pub overview: bool,
+    /// Which vendors the Overview lists (`[ui] overview_vendors`); `None` = all.
+    pub overview_vendors: Option<Vec<VendorId>>,
     pub theme: Theme,
     pub quit: bool,
     /// When `Some`, the Settings overlay is open and consuming key events.
@@ -122,6 +127,8 @@ impl App {
             active: 0,
             tabs: vec![TabState::Loading; n],
             tab_generation: 0,
+            overview: false,
+            overview_vendors: None,
             theme,
             quit: false,
             settings: None,
@@ -136,7 +143,13 @@ impl App {
     /// isn't present (e.g. it was disabled).
     pub fn new_with_primary(tabs_meta: Vec<TabId>, primary: Option<VendorId>) -> Self {
         let mut app = Self::new(tabs_meta);
-        app.select_primary(primary);
+        // Default landing is the Overview (show everything at once). An explicit
+        // `[ui] primary` opts into opening on that vendor's tab instead.
+        if primary.is_some() {
+            app.select_primary(primary);
+        } else {
+            app.overview = true;
+        }
         app
     }
 
@@ -182,18 +195,53 @@ impl App {
             && let Some(idx) = self.tabs_meta.iter().position(|t| t.vendor == p)
         {
             self.active = idx;
+            self.overview = false;
         }
     }
 
+    /// The selectable ring is `[Overview, tab0, tab1, …]`. `next_tab`/`prev_tab`
+    /// walk it, wrapping through the Overview at the ends.
     pub fn next_tab(&mut self) {
-        if !self.tabs_meta.is_empty() {
-            self.active = (self.active + 1) % self.tabs_meta.len();
+        if self.overview {
+            if !self.tabs_meta.is_empty() {
+                self.overview = false;
+                self.active = 0;
+            }
+        } else if self.active + 1 < self.tabs_meta.len() {
+            self.active += 1;
+        } else {
+            self.overview = true;
         }
     }
 
     pub fn prev_tab(&mut self) {
-        if !self.tabs_meta.is_empty() {
-            self.active = (self.active + self.tabs_meta.len() - 1) % self.tabs_meta.len();
+        if self.overview {
+            if !self.tabs_meta.is_empty() {
+                self.overview = false;
+                self.active = self.tabs_meta.len() - 1;
+            }
+        } else if self.active > 0 {
+            self.active -= 1;
+        } else {
+            self.overview = true;
+        }
+    }
+
+    /// Tabs the Overview should list: `overview_vendors` filtered against the
+    /// live tab set (preserving the config order), or all tabs when unset.
+    pub fn overview_tabs(&self) -> Vec<usize> {
+        match &self.overview_vendors {
+            None => (0..self.tabs_meta.len()).collect(),
+            Some(wanted) => wanted
+                .iter()
+                .flat_map(|v| {
+                    self.tabs_meta
+                        .iter()
+                        .enumerate()
+                        .filter(move |(_, t)| t.vendor == *v)
+                        .map(|(i, _)| i)
+                })
+                .collect(),
         }
     }
 }
@@ -476,6 +524,55 @@ mod tests {
         let mut app = App::with_theme(vec![TabId::vendor(VendorId::Anthropic)], Theme::default());
         app.select_primary(Some(VendorId::Openai));
         assert_eq!(app.active_vendor(), Some(VendorId::Anthropic));
+    }
+
+    #[test]
+    fn nav_ring_wraps_through_the_overview_at_both_ends() {
+        let mut app = App::with_theme(
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::vendor(VendorId::Openai),
+            ],
+            Theme::default(),
+        );
+        app.overview = true;
+
+        app.next_tab(); // Overview -> first vendor
+        assert!(!app.overview);
+        assert_eq!(app.active, 0);
+        app.next_tab();
+        assert_eq!(app.active, 1);
+        app.next_tab(); // last vendor -> Overview
+        assert!(app.overview);
+
+        app.prev_tab(); // Overview -> last vendor
+        assert!(!app.overview);
+        assert_eq!(app.active, 1);
+        app.prev_tab();
+        assert_eq!(app.active, 0);
+        app.prev_tab(); // first vendor -> Overview
+        assert!(app.overview);
+    }
+
+    #[test]
+    fn overview_tabs_defaults_to_all_and_honors_the_config_filter() {
+        let mut app = App::with_theme(
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::vendor(VendorId::Openai),
+                TabId::vendor(VendorId::Zai),
+            ],
+            Theme::default(),
+        );
+        assert_eq!(app.overview_tabs(), vec![0, 1, 2]);
+
+        // Subset in the given order.
+        app.overview_vendors = Some(vec![VendorId::Zai, VendorId::Anthropic]);
+        assert_eq!(app.overview_tabs(), vec![2, 0]);
+
+        // A listed-but-absent vendor is simply skipped.
+        app.overview_vendors = Some(vec![VendorId::Grok, VendorId::Openai]);
+        assert_eq!(app.overview_tabs(), vec![1]);
     }
 
     fn config_with_accounts(labels: &[&str]) -> Config {

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -89,6 +89,7 @@ pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> 
                 VendorSnapshot::Moonshot(s) => moonshot_sections(s),
                 VendorSnapshot::Grok(s) => grok_sections(s),
                 VendorSnapshot::Antigravity(s) => antigravity_sections(s, now),
+                VendorSnapshot::Cursor(s) => cursor_sections(s, now),
             };
             // Inject the (already-absolute) fetched-at instant into the title
             // row, right-aligned. Pre-snapshotted in app::refresh_one so it
@@ -366,6 +367,47 @@ fn antigravity_sections(s: &crate::usage::AntigravitySnapshot, now: DateTime<Utc
             push_window(&mut v, GROUP_THIRD_PARTY, w, now, 5, false);
         }
     }
+    v
+}
+
+fn cursor_sections(s: &crate::usage::CursorSnapshot, now: DateTime<Utc>) -> Vec<Section> {
+    let mut v = vec![Section::Title {
+        left: format!("Cursor {}", s.plan),
+        right: None,
+    }];
+    if s.unlimited {
+        v.push(Section::Spacer);
+        v.push(Section::Text {
+            label: "Plan".into(),
+            value: "Unlimited — pools don't cap".into(),
+        });
+    } else {
+        // Two included-usage pools, mirroring the dashboard's two bars.
+        v.push(Section::Spacer);
+        v.push(Section::Metric {
+            label: "Cursor Models".into(),
+            pct: s.auto_pct.clamp(0, 100) as u16,
+            severity: severity_for(s.auto_pct),
+            value_label: format!("{}%", s.auto_pct),
+            footnote: "Auto + Composer".into(),
+        });
+        v.push(Section::Spacer);
+        v.push(Section::Metric {
+            label: "Other Models".into(),
+            pct: s.api_pct.clamp(0, 100) as u16,
+            severity: severity_for(s.api_pct),
+            value_label: format!("{}%", s.api_pct),
+            footnote: format!(
+                "Named / API models · on-demand {}",
+                if s.on_demand_enabled { "on" } else { "off" }
+            ),
+        });
+    }
+    v.push(Section::Spacer);
+    v.push(Section::Text {
+        label: "Resets".into(),
+        value: countdown::format(s.reset_at, now),
+    });
     v
 }
 
@@ -1128,6 +1170,63 @@ mod tests {
             .filter(|s| matches!(s, Section::Metric { .. }))
             .count();
         assert_eq!(metric_count, 1);
+    }
+
+    fn cursor_snap() -> crate::usage::CursorSnapshot {
+        crate::usage::CursorSnapshot {
+            plan: "Ultra".into(),
+            auto_pct: 98,
+            api_pct: 100,
+            total_pct: 99,
+            unlimited: false,
+            on_demand_enabled: false,
+            reset_at: Some(now() + chrono::Duration::days(9)),
+        }
+    }
+
+    #[test]
+    fn cursor_sections_show_both_pools_and_reset() {
+        let sections = sections_for(&ready(VendorSnapshot::Cursor(cursor_snap())), now(), 5);
+        let metrics: Vec<_> = sections
+            .iter()
+            .filter_map(|s| match s {
+                Section::Metric {
+                    label, value_label, ..
+                } => Some((label.clone(), value_label.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(metrics.len(), 2, "two pools");
+        assert!(
+            metrics
+                .iter()
+                .any(|(l, v)| l == "Cursor Models" && v == "98%")
+        );
+        assert!(
+            metrics
+                .iter()
+                .any(|(l, v)| l == "Other Models" && v == "100%")
+        );
+        assert!(sections.iter().any(|s| matches!(
+            s,
+            Section::Text { label, value } if label == "Resets" && value.contains("9d")
+        )));
+    }
+
+    #[test]
+    fn cursor_unlimited_plan_shows_no_pool_bars() {
+        let mut snap = cursor_snap();
+        snap.unlimited = true;
+        let sections = sections_for(&ready(VendorSnapshot::Cursor(snap)), now(), 5);
+        let metric_count = sections
+            .iter()
+            .filter(|s| matches!(s, Section::Metric { .. }))
+            .count();
+        assert_eq!(metric_count, 0);
+        assert!(sections.iter().any(|s| matches!(
+            s,
+            Section::Text { value, .. } if value.contains("Unlimited")
+        )));
     }
 
     #[test]

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -135,6 +135,49 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
     }
 }
 
+/// The single most-relevant percentage for a vendor in the Overview — what its
+/// per-row mini bar shows. Mirrors the macOS menu bar's headline: Cursor is the
+/// combined included-total, quota vendors the most-exhausted window; balance
+/// vendors have no meaningful percentage (`None` → no bar).
+pub fn headline_pct(snapshot: &VendorSnapshot) -> Option<i32> {
+    match snapshot {
+        VendorSnapshot::Anthropic(s) => [
+            Some(s.session.utilization_pct),
+            Some(s.weekly.utilization_pct),
+            s.sonnet.as_ref().map(|w| w.utilization_pct),
+        ]
+        .into_iter()
+        .flatten()
+        .max(),
+        VendorSnapshot::AnthropicApi(s) => s.pct(),
+        VendorSnapshot::Openai(s) => [
+            s.session.as_ref().map(|w| w.utilization_pct),
+            s.weekly.as_ref().map(|w| w.utilization_pct),
+        ]
+        .into_iter()
+        .flatten()
+        .max(),
+        VendorSnapshot::Zai(s) => [
+            s.session.as_ref().map(|w| w.utilization_pct),
+            s.weekly.as_ref().map(|w| w.utilization_pct),
+        ]
+        .into_iter()
+        .flatten()
+        .max(),
+        VendorSnapshot::Kimi(s) => Some(s.weekly_pct().max(s.window_pct())),
+        VendorSnapshot::Antigravity(s) => {
+            Some(s.session.utilization_pct.max(s.weekly.utilization_pct))
+        }
+        VendorSnapshot::Cursor(s) => (!s.unlimited).then_some(s.total_pct),
+        VendorSnapshot::Openrouter(_)
+        | VendorSnapshot::Deepseek(_)
+        | VendorSnapshot::Kilo(_)
+        | VendorSnapshot::Novita(_)
+        | VendorSnapshot::Moonshot(_)
+        | VendorSnapshot::Grok(_) => None,
+    }
+}
+
 /// Build the section list for the currently-active vendor's snapshot.
 pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> Vec<Section> {
     match tab {
@@ -1284,6 +1327,19 @@ mod tests {
         }));
         assert!(plan.is_empty());
         assert_eq!(cells, vec![("$8.42".to_string(), PaceSeverity::Low)]);
+    }
+
+    #[test]
+    fn headline_pct_is_the_worst_window_or_combined_total() {
+        // Cursor: the combined total, not the worse pool (mirrors the menu bar).
+        assert_eq!(headline_pct(&VendorSnapshot::Cursor(cursor_snap())), Some(99));
+
+        // Balance-only vendors have no meaningful percentage → no bar.
+        let kilo = VendorSnapshot::Kilo(crate::usage::KiloSnapshot {
+            label: "Kilo".into(),
+            balance: 8.42,
+        });
+        assert_eq!(headline_pct(&kilo), None);
     }
 
     #[test]

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -51,6 +51,90 @@ pub enum Section {
     Spacer,
 }
 
+/// Compact one-line projection of a vendor snapshot for the Overview: a short
+/// plan/tier sub-label (may be empty) plus a few key metric cells — a percent
+/// or a balance — each carrying a severity for coloring. Same numbers as
+/// [`sections_for`], flattened for a dense multi-vendor list. The vendor's name
+/// is supplied by the caller, so it is not repeated here.
+pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSeverity)>) {
+    let pct = |label: &str, p: i32| (format!("{label} {p}%"), severity_for(p));
+    let money = |v: f64| (format!("${v:.2}"), PaceSeverity::Low);
+    let ccy = |v: f64, c: &str| {
+        let s = match c {
+            "USD" => format!("${v:.2}"),
+            "CNY" => format!("¥{v:.2}"),
+            _ => format!("{v:.2} {c}"),
+        };
+        (s, PaceSeverity::Low)
+    };
+    match snapshot {
+        VendorSnapshot::Anthropic(s) => {
+            let mut cells = vec![
+                pct("S", s.session.utilization_pct),
+                pct("W", s.weekly.utilization_pct),
+            ];
+            if let Some(sonnet) = &s.sonnet {
+                cells.push(pct("Son", sonnet.utilization_pct));
+            }
+            (s.plan.clone(), cells)
+        }
+        VendorSnapshot::AnthropicApi(s) => {
+            let cell = match s.pct() {
+                Some(p) => pct("spend", p),
+                None => (format!("${:.2}/mo", s.spent), PaceSeverity::Low),
+            };
+            (String::new(), vec![cell])
+        }
+        VendorSnapshot::Openai(s) => {
+            let mut cells = Vec::new();
+            if let Some(w) = &s.session {
+                cells.push(pct("5h", w.utilization_pct));
+            }
+            if let Some(w) = &s.weekly {
+                cells.push(pct("7d", w.utilization_pct));
+            }
+            if cells.is_empty() {
+                cells.push(("—".into(), PaceSeverity::Low));
+            }
+            (s.plan.clone(), cells)
+        }
+        VendorSnapshot::Zai(s) => {
+            let mut cells = Vec::new();
+            if let Some(w) = &s.session {
+                cells.push(pct("S", w.utilization_pct));
+            }
+            if let Some(w) = &s.weekly {
+                cells.push(pct("W", w.utilization_pct));
+            }
+            if cells.is_empty() {
+                cells.push(("—".into(), PaceSeverity::Low));
+            }
+            (s.plan.clone(), cells)
+        }
+        VendorSnapshot::Openrouter(s) => (String::new(), vec![money(s.balance())]),
+        VendorSnapshot::Deepseek(s) => (String::new(), vec![ccy(s.balance, &s.currency)]),
+        VendorSnapshot::Kimi(s) => (
+            s.plan.clone().unwrap_or_default(),
+            vec![pct("wk", s.weekly_pct()), pct("5h", s.window_pct())],
+        ),
+        VendorSnapshot::Kilo(s) => (String::new(), vec![money(s.balance)]),
+        VendorSnapshot::Novita(s) => (String::new(), vec![money(s.available)]),
+        VendorSnapshot::Moonshot(s) => (String::new(), vec![ccy(s.available, &s.currency)]),
+        VendorSnapshot::Grok(s) => (String::new(), vec![money(s.balance)]),
+        VendorSnapshot::Antigravity(s) => (
+            s.plan.clone(),
+            vec![
+                pct("S", s.session.utilization_pct),
+                pct("W", s.weekly.utilization_pct),
+            ],
+        ),
+        VendorSnapshot::Cursor(s) => (
+            s.plan.clone(),
+            vec![pct("auto", s.auto_pct), pct("premium", s.api_pct)],
+        ),
+    }
+}
+
 /// Build the section list for the currently-active vendor's snapshot.
 pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> Vec<Section> {
     match tab {
@@ -1182,6 +1266,24 @@ mod tests {
             on_demand_enabled: false,
             reset_at: Some(now() + chrono::Duration::days(9)),
         }
+    }
+
+    #[test]
+    fn compact_cells_flatten_key_metrics_for_the_overview() {
+        // Percent vendor (Cursor): plan + two colored pool cells.
+        let (plan, cells) = compact_cells(&VendorSnapshot::Cursor(cursor_snap()));
+        assert_eq!(plan, "Ultra");
+        assert_eq!(cells[0].0, "auto 98%");
+        assert_eq!(cells[1].0, "premium 100%");
+        assert_eq!(cells[1].1, PaceSeverity::Critical); // 100% is critical
+
+        // Balance vendor (Kilo): no plan, a single money cell, calm severity.
+        let (plan, cells) = compact_cells(&VendorSnapshot::Kilo(crate::usage::KiloSnapshot {
+            label: "Kilo".into(),
+            balance: 8.42,
+        }));
+        assert!(plan.is_empty());
+        assert_eq!(cells, vec![("$8.42".to_string(), PaceSeverity::Low)]);
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -744,6 +744,7 @@ fn vendor_label(v: VendorId) -> &'static str {
         VendorId::Moonshot => "Moonshot",
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
+        VendorId::Cursor => "Cursor",
     }
 }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -82,6 +82,7 @@ fn vendor_label(id: VendorId) -> &'static str {
         VendorId::Moonshot => "Moonshot",
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
+        VendorId::Cursor => "Cursor",
     }
 }
 
@@ -99,6 +100,7 @@ fn compact_vendor_label(id: VendorId) -> &'static str {
         VendorId::Moonshot => "Moonshot",
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
+        VendorId::Cursor => "Cursor",
     }
 }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -12,7 +12,7 @@ use crate::tui::app::App;
 use crate::tui::app::TabId;
 use crate::tui::app::TabState;
 use crate::tui::panels;
-use crate::tui::style::{bubble_theme, severity_color};
+use crate::tui::style::{bubble_theme, color, severity_color};
 use crate::vendor::VendorId;
 
 const WIDE_LAYOUT_MIN_WIDTH: u16 = 86;
@@ -212,7 +212,7 @@ fn draw_top_nav(f: &mut Frame, app: &App, area: Rect) {
 
     let mut spans = vec![theme.muted(" ")];
     // Overview entry first, then each vendor tab.
-    let mut push_entry = |spans: &mut Vec<Span>, first: bool, selected: bool, label: String| {
+    let push_entry = |spans: &mut Vec<Span>, first: bool, selected: bool, label: String| {
         if !first {
             spans.push(theme.muted("  "));
         }
@@ -262,6 +262,9 @@ fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
 
 /// Render the Overview: one compact row per configured vendor — its name, a
 /// plan/tier sub-label, and its key metric cells colored by severity.
+/// Width of the per-row mini bar in the Overview (cells).
+const OVERVIEW_BAR_W: usize = 12;
+
 fn draw_overview(f: &mut Frame, app: &App, area: Rect) {
     let theme = bubble_theme(&app.theme);
     let idxs = app.overview_tabs();
@@ -291,6 +294,24 @@ fn draw_overview(f: &mut Frame, app: &App, area: Rect) {
         ];
         match app.tabs.get(i) {
             Some(TabState::Ready(r)) => {
+                // Mini bar for the vendor's headline metric, mirroring the
+                // menu-bar overview; balance-only vendors have none.
+                if let Some(p) = panels::headline_pct(&r.snapshot) {
+                    let filled = (p.clamp(0, 100) as usize * OVERVIEW_BAR_W).div_ceil(100);
+                    let sev_color =
+                        severity_color(&app.theme, &theme, crate::pango::severity_for(p));
+                    spans.push(Span::styled(
+                        "█".repeat(filled),
+                        Style::default().fg(sev_color),
+                    ));
+                    let empty =
+                        color(&app.theme.bar_empty).unwrap_or(theme.palette.selected_background);
+                    spans.push(Span::styled(
+                        "░".repeat(OVERVIEW_BAR_W - filled),
+                        Style::default().fg(empty),
+                    ));
+                    spans.push(theme.span("  "));
+                }
                 let (plan, cells) = panels::compact_cells(&r.snapshot);
                 if !plan.is_empty() {
                     spans.push(theme.muted(format!("{plan}  ")));

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -2,6 +2,7 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::Style;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Paragraph;
 use ratatui_bubbletea_components::{Help, KeyBinding, ListItem, SelectList};
@@ -11,7 +12,7 @@ use crate::tui::app::App;
 use crate::tui::app::TabId;
 use crate::tui::app::TabState;
 use crate::tui::panels;
-use crate::tui::style::bubble_theme;
+use crate::tui::style::{bubble_theme, severity_color};
 use crate::vendor::VendorId;
 
 const WIDE_LAYOUT_MIN_WIDTH: u16 = 86;
@@ -128,10 +129,13 @@ fn draw_header(f: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let active = app
-        .active_tab_id()
-        .map(tab_label)
-        .unwrap_or_else(|| "no vendor".to_string());
+    let active = if app.overview {
+        "Overview".to_string()
+    } else {
+        app.active_tab_id()
+            .map(tab_label)
+            .unwrap_or_else(|| "no vendor".to_string())
+    };
     let line = Line::from(vec![
         theme.accent("  Usage dashboard"),
         theme.muted(" · "),
@@ -188,16 +192,13 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect) {
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    let items = app
-        .tabs_meta
-        .iter()
-        .enumerate()
-        .map(|(index, tab)| {
-            ListItem::new(tab_label(tab)).description(tab_status(app.tabs.get(index)))
-        })
-        .collect::<Vec<_>>();
+    // The Overview is the virtual first entry, before the per-vendor tabs.
+    let mut items = vec![ListItem::new("Overview").description("all vendors")];
+    items.extend(app.tabs_meta.iter().enumerate().map(|(index, tab)| {
+        ListItem::new(tab_label(tab)).description(tab_status(app.tabs.get(index)))
+    }));
     let mut list = SelectList::new(items).theme(theme);
-    list.select(Some(app.active));
+    list.select(Some(if app.overview { 0 } else { app.active + 1 }));
     f.render_widget(&list, inner);
 }
 
@@ -210,11 +211,11 @@ fn draw_top_nav(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(block, area);
 
     let mut spans = vec![theme.muted(" ")];
-    for (index, tab) in app.tabs_meta.iter().enumerate() {
-        if index > 0 {
+    // Overview entry first, then each vendor tab.
+    let mut push_entry = |spans: &mut Vec<Span>, first: bool, selected: bool, label: String| {
+        if !first {
             spans.push(theme.muted("  "));
         }
-        let selected = index == app.active;
         let marker = if selected {
             theme.symbols.selected
         } else {
@@ -224,26 +225,97 @@ fn draw_top_nav(f: &mut Frame, app: &App, area: Rect) {
         let label_style = if selected { theme.selected } else { theme.text };
         spans.push(Span::styled(marker, marker_style));
         spans.push(theme.span(" "));
-        spans.push(Span::styled(compact_tab_label(tab), label_style));
+        spans.push(Span::styled(label, label_style));
+    };
+    push_entry(&mut spans, true, app.overview, "Overview".to_string());
+    for (index, tab) in app.tabs_meta.iter().enumerate() {
+        let selected = !app.overview && index == app.active;
+        push_entry(&mut spans, false, selected, compact_tab_label(tab));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), inner);
 }
 
 fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
     let theme = bubble_theme(&app.theme);
-    let title = app
-        .active_tab_id()
-        .map(|tab| format!(" {} ", tab_label(tab)))
-        .unwrap_or_else(|| " details ".to_string());
+    let title = if app.overview {
+        " Overview ".to_string()
+    } else {
+        app.active_tab_id()
+            .map(|tab| format!(" {} ", tab_label(tab)))
+            .unwrap_or_else(|| " details ".to_string())
+    };
     let block = theme.titled_block(title);
     let inner = block.inner(area);
     f.render_widget(block, area);
+
+    if app.overview {
+        draw_overview(f, app, inner);
+        return;
+    }
 
     let Some(tab) = app.tabs.get(app.active) else {
         return;
     };
     let sections = panels::sections_for(tab, chrono::Utc::now(), 5);
     panels::render(f, inner, &app.theme, &sections);
+}
+
+/// Render the Overview: one compact row per configured vendor — its name, a
+/// plan/tier sub-label, and its key metric cells colored by severity.
+fn draw_overview(f: &mut Frame, app: &App, area: Rect) {
+    let theme = bubble_theme(&app.theme);
+    let idxs = app.overview_tabs();
+    if idxs.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(theme.muted("  No vendors to summarize."))),
+            area,
+        );
+        return;
+    }
+    // Left-align the metric columns by padding the vendor-name column to the
+    // widest name (bounded so one long account label can't blow out the layout).
+    let name_w = idxs
+        .iter()
+        .map(|&i| tab_label(&app.tabs_meta[i]).chars().count())
+        .max()
+        .unwrap_or(6)
+        .clamp(6, 22);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for &i in &idxs {
+        let name = tab_label(&app.tabs_meta[i]);
+        let pad = name_w.saturating_sub(name.chars().count());
+        let mut spans = vec![
+            Span::styled(name, theme.text),
+            theme.span(" ".repeat(pad + 2)),
+        ];
+        match app.tabs.get(i) {
+            Some(TabState::Ready(r)) => {
+                let (plan, cells) = panels::compact_cells(&r.snapshot);
+                if !plan.is_empty() {
+                    spans.push(theme.muted(format!("{plan}  ")));
+                }
+                for (j, (text, sev)) in cells.iter().enumerate() {
+                    if j > 0 {
+                        spans.push(theme.span("  "));
+                    }
+                    let color = severity_color(&app.theme, &theme, *sev);
+                    spans.push(Span::styled(text.clone(), Style::default().fg(color)));
+                }
+                if r.stale {
+                    spans.push(theme.muted("  ⏸"));
+                }
+            }
+            Some(TabState::Error(_)) => spans.push(Span::styled(
+                "error",
+                Style::default().fg(theme.palette.error),
+            )),
+            Some(TabState::Loading) | None => spans.push(theme.muted("fetching…")),
+        }
+        lines.push(Line::from(spans));
+        lines.push(Line::from(""));
+    }
+    f.render_widget(Paragraph::new(lines), area);
 }
 
 fn tab_status(tab: Option<&TabState>) -> &'static str {

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -222,6 +222,47 @@ impl Default for DeepseekSnapshot {
     }
 }
 
+/// Cursor — the two included-usage pools the dashboard shows, from the
+/// undocumented `cursor.com/api/usage-summary` endpoint (the same one the
+/// dashboard's own frontend calls), authenticated with the session token the
+/// Cursor IDE wrote to its local `state.vscdb`.
+///
+/// Since Cursor's mid-2026 pricing, a plan's included compute is split into two
+/// quota pools, each shown as a percentage: **Cursor Models** (Auto + Composer,
+/// `autoPercentUsed`) and **Other Models** (named / third-party, `apiPercentUsed`).
+/// Overflow past either pool falls to on-demand spend. Percentages are integers
+/// (rounded from the wire floats) to match the dashboard and every other
+/// vendor's integer-percent convention; they can exceed 100 when a pool is over
+/// its included allowance.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CursorSnapshot {
+    /// Membership label, title-cased from `membershipType` (e.g. "Ultra").
+    pub plan: String,
+    /// "Cursor Models" pool — Auto + Composer (`autoPercentUsed`, rounded).
+    pub auto_pct: i32,
+    /// "Other Models" pool — named / third-party (`apiPercentUsed`, rounded).
+    pub api_pct: i32,
+    /// Overall included usage (`totalPercentUsed`, rounded) — the dashboard's
+    /// "you've used N% of your included total usage" headline.
+    pub total_pct: i32,
+    /// `true` when the plan reports `isUnlimited` — the pools don't cap and the
+    /// percentages are not meaningful.
+    pub unlimited: bool,
+    /// Whether on-demand (overage) spend is turned on (`onDemand.enabled`).
+    pub on_demand_enabled: bool,
+    /// End of the current billing cycle (`billingCycleEnd`) — when the pools
+    /// reset.
+    pub reset_at: Option<DateTime<Utc>>,
+}
+
+impl CursorSnapshot {
+    /// The binding pool — whichever is closest to (or furthest past) its cap.
+    /// Drives the bar color and the single generic `session_pct` alias.
+    pub fn worst_pct(&self) -> i32 {
+        self.auto_pct.max(self.api_pct)
+    }
+}
+
 /// Kimi Code — weekly subscription quota plus a 5h rolling rate-limit window.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct KimiSnapshot {
@@ -276,6 +317,7 @@ pub enum VendorSnapshot {
     Grok(GrokSnapshot),
     AnthropicApi(AnthropicApiSnapshot),
     Antigravity(AntigravitySnapshot),
+    Cursor(CursorSnapshot),
 }
 
 /// Google Antigravity 2.0 / CLI snapshot. The API groups models into Gemini

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -70,6 +70,7 @@ pub enum VendorId {
     Moonshot,
     Grok,
     Antigravity,
+    Cursor,
 }
 
 impl VendorId {
@@ -87,6 +88,7 @@ impl VendorId {
             VendorId::Moonshot => "moonshot",
             VendorId::Grok => "grok",
             VendorId::Antigravity => "antigravity",
+            VendorId::Cursor => "cursor",
         }
     }
 
@@ -104,6 +106,7 @@ impl VendorId {
             VendorId::Moonshot,
             VendorId::Grok,
             VendorId::Antigravity,
+            VendorId::Cursor,
         ]
     }
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -138,6 +138,7 @@ pub enum Vendor {
     Moonshot,
     Grok,
     Antigravity,
+    Cursor,
 }
 
 impl Vendor {
@@ -155,6 +156,7 @@ impl Vendor {
             Vendor::Moonshot => crate::vendor::VendorId::Moonshot,
             Vendor::Grok => crate::vendor::VendorId::Grok,
             Vendor::Antigravity => crate::vendor::VendorId::Antigravity,
+            Vendor::Cursor => crate::vendor::VendorId::Cursor,
         }
     }
 }
@@ -239,6 +241,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::Moonshot => Vendor::Moonshot,
         crate::vendor::VendorId::Grok => Vendor::Grok,
         crate::vendor::VendorId::Antigravity => Vendor::Antigravity,
+        crate::vendor::VendorId::Cursor => Vendor::Cursor,
     }
 }
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -13,6 +13,7 @@ use crate::anthropic_api;
 use crate::antigravity;
 use crate::cache::{Cache, DEFAULT_TTL};
 use crate::config::Config;
+use crate::cursor;
 use crate::deepseek;
 use crate::error::{AppError, Result};
 use crate::grok;
@@ -149,6 +150,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::Moonshot => moonshot_output(cli, &config).await,
         Vendor::Grok => grok_output(cli, &config).await,
         Vendor::Antigravity => antigravity_output(cli, &config).await,
+        Vendor::Cursor => cursor_output(cli, &config).await,
     }
 }
 
@@ -175,6 +177,38 @@ async fn antigravity_output(cli: &Cli, _config: &Config) -> Result<WaybarOutput>
     let vendor_outcome: VendorOutcome = outcome.into();
     let opts = RenderOpts::from_cli(cli);
     Ok(antigravity::vendor::render(
+        &vendor_outcome,
+        &snap,
+        &theme,
+        &opts,
+        chrono::Utc::now(),
+    ))
+}
+
+/// Cursor authenticates via a session token the Cursor IDE already wrote to
+/// its local `state.vscdb` — no API key to resolve, but (unlike Antigravity)
+/// a real on-disk path that can be overridden, mirroring OpenAI's
+/// `codex_auth_path`.
+async fn cursor_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "cursor")?;
+    let db_path = match config.cursor.db_path.as_deref() {
+        Some(p) => p.to_path_buf(),
+        None => cursor::db::default_db_path()?,
+    };
+    let endpoints = cursor::fetch::Endpoints::default();
+    let outcome =
+        match cursor::fetch_snapshot(&client, &db_path, &cache, &endpoints, DEFAULT_TTL).await {
+            Ok(o) => o,
+            Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
+            Err(e) => return Err(e),
+        };
+
+    let theme = theme_from_cli(cli);
+    let snap = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    let opts = RenderOpts::from_cli(cli);
+    Ok(cursor::vendor::render(
         &vendor_outcome,
         &snap,
         &theme,

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -39,11 +39,16 @@
 //!   window are optional, so the smoke test validates their public fields only
 //!   when present; the snapshot does not expose raw wire duration/unit.
 //!   `kimi_live` skips when optional `KIMI_API_KEY` is unset.
+//! - **Cursor**: reads the session token from the local `state.vscdb`, then
+//!   asserts `premium_pct` is 0..=100 and a future `premium_reset_at` was
+//!   derived from `startOfMonth`. `cursor_live` skips when there is no Cursor
+//!   install (no state DB and no `CURSOR_DB_PATH`).
 
 use std::time::Duration;
 
 use ai_usagebar::anthropic;
 use ai_usagebar::cache::Cache;
+use ai_usagebar::cursor;
 use ai_usagebar::error::AppError;
 use ai_usagebar::kimi;
 use ai_usagebar::openai;
@@ -308,5 +313,69 @@ async fn kimi_live() {
         out.snapshot.window_limit,
         out.snapshot.window_remaining,
         out.snapshot.window_reset_at,
+    );
+}
+
+#[tokio::test]
+#[ignore = "live API; run with --ignored"]
+async fn cursor_live() {
+    // Cursor has no API key — the credential is the session token the Cursor
+    // IDE wrote to its local state DB. So this test needs a real Cursor install
+    // (or `CURSOR_DB_PATH` pointing at a copied `state.vscdb`) and skips
+    // otherwise, the same way `kimi_live` skips without a key. Nothing to fetch
+    // on a CI box with no Cursor.
+    let db_path = match std::env::var("CURSOR_DB_PATH") {
+        Ok(p) if !p.trim().is_empty() => std::path::PathBuf::from(p),
+        _ => cursor::db::default_db_path().expect("resolve platform config dir"),
+    };
+    if !db_path.exists() {
+        eprintln!(
+            "cursor_live: no Cursor state DB at {} — skipping (sign in to the Cursor IDE, or set CURSOR_DB_PATH)",
+            db_path.display()
+        );
+        return;
+    }
+
+    let cache = xdg_cache_for("cursor");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let endpoints = cursor::fetch::Endpoints::default();
+    let out = cursor::fetch_snapshot(
+        &client,
+        &db_path,
+        &cache,
+        &endpoints,
+        Duration::from_secs(0),
+    )
+    .await
+    .expect("cursor fetch should succeed against the real API");
+
+    // The fields the widget depends on: two pool percentages (>= 0; a pool can
+    // exceed 100 when over its included allowance, so only the low bound is
+    // asserted) and a future billing-cycle reset.
+    assert!(
+        out.snapshot.auto_pct >= 0 && out.snapshot.api_pct >= 0,
+        "cursor: negative pool percentage — shape changed? auto={} api={}",
+        out.snapshot.auto_pct,
+        out.snapshot.api_pct
+    );
+    assert!(!out.snapshot.plan.is_empty(), "cursor plan label empty");
+    assert!(
+        out.snapshot
+            .reset_at
+            .is_some_and(|r| r > chrono::Utc::now()),
+        "cursor: reset_at should be a future instant, got {:?}",
+        out.snapshot.reset_at
+    );
+    println!(
+        "✅ cursor — plan={}, Cursor Models {}%, Other Models {}%, total {}%, on-demand={}, reset {:?}",
+        out.snapshot.plan,
+        out.snapshot.auto_pct,
+        out.snapshot.api_pct,
+        out.snapshot.total_pct,
+        out.snapshot.on_demand_enabled,
+        out.snapshot.reset_at,
     );
 }


### PR DESCRIPTION
## What

Every named Anthropic account — explicit `[[anthropic.accounts]]` entries and `[anthropic] accounts_dir` auto-discoveries, the same config the binary and TUI already read — becomes its own selectable entry in the macOS menu-bar app:

- **"Trocar vendor" submenu**, the **⌥⌘\ swap ring**, and the **Preferences vendor picker** list each account as "Claude · label", checkmark on the active one.
- **Overview** shows one dropdown row and one status-bar segment per account, labeled by the account label (not the shared "Claude"), each row clickable.
- The dropdown header names the active account ("Claude Max 20x · work").
- `[anthropic] show_default_account = false` hides the default (unnamed) Claude entry, mirroring the TUI semantics (ignored when there are no named accounts).

## How

Accounts map to pseudo-ids `anthropic@<label>`; fetches run `--vendor anthropic --account <label>`, so per-account cache isolation and token refresh stay entirely in the Rust binary — the app never reads credentials. Config parsing is the app's existing line-scan TOML reader plus a small `[[anthropic.accounts]]` block scanner and an `accounts_dir` subdirectory scan mirroring the Rust discovery rule.

Pure helpers (label scan, dir discovery, merge precedence, id mapping, ring behavior) are covered in the `SWIFT_TEST_HARNESS` suite (`./run-tests.sh` — all green).

## Stacking

Built on the Overview branch (#40), which in turn shows #38/#39's commits until they merge; pairs with #41 (`accounts_dir`) on the Rust side — its keychain-first named-account resolution is what makes `CLAUDE_CONFIG_DIR`-style logins on macOS actually resolvable per account. Until those merge, this PR's diff includes their commits (standard fork-stack caveat).

## Known limitation

`accounts_dir` discovery (Rust and this mirror of it) keys on `<dir>/<label>/.credentials.json` existing; on macOS a fresh `CLAUDE_CONFIG_DIR` login writes only the Keychain, so a keychain-only account dir isn't auto-discovered yet — declare it in `[[anthropic.accounts]]` (the resolution itself then finds the Keychain item). Follow-up candidate for #41.
