### PR TITLE
Per-provider on/off toggle in the Overview (macOS menu bar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ Each release is also published at
 
 ### Added
 
+- **Per-provider on/off toggle in the Overview (macOS menu bar).** Each row in
+  the Overview dropdown is now a checkbox: click it to drop that provider from
+  the always-visible top-bar summary (checkmark = shown; unchecked + dimmed =
+  hidden). Hidden providers stay listed in the dropdown so you can turn them
+  back on, and dropping some also frees up the top bar to draw mini bars again
+  instead of compact text. The choice persists (UserDefaults). Jumping to a
+  provider's detail view moves to the *Trocar vendor* submenu / **⌥⌘\\** (the
+  Overview row click now toggles instead).
+
 - **Live `config.toml` reload — no more restart after editing it.** Both the
   **macOS menu-bar app** and the **TUI** now watch `config.toml` and pick up
   changes on the fly: enable a vendor, add an `[[anthropic.accounts]]` entry,

--- a/macos/README.md
+++ b/macos/README.md
@@ -89,6 +89,12 @@ Settings persist in `UserDefaults` and apply **live, no rebuild**.
 `config.toml` limits and orders the Overview on macOS exactly as it does in the
 TUI. Requesting `anthropic` includes every configured named Claude account.
 
+In Overview mode, each dropdown row is a **checkbox**: click it to drop that
+provider from the always-visible top-bar summary (checkmark = shown; unchecked +
+dimmed = hidden). Hidden providers stay listed so you can re-enable them, and the
+choice persists. Jumping to a provider's detail view is via the *Trocar vendor*
+submenu / ⌥⌘\ (the Overview row click toggles visibility instead).
+
 The Preferences window needs **macOS 12+** (the menu bar itself works on
 10.15+). Tags/labels use the system label colors, so they adapt to a light or
 dark menu bar; only the bar fill/empty colors are configurable.

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1306,6 +1306,25 @@ func overviewUsesBars(count: Int, barsMax: Int, compact: Bool) -> Bool {
     !compact && count <= barsMax
 }
 
+/// Provider ids the user toggled out of the always-visible top-bar summary in
+/// Overview mode. The dropdown still lists them (unchecked + dimmed) so they can
+/// be turned back on. Persisted in UserDefaults; absent key → nothing hidden.
+func overviewHiddenProviders() -> Set<String> {
+    Set(DEF.stringArray(forKey: "overviewHiddenProviders") ?? [])
+}
+
+func setOverviewProvider(_ id: String, hidden: Bool) {
+    var hiddenSet = overviewHiddenProviders()
+    if hidden { hiddenSet.insert(id) } else { hiddenSet.remove(id) }
+    DEF.set(hiddenSet.sorted(), forKey: "overviewHiddenProviders")
+}
+
+/// The ids that survive the top-bar filter, in their original order. Pure +
+/// testable — the render path (which also drops nil snapshots) is not.
+func overviewVisibleIds(_ ids: [String], hidden: Set<String>) -> [String] {
+    ids.filter { !hidden.contains($0) }
+}
+
 /// The next id in the cycle, wrapping. `current` absent from `ids` (e.g. the
 /// selected vendor was disabled) starts at the first (or last, backward).
 /// Pure + testable — the hot-key handler is not.
