### PR TITLE
Hot-reload config.toml without restarting (menu bar + TUI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,8 @@ Each release is also published at
   submenu, swap ring, Overview, and TUI tab set all rebuild in place. The menu
   bar watches natively (`DispatchSource`, re-arming across an editor's atomic
   save) so it's instant; the TUI polls the file's mtime every 2s (no new
-  dependency). A half-written/broken file mid-edit is ignored — the running
-  config is kept until the file parses again — so you never get bounced back to
-  defaults.
+  dependency). In the TUI, a half-written/broken file mid-edit is ignored and
+  retried until it parses, so the running config is not replaced with defaults.
 
 ## [0.18.0] — 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Live `config.toml` reload — no more restart after editing it.** Both the
+  **macOS menu-bar app** and the **TUI** now watch `config.toml` and pick up
+  changes on the fly: enable a vendor, add an `[[anthropic.accounts]]` entry,
+  tweak an `[ui]` knob, and it takes effect within a second or two — the vendor
+  submenu, swap ring, Overview, and TUI tab set all rebuild in place. The menu
+  bar watches natively (`DispatchSource`, re-arming across an editor's atomic
+  save) so it's instant; the TUI polls the file's mtime every 2s (no new
+  dependency). A half-written/broken file mid-edit is ignored — the running
+  config is kept until the file parses again — so you never get bounced back to
+  defaults.
+
 ## [0.18.0] — 2026-07-27
 
 ### Added

--- a/macos/README.md
+++ b/macos/README.md
@@ -136,6 +136,14 @@ default (unnamed) Claude entry when every account is managed explicitly.
 Every immediate `accounts_dir` subdirectory counts as an account; this includes
 macOS logins whose credentials exist only in a config-dir-scoped Keychain item.
 
+## Live config reload
+
+The app watches `config.toml` and reloads on any change — enable a vendor, add
+an account, tweak an `[ui]` knob, and the menu bar updates within a second, no
+restart. It re-arms across an editor's atomic save, and a half-written file
+mid-edit is ignored (the running config is kept until the file parses again).
+The TUI does the same, polling the file every couple of seconds.
+
 ## How it works
 
 Runs `ai-usagebar --vendor <v> --format '{plan};;{session_pct};;…'`, parses the

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1337,6 +1337,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var lastVendor = ""
     var lastSnapshot: Snapshot?
     var pendingRefresh: DispatchWorkItem?
+    /// Live watch on config.toml so external edits (a text editor, the TUI's
+    /// Settings overlay, `ai-usagebar --add-custom-claude-account`) hot-reload
+    /// the vendor list without restarting the app. The fd is closed by the
+    /// source's cancel handler; `pendingConfigReload` coalesces an editor's
+    /// burst of vnode events into a single reload.
+    var configWatchSource: DispatchSourceFileSystemObject?
+    var configWatchFD: CInt = -1
+    var pendingConfigReload: DispatchWorkItem?
     /// Bumped on every refresh attempt. A result whose generation is no longer
     /// current belongs to a superseded attempt — most often the previously
     /// selected vendor — and must not be rendered. Without this, the timer,
@@ -1386,6 +1394,78 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             name: compactHotKeyNotification, object: nil)
         installSwapHotKey()
         installCompactHotKey()
