### PR TITLE
feat(tui): configurable vendor_box navigation style (sidebar|navbar|none)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -15,6 +15,9 @@
 # Which vendors the Overview lists (the TUI's first tab / the macOS menu-bar's
 # top section), in this order. Omit for every enabled vendor.
 # overview_vendors = ["anthropic", "cursor", "openai"]
+# Presentation of vendor tab navigation: sidebar (vertical box) | navbar (top strip) | none (hidden).
+# Default sidebar (falls back to navbar on narrow terminals).
+# vendor_box = "sidebar"
 
 # Optional, TUI-only monitor for local Claude Code session context. When
 # enabled, press `c` in ai-usagebar-tui. The scanner reads only bounded tails

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -68,6 +68,7 @@ async fn run() -> io::Result<()> {
     let mut app = App::new_with_primary(tabs, config.ui.primary);
     app.context_enabled = config.context.enabled;
     app.overview_vendors = config.ui.overview_vendors.clone();
+    app.vendor_box = config.ui.vendor_box();
 
     // RAII: restoring the terminal must survive an error or a panic in the
     // loop below. Doing it inline left the user in raw mode on the alternate
@@ -163,6 +164,7 @@ fn reload_config(
     *config = reloaded;
     app.context_enabled = config.context.enabled;
     app.overview_vendors = config.ui.overview_vendors.clone();
+    app.vendor_box = config.ui.vendor_box();
     app.set_tabs(tabs_from_config(config));
     if reselect_primary {
         app.select_primary(config.ui.primary);

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,27 @@ pub struct UiConfig {
     /// menu-bar's top section), in this order. `None` → every enabled vendor,
     /// in the canonical order.
     pub overview_vendors: Option<Vec<VendorId>>,
+    /// Layout style for vendor navigation in the TUI: sidebar | navbar | none.
+    pub vendor_box: Option<VendorBoxStyle>,
+}
+
+impl UiConfig {
+    pub fn vendor_box(&self) -> VendorBoxStyle {
+        self.vendor_box.unwrap_or_default()
+    }
+}
+
+/// Presentation style of the TUI vendor navigation box.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VendorBoxStyle {
+    /// Vertical sidebar box on wide terminals; falls back to top navbar on narrow terminals.
+    #[default]
+    Sidebar,
+    /// Horizontal navbar strip above the dashboard detail panel.
+    Navbar,
+    /// Completely hide vendor navigation (dashboards expand to fill full width).
+    None,
 }
 
 /// Where the context view docks in the dashboard body. `v` cycles it while the
@@ -994,6 +1015,27 @@ enabled = false
         assert!(
             Config::load_from(file.path()).is_err(),
             "an unknown layout must be rejected, not silently defaulted"
+        );
+    }
+
+    #[test]
+    fn vendor_box_defaults_to_sidebar_and_parses_each_variant() {
+        assert_eq!(Config::default().ui.vendor_box(), VendorBoxStyle::Sidebar);
+        for (text, want) in [
+            ("sidebar", VendorBoxStyle::Sidebar),
+            ("navbar", VendorBoxStyle::Navbar),
+            ("none", VendorBoxStyle::None),
+        ] {
+            let file = write_toml(&format!("[ui]\nvendor_box = \"{text}\"\n"));
+            assert_eq!(
+                Config::load_from(file.path()).unwrap().ui.vendor_box(),
+                want
+            );
+        }
+        let file = write_toml("[ui]\nvendor_box = \"floating\"\n");
+        assert!(
+            Config::load_from(file.path()).is_err(),
+            "an unknown vendor_box style must be rejected, not silently defaulted"
         );
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -114,6 +114,8 @@ pub struct App {
     pub context_generation: u64,
     /// When `Some`, the local Claude Code context overlay owns keyboard input.
     pub context: Option<crate::tui::context::ContextState>,
+    /// Presentation style for the vendor navigation box (`[ui] vendor_box`).
+    pub vendor_box: crate::config::VendorBoxStyle,
 }
 
 impl App {
@@ -143,6 +145,7 @@ impl App {
             context_enabled: false,
             context_generation: 0,
             context: None,
+            vendor_box: crate::config::VendorBoxStyle::Sidebar,
         }
     }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -167,20 +167,37 @@ fn header_refresh_text(app: &App) -> String {
 }
 
 fn draw_main(f: &mut Frame, app: &App, area: Rect) {
-    if area.width >= WIDE_LAYOUT_MIN_WIDTH {
-        let chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([Constraint::Length(SIDEBAR_WIDTH), Constraint::Min(1)])
-            .split(area);
-        draw_sidebar(f, app, chunks[0]);
-        draw_detail(f, app, chunks[1]);
-    } else {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Length(3), Constraint::Min(1)])
-            .split(area);
-        draw_top_nav(f, app, chunks[0]);
-        draw_detail(f, app, chunks[1]);
+    use crate::config::VendorBoxStyle;
+
+    match app.vendor_box {
+        VendorBoxStyle::Sidebar => {
+            if area.width >= WIDE_LAYOUT_MIN_WIDTH {
+                let chunks = Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Length(SIDEBAR_WIDTH), Constraint::Min(1)])
+                    .split(area);
+                draw_sidebar(f, app, chunks[0]);
+                draw_detail(f, app, chunks[1]);
+            } else {
+                let chunks = Layout::default()
+                    .direction(Direction::Vertical)
+                    .constraints([Constraint::Length(3), Constraint::Min(1)])
+                    .split(area);
+                draw_top_nav(f, app, chunks[0]);
+                draw_detail(f, app, chunks[1]);
+            }
+        }
+        VendorBoxStyle::Navbar => {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(3), Constraint::Min(1)])
+                .split(area);
+            draw_top_nav(f, app, chunks[0]);
+            draw_detail(f, app, chunks[1]);
+        }
+        VendorBoxStyle::None => {
+            draw_detail(f, app, area);
+        }
     }
 }
 