@@ -1966,9 +1985,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func overviewBarTitle(_ items: [(name: String, id: String, snap: Snapshot?)],
                           _ appearance: NSAppearance) -> NSAttributedString {
         let secondary = menuBarTextColor(appearance, secondary: true)
+        // Providers toggled off in the dropdown are dropped from the always-on
+        // top summary (but still listed there so they can be re-enabled).
+        let hidden = overviewHiddenProviders()
         let heads: [(name: String, pct: Int, elapsed: Int?, value: String, reset: String?)] =
             items.compactMap {
-                guard let s = $0.snap else { return nil }
+                guard !hidden.contains($0.id), let s = $0.snap else { return nil }
                 if let cb = s.creditBalance { return ($0.name, -1, nil, "cr \(cb)", nil) }
                 let h = overviewHeadline(s)
                 return ($0.name, h.pct, h.elapsed, "\(h.pct)%", h.reset.flatMap(shortReset))
@@ -2032,13 +2054,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             String(repeating: " ", count: max(0, w - s.count)) + s
         }
 
+        let hidden = overviewHiddenProviders()
         for (i, item) in items.enumerated() where i < overviewRows.count {
             let it = overviewRows[i]
             it.isHidden = false
-            // Click a row to jump straight to that vendor's detail view.
+            // Click a row to toggle whether this provider shows in the top-bar
+            // summary. Checkmark = shown; unchecked + dimmed = hidden from the
+            // bar (still listed here so it can be turned back on). Jump-to-vendor
+            // moved to the "Trocar vendor" submenu and ⌥⌘\.
+            let isHidden = hidden.contains(item.id)
+            it.state = isHidden ? .off : .on
             it.representedObject = item.id
             it.target = self
-            it.action = #selector(switchVendor(_:))
+            it.action = #selector(toggleOverviewProvider(_:))
             let a = NSMutableAttributedString()
             let fitted = item.name.count > nameW
                 ? String(item.name.prefix(nameW - 1)) + "…"
@@ -2058,6 +2086,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 }
             } else {
                 a.append(run("—", .secondaryLabelColor))
+            }
+            // Grey the whole row while hidden, so "off" reads at a glance.
+            if isHidden {
+                a.addAttribute(.foregroundColor, value: NSColor.tertiaryLabelColor,
+                               range: NSRange(location: 0, length: a.length))
             }
             it.attributedTitle = a
         }
@@ -2205,6 +2238,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func switchVendor(_ sender: NSMenuItem) {
         guard let id = sender.representedObject as? String else { return }
         DEF.set(id, forKey: "vendor")
+    }
+
+    /// Toggle whether a provider appears in the Overview top-bar summary, from
+    /// its dropdown row. Re-renders from the last fetch (visibility only — no
+    /// re-fetch), so the bar and the row's checkmark update at once.
+    @objc func toggleOverviewProvider(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? String else { return }
+        setOverviewProvider(id, hidden: !overviewHiddenProviders().contains(id))
+        if let ov = lastOverview { renderOverview(ov) }
     }
 
     func setError(_ msg: String) {

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1364,6 +1364,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var configWatchSource: DispatchSourceFileSystemObject?
     var configWatchFD: CInt = -1
     var pendingConfigReload: DispatchWorkItem?
+    /// A visibility checkbox changes presentation only. Its UserDefaults
+    /// notification should repaint from cache without restarting the timer or
+    /// launching a fresh round of provider subprocesses.
+    var overviewVisibilityChangePending = false
     /// Bumped on every refresh attempt. A result whose generation is no longer
     /// current belongs to a superseded attempt — most often the previously
     /// selected vendor — and must not be rendered. Without this, the timer,
@@ -1750,6 +1754,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Settings changed in Preferences: re-render instantly from cache, re-arm
     // the timer, and re-fetch (debounced) in case vendor/binary changed.
     @objc func settingsChanged() {
+        if overviewVisibilityChangePending {
+            overviewVisibilityChangePending = false
+            if VENDOR == "overview", let ov = lastOverview { renderOverview(ov) }
+            return
+        }
         // The swap-shortcut toggle lives in defaults too; re-register only when
         // its state and the live registration disagree (avoids churn on every
         // vendor switch, which itself writes defaults).
@@ -1988,9 +1997,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Providers toggled off in the dropdown are dropped from the always-on
         // top summary (but still listed there so they can be re-enabled).
         let hidden = overviewHiddenProviders()
+        let visible = Set(overviewVisibleIds(items.map { $0.id }, hidden: hidden))
         let heads: [(name: String, pct: Int, elapsed: Int?, value: String, reset: String?)] =
             items.compactMap {
-                guard !hidden.contains($0.id), let s = $0.snap else { return nil }
+                guard visible.contains($0.id), let s = $0.snap else { return nil }
                 if let cb = s.creditBalance { return ($0.name, -1, nil, "cr \(cb)", nil) }
                 let h = overviewHeadline(s)
                 return ($0.name, h.pct, h.elapsed, "\(h.pct)%", h.reset.flatMap(shortReset))
@@ -2241,12 +2251,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Toggle whether a provider appears in the Overview top-bar summary, from
-    /// its dropdown row. Re-renders from the last fetch (visibility only — no
-    /// re-fetch), so the bar and the row's checkmark update at once.
+    /// its dropdown row. The UserDefaults observer re-renders from the last
+    /// fetch and consumes this presentation-only change without re-fetching.
     @objc func toggleOverviewProvider(_ sender: NSMenuItem) {
         guard let id = sender.representedObject as? String else { return }
+        overviewVisibilityChangePending = true
         setOverviewProvider(id, hidden: !overviewHiddenProviders().contains(id))
-        if let ov = lastOverview { renderOverview(ov) }
     }
 
     func setError(_ msg: String) {

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -466,6 +466,16 @@ func testShortReset() {
     assertEqual(shortReset(""), nil, "empty → nil")
 }
 
+func testOverviewProviderToggle() {
+    // The top-bar summary keeps only providers not toggled off, in order.
+    let ids = ["anthropic@struct", "anthropic@gmail", "cursor"]
+    assertEqual(overviewVisibleIds(ids, hidden: []), ids, "nothing hidden → all shown, in order")
+    assertEqual(overviewVisibleIds(ids, hidden: ["anthropic@gmail"]),
+                ["anthropic@struct", "cursor"], "a hidden provider drops out, order preserved")
+    assertEqual(overviewVisibleIds(ids, hidden: Set(ids)), [], "all hidden → empty summary")
+    assertEqual(overviewVisibleIds(ids, hidden: ["gone"]), ids, "a stale hidden id matches nothing")
+}
+
 func testSystemIntegrations() {
     print("launch agent + hot-key status")
     do {
@@ -499,6 +509,7 @@ struct TestRunner {
         testClaudeAccounts()
         testCompactToggle()
         testShortReset()
+        testOverviewProviderToggle()
         testSystemIntegrations()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")


### PR DESCRIPTION
## What

Each row in the **Overview dropdown** is now a checkbox that controls whether that provider shows in the always-visible top-bar summary.

- **Checkmark = shown; unchecked + dimmed (greyed row) = hidden** from the top bar.
- Hidden providers **stay listed** in the dropdown, so you can turn them back on with a click.
- Hiding some providers also shrinks the top-bar count, so it can draw **mini bars again** instead of falling back to compact %-text.
- The choice **persists** (UserDefaults `overviewHiddenProviders`).
- Because the row click now toggles visibility, **jump-to-a-vendor's-detail** moves to the existing *Trocar vendor* submenu and **⌥⌘\\**.

![overview toggles](placeholder — paste screenshot)

## Implementation

- Pure `overviewVisibleIds(ids, hidden)` filter (harness-tested); `overviewBarTitle` drops hidden ids before building the summary.
- `renderOverview` sets each row's `.state` (checkmark), greys the row's attributed title when hidden, and points the row action at `toggleOverviewProvider(_:)`, which flips the id in the persisted set and re-renders from the last fetch (no re-fetch — pure visibility).

## Verification

- `./macos/build.sh` clean; `./macos/run-tests.sh` green (added `testOverviewProviderToggle`: nothing-hidden, one-hidden order-preserved, all-hidden, stale-id).

## Notes

Menu-bar-only, independent feature. Branches off `feat/config-watch` (#47) since both touch the Overview menu code; merge #47 first. (The design — checkmark row-toggle vs. an inline switch widget that preserves click-to-jump — was chosen deliberately for the native, low-risk option.)