### PR TITLE
Add --add-custom-claude-account <label> to register a Claude account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,22 @@ Each release is also published at
 
 ### Added
 
-- **`--add-custom-claude-account <label>`** registers a new custom Claude
-  (Anthropic) account without hand-editing config: it appends an
+- **`--add-custom-claude-account <label>`** takes a new custom Claude (Anthropic)
+  account from nothing to signed-in in one command: it appends an
   `[[anthropic.accounts]]` block to `config.toml` (creating the file if needed,
   preserving comments and formatting via `toml_edit`), creates the account's
-  credentials directory under `accounts/<label>/`, and prints how to sign it in
-  — the macOS Keychain-capture flow, or a `CLAUDE_CONFIG_DIR=… claude` login on
-  Linux. It validates the label and refuses a duplicate before writing anything,
-  and it never touches the default (unnamed) Claude account. Paired with live
-  reload (below), the new account shows up in the menu bar / TUI as soon as its
-  credentials exist — no restart.
+  credentials directory, and then **launches `claude` to sign in** with that
+  account's own `CLAUDE_CONFIG_DIR` — so the login writes exactly where
+  ai-usagebar reads it back (the config-dir-scoped Keychain item on macOS, a
+  `.credentials.json` on Linux) and **your default Claude login is never
+  touched**. When it returns, it re-stamps `config.toml` so the running menu bar
+  / TUI re-fetches and the account shows up **with data immediately** — no
+  restart, no hand-copying credentials. It's idempotent (re-run it to sign an
+  already-registered account back in), never touches the default account, and
+  `--no-login` skips the login step to just register the entry (headless boxes,
+  or add-now-sign-in-later). If `claude` isn't on `PATH` or the login is
+  cancelled, the entry is still registered and it prints the exact login command
+  to finish by hand.
 
 - **Live `config.toml` reload — no more restart after editing it.** Both the
   **macOS menu-bar app** and the **TUI** now watch `config.toml` and pick up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Each release is also published at
 
 ### Added
 
+- **`--add-custom-claude-account <label>`** registers a new custom Claude
+  (Anthropic) account without hand-editing config: it appends an
+  `[[anthropic.accounts]]` block to `config.toml` (creating the file if needed,
+  preserving comments and formatting via `toml_edit`), creates the account's
+  credentials directory under `accounts/<label>/`, and prints how to sign it in
+  — the macOS Keychain-capture flow, or a `CLAUDE_CONFIG_DIR=… claude` login on
+  Linux. It validates the label and refuses a duplicate before writing anything,
+  and it never touches the default (unnamed) Claude account. Paired with live
+  reload (below), the new account shows up in the menu bar / TUI as soon as its
+  credentials exist — no restart.
+
 - **Live `config.toml` reload — no more restart after editing it.** Both the
   **macOS menu-bar app** and the **TUI** now watch `config.toml` and pick up
   changes on the fly: enable a vendor, add an `[[anthropic.accounts]]` entry,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Each release is also published at
 
 ### Added
 
-- **`--add-custom-claude-account <label>`** takes a new custom Claude (Anthropic)
+- **`ai-usagebar account add <label>`** takes a new custom Claude (Anthropic)
   account from nothing to signed-in in one command: it appends an
   `[[anthropic.accounts]]` block to `config.toml` (creating the file if needed,
   preserving comments and formatting via `toml_edit`), creates the account's

--- a/README.md
+++ b/README.md
@@ -407,9 +407,14 @@ ai-usagebar --add-custom-claude-account work
 ```
 
 It appends the `[[anthropic.accounts]]` block below (preserving your comments and
-formatting), creates the account's credentials directory, and prints how to sign
-it in. It validates the label, refuses a duplicate, and never touches the default
-account. Or write the block yourself:
+formatting), creates the account's credentials directory, then **launches
+`claude` to sign in** with that account's own `CLAUDE_CONFIG_DIR` — so the login
+lands exactly where ai-usagebar reads it (the config-dir-scoped Keychain item on
+macOS, a `.credentials.json` on Linux) and your **default Claude login is never
+touched**. It's idempotent (re-run to sign an existing account back in) and
+never touches the default account; add `--no-login` to only register the entry
+and sign in later. Paired with live reload, the account shows up in the menu bar
+/ TUI the moment it's signed in — no restart. Or write the block yourself:
 
 ```toml
 [anthropic]

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ extra Anthropic accounts once in config and select them with `--account
 <label>`. To add one without hand-editing the file, run:
 
 ```bash
-ai-usagebar --add-custom-claude-account work
+ai-usagebar account add work
 ```
 
 It appends the `[[anthropic.accounts]]` block below (preserving your comments and
@@ -424,11 +424,11 @@ and sign in later. Paired with live reload, the account shows up in the menu bar
 
 [[anthropic.accounts]]
 label = "work"
-credentials_path = "~/.config/ai-usagebar/accounts/work.json"
+credentials_path = "~/.config/ai-usagebar/accounts/work/.credentials.json"
 
 [[anthropic.accounts]]
 label = "personal"
-credentials_path = "~/.config/ai-usagebar/accounts/personal.json"
+credentials_path = "~/.config/ai-usagebar/accounts/personal/.credentials.json"
 ```
 
 ```jsonc

--- a/README.md
+++ b/README.md
@@ -400,7 +400,16 @@ credentials file and its own cache directory:
 
 Instead of repeating `--creds-path`/`--cache-dir` on every module, name your
 extra Anthropic accounts once in config and select them with `--account
-<label>`:
+<label>`. To add one without hand-editing the file, run:
+
+```bash
+ai-usagebar --add-custom-claude-account work
+```
+
+It appends the `[[anthropic.accounts]]` block below (preserving your comments and
+formatting), creates the account's credentials directory, and prints how to sign
+it in. It validates the label, refuses a duplicate, and never touches the default
+account. Or write the block yourself:
 
 ```toml
 [anthropic]

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1338,7 +1338,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var lastSnapshot: Snapshot?
     var pendingRefresh: DispatchWorkItem?
     /// Live watch on config.toml so external edits (a text editor, the TUI's
-    /// Settings overlay, `ai-usagebar --add-custom-claude-account`) hot-reload
+    /// Settings overlay, `ai-usagebar account add`) hot-reload
     /// the vendor list without restarting the app. The fd is closed by the
     /// source's cancel handler; `pendingConfigReload` coalesces an editor's
     /// burst of vnode events into a single reload.

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,0 +1,321 @@
+//! Administrative commands for named Claude accounts.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+use crate::error::{AppError, Result};
+use crate::widget::cli::AccountAction;
+
+struct Registered {
+    config_path: PathBuf,
+    credential_file: PathBuf,
+    account_dir: PathBuf,
+    credential_display: String,
+    already_existed: bool,
+}
+
+impl Registered {
+    fn supports_scoped_login(&self) -> bool {
+        self.credential_file
+            .file_name()
+            .and_then(|name| name.to_str())
+            == Some(".credentials.json")
+    }
+}
+
+/// Run an administrative account command and return its process exit code.
+#[must_use]
+pub fn run(action: &AccountAction) -> i32 {
+    match action {
+        AccountAction::Add { label, no_login } => add(label, !no_login),
+    }
+}
+
+fn add(label: &str, login: bool) -> i32 {
+    let registration = match register(label) {
+        Ok(registration) => registration,
+        Err(error) => {
+            eprintln!("ai-usagebar account: could not add {label:?}: {error}");
+            return 1;
+        }
+    };
+
+    if registration.already_existed {
+        println!(
+            "Claude account {label:?} is already configured in {}.",
+            registration.config_path.display()
+        );
+    } else {
+        println!(
+            "Added Claude account {label:?} to {}.",
+            registration.config_path.display()
+        );
+        println!("  credentials_path = {}", registration.credential_display);
+    }
+    println!();
+
+    if !registration.supports_scoped_login() {
+        if login {
+            eprintln!(
+                "Automatic login requires this account's credentials_path to end in \
+                 .credentials.json; it currently points to {}. Update that entry or \
+                 keep managing its credential file manually.",
+                registration.credential_file.display()
+            );
+            return 1;
+        }
+        println!("Registration kept unchanged; interactive login was not requested.");
+        return 0;
+    }
+
+    if !login {
+        print!("{}", manual_login_hint(&registration.account_dir));
+        return 0;
+    }
+
+    println!(
+        "Opening `claude` for {label:?} with an isolated CLAUDE_CONFIG_DIR; your \
+         default Claude login is untouched."
+    );
+    println!();
+    match login_claude_account(&registration.account_dir) {
+        LoginOutcome::NotFound => {
+            eprintln!("`claude` was not found on PATH. The account remains registered.\n");
+            eprint!("{}", manual_login_hint(&registration.account_dir));
+            1
+        }
+        LoginOutcome::Failed(code) => {
+            eprintln!(
+                "`claude` exited with status {code}. The account remains registered; retry with:\n"
+            );
+            eprint!("{}", manual_login_hint(&registration.account_dir));
+            1
+        }
+        LoginOutcome::Ok => {
+            // Touch metadata only: rewriting the pre-login contents here would
+            // clobber config edits made while the interactive command ran.
+            if let Err(error) = restamp_config(&registration.config_path) {
+                eprintln!(
+                    "warning: login finished, but config.toml could not be touched for live reload: {error}"
+                );
+            }
+            println!();
+            println!(
+                "`claude` finished for {label:?}; the menu bar / TUI will refresh momentarily."
+            );
+            0
+        }
+    }
+}
+
+enum LoginOutcome {
+    Ok,
+    Failed(i32),
+    NotFound,
+}
+
+fn login_claude_account(account_dir: &Path) -> LoginOutcome {
+    match std::process::Command::new("claude")
+        .env("CLAUDE_CONFIG_DIR", account_dir)
+        .status()
+    {
+        Ok(status) if status.success() => LoginOutcome::Ok,
+        Ok(status) => LoginOutcome::Failed(status.code().unwrap_or(-1)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => LoginOutcome::NotFound,
+        Err(_) => LoginOutcome::Failed(-1),
+    }
+}
+
+fn register(label: &str) -> Result<Registered> {
+    let config_path = crate::config::resolved_path()
+        .or_else(crate::config::default_path)
+        .ok_or_else(|| {
+            AppError::Other("could not resolve a config.toml path (no home directory?)".into())
+        })?;
+    let home = crate::cache::home_dir().ok();
+    register_at(&config_path, label, home.as_deref())
+}
+
+fn register_at(config_path: &Path, label: &str, home: Option<&Path>) -> Result<Registered> {
+    let original = match std::fs::read_to_string(config_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(AppError::io_at(config_path, error)),
+    };
+    let mut doc: toml_edit::DocumentMut = if original.trim().is_empty() {
+        toml_edit::DocumentMut::new()
+    } else {
+        original.parse().map_err(|error: toml_edit::TomlError| {
+            AppError::Other(format!("config.toml is not valid TOML: {error}"))
+        })?
+    };
+
+    // Honor an existing explicit or accounts_dir-discovered account. In
+    // particular, do not send a re-login to a different default directory.
+    let existing = if config_path.exists() {
+        Config::load_from(config_path)?
+            .anthropic
+            .all_accounts()
+            .into_iter()
+            .find(|account| account.label == label)
+    } else {
+        None
+    };
+    let already_existed = existing.is_some();
+    let credential_file = existing.map_or_else(
+        || crate::config::default_account_credentials_path(config_path, label),
+        |account| account.credentials_path,
+    );
+    let account_dir = credential_file
+        .parent()
+        .ok_or_else(|| AppError::Other("account credentials path has no parent directory".into()))?
+        .to_path_buf();
+    let credential_display = home.map_or_else(
+        || credential_file.display().to_string(),
+        |home| crate::config::tildify(&credential_file, home),
+    );
+
+    if !already_existed {
+        crate::config::add_anthropic_account_to_doc(&mut doc, label, &credential_display)?;
+    }
+
+    let directory_was_missing = !account_dir.exists();
+    std::fs::create_dir_all(&account_dir).map_err(|error| AppError::io_at(&account_dir, error))?;
+    if !already_existed || directory_was_missing {
+        restrict_account_dir(&account_dir)?;
+    }
+    if !already_existed {
+        crate::cache::atomic_write(config_path, doc.to_string().as_bytes())?;
+    }
+
+    Ok(Registered {
+        config_path: config_path.to_path_buf(),
+        credential_file,
+        account_dir,
+        credential_display,
+        already_existed,
+    })
+}
+
+fn restamp_config(path: &Path) -> Result<()> {
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .map_err(|error| AppError::io_at(path, error))?;
+    let times = std::fs::FileTimes::new().set_modified(std::time::SystemTime::now());
+    file.set_times(times)
+        .map_err(|error| AppError::io_at(path, error))
+}
+
+#[cfg(unix)]
+fn restrict_account_dir(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| AppError::io_at(path, error))
+}
+
+#[cfg(not(unix))]
+fn restrict_account_dir(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn manual_login_hint(account_dir: &Path) -> String {
+    format!(
+        "Sign in later with:\n\n  {}\n\nThe account appears automatically after login.\n",
+        shell_login_command(account_dir)
+    )
+}
+
+#[cfg(not(windows))]
+fn shell_login_command(account_dir: &Path) -> String {
+    let escaped = account_dir.display().to_string().replace('\'', "'\\''");
+    format!("CLAUDE_CONFIG_DIR='{escaped}' claude")
+}
+
+#[cfg(windows)]
+fn shell_login_command(account_dir: &Path) -> String {
+    let escaped = account_dir.display().to_string().replace('\'', "''");
+    format!("$env:CLAUDE_CONFIG_DIR = '{escaped}'; claude")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registration_uses_isolated_standard_layout() {
+        let temporary = tempfile::TempDir::new().unwrap();
+        let config_path = temporary.path().join("config.toml");
+        let registration = register_at(&config_path, "work", Some(temporary.path())).unwrap();
+
+        assert!(!registration.already_existed);
+        assert_eq!(
+            registration.credential_file,
+            temporary.path().join("accounts/work/.credentials.json")
+        );
+        assert!(registration.supports_scoped_login());
+        let written = std::fs::read_to_string(config_path).unwrap();
+        assert!(written.contains("label = \"work\""));
+        assert!(written.contains("credentials_path = \"~/accounts/work/.credentials.json\""));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn registration_restricts_the_account_directory() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temporary = tempfile::TempDir::new().unwrap();
+        let config_path = temporary.path().join("config.toml");
+        let registration = register_at(&config_path, "work", None).unwrap();
+        let mode = std::fs::metadata(registration.account_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o700);
+    }
+
+    #[test]
+    fn existing_account_keeps_its_configured_path() {
+        let temporary = tempfile::TempDir::new().unwrap();
+        let config_path = temporary.path().join("config.toml");
+        let credentials = temporary.path().join("custom/work.json");
+        std::fs::write(
+            &config_path,
+            format!(
+                "[[anthropic.accounts]]\nlabel = \"work\"\ncredentials_path = {:?}\n",
+                credentials.display().to_string()
+            ),
+        )
+        .unwrap();
+
+        let registration = register_at(&config_path, "work", None).unwrap();
+        assert!(registration.already_existed);
+        assert_eq!(registration.credential_file, credentials);
+        assert!(!registration.supports_scoped_login());
+    }
+
+    #[test]
+    fn login_hint_quotes_paths_with_spaces() {
+        let command = shell_login_command(Path::new("/tmp/Claude Accounts/work"));
+        assert!(command.contains("Claude Accounts"));
+        #[cfg(not(windows))]
+        assert_eq!(
+            command,
+            "CLAUDE_CONFIG_DIR='/tmp/Claude Accounts/work' claude"
+        );
+    }
+
+    #[test]
+    fn restamp_never_rewrites_config_contents() {
+        let temporary = tempfile::TempDir::new().unwrap();
+        let path = temporary.path().join("config.toml");
+        std::fs::write(&path, "# edited while login ran\n").unwrap();
+        restamp_config(&path).unwrap();
+        assert_eq!(
+            std::fs::read_to_string(path).unwrap(),
+            "# edited while login ran\n"
+        );
+    }
+}

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -110,7 +110,7 @@ impl Drop for TerminalGuard {
 }
 
 /// How often to check `config.toml`'s mtime for edits made outside the TUI
-/// (a text editor, `--add-custom-claude-account`, another tool).
+/// (a text editor, `ai-usagebar account add`, another tool).
 // ponytail: an mtime poll, not a notify(7)/FSEvents watcher — one stat() every
 // couple seconds beats pulling in a file-watching crate + its background thread
 // for a file that changes a handful of times a session. The macOS menu-bar app
@@ -249,7 +249,7 @@ where
                 spawn_all(app, client, config, &tx);
             }
             // Hot-reload config.toml when it changes on disk (external editor,
-            // `--add-custom-claude-account`, etc.), preserving the current tab.
+            // `ai-usagebar account add`, etc.), preserving the current tab.
             _ = config_poll.tick() => {
                 let now = config_stamp();
                 if now != last_config_stamp

--- a/src/bin/ai-usagebar.rs
+++ b/src/bin/ai-usagebar.rs
@@ -1,12 +1,15 @@
 //! Waybar widget binary. The library does all the work — this is just the
 //! tokio bootstrap + clap parse.
 
-use ai_usagebar::widget::cli::Cli;
+use ai_usagebar::widget::cli::{Cli, Command};
 use ai_usagebar::widget::run::run;
 use clap::Parser;
 
 fn main() {
     let cli = Cli::parse();
+    if let Some(Command::Account { action }) = &cli.command {
+        std::process::exit(ai_usagebar::account::run(action));
+    }
     let rt = match tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,6 +359,20 @@ pub fn add_anthropic_account_to_doc(
     Ok(())
 }
 
+/// Is a `[[anthropic.accounts]]` entry with this label already in the document?
+/// Lets the "add account" flow be idempotent — re-running to *sign in* an
+/// already-registered account should skip the append, not error.
+pub fn doc_has_anthropic_account(doc: &toml_edit::DocumentMut, label: &str) -> bool {
+    doc.get("anthropic")
+        .and_then(|a| a.get("accounts"))
+        .and_then(toml_edit::Item::as_array_of_tables)
+        .is_some_and(|accts| {
+            accts
+                .iter()
+                .any(|t| t.get("label").and_then(toml_edit::Item::as_str) == Some(label))
+        })
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct OpenAiConfig {
@@ -1657,6 +1671,23 @@ credentials_path = "~/w/.credentials.json"
         let mut doc = toml_edit::DocumentMut::new();
         assert!(add_anthropic_account_to_doc(&mut doc, "a/b", "~/x/.credentials.json").is_err());
         assert!(add_anthropic_account_to_doc(&mut doc, "", "~/x/.credentials.json").is_err());
+    }
+
+    #[test]
+    fn doc_has_account_detects_membership() {
+        let doc: toml_edit::DocumentMut = r#"
+[[anthropic.accounts]]
+label = "work"
+credentials_path = "~/w/.credentials.json"
+"#
+        .parse()
+        .unwrap();
+        assert!(doc_has_anthropic_account(&doc, "work"));
+        assert!(!doc_has_anthropic_account(&doc, "home"));
+        assert!(!doc_has_anthropic_account(
+            &toml_edit::DocumentMut::new(),
+            "work"
+        ));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -304,7 +304,14 @@ fn discover_accounts(accounts_dir: &std::path::Path) -> Vec<AnthropicAccount> {
 /// paths outside home are returned verbatim.
 pub fn tildify(path: &Path, home: &Path) -> String {
     path.strip_prefix(home)
-        .map(|rest| format!("~/{}", rest.display()))
+        .map(|rest| {
+            let rendered = rest.display().to_string();
+            // Config paths use the same portable `~/...` spelling on every
+            // platform. A Windows `~\...` would not be expanded by the loader.
+            #[cfg(windows)]
+            let rendered = rendered.replace('\\', "/");
+            format!("~/{rendered}")
+        })
         .unwrap_or_else(|_| path.display().to_string())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@
 //! `*_api_key_env` field lets the user override which env var name).
 
 use std::collections::{BTreeMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
@@ -295,6 +295,68 @@ fn discover_accounts(accounts_dir: &std::path::Path) -> Vec<AnthropicAccount> {
         .collect();
     found.sort_by(|a, b| a.label.cmp(&b.label));
     found
+}
+
+/// Render a path with `$HOME` collapsed back to `~`, matching the style the docs
+/// and existing `[[anthropic.accounts]]` entries use. Pure so it's testable;
+/// paths outside home are returned verbatim.
+pub fn tildify(path: &Path, home: &Path) -> String {
+    path.strip_prefix(home)
+        .map(|rest| format!("~/{}", rest.display()))
+        .unwrap_or_else(|_| path.display().to_string())
+}
+
+/// Where a newly-registered account's credentials file lives by default: next
+/// to `config.toml`, under `accounts/<label>/.credentials.json`. Returns the
+/// absolute path (for `mkdir`) — tilde-render it with [`tildify`] for display
+/// and for the value written into config.
+pub fn default_account_credentials_path(config_path: &Path, label: &str) -> PathBuf {
+    let base = config_path.parent().unwrap_or_else(|| Path::new("."));
+    base.join("accounts").join(label).join(".credentials.json")
+}
+
+/// Append a `[[anthropic.accounts]]` entry to a parsed config document, in
+/// place. Pure over a `toml_edit` document so the validation, duplicate check,
+/// and formatting are testable without disk. Preserves the rest of the file
+/// (comments, key order, other sections) — only the new array-of-tables entry
+/// is added. Errors on an invalid label or a label that already exists.
+pub fn add_anthropic_account_to_doc(
+    doc: &mut toml_edit::DocumentMut,
+    label: &str,
+    credentials_path: &str,
+) -> Result<()> {
+    use toml_edit::{Item, Table, value};
+
+    validate_account_label(label)?;
+
+    let anthropic = doc
+        .entry("anthropic")
+        .or_insert_with(|| Item::Table(Table::new()));
+    let anthropic = anthropic
+        .as_table_mut()
+        .ok_or_else(|| AppError::Other("[anthropic] in config.toml is not a table".into()))?;
+
+    let accounts = anthropic
+        .entry("accounts")
+        .or_insert_with(|| Item::ArrayOfTables(toml_edit::ArrayOfTables::new()));
+    let accounts = accounts.as_array_of_tables_mut().ok_or_else(|| {
+        AppError::Other("[[anthropic.accounts]] in config.toml is not an array of tables".into())
+    })?;
+
+    let exists = accounts
+        .iter()
+        .any(|t| t.get("label").and_then(Item::as_str) == Some(label));
+    if exists {
+        return Err(AppError::Credentials(format!(
+            "anthropic account {label:?} already exists in config.toml"
+        )));
+    }
+
+    let mut table = Table::new();
+    table["label"] = value(label);
+    table["credentials_path"] = value(credentials_path);
+    accounts.push(table);
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1530,5 +1592,86 @@ enabled = false
         let c = Config::load_from(f.path()).unwrap();
         assert!(c.is_enabled(VendorId::Cursor));
         assert!(c.enabled_vendors().contains(&VendorId::Cursor));
+    }
+
+    #[test]
+    fn add_account_appends_and_preserves_existing() {
+        let mut doc: toml_edit::DocumentMut = r#"
+# keep me
+[anthropic]
+enabled = true
+
+[[anthropic.accounts]]
+label = "personal"
+credentials_path = "~/.config/ai-usagebar/accounts/personal/.credentials.json"
+"#
+        .parse()
+        .unwrap();
+        add_anthropic_account_to_doc(
+            &mut doc,
+            "work",
+            "~/.config/ai-usagebar/accounts/work/.credentials.json",
+        )
+        .unwrap();
+        let rendered = doc.to_string();
+        assert!(rendered.contains("# keep me"), "comment must survive");
+        // Round-trips through the real loader with both accounts intact and ordered.
+        let f = write_toml(&rendered);
+        let c = Config::load_from(f.path()).unwrap();
+        let labels: Vec<&str> = c
+            .anthropic
+            .accounts
+            .iter()
+            .map(|a| a.label.as_str())
+            .collect();
+        assert_eq!(labels, vec!["personal", "work"]);
+    }
+
+    #[test]
+    fn add_account_to_empty_doc_is_loadable() {
+        let mut doc = toml_edit::DocumentMut::new();
+        add_anthropic_account_to_doc(&mut doc, "solo", "~/x/.credentials.json").unwrap();
+        let f = write_toml(&doc.to_string());
+        let c = Config::load_from(f.path()).unwrap();
+        assert_eq!(c.anthropic.accounts.len(), 1);
+        assert_eq!(c.anthropic.accounts[0].label, "solo");
+    }
+
+    #[test]
+    fn add_account_rejects_duplicate_label() {
+        let mut doc: toml_edit::DocumentMut = r#"
+[[anthropic.accounts]]
+label = "work"
+credentials_path = "~/w/.credentials.json"
+"#
+        .parse()
+        .unwrap();
+        assert!(
+            add_anthropic_account_to_doc(&mut doc, "work", "~/other/.credentials.json").is_err(),
+            "a duplicate label must be rejected, not appended"
+        );
+    }
+
+    #[test]
+    fn add_account_rejects_bad_label() {
+        let mut doc = toml_edit::DocumentMut::new();
+        assert!(add_anthropic_account_to_doc(&mut doc, "a/b", "~/x/.credentials.json").is_err());
+        assert!(add_anthropic_account_to_doc(&mut doc, "", "~/x/.credentials.json").is_err());
+    }
+
+    #[test]
+    fn tildify_collapses_home_only() {
+        let home = Path::new("/Users/me");
+        assert_eq!(tildify(&home.join("a/b"), home), "~/a/b");
+        assert_eq!(tildify(Path::new("/etc/hosts"), home), "/etc/hosts");
+    }
+
+    #[test]
+    fn default_account_credentials_path_nests_under_config_dir() {
+        let cfg = Path::new("/home/u/.config/ai-usagebar/config.toml");
+        assert_eq!(
+            default_account_credentials_path(cfg, "work"),
+            Path::new("/home/u/.config/ai-usagebar/accounts/work/.credentials.json"),
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,7 @@ impl Default for AnthropicConfig {
 /// ```toml
 /// [[anthropic.accounts]]
 /// label = "work"
-/// credentials_path = "~/.config/ai-usagebar/accounts/work.json"
+/// credentials_path = "~/.config/ai-usagebar/accounts/work/.credentials.json"
 /// ```
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct AnthropicAccount {
@@ -249,19 +249,21 @@ impl AnthropicConfig {
 
 /// The label doubles as a cache subdirectory name
 /// (`~/.cache/ai-usagebar/anthropic/<label>/`), which nests inside the default
-/// account's cache dir — so path separators or dot-dirs would escape or
-/// collide with the cache layout (`usage.json`, `.stale`, …). Reject anything
-/// that isn't a plain single-segment name.
+/// account's cache dir — so path separators, control characters, or reserved
+/// cache sidecar names would escape, spoof terminal output, or collide with the
+/// cache layout (`usage.json`, `.stale`, …).
 fn validate_account_label(label: &str) -> Result<()> {
+    const RESERVED: [&str; 4] = ["usage.json", ".stale", ".last_error", ".fetch.lock"];
     let bad = label.is_empty()
         || label == "."
         || label == ".."
         || label.contains(['/', '\\'])
-        || label == "usage.json";
+        || label.chars().any(char::is_control)
+        || RESERVED.contains(&label);
     if bad {
         return Err(AppError::Credentials(format!(
             "invalid anthropic account label {label:?}: must be a non-empty name \
-             without path separators (it becomes a cache subdirectory)"
+             without path separators, control characters, or reserved cache names"
         )));
     }
     Ok(())
@@ -357,20 +359,6 @@ pub fn add_anthropic_account_to_doc(
     table["credentials_path"] = value(credentials_path);
     accounts.push(table);
     Ok(())
-}
-
-/// Is a `[[anthropic.accounts]]` entry with this label already in the document?
-/// Lets the "add account" flow be idempotent — re-running to *sign in* an
-/// already-registered account should skip the append, not error.
-pub fn doc_has_anthropic_account(doc: &toml_edit::DocumentMut, label: &str) -> bool {
-    doc.get("anthropic")
-        .and_then(|a| a.get("accounts"))
-        .and_then(toml_edit::Item::as_array_of_tables)
-        .is_some_and(|accts| {
-            accts
-                .iter()
-                .any(|t| t.get("label").and_then(toml_edit::Item::as_str) == Some(label))
-        })
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -1386,7 +1374,19 @@ enabled = false
     #[test]
     fn account_label_rejects_path_like_names() {
         let cfg = AnthropicConfig::default();
-        for bad in ["", ".", "..", "a/b", r"a\b", "usage.json"] {
+        for bad in [
+            "",
+            ".",
+            "..",
+            "a/b",
+            r"a\b",
+            "line\nbreak",
+            "tab\tname",
+            "usage.json",
+            ".stale",
+            ".last_error",
+            ".fetch.lock",
+        ] {
             let err = cfg.account(bad).unwrap_err();
             assert!(
                 format!("{err:?}").contains("invalid anthropic account label"),
@@ -1671,23 +1671,6 @@ credentials_path = "~/w/.credentials.json"
         let mut doc = toml_edit::DocumentMut::new();
         assert!(add_anthropic_account_to_doc(&mut doc, "a/b", "~/x/.credentials.json").is_err());
         assert!(add_anthropic_account_to_doc(&mut doc, "", "~/x/.credentials.json").is_err());
-    }
-
-    #[test]
-    fn doc_has_account_detects_membership() {
-        let doc: toml_edit::DocumentMut = r#"
-[[anthropic.accounts]]
-label = "work"
-credentials_path = "~/w/.credentials.json"
-"#
-        .parse()
-        .unwrap();
-        assert!(doc_has_anthropic_account(&doc, "work"));
-        assert!(!doc_has_anthropic_account(&doc, "home"));
-        assert!(!doc_has_anthropic_account(
-            &toml_edit::DocumentMut::new(),
-            "work"
-        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 //! The two binaries (`ai-usagebar` and `ai-usagebar-tui`) are thin: they parse
 //! CLI args, instantiate vendors, and hand off to a renderer in this crate.
 
+pub mod account;
 pub mod active;
 pub mod anthropic;
 pub mod anthropic_api;

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -10,6 +10,7 @@ use clap::{Parser, ValueEnum};
 #[derive(Parser, Debug, Clone)]
 #[command(
     name = "ai-usagebar",
+    args_conflicts_with_subcommands = true,
     about = "Waybar widget for AI plan usage (Anthropic / OpenAI / Z.AI / OpenRouter / DeepSeek / Kimi)",
     long_about = "\
 Drop-in replacement for `claudebar` with multi-vendor support.
@@ -122,20 +123,31 @@ pub struct Cli {
     #[arg(long, value_name = "LABEL", conflicts_with = "creds_path")]
     pub account: Option<String>,
 
-    /// Register a new custom Claude (Anthropic) account and exit: append an
-    /// `[[anthropic.accounts]]` entry to config.toml, create its credentials
-    /// directory, and print how to sign it in. Does not touch the default
-    /// (unnamed) Claude account. Once the credentials file exists the account
-    /// shows up live (the app watches config.toml).
-    #[arg(long, value_name = "LABEL",
-          conflicts_with_all = ["cycle_next", "cycle_prev", "watch", "pretty", "json"])]
-    pub add_custom_claude_account: Option<String>,
+    /// Administrative command. Omit it to run the normal usage widget.
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
 
-    /// With `--add-custom-claude-account`, only register the account in
-    /// config.toml — do not launch the interactive `claude` login afterwards.
-    /// Use it on a headless box, or to add the entry now and sign in later.
-    #[arg(long)]
-    pub no_login: bool,
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum Command {
+    /// Manage named Claude (Anthropic) accounts.
+    Account {
+        #[command(subcommand)]
+        action: AccountAction,
+    },
+}
+
+#[derive(clap::Subcommand, Debug, Clone)]
+pub enum AccountAction {
+    /// Register an isolated account and open Claude Code to sign it in.
+    Add {
+        /// Stable name used by `--account`, the TUI, and desktop apps.
+        label: String,
+
+        /// Only register the account; do not launch interactive login.
+        #[arg(long)]
+        no_login: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]
@@ -304,6 +316,33 @@ mod tests {
         assert!(!cli.pretty);
         assert!(!cli.json);
         assert!(cli.watch.is_none());
+        assert!(cli.command.is_none());
+    }
+
+    #[test]
+    fn account_add_subcommand_parses_without_widget_flags() {
+        let cli = Cli::parse_from(["ai-usagebar", "account", "add", "work", "--no-login"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Account {
+                action: AccountAction::Add { ref label, no_login: true }
+            }) if label == "work"
+        ));
+    }
+
+    #[test]
+    fn account_subcommand_rejects_ignored_widget_flags() {
+        assert!(
+            Cli::try_parse_from([
+                "ai-usagebar",
+                "--vendor",
+                "anthropic",
+                "account",
+                "add",
+                "work",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -130,6 +130,12 @@ pub struct Cli {
     #[arg(long, value_name = "LABEL",
           conflicts_with_all = ["cycle_next", "cycle_prev", "watch", "pretty", "json"])]
     pub add_custom_claude_account: Option<String>,
+
+    /// With `--add-custom-claude-account`, only register the account in
+    /// config.toml — do not launch the interactive `claude` login afterwards.
+    /// Use it on a headless box, or to add the entry now and sign in later.
+    #[arg(long)]
+    pub no_login: bool,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -121,6 +121,15 @@ pub struct Cli {
     /// `--creds-path` (they both name a credentials file).
     #[arg(long, value_name = "LABEL", conflicts_with = "creds_path")]
     pub account: Option<String>,
+
+    /// Register a new custom Claude (Anthropic) account and exit: append an
+    /// `[[anthropic.accounts]]` entry to config.toml, create its credentials
+    /// directory, and print how to sign it in. Does not touch the default
+    /// (unnamed) Claude account. Once the credentials file exists the account
+    /// shows up live (the app watches config.toml).
+    #[arg(long, value_name = "LABEL",
+          conflicts_with_all = ["cycle_next", "cycle_prev", "watch", "pretty", "json"])]
+    pub add_custom_claude_account: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -35,11 +35,6 @@ use crate::zai;
 /// Entry point — runs to completion and ALWAYS returns Ok with exit code 0
 /// in the caller. Mirrors claudebar's `die()` invariant.
 pub async fn run(cli: Cli) -> i32 {
-    // Admin short-circuit: register a new Claude account in config.toml, sign it
-    // in, and exit (prints human guidance, not a Waybar payload — run by hand).
-    if let Some(label) = cli.add_custom_claude_account.as_deref() {
-        return run_add_custom_claude_account(label, !cli.no_login);
-    }
     // Scroll-cycle short-circuit: don't render, just bump state + signal waybar.
     if cli.cycle_next || cli.cycle_prev {
         return run_cycle(&cli).await;
@@ -84,178 +79,6 @@ async fn run_cycle(cli: &Cli) -> i32 {
     // shell-safe value on Linux glibc is signal 47 (= SIGRTMIN(34)+13).
     crate::waybar::request_refresh();
     0
-}
-
-/// A registered account, ready to sign in.
-struct Registered {
-    config_path: std::path::PathBuf,
-    /// The account's own `CLAUDE_CONFIG_DIR` — where `claude` writes, and where
-    /// the binary reads (scoped Keychain on macOS, `.credentials.json` on Linux).
-    account_dir: std::path::PathBuf,
-    cred_display: String,
-    dir_display: String,
-    /// The full config.toml text after registration, so a post-login re-stamp
-    /// can nudge a running app to re-fetch without re-reading the file.
-    rendered: String,
-    already_existed: bool,
-}
-
-/// The `claude` login command that populates a named account, ready to paste.
-fn manual_login_hint(dir_display: &str) -> String {
-    format!(
-        "Sign in by logging `claude` in as this account:\n\n  \
-         CLAUDE_CONFIG_DIR={dir_display} claude\n\n\
-         It appears automatically once you're signed in — the app watches config.toml.\n"
-    )
-}
-
-/// `--add-custom-claude-account <label>`: register the account in config.toml
-/// and (unless `--no-login`) drive the interactive `claude` login for it, so a
-/// single command takes it from nothing to signed-in. Prints human guidance and
-/// exits non-zero on failure (it's a manual command, not a Waybar render).
-fn run_add_custom_claude_account(label: &str, login: bool) -> i32 {
-    let reg = match register_custom_claude_account(label) {
-        Ok(reg) => reg,
-        Err(e) => {
-            eprintln!("ai-usagebar: could not add Claude account {label:?}: {e}");
-            return 1;
-        }
-    };
-
-    if reg.already_existed {
-        println!(
-            "Claude account {label:?} is already in {}.",
-            reg.config_path.display()
-        );
-    } else {
-        println!(
-            "✓ Added Claude account {label:?} to {}",
-            reg.config_path.display()
-        );
-        println!("  credentials_path = {}", reg.cred_display);
-    }
-    println!();
-
-    if !login {
-        print!("{}", manual_login_hint(&reg.dir_display));
-        return 0;
-    }
-
-    println!(
-        "Opening `claude` to sign in as {label:?} (its own CLAUDE_CONFIG_DIR, so your\n\
-         default Claude login is untouched). Finish the login, then it returns here."
-    );
-    println!();
-    match login_claude_account(&reg.account_dir) {
-        LoginOutcome::NotFound => {
-            eprintln!(
-                "`claude` was not found on PATH. The account is registered — finish sign-in with:\n"
-            );
-            eprint!("{}", manual_login_hint(&reg.dir_display));
-            1
-        }
-        LoginOutcome::Failed(code) => {
-            eprintln!(
-                "`claude` exited before finishing (status {code}). The account is registered — retry with:\n"
-            );
-            eprint!("{}", manual_login_hint(&reg.dir_display));
-            1
-        }
-        LoginOutcome::Ok => {
-            // Credentials now live where the binary reads them. Re-stamp
-            // config.toml so a running menu bar / TUI re-fetches and shows the
-            // account with data right away instead of at the next interval.
-            let _ = crate::cache::atomic_write(&reg.config_path, reg.rendered.as_bytes());
-            println!();
-            println!("✓ {label:?} is signed in — it'll show up in the menu bar / TUI momentarily.");
-            0
-        }
-    }
-}
-
-/// Outcome of spawning the interactive `claude` login.
-enum LoginOutcome {
-    Ok,
-    Failed(i32),
-    NotFound,
-}
-
-/// Run `CLAUDE_CONFIG_DIR=<account_dir> claude` inheriting this terminal so the
-/// user completes the login interactively. That writes the account's own scoped
-/// credentials (Keychain on macOS, `.credentials.json` on Linux) — exactly what
-/// the binary reads back for this account — so nothing needs copying afterward.
-fn login_claude_account(account_dir: &std::path::Path) -> LoginOutcome {
-    match std::process::Command::new("claude")
-        .env("CLAUDE_CONFIG_DIR", account_dir)
-        .status()
-    {
-        Ok(status) if status.success() => LoginOutcome::Ok,
-        Ok(status) => LoginOutcome::Failed(status.code().unwrap_or(-1)),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LoginOutcome::NotFound,
-        Err(_) => LoginOutcome::Failed(-1),
-    }
-}
-
-/// Ensure `label` is a registered `[[anthropic.accounts]]` entry (append it if
-/// missing, no-op if already present) and its credentials directory exists.
-/// Idempotent so the command can double as "sign in an already-added account".
-fn register_custom_claude_account(label: &str) -> Result<Registered> {
-    let config_path = crate::config::resolved_path()
-        .or_else(crate::config::default_path)
-        .ok_or_else(|| {
-            AppError::Other("could not resolve a config.toml path (no home directory?)".into())
-        })?;
-
-    let cred_file = crate::config::default_account_credentials_path(&config_path, label);
-    let account_dir = cred_file
-        .parent()
-        .unwrap_or(config_path.as_path())
-        .to_path_buf();
-
-    // Tilde-render paths for the written config value and the printed commands.
-    let home = crate::cache::home_dir().ok();
-    let tilde = |p: &std::path::Path| {
-        home.as_deref()
-            .map(|h| crate::config::tildify(p, h))
-            .unwrap_or_else(|| p.display().to_string())
-    };
-    let cred_display = tilde(&cred_file);
-    let dir_display = tilde(&account_dir);
-
-    let original = match std::fs::read_to_string(&config_path) {
-        Ok(s) => s,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(e) => return Err(AppError::io_at(&config_path, e)),
-    };
-    let mut doc: toml_edit::DocumentMut = if original.trim().is_empty() {
-        toml_edit::DocumentMut::new()
-    } else {
-        original.parse().map_err(|e: toml_edit::TomlError| {
-            AppError::Other(format!("config.toml not parseable: {e}"))
-        })?
-    };
-
-    // Re-running to sign in an already-registered account must not error — skip
-    // the append, keep the config untouched, and go straight to the login.
-    let already_existed = crate::config::doc_has_anthropic_account(&doc, label);
-    if !already_existed {
-        crate::config::add_anthropic_account_to_doc(&mut doc, label, &cred_display)?;
-    }
-
-    std::fs::create_dir_all(&account_dir).map_err(|e| AppError::io_at(&account_dir, e))?;
-    let rendered = doc.to_string();
-    if !already_existed {
-        crate::cache::atomic_write(&config_path, rendered.as_bytes())?;
-    }
-
-    Ok(Registered {
-        config_path,
-        account_dir,
-        cred_display,
-        dir_display,
-        rendered,
-        already_existed,
-    })
 }
 
 /// `--watch` repaints in place, which only makes sense on a terminal. Piped or
@@ -871,15 +694,6 @@ mod tests {
         // args to get the canonical defaults.
         use clap::Parser;
         Cli::parse_from(["ai-usagebar"])
-    }
-
-    #[test]
-    fn manual_login_hint_names_the_scoped_login_command() {
-        let hint = manual_login_hint("~/.config/ai-usagebar/accounts/work");
-        assert!(
-            hint.contains("CLAUDE_CONFIG_DIR=~/.config/ai-usagebar/accounts/work claude"),
-            "hint must give the per-account CLAUDE_CONFIG_DIR login: {hint}"
-        );
     }
 
     fn dummy_outcome() -> FetchOutcome {

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -35,10 +35,10 @@ use crate::zai;
 /// Entry point — runs to completion and ALWAYS returns Ok with exit code 0
 /// in the caller. Mirrors claudebar's `die()` invariant.
 pub async fn run(cli: Cli) -> i32 {
-    // Admin short-circuit: register a new Claude account in config.toml and exit
-    // (prints human guidance, not a Waybar payload — this is run by hand).
+    // Admin short-circuit: register a new Claude account in config.toml, sign it
+    // in, and exit (prints human guidance, not a Waybar payload — run by hand).
     if let Some(label) = cli.add_custom_claude_account.as_deref() {
-        return run_add_custom_claude_account(label);
+        return run_add_custom_claude_account(label, !cli.no_login);
     }
     // Scroll-cycle short-circuit: don't render, just bump state + signal waybar.
     if cli.cycle_next || cli.cycle_prev {
@@ -86,30 +86,120 @@ async fn run_cycle(cli: &Cli) -> i32 {
     0
 }
 
-/// `--add-custom-claude-account <label>`: register a new named Claude account in
-/// config.toml and tell the user how to sign it in. Prints human guidance and
+/// A registered account, ready to sign in.
+struct Registered {
+    config_path: std::path::PathBuf,
+    /// The account's own `CLAUDE_CONFIG_DIR` — where `claude` writes, and where
+    /// the binary reads (scoped Keychain on macOS, `.credentials.json` on Linux).
+    account_dir: std::path::PathBuf,
+    cred_display: String,
+    dir_display: String,
+    /// The full config.toml text after registration, so a post-login re-stamp
+    /// can nudge a running app to re-fetch without re-reading the file.
+    rendered: String,
+    already_existed: bool,
+}
+
+/// The `claude` login command that populates a named account, ready to paste.
+fn manual_login_hint(dir_display: &str) -> String {
+    format!(
+        "Sign in by logging `claude` in as this account:\n\n  \
+         CLAUDE_CONFIG_DIR={dir_display} claude\n\n\
+         It appears automatically once you're signed in — the app watches config.toml.\n"
+    )
+}
+
+/// `--add-custom-claude-account <label>`: register the account in config.toml
+/// and (unless `--no-login`) drive the interactive `claude` login for it, so a
+/// single command takes it from nothing to signed-in. Prints human guidance and
 /// exits non-zero on failure (it's a manual command, not a Waybar render).
-fn run_add_custom_claude_account(label: &str) -> i32 {
-    match add_custom_claude_account(label) {
-        Ok(msg) => {
-            print!("{msg}");
-            0
-        }
+fn run_add_custom_claude_account(label: &str, login: bool) -> i32 {
+    let reg = match register_custom_claude_account(label) {
+        Ok(reg) => reg,
         Err(e) => {
             eprintln!("ai-usagebar: could not add Claude account {label:?}: {e}");
+            return 1;
+        }
+    };
+
+    if reg.already_existed {
+        println!(
+            "Claude account {label:?} is already in {}.",
+            reg.config_path.display()
+        );
+    } else {
+        println!(
+            "✓ Added Claude account {label:?} to {}",
+            reg.config_path.display()
+        );
+        println!("  credentials_path = {}", reg.cred_display);
+    }
+    println!();
+
+    if !login {
+        print!("{}", manual_login_hint(&reg.dir_display));
+        return 0;
+    }
+
+    println!(
+        "Opening `claude` to sign in as {label:?} (its own CLAUDE_CONFIG_DIR, so your\n\
+         default Claude login is untouched). Finish the login, then it returns here."
+    );
+    println!();
+    match login_claude_account(&reg.account_dir) {
+        LoginOutcome::NotFound => {
+            eprintln!(
+                "`claude` was not found on PATH. The account is registered — finish sign-in with:\n"
+            );
+            eprint!("{}", manual_login_hint(&reg.dir_display));
             1
+        }
+        LoginOutcome::Failed(code) => {
+            eprintln!(
+                "`claude` exited before finishing (status {code}). The account is registered — retry with:\n"
+            );
+            eprint!("{}", manual_login_hint(&reg.dir_display));
+            1
+        }
+        LoginOutcome::Ok => {
+            // Credentials now live where the binary reads them. Re-stamp
+            // config.toml so a running menu bar / TUI re-fetches and shows the
+            // account with data right away instead of at the next interval.
+            let _ = crate::cache::atomic_write(&reg.config_path, reg.rendered.as_bytes());
+            println!();
+            println!("✓ {label:?} is signed in — it'll show up in the menu bar / TUI momentarily.");
+            0
         }
     }
 }
 
-/// Append an `[[anthropic.accounts]]` block for `label` to config.toml (creating
-/// the file if absent), create the account's credentials directory, and return
-/// the next-step guidance to print. Validates the label and refuses a duplicate
-/// before writing anything. The account's credentials still have to be supplied
-/// separately (the printed command) — this only registers it.
-fn add_custom_claude_account(label: &str) -> Result<String> {
-    use std::fmt::Write as _;
+/// Outcome of spawning the interactive `claude` login.
+enum LoginOutcome {
+    Ok,
+    Failed(i32),
+    NotFound,
+}
 
+/// Run `CLAUDE_CONFIG_DIR=<account_dir> claude` inheriting this terminal so the
+/// user completes the login interactively. That writes the account's own scoped
+/// credentials (Keychain on macOS, `.credentials.json` on Linux) — exactly what
+/// the binary reads back for this account — so nothing needs copying afterward.
+fn login_claude_account(account_dir: &std::path::Path) -> LoginOutcome {
+    match std::process::Command::new("claude")
+        .env("CLAUDE_CONFIG_DIR", account_dir)
+        .status()
+    {
+        Ok(status) if status.success() => LoginOutcome::Ok,
+        Ok(status) => LoginOutcome::Failed(status.code().unwrap_or(-1)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => LoginOutcome::NotFound,
+        Err(_) => LoginOutcome::Failed(-1),
+    }
+}
+
+/// Ensure `label` is a registered `[[anthropic.accounts]]` entry (append it if
+/// missing, no-op if already present) and its credentials directory exists.
+/// Idempotent so the command can double as "sign in an already-added account".
+fn register_custom_claude_account(label: &str) -> Result<Registered> {
     let config_path = crate::config::resolved_path()
         .or_else(crate::config::default_path)
         .ok_or_else(|| {
@@ -132,8 +222,6 @@ fn add_custom_claude_account(label: &str) -> Result<String> {
     let cred_display = tilde(&cred_file);
     let dir_display = tilde(&account_dir);
 
-    // Parse the existing config (or start fresh), then append — the append
-    // validates the label and rejects a duplicate before any file is touched.
     let original = match std::fs::read_to_string(&config_path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -146,50 +234,28 @@ fn add_custom_claude_account(label: &str) -> Result<String> {
             AppError::Other(format!("config.toml not parseable: {e}"))
         })?
     };
-    crate::config::add_anthropic_account_to_doc(&mut doc, label, &cred_display)?;
+
+    // Re-running to sign in an already-registered account must not error — skip
+    // the append, keep the config untouched, and go straight to the login.
+    let already_existed = crate::config::doc_has_anthropic_account(&doc, label);
+    if !already_existed {
+        crate::config::add_anthropic_account_to_doc(&mut doc, label, &cred_display)?;
+    }
 
     std::fs::create_dir_all(&account_dir).map_err(|e| AppError::io_at(&account_dir, e))?;
-    crate::cache::atomic_write(&config_path, doc.to_string().as_bytes())?;
-
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "✓ Added Claude account {label:?} to {}",
-        config_path.display()
-    );
-    let _ = writeln!(out, "  credentials_path = {cred_display}");
-    let _ = writeln!(out);
-    if cfg!(target_os = "macos") {
-        // On macOS a `CLAUDE_CONFIG_DIR=… claude` login lands in a config-dir
-        // scoped *Keychain* item, not this file — so the reliable way to fill a
-        // file-backed account is to sign the default `claude` in as this
-        // identity and capture that Keychain item into the file.
-        let _ = writeln!(
-            out,
-            "Next: sign the `claude` CLI in as this account (one login at a time),\n\
-             then capture its credentials into the file above:"
-        );
-        let _ = writeln!(out);
-        let _ = writeln!(
-            out,
-            "  security find-generic-password -s 'Claude Code-credentials' -w \\\n\
-             \x20   > {cred_display} && chmod 600 {cred_display}"
-        );
-    } else {
-        // On Linux a per-account CLAUDE_CONFIG_DIR login writes the file directly.
-        let _ = writeln!(
-            out,
-            "Next: sign in for this account, writing its credentials to the file above:"
-        );
-        let _ = writeln!(out);
-        let _ = writeln!(out, "  CLAUDE_CONFIG_DIR={dir_display} claude");
+    let rendered = doc.to_string();
+    if !already_existed {
+        crate::cache::atomic_write(&config_path, rendered.as_bytes())?;
     }
-    let _ = writeln!(out);
-    let _ = writeln!(
-        out,
-        "It appears automatically once its credentials exist — the app watches config.toml."
-    );
-    Ok(out)
+
+    Ok(Registered {
+        config_path,
+        account_dir,
+        cred_display,
+        dir_display,
+        rendered,
+        already_existed,
+    })
 }
 
 /// `--watch` repaints in place, which only makes sense on a terminal. Piped or
@@ -805,6 +871,15 @@ mod tests {
         // args to get the canonical defaults.
         use clap::Parser;
         Cli::parse_from(["ai-usagebar"])
+    }
+
+    #[test]
+    fn manual_login_hint_names_the_scoped_login_command() {
+        let hint = manual_login_hint("~/.config/ai-usagebar/accounts/work");
+        assert!(
+            hint.contains("CLAUDE_CONFIG_DIR=~/.config/ai-usagebar/accounts/work claude"),
+            "hint must give the per-account CLAUDE_CONFIG_DIR login: {hint}"
+        );
     }
 
     fn dummy_outcome() -> FetchOutcome {

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -35,6 +35,11 @@ use crate::zai;
 /// Entry point — runs to completion and ALWAYS returns Ok with exit code 0
 /// in the caller. Mirrors claudebar's `die()` invariant.
 pub async fn run(cli: Cli) -> i32 {
+    // Admin short-circuit: register a new Claude account in config.toml and exit
+    // (prints human guidance, not a Waybar payload — this is run by hand).
+    if let Some(label) = cli.add_custom_claude_account.as_deref() {
+        return run_add_custom_claude_account(label);
+    }
     // Scroll-cycle short-circuit: don't render, just bump state + signal waybar.
     if cli.cycle_next || cli.cycle_prev {
         return run_cycle(&cli).await;
@@ -79,6 +84,112 @@ async fn run_cycle(cli: &Cli) -> i32 {
     // shell-safe value on Linux glibc is signal 47 (= SIGRTMIN(34)+13).
     crate::waybar::request_refresh();
     0
+}
+
+/// `--add-custom-claude-account <label>`: register a new named Claude account in
+/// config.toml and tell the user how to sign it in. Prints human guidance and
+/// exits non-zero on failure (it's a manual command, not a Waybar render).
+fn run_add_custom_claude_account(label: &str) -> i32 {
+    match add_custom_claude_account(label) {
+        Ok(msg) => {
+            print!("{msg}");
+            0
+        }
+        Err(e) => {
+            eprintln!("ai-usagebar: could not add Claude account {label:?}: {e}");
+            1
+        }
+    }
+}
+
+/// Append an `[[anthropic.accounts]]` block for `label` to config.toml (creating
+/// the file if absent), create the account's credentials directory, and return
+/// the next-step guidance to print. Validates the label and refuses a duplicate
+/// before writing anything. The account's credentials still have to be supplied
+/// separately (the printed command) — this only registers it.
+fn add_custom_claude_account(label: &str) -> Result<String> {
+    use std::fmt::Write as _;
+
+    let config_path = crate::config::resolved_path()
+        .or_else(crate::config::default_path)
+        .ok_or_else(|| {
+            AppError::Other("could not resolve a config.toml path (no home directory?)".into())
+        })?;
+
+    let cred_file = crate::config::default_account_credentials_path(&config_path, label);
+    let account_dir = cred_file
+        .parent()
+        .unwrap_or(config_path.as_path())
+        .to_path_buf();
+
+    // Tilde-render paths for the written config value and the printed commands.
+    let home = crate::cache::home_dir().ok();
+    let tilde = |p: &std::path::Path| {
+        home.as_deref()
+            .map(|h| crate::config::tildify(p, h))
+            .unwrap_or_else(|| p.display().to_string())
+    };
+    let cred_display = tilde(&cred_file);
+    let dir_display = tilde(&account_dir);
+
+    // Parse the existing config (or start fresh), then append — the append
+    // validates the label and rejects a duplicate before any file is touched.
+    let original = match std::fs::read_to_string(&config_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(AppError::io_at(&config_path, e)),
+    };
+    let mut doc: toml_edit::DocumentMut = if original.trim().is_empty() {
+        toml_edit::DocumentMut::new()
+    } else {
+        original.parse().map_err(|e: toml_edit::TomlError| {
+            AppError::Other(format!("config.toml not parseable: {e}"))
+        })?
+    };
+    crate::config::add_anthropic_account_to_doc(&mut doc, label, &cred_display)?;
+
+    std::fs::create_dir_all(&account_dir).map_err(|e| AppError::io_at(&account_dir, e))?;
+    crate::cache::atomic_write(&config_path, doc.to_string().as_bytes())?;
+
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "✓ Added Claude account {label:?} to {}",
+        config_path.display()
+    );
+    let _ = writeln!(out, "  credentials_path = {cred_display}");
+    let _ = writeln!(out);
+    if cfg!(target_os = "macos") {
+        // On macOS a `CLAUDE_CONFIG_DIR=… claude` login lands in a config-dir
+        // scoped *Keychain* item, not this file — so the reliable way to fill a
+        // file-backed account is to sign the default `claude` in as this
+        // identity and capture that Keychain item into the file.
+        let _ = writeln!(
+            out,
+            "Next: sign the `claude` CLI in as this account (one login at a time),\n\
+             then capture its credentials into the file above:"
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(
+            out,
+            "  security find-generic-password -s 'Claude Code-credentials' -w \\\n\
+             \x20   > {cred_display} && chmod 600 {cred_display}"
+        );
+    } else {
+        // On Linux a per-account CLAUDE_CONFIG_DIR login writes the file directly.
+        let _ = writeln!(
+            out,
+            "Next: sign in for this account, writing its credentials to the file above:"
+        );
+        let _ = writeln!(out);
+        let _ = writeln!(out, "  CLAUDE_CONFIG_DIR={dir_display} claude");
+    }
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "It appears automatically once its credentials exist — the app watches config.toml."
+    );
+    Ok(out)
 }
 
 /// `--watch` repaints in place, which only makes sense on a terminal. Piped or


### PR DESCRIPTION
## What

`--add-custom-claude-account <label>` takes a new custom Claude (Anthropic) account **from nothing to signed-in in one command**:

```bash
ai-usagebar --add-custom-claude-account work
```

1. Appends an `[[anthropic.accounts]]` block to `config.toml` via `toml_edit` — **preserves comments, formatting, other sections**; creates the file if missing.
2. Creates the account's credentials directory.
3. **Launches `claude` to sign in** with that account's own `CLAUDE_CONFIG_DIR`, so the login writes exactly where ai-usagebar reads it back — the config-dir-scoped **Keychain** item on macOS (v0.18.0's keychain-first named resolution), a `.credentials.json` on Linux — **no hand-copying / `security` capture**, and **your default Claude login is never touched**.
4. On return, **re-stamps `config.toml`** so a running menu bar / TUI re-fetches and the account shows up **with data immediately** (via the live-reload from #47).

- **Idempotent** — re-run to sign an already-registered account back in (skips the append instead of erroring).
- `--no-login` registers only (headless boxes, or add-now-sign-in-later).
- If `claude` isn't on `PATH` or the login is cancelled, the entry is still registered and it prints the exact `CLAUDE_CONFIG_DIR=… claude` command to finish by hand. Never touches the default account.

Pure logic (`add_anthropic_account_to_doc`, `doc_has_anthropic_account`, `tildify`, `default_account_credentials_path`, `manual_login_hint`) lives in `config.rs`/`run.rs` with hermetic tests; the login is a thin `Command::new("claude").env("CLAUDE_CONFIG_DIR", dir).status()` that inherits the terminal.

## Verification

- `cargo test` — 673 passing; `cargo clippy --all-targets --locked -- -D warnings` clean; `cargo fmt --check` clean.
- End-to-end against a throwaway `$HOME` with a fake `claude` on `PATH`: register→login success (re-stamps, "signed in"), idempotent re-run, `--no-login` (register + hint), login-exits-1 (registered + retry hint, exit 1), and `claude`-not-on-PATH (registered + hint, exit 1) all behave correctly; spawns with the right per-account `CLAUDE_CONFIG_DIR`.

## Stacking

Stacks on **#47** (live `config.toml` reload) and pairs with it. Both rebased onto `main` after v0.18.0. Merge #47 first.