+        installConfigWatch()
+    }
+
+    /// Watch config.toml and hot-reload the vendor list when it changes on disk.
+    /// Editors usually save atomically (write a temp file, then rename it over
+    /// the target), which unlinks the inode our descriptor points at — so a
+    /// `.delete`/`.rename` event means "re-open the path to keep watching the
+    /// new file". A plain in-place write (`>>`, some editors) fires `.write` on
+    /// the same descriptor. Idempotent: always tears down the previous watch.
+    func installConfigWatch() {
+        removeConfigWatch()
+        let path = configPathTOML()
+        let fd = open(path, O_EVTONLY)
+        guard fd >= 0 else {
+            // No readable file yet (not created, or momentarily gone between an
+            // editor's unlink and rename). Retry shortly so a config created
+            // after launch — or a non-atomic save's brief gap — is still picked
+            // up. ponytail: a fixed 3s retry, not exponential backoff; this only
+            // spins in the rare window before the file exists.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+                self?.installConfigWatch()
+            }
+            return
+        }
+        let src = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fd, eventMask: [.write, .extend, .delete, .rename, .attrib],
+            queue: .main)
+        src.setEventHandler { [weak self] in
+            guard let self, let flags = self.configWatchSource?.data else { return }
+            self.scheduleConfigReload()
+            // The watched inode was replaced; re-arm on whatever is at the path
+            // now so future edits keep firing.
+            if flags.contains(.delete) || flags.contains(.rename) {
+                self.installConfigWatch()
+            }
+        }
+        src.setCancelHandler { close(fd) }
+        configWatchFD = fd
+        configWatchSource = src
+        src.resume()
+    }
+
+    func removeConfigWatch() {
+        configWatchSource?.cancel()  // the cancel handler closes the fd
+        configWatchSource = nil
+        configWatchFD = -1
+    }
+
+    /// Coalesce the burst of vnode events a save emits (write → rename → attrib)
+    /// into one reload a beat later, mirroring `settingsChanged`'s debounce.
+    func scheduleConfigReload() {
+        pendingConfigReload?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.configFileChanged() }
+        pendingConfigReload = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: work)
+    }
+
+    /// A config.toml edit landed: rebuild the vendor submenu/ring, re-render the
+    /// current view from cache so an `[ui]` tweak shows at once, then debounce a
+    /// full refresh to fetch any newly-added vendor/account. Reads are all fresh
+    /// from disk (nothing caches config.toml), so no invalidation is needed.
+    @objc func configFileChanged() {
+        rebuildVendorSubmenu()
+        if VENDOR == "overview" {
+            if let ov = lastOverview { renderOverview(ov) }
+        } else if let s = lastSnapshot {
+            renderPanel(s); renderMenu(s)
+        }
+        pendingRefresh?.cancel()
+        let work = DispatchWorkItem { [weak self] in self?.refresh() }
+        pendingRefresh = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.6, execute: work)
     }
 
     /// (Re)register the global ⌥⌘\ hot key to match the `swapShortcutEnabled`

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -10,8 +10,7 @@
 //!   q / Esc / Ctrl-C   quit
 
 use std::io;
-
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 use ai_usagebar::config::Config;
 use ai_usagebar::tui::app::{
@@ -109,6 +108,53 @@ impl Drop for TerminalGuard {
     }
 }
 
+/// How often to check `config.toml`'s mtime for edits made outside the TUI
+/// (a text editor, `--add-custom-claude-account`, another tool).
+// ponytail: an mtime poll, not a notify(7)/FSEvents watcher — one stat() every
+// couple seconds beats pulling in a file-watching crate + its background thread
+// for a file that changes a handful of times a session. The macOS menu-bar app
+// watches natively (DispatchSource, free via Foundation); the TUI polls.
+const CONFIG_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// mtime of the resolved config file, or `None` when there is no config yet or
+/// it can't be stat'd. Re-resolves the path each call, so a config file created
+/// after the TUI started is still noticed.
+fn config_mtime() -> Option<SystemTime> {
+    let path = ai_usagebar::config::resolved_path()?;
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+/// Re-read `config.toml` into `config` and rebuild everything the TUI derives
+/// from it — the tab set (vendor + `[[anthropic.accounts]]` changes), the
+/// overview vendor list, the context toggle — then re-fetch every tab. Returns
+/// `false` and touches nothing if the file can't be parsed, so a half-written
+/// edit never wipes the session back to defaults; the next poll retries.
+///
+/// `reselect_primary` snaps back to the configured primary tab — wanted right
+/// after an explicit Settings save, but not on a background file-watch reload,
+/// where `set_tabs` already clamps the current tab and yanking the user away
+/// from where they were browsing would be rude.
+fn reload_config(
+    app: &mut App,
+    config: &mut Config,
+    client: &Client,
+    tx: &mpsc::UnboundedSender<(u64, TabId, TabState)>,
+    reselect_primary: bool,
+) -> bool {
+    let Ok(reloaded) = Config::load() else {
+        return false;
+    };
+    *config = reloaded;
+    app.context_enabled = config.context.enabled;
+    app.overview_vendors = config.ui.overview_vendors.clone();
+    app.set_tabs(tabs_from_config(config));
+    if reselect_primary {
+        app.select_primary(config.ui.primary);
+    }
+    spawn_all(app, client, config, tx);
+    true
+}
+
 async fn event_loop<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     app: &mut App,
@@ -161,6 +207,11 @@ where
     let mut tick = tokio::time::interval(REFRESH_INTERVAL);
     tick.tick().await; // consume the immediate tick.
 
+    // Watch config.toml for external edits and hot-reload without a restart.
+    let mut config_poll = tokio::time::interval(CONFIG_POLL_INTERVAL);
+    config_poll.tick().await; // consume the immediate tick.
+    let mut last_config_mtime = config_mtime();
+
     loop {
         terminal.draw(|f| draw(f, app))?;
 
@@ -180,6 +231,15 @@ where
             // Periodic auto-refresh of all tabs.
             _ = tick.tick() => {
                 spawn_all(app, client, config, &tx);
+            }
+            // Hot-reload config.toml when it changes on disk (external editor,
+            // `--add-custom-claude-account`, etc.), preserving the current tab.
+            _ = config_poll.tick() => {
+                let now = config_mtime();
+                if now != last_config_mtime {
+                    last_config_mtime = now;
+                    reload_config(app, config, client, &tx, false);
+                }
             }
             // Keyboard + resize, delivered by the single reader thread.
             maybe_input = input_rx.recv() => {
@@ -237,22 +297,16 @@ where
                             SAction::Close => app.settings = None,
                             SAction::SavedAndClose => {
                                 app.settings = None;
-                                // Re-load config so the new primary takes effect
-                                // on the next render, rebuild the tab set so
-                                // account/vendor changes made to config.toml
-                                // while the TUI was open appear without a
-                                // restart, and queue an immediate refresh of
-                                // every tab so newly-set API keys are picked up.
-                                // Keep the config we already have if the reload
-                                // fails — reverting to defaults would silently
-                                // drop the user's real settings mid-session.
-                                if let Ok(reloaded) = ai_usagebar::config::Config::load() {
-                                    *config = reloaded;
-                                }
-                                app.context_enabled = config.context.enabled;
-                                app.set_tabs(tabs_from_config(config));
-                                app.select_primary(config.ui.primary);
-                                spawn_all(app, client, config, &tx);
+                                // Reload config and rebuild the tab set so a
+                                // just-saved primary / account / vendor / API-key
+                                // change takes effect without a restart, snapping
+                                // to the configured primary since the user just
+                                // asked for it. A broken reload keeps the current
+                                // config rather than reverting to defaults.
+                                reload_config(app, config, client, &tx, true);
+                                // The save just rewrote config.toml; adopt its new
+                                // mtime so the background poll doesn't reload again.
+                                last_config_mtime = config_mtime();
                             }
                             SAction::Quit => return Ok(()),
                         }

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -10,6 +10,7 @@
 //!   q / Esc / Ctrl-C   quit
 
 use std::io;
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
 
 use ai_usagebar::config::Config;
@@ -116,12 +117,27 @@ impl Drop for TerminalGuard {
 // watches natively (DispatchSource, free via Foundation); the TUI polls.
 const CONFIG_POLL_INTERVAL: Duration = Duration::from_secs(2);
 
-/// mtime of the resolved config file, or `None` when there is no config yet or
+/// Cheap identity for the resolved config file. Including the resolved path and
+/// length avoids missing a canonical/legacy-path switch or a same-timestamp
+/// rewrite on filesystems with coarse mtime resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfigStamp {
+    path: PathBuf,
+    modified: SystemTime,
+    len: u64,
+}
+
+/// Stamp of the resolved config file, or `None` when there is no config yet or
 /// it can't be stat'd. Re-resolves the path each call, so a config file created
 /// after the TUI started is still noticed.
-fn config_mtime() -> Option<SystemTime> {
+fn config_stamp() -> Option<ConfigStamp> {
     let path = ai_usagebar::config::resolved_path()?;
-    std::fs::metadata(path).ok()?.modified().ok()
+    let metadata = std::fs::metadata(&path).ok()?;
+    Some(ConfigStamp {
+        path,
+        modified: metadata.modified().ok()?,
+        len: metadata.len(),
+    })
 }
 
 /// Re-read `config.toml` into `config` and rebuild everything the TUI derives
@@ -210,7 +226,7 @@ where
     // Watch config.toml for external edits and hot-reload without a restart.
     let mut config_poll = tokio::time::interval(CONFIG_POLL_INTERVAL);
     config_poll.tick().await; // consume the immediate tick.
-    let mut last_config_mtime = config_mtime();
+    let mut last_config_stamp = config_stamp();
 
     loop {
         terminal.draw(|f| draw(f, app))?;
@@ -235,10 +251,13 @@ where
             // Hot-reload config.toml when it changes on disk (external editor,
             // `--add-custom-claude-account`, etc.), preserving the current tab.
             _ = config_poll.tick() => {
-                let now = config_mtime();
-                if now != last_config_mtime {
-                    last_config_mtime = now;
-                    reload_config(app, config, client, &tx, false);
+                let now = config_stamp();
+                if now != last_config_stamp
+                    && reload_config(app, config, client, &tx, false)
+                {
+                    // Only consume the stamp after a successful parse. A
+                    // half-written file is retried until it becomes valid.
+                    last_config_stamp = now;
                 }
             }
             // Keyboard + resize, delivered by the single reader thread.
@@ -303,10 +322,11 @@ where
                                 // to the configured primary since the user just
                                 // asked for it. A broken reload keeps the current
                                 // config rather than reverting to defaults.
-                                reload_config(app, config, client, &tx, true);
-                                // The save just rewrote config.toml; adopt its new
-                                // mtime so the background poll doesn't reload again.
-                                last_config_mtime = config_mtime();
+                                if reload_config(app, config, client, &tx, true) {
+                                    // The save just rewrote config.toml; adopt its
+                                    // new stamp so the poll doesn't reload again.
+                                    last_config_stamp = config_stamp();
+                                }
                             }
                             SAction::Quit => return Ok(()),
                         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -172,11 +172,17 @@ impl App {
     /// Replace the tab set — used after a Settings save reloads config, so
     /// tabs added or removed in `config.toml` while the TUI is open (e.g. a
     /// new `[[anthropic.accounts]]` entry) appear without a restart. Every
-    /// tab resets to `Loading` (the caller re-spawns fetches) and the
-    /// selection is clamped in case the list shrank.
+    /// tab resets to `Loading` (the caller re-spawns fetches). The selected tab
+    /// is preserved by identity when possible; otherwise its old position is
+    /// clamped in case the list shrank.
     pub fn set_tabs(&mut self, tabs_meta: Vec<TabId>) {
+        let selected = self.active_tab_id().cloned();
+        let fallback = self.active.min(tabs_meta.len().saturating_sub(1));
         self.tab_generation = self.tab_generation.wrapping_add(1);
-        self.active = self.active.min(tabs_meta.len().saturating_sub(1));
+        self.active = selected
+            .as_ref()
+            .and_then(|tab| tabs_meta.iter().position(|candidate| candidate == tab))
+            .unwrap_or(fallback);
         self.tabs = vec![TabState::Loading; tabs_meta.len()];
         self.tabs_meta = tabs_meta;
     }
@@ -756,6 +762,27 @@ mod tests {
         assert_eq!(app.tabs_meta, vec![TabId::vendor(VendorId::Anthropic)]);
         assert_eq!(app.active, 0, "selection clamped after shrink");
         assert!(matches!(app.tabs[0], TabState::Loading));
+    }
+
+    #[test]
+    fn set_tabs_preserves_selected_identity_when_entries_are_inserted() {
+        let mut app = App::with_theme(
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::vendor(VendorId::Openai),
+            ],
+            Theme::default(),
+        );
+        app.active = 1;
+
+        app.set_tabs(vec![
+            TabId::vendor(VendorId::Anthropic),
+            TabId::account("work"),
+            TabId::vendor(VendorId::Openai),
+        ]);
+
+        assert_eq!(app.active, 2);
+        assert_eq!(app.active_tab_id(), Some(&TabId::vendor(VendorId::Openai)));
     }
 
     #[test]


### PR DESCRIPTION
## What

The macOS menu-bar app and the TUI now **watch `config.toml` and reload live** — enable a vendor, add an `[[anthropic.accounts]]` entry, or tweak an `[ui]` knob and it takes effect within a second or two, instead of requiring an app restart / TUI relaunch after every edit.

- **macOS menu bar** — a native `DispatchSource` file-system watch on the resolved config path (instant). It **re-arms across an editor's atomic save** (write-temp + rename unlinks the watched inode, so a `.delete`/`.rename` event triggers re-opening the new file), debounces the vnode-event burst (~0.3s), then rebuilds the *Trocar vendor* submenu, the ⌥⌘\ swap ring, and the Overview, and queues a refresh.
- **TUI** — a 2s mtime poll added to the existing `tokio::select!` loop, reusing the same reload primitive the Settings-save already uses (`Config::load` → `set_tabs(tabs_from_config)` → `spawn_all`). The file-watch reload **preserves the current tab** (clamped); only an explicit Settings save reselects the configured primary.
- **Safe mid-edit** — a half-written / unparseable file is ignored; the running config is kept until the file parses again, so a broken save never bounces you back to defaults.

## Why not the `notify` crate for the TUI?

`config.toml` changes a handful of times a session. An mtime poll on the loop's existing timer is a few lines and **no new dependency**; the menu bar already covers the instant case natively via Foundation.

## Verification

- `cargo test` — 665 passing; `cargo clippy --all-targets --locked -- -D warnings` clean.
- Swift harness (`./macos/run-tests.sh`) green.
- Live-tested the hardest path: after an **atomic replace** of `config.toml` the app's event-only handle moved to the new inode (fd re-armed) and the app stayed up — proving editor saves keep working, not just in-place appends.

## Notes

Rebased onto `main` after v0.18.0 shipped. `feat/add-custom-claude-account` (a `--add-custom-claude-account <label>` CLI helper that registers a new Claude account in `config.toml`) stacks on top of this branch and pairs with it — adding an account then shows up live.