@@ -530,5 +547,80 @@ mod tests {
 
         let enabled = rendered(app_with(vec![TabState::Loading, TabState::Loading]), true);
         assert!(enabled.contains("context"));
+    }
+
+    /// Renders `draw_main` alone (no header/footer) into `width x height` and
+    /// returns it as one string per row, so a test can inspect which titled
+    /// blocks landed on which row — that's what tells a horizontal sidebar
+    /// split (both titles on row 0) apart from a stacked navbar (nav title on
+    /// row 0, detail title only once the 3-row nav strip ends).
+    fn main_rows(app: &App, width: u16, height: u16) -> Vec<String> {
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|frame| draw_main(frame, app, frame.area()))
+            .unwrap();
+        let buffer = terminal.backend().buffer();
+        (0..height)
+            .map(|row| {
+                (0..width)
+                    .map(|col| buffer[(col, row)].symbol())
+                    .collect::<Vec<_>>()
+                    .concat()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn vendor_box_sidebar_splits_horizontally_on_wide_terminals() {
+        let mut app = app_with(vec![TabState::Loading, TabState::Loading]);
+        app.overview = true;
+        let rows = main_rows(&app, 160, 24);
+        // Sidebar and detail panel sit side by side, so their titles share row 0.
+        assert!(rows[0].contains("vendors"), "{:?}", rows[0]);
+        assert!(rows[0].contains("Overview"), "{:?}", rows[0]);
+    }
+
+    #[test]
+    fn vendor_box_sidebar_falls_back_to_top_nav_on_narrow_terminals() {
+        let mut app = app_with(vec![TabState::Loading, TabState::Loading]);
+        app.overview = true;
+        let rows = main_rows(&app, 60, 24);
+        assert!(rows[0].contains("vendors"), "{:?}", rows[0]);
+        // Stacked layout: the detail panel's own title lands below the 3-row
+        // nav strip, not sharing row 0 with it.
+        assert!(!rows[0].contains(" Overview "), "{:?}", rows[0]);
+        assert!(
+            rows.iter().any(|r| r.contains(" Overview ")),
+            "detail title missing entirely: {rows:?}"
+        );
+    }
+
+    #[test]
+    fn vendor_box_navbar_forces_top_nav_even_on_wide_terminals() {
+        let mut app = app_with(vec![TabState::Loading, TabState::Loading]);
+        app.overview = true;
+        app.vendor_box = crate::config::VendorBoxStyle::Navbar;
+        let rows = main_rows(&app, 160, 24);
+        assert!(rows[0].contains("vendors"), "{:?}", rows[0]);
+        assert!(
+            !rows[0].contains(" Overview "),
+            "navbar must stack, not sit beside the detail panel: {:?}",
+            rows[0]
+        );
+    }
+
+    #[test]
+    fn vendor_box_none_hides_navigation_and_uses_full_width() {
+        let mut app = app_with(vec![TabState::Loading, TabState::Loading]);
+        app.overview = true;
+        app.vendor_box = crate::config::VendorBoxStyle::None;
+        let rows = main_rows(&app, 160, 24);
+        assert!(
+            !rows.iter().any(|r| r.contains("vendors")),
+            "vendor nav must be fully hidden: {rows:?}"
+        );
+        assert!(rows[0].contains(" Overview "), "{:?}", rows[0]);
     }
 }


### PR DESCRIPTION
## Summary
- Adds an optional `[ui] vendor_box` config field (`sidebar` | `navbar` | `none`) so the TUI's vendor navigation presentation is user-controllable instead of being purely width-driven.
- `sidebar` (default) keeps the existing behavior byte-for-byte: vertical sidebar on wide terminals (`>= 86` cols), auto-falls back to the existing top navbar on narrow ones.
- `navbar` forces the horizontal top-nav strip (already used internally as the narrow-terminal fallback) even on wide terminals — useful on narrow/vertical monitors where the 28-col sidebar eats too much width.
- `none` hides the vendor navigation entirely, expanding the detail/Overview panel to the full width — for minimal setups that live in the Overview tab and navigate via `Tab`/`Shift+Tab`.

## Motivation
On narrow terminal windows or vertical monitors, the fixed 28-column sidebar box consumes a large share of the width, pushing the Overview/vendor panels into awkward wrapping. The narrow-terminal top-nav fallback already existed but wasn't user-selectable — this makes the choice explicit via config.

## Changes
- `src/config.rs`: `VendorBoxStyle` enum (`#[serde(rename_all = "lowercase")]`), `UiConfig.vendor_box: Option<VendorBoxStyle>` + `vendor_box()` accessor defaulting to `Sidebar`.
- `src/tui/app.rs`: `App.vendor_box` field, initialized to `Sidebar` in `with_theme`.
- `src/bin/ai-usagebar-tui.rs`: wired from config on startup and on the existing live config-reload path (config.toml is polled every 2s already).
- `src/tui/view.rs`: `draw_main` switches on the three styles; `Sidebar` preserves the exact original width-based branch.
- `config.example.toml`: documents the new option under `[ui]`.

## Test plan
- [x] `cargo test` (all existing + new tests green)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] New unit tests: TOML deserialization of `vendor_box` (default/sidebar/navbar/none/invalid), plus `ratatui` `TestBackend` layout tests asserting `draw_main` produces a horizontal split for `sidebar`+wide, a stacked split for `sidebar`+narrow and for `navbar` even when wide, and no vendor box at all for `none`.
- [x] Manually exercised all three styles (and the narrow-terminal `sidebar` fallback) in a real terminal via the TUI's live config reload.