### PR TITLE
Capture Claude Desktop accounts + menu-bar account switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,36 @@ Each release is also published at
   the two copies within hours. A CLI login that belongs to no configured
   account is never silently discarded: the switch refuses unless `--force`.
 
-  Desktop accounts are read from (and written back to) the profile store
-  created by [claude-acc](https://github.com/ohmaseclaro/claude-acc), whose
-  reverse-engineering of the Claude Desktop internals this builds on and whose
-  `switch` command it ports; `[anthropic] desktop_profiles_dir` overrides the
-  location. Capturing (`add`), forgetting (`remove`), and chat filtering
-  (`only`/`reset`) stay with claude-acc. Nothing here affects the Linux build:
+- **`ai-usagebar account add <label> --desktop` captures a Claude Desktop
+  account**, so a machine can build its account list from nothing. The CLI half
+  of `add` is easy — `CLAUDE_CONFIG_DIR` gives `claude` as many isolated logins
+  as you want — but the Desktop app has a single login slot and no way to ask
+  for a second, so the only way to obtain another account's credential is to
+  sign the app out, wait for you to sign in as that account, and keep what it
+  writes. That is what this does: it saves the current account into its own
+  profile, copies the live login aside, clears it, reopens the app at its login
+  screen, polls until the sign-in completes, then captures the credential,
+  browser state and organisation, and seeds the new account with the history
+  this machine already has so its first login is not an empty sidebar. Cancel
+  it — or let the five-minute window lapse — and your previous login is put
+  back exactly as it was.
+
+- **Claude Desktop ▸ and Claude Code ▸ submenus in the macOS menu bar.** Each
+  lists the accounts that surface knows, checkmarks the active one, and
+  switches on click; **Adicionar conta…** captures a new one (in Terminal,
+  since it is interactive). A dim line under the header shows both active
+  accounts at a glance. The Desktop switch confirms first, because it quits and
+  reopens Claude.app. The submenus refresh on launch, on a `config.toml` change,
+  and when the menu opens (debounced), so a switch made in a terminal shows up
+  without restarting anything.
+
+  Desktop accounts are stored in [claude-acc](https://github.com/ohmaseclaro/claude-acc)'s
+  profile format, so existing claude-acc users' profiles work here untouched and
+  either tool can capture or switch them; `[anthropic] desktop_profiles_dir`
+  overrides the location. That project's reverse-engineering of the Claude
+  Desktop internals is what this builds on, and the Desktop halves of `add` and
+  `switch` are ports of its commands. Removing an account and chat filtering
+  (`only`/`reset`) are not implemented here. Nothing affects the Linux build:
   the modules compile and are tested everywhere, and simply find no Claude
   Desktop installation.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **`ai-usagebar account status` and `account switch <label>` — see and change
+  which Claude account you are actually signed in as (macOS).** There are two
+  separate identities on a Mac and they drift apart constantly: the **Claude
+  Desktop app** (signed in through its own `config.json`) and the **`claude`
+  CLI** (one default login in the login Keychain). `account status` reports both
+  — with each account's e-mail, session count, and whether its credential and
+  browser state have been captured — and `--json` makes that available to
+  scripts and the menu bar. `account switch` moves either one: `--desktop`,
+  `--cli`, or neither for both, with `--dry-run` to see exactly what would
+  happen first.
+
+  Switching the **Desktop app** merges your local history into the target
+  account first — session indexes newest-wins, routines/schedules unioned by
+  task id — so the account you land on shows the union of everything rather
+  than only its own chats; then it quits the app, swaps the credential and the
+  cookie/LevelDB state, and reopens it. Before any of that it writes a rollback
+  archive of everything a switch can destroy (`--keep-backups`, default 10;
+  `--backup-sessions` for a full session-tree archive), and it writes
+  `config.json` atomically so a crash mid-switch cannot strand every account's
+  tokens. The volatile `bridge-state.json` is cleared each time, since a stale
+  cloud-session id makes `/remote-control` fail to disconnect; `--keep-bridge`
+  turns that off for diagnosing browser-connection issues.
+
+  Switching the **CLI** copies the account's stored credential into the one
+  default slot plain `claude` reads. The outgoing account's credential is saved
+  back into its own slot first, and while a label is the live CLI login
+  ai-usagebar reads that label from the default slot — so one rotating refresh
+  token is never live in two places, which is what would otherwise 401 one of
+  the two copies within hours. A CLI login that belongs to no configured
+  account is never silently discarded: the switch refuses unless `--force`.
+
+  Desktop accounts are read from (and written back to) the profile store
+  created by [claude-acc](https://github.com/ohmaseclaro/claude-acc), whose
+  reverse-engineering of the Claude Desktop internals this builds on and whose
+  `switch` command it ports; `[anthropic] desktop_profiles_dir` overrides the
+  location. Capturing (`add`), forgetting (`remove`), and chat filtering
+  (`only`/`reset`) stay with claude-acc. Nothing here affects the Linux build:
+  the modules compile and are tested everywhere, and simply find no Claude
+  Desktop installation.
+
 ## [0.19.0] — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -491,6 +491,67 @@ that manages multiple Claude Code logins (not just one specific account
 switcher) works with it; a rotating account manager just needs to drop or
 refresh each login under this directory.
 
+#### Switching the active Claude account (macOS)
+
+Reading usage for several accounts is one thing; being signed in as one of them
+is another. There are **two separate identities**, and they drift apart:
+
+- the **Claude Desktop app**, signed in through its own `config.json`;
+- the **`claude` CLI**, whose one default login lives in the login Keychain.
+
+`account status` reports both, and `account switch` moves either one:
+
+```bash
+ai-usagebar account status                     # who is each surface signed in as?
+ai-usagebar account status --json              # same, for scripts and the menu bar
+ai-usagebar account switch work --dry-run      # what would change, changing nothing
+ai-usagebar account switch work --desktop      # Desktop app only (quits + reopens it)
+ai-usagebar account switch work --cli          # the `claude` CLI's default login only
+```
+
+Passing neither `--desktop` nor `--cli` does both; a label that only exists on
+one side is skipped with a note rather than failing.
+
+**Switching the Desktop app** merges your local history into the target account
+first (session indexes newest-wins, routines/schedules unioned by id) so the
+account you land on shows the union of everything, then quits the app, swaps its
+credential and browser state, and reopens it. A rollback archive of everything
+the switch can destroy is written to `~/.claude-acc/backups/` beforehand
+(`--keep-backups N`, default 10; `--backup-sessions` also archives the whole
+session tree). The volatile `bridge-state.json` is cleared on every switch —
+a stale cloud-session id makes `/remote-control` fail to disconnect —
+which `--keep-bridge` turns off if you want to test that.
+
+**Switching the CLI** copies the account's stored credential into the single
+default slot that plain `claude` reads. The outgoing account's credential is
+saved back into its own slot *first*, and while a label is the live CLI login
+ai-usagebar reads it from that default slot — so the same rotating refresh
+token is never live in two places, which is what would otherwise 401 one of
+them within hours. If the CLI is signed into an account ai-usagebar doesn't
+manage, the switch refuses rather than discarding a login it cannot save
+(`--force` overrides, and genuinely discards it).
+
+**Prerequisites.** Desktop accounts come from
+[**claude-acc**](https://github.com/ohmaseclaro/claude-acc)'s profile store
+(`~/.claude-acc/profiles`, or `[anthropic] desktop_profiles_dir`) — capture one
+with `claude-acc add <label>`. CLI accounts come from `[[anthropic.accounts]]` /
+`accounts_dir` — add one with `ai-usagebar account add <label>`. The two are
+independent: a Claude Code login cannot seed a Desktop login or vice versa, as
+they are different OAuth clients.
+
+**What this does not do.** Capture (`add`), forget (`remove`), and chat
+filtering (`only` / `reset`) stay with claude-acc. Cowork (agent-mode) sessions
+are not migrated by a switch and stay with the account that created them —
+their transcript lives at a path that embeds the owning account's UUID, so a
+copy renders empty. Switch back to that account to read one.
+
+**Credits.** The Claude Desktop internals used here — the data-directory
+layout, the `oauth:tokenCache` / `lastKnownAccountUuid` fields, which cookie
+and LevelDB stores carry the app's identity, the newest-wins history rule, and
+the `bridge-state.json` behaviour — were reverse-engineered by
+[claude-acc](https://github.com/ohmaseclaro/claude-acc) (MIT), and the switch is
+a port of its `switch` command reading and writing the same profile store.
+
 ## Hyprland: float the TUI window
 
 By default Hyprland tiles the TUI. To make `ai-usagebar-tui` open as a centered floating window, the same way Omarchy floats its own settings TUIs (Wi-Fi/`impala`, audio/`wiremix`, Bluetooth/`bluetui`), add this to `~/.config/hypr/hyprland.conf` or any sourced `.conf`, such as `looknfeel.conf`:

--- a/README.md
+++ b/README.md
@@ -499,9 +499,12 @@ is another. There are **two separate identities**, and they drift apart:
 - the **Claude Desktop app**, signed in through its own `config.json`;
 - the **`claude` CLI**, whose one default login lives in the login Keychain.
 
-`account status` reports both, and `account switch` moves either one:
+`account add` captures each, `account status` reports both, and `account switch`
+moves either one:
 
 ```bash
+ai-usagebar account add work                   # a `claude` CLI account (runs `claude` to sign in)
+ai-usagebar account add work --desktop         # a Claude Desktop account (see below)
 ai-usagebar account status                     # who is each surface signed in as?
 ai-usagebar account status --json              # same, for scripts and the menu bar
 ai-usagebar account switch work --dry-run      # what would change, changing nothing
@@ -510,7 +513,23 @@ ai-usagebar account switch work --cli          # the `claude` CLI's default logi
 ```
 
 Passing neither `--desktop` nor `--cli` does both; a label that only exists on
-one side is skipped with a note rather than failing.
+one side is skipped with a note rather than failing. Use the same label on both
+sides and one name refers to the whole account.
+
+**Capturing a Desktop account** works differently from a CLI one, and the
+reason is worth knowing. `CLAUDE_CONFIG_DIR=<dir> claude` gives the CLI as many
+isolated logins as you like, so `account add <label>` just signs one in without
+disturbing anything. The Desktop app has a *single* login slot and no way to
+ask for a second, so `account add <label> --desktop` has to sign it out, wait
+for you to sign in as the account being saved, and keep what the app then
+writes. Before it clears anything it copies the live login aside and saves the
+current account into its own profile — cancel, or walk away past the five-minute
+window, and you are put back exactly where you were. The new account is seeded
+with the history this machine already has, so its first login is not an empty
+sidebar.
+
+A Claude Code login cannot seed a Desktop one or vice versa — they are
+different OAuth clients — so each surface is captured once, on its own.
 
 **Switching the Desktop app** merges your local history into the target account
 first (session indexes newest-wins, routines/schedules unioned by id) so the
@@ -531,26 +550,27 @@ them within hours. If the CLI is signed into an account ai-usagebar doesn't
 manage, the switch refuses rather than discarding a login it cannot save
 (`--force` overrides, and genuinely discards it).
 
-**Prerequisites.** Desktop accounts come from
-[**claude-acc**](https://github.com/ohmaseclaro/claude-acc)'s profile store
-(`~/.claude-acc/profiles`, or `[anthropic] desktop_profiles_dir`) — capture one
-with `claude-acc add <label>`. CLI accounts come from `[[anthropic.accounts]]` /
-`accounts_dir` — add one with `ai-usagebar account add <label>`. The two are
-independent: a Claude Code login cannot seed a Desktop login or vice versa, as
-they are different OAuth clients.
+**Where accounts are stored.** CLI accounts are ordinary
+`[[anthropic.accounts]]` / `accounts_dir` entries. Desktop accounts live in
+`~/.claude-acc/profiles` (override with `[anthropic] desktop_profiles_dir`) in
+claude-acc's format, so if you already use that tool your existing profiles work
+here untouched, and either tool can capture or switch them.
 
-**What this does not do.** Capture (`add`), forget (`remove`), and chat
-filtering (`only` / `reset`) stay with claude-acc. Cowork (agent-mode) sessions
-are not migrated by a switch and stay with the account that created them —
-their transcript lives at a path that embeds the owning account's UUID, so a
-copy renders empty. Switch back to that account to read one.
+**What this does not do.** Forgetting an account (`remove`) and chat filtering
+(`only` / `reset`) are not implemented — delete a profile directory by hand, or
+use claude-acc. Cowork (agent-mode) sessions are not migrated by a switch and
+stay with the account that created them: their transcript lives at a path that
+embeds the owning account's UUID, so a copy renders empty. Switch back to that
+account to read one.
 
 **Credits.** The Claude Desktop internals used here — the data-directory
 layout, the `oauth:tokenCache` / `lastKnownAccountUuid` fields, which cookie
-and LevelDB stores carry the app's identity, the newest-wins history rule, and
-the `bridge-state.json` behaviour — were reverse-engineered by
-[claude-acc](https://github.com/ohmaseclaro/claude-acc) (MIT), and the switch is
-a port of its `switch` command reading and writing the same profile store.
+and LevelDB stores carry the app's identity, the newest-wins history rule, the
+sign-out-and-poll capture sequence, and the `bridge-state.json` behaviour —
+were reverse-engineered by
+[claude-acc](https://github.com/ohmaseclaro/claude-acc) (MIT). The Desktop half
+of `add` and `switch` are ports of its `add` and `switch` commands, sharing the
+same profile store.
 
 ## Hyprland: float the TUI window
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -51,6 +51,10 @@ enabled = true
 # above — otherwise you get an extra tab for the ambient ~/.claude / Keychain
 # login. Default true; ignored when there are no named accounts.
 # show_default_account = false
+# Where the Claude *Desktop app*'s saved accounts live, for `account switch`.
+# Defaults to the store claude-acc creates (https://github.com/ohmaseclaro/claude-acc);
+# unrelated to accounts_dir above, which is the `claude` CLI's own accounts.
+# desktop_profiles_dir = "~/.claude-acc/profiles"
 # Or list accounts explicitly:
 # [[anthropic.accounts]]
 # label = "work"

--- a/macos/README.md
+++ b/macos/README.md
@@ -142,6 +142,23 @@ default (unnamed) Claude entry when every account is managed explicitly.
 Every immediate `accounts_dir` subdirectory counts as an account; this includes
 macOS logins whose credentials exist only in a config-dir-scoped Keychain item.
 
+### Switching which account you are signed in as
+
+Those entries decide whose usage is *shown*. Which account you are actually
+signed in as is a separate thing — and there are two of them, the Claude
+Desktop app and the `claude` CLI, which drift apart. The binary reports and
+changes both:
+
+```bash
+ai-usagebar account status                  # who each surface is signed in as
+ai-usagebar account switch work --dry-run   # what a switch would do
+ai-usagebar account switch work --desktop   # quits and reopens Claude.app
+```
+
+See the main README's *Switching the active Claude account* for the full story,
+including the rollback archive and the prerequisite that Desktop accounts are
+captured by [claude-acc](https://github.com/ohmaseclaro/claude-acc).
+
 ## Live config reload
 
 The app watches `config.toml` and reloads on any change — enable a vendor, add

--- a/macos/README.md
+++ b/macos/README.md
@@ -146,18 +146,30 @@ macOS logins whose credentials exist only in a config-dir-scoped Keychain item.
 
 Those entries decide whose usage is *shown*. Which account you are actually
 signed in as is a separate thing — and there are two of them, the Claude
-Desktop app and the `claude` CLI, which drift apart. The binary reports and
-changes both:
+Desktop app and the `claude` CLI, which drift apart.
+
+The dropdown gets a **Claude Desktop ▸** and a **Claude Code ▸** submenu, each
+listing the accounts it knows with a checkmark on the active one. Pick another
+to switch to it; pick **Adicionar conta…** to capture a new one (that part is
+interactive, so it opens in Terminal). A dim line under the header shows both
+active accounts at a glance — `Desktop: work · Code: personal`.
+
+Switching the Desktop app **quits and reopens Claude.app**, so the menu confirms
+first; your local history is merged into the target account and a rollback
+archive is written before anything changes. The Claude Code switch has no
+visible side effect and happens straight away. Both submenus grey out while a
+switch is running.
+
+The same thing from the shell:
 
 ```bash
 ai-usagebar account status                  # who each surface is signed in as
+ai-usagebar account add work --desktop      # capture a Claude Desktop account
 ai-usagebar account switch work --dry-run   # what a switch would do
 ai-usagebar account switch work --desktop   # quits and reopens Claude.app
 ```
 
-See the main README's *Switching the active Claude account* for the full story,
-including the rollback archive and the prerequisite that Desktop accounts are
-captured by [claude-acc](https://github.com/ohmaseclaro/claude-acc).
+See the main README's *Switching the active Claude account* for the full story.
 
 ## Live config reload
 

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -48,6 +48,9 @@ var INTERVAL: Double { let v = DEF.double(forKey: "interval"); return v > 0 ? v 
 /// bound a hung run holds a worker indefinitely and the panel simply stops
 /// updating with no explanation. Matches the GNOME extension's own timeout.
 let REFRESH_TIMEOUT: Double = 45
+/// A Desktop account switch merges history, writes an archive, and quits and
+/// reopens Claude.app — minutes of work on a large history, not seconds.
+let ACCOUNT_SWITCH_TIMEOUT: Double = 300
 var BAR_WIDTH: Int { max(4, min(20, DEF.integer(forKey: "barWidth"))) }
 let MENU_BAR_W = 14
 var SHOW_SESSION: Bool { DEF.bool(forKey: "showSession") }
@@ -883,6 +886,75 @@ func entryDisplayName(_ id: String) -> String {
     return VENDOR_AUTH.first { $0.id == id }?.name ?? id
 }
 
+// MARK: - Which account each surface is signed in as
+//
+// Separate from the vendor entries above: those decide whose usage is *shown*,
+// these are who the Claude Desktop app and the `claude` CLI are actually signed
+// in as. Both come from `ai-usagebar account status --json`; the binary owns
+// every path and credential detail, so this side only parses and displays.
+
+struct AccountStatus: Equatable {
+    /// False when there is no Claude Desktop app on this machine. Distinct from
+    /// "no accounts saved yet": with the app present but nothing captured, the
+    /// submenu still has to appear so the user can add the first one.
+    var desktopAvailable = false
+    var desktopActive: String?
+    var cliActive: String?
+    var desktopLabels: [String] = []
+    var cliLabels: [String] = []
+}
+
+/// Parse `account status --json`. Every field is optional on purpose: a Mac
+/// with no Claude Desktop app reports `"desktop": null`, and an older binary
+/// may not know the subcommand at all — both must degrade to "no submenus"
+/// rather than crash.
+func parseAccountStatus(_ data: Data) -> AccountStatus? {
+    guard let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    func labels(_ side: Any?, _ key: String) -> [String] {
+        guard let side = side as? [String: Any], let rows = side[key] as? [[String: Any]] else {
+            return []
+        }
+        return rows.compactMap { $0["label"] as? String }
+    }
+    func active(_ side: Any?) -> String? {
+        (side as? [String: Any])?["active_label"] as? String
+    }
+    let desktop = root["desktop"], cli = root["cli"]
+    return AccountStatus(desktopAvailable: desktop is [String: Any],
+                         desktopActive: active(desktop),
+                         cliActive: active(cli),
+                         desktopLabels: labels(desktop, "profiles"),
+                         cliLabels: labels(cli, "accounts"))
+}
+
+/// The one dim line under the header. Empty when neither surface resolved, so
+/// the caller can hide the row entirely rather than show a bare label.
+func accountsSummaryLine(_ s: AccountStatus) -> String {
+    var parts: [String] = []
+    if !s.desktopLabels.isEmpty { parts.append("Desktop: \(s.desktopActive ?? "?")") }
+    if !s.cliLabels.isEmpty { parts.append("Code: \(s.cliActive ?? "?")") }
+    return parts.joined(separator: "   ·   ")
+}
+
+/// `-y` because the menu has already asked; without it the binary would prompt
+/// on a stdin that is not a terminal and abort.
+func switchArgs(label: String, desktop: Bool) -> [String] {
+    ["account", "switch", label, desktop ? "--desktop" : "--cli", "-y"]
+}
+
+/// Adding an account is interactive — a Desktop capture waits for you to sign
+/// in, and a CLI one runs `claude` — so it goes to Terminal rather than being
+/// swallowed by a background subprocess. Single-quoted with `'` doubled out,
+/// so a label with a quote in it can't break out of the command.
+func addAccountScript(binary: String, label: String, desktop: Bool) -> String {
+    func quote(_ s: String) -> String { "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'" }
+    return "#!/usr/bin/env bash\n"
+        + "\(quote(binary)) account add \(quote(label))\(desktop ? " --desktop" : "")\n"
+        + "echo; read -n 1 -s -r -p 'Pressione qualquer tecla para fechar…'\n"
+}
+
 /// Rust defaults (`src/config.rs`): the OAuth/api-key vendors that ship enabled,
 /// versus the opt-in balance vendors that default to disabled. An omitted
 /// `[vendor].enabled` must reproduce these, not silently enable everything.
@@ -1340,7 +1412,7 @@ func hotKeyRegistrationSucceeded(_ status: OSStatus) -> Bool {
     status == noErr
 }
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var statusItem: NSStatusItem!
     var swapHotKeyRef: EventHotKeyRef?
     var compactHotKeyRef: EventHotKeyRef?
@@ -1395,6 +1467,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// Overview-only: forces the status-bar title into the compact %-text mode
     /// ("Compactar"); while compact it reads "Expandir" and turns it back off.
     let compactItem = NSMenuItem(title: "Compactar", action: nil, keyEquivalent: "")
+    /// Which account each surface is signed in as. One dim line under the
+    /// header, plus a submenu per surface. All three stay hidden until
+    /// `account status --json` answers, so an older binary that doesn't know
+    /// the subcommand simply shows the menu it always did.
+    let accountsInfoItem = NSMenuItem()
+    let desktopAccountSubmenu = NSMenu()
+    let desktopAccountItem = NSMenuItem(title: "Claude Desktop", action: nil, keyEquivalent: "")
+    let cliAccountSubmenu = NSMenu()
+    let cliAccountItem = NSMenuItem(title: "Claude Code", action: nil, keyEquivalent: "")
+    var lastAccountStatus: AccountStatus?
+    var accountStatusFetchedAt = Date.distantPast
+    /// A switch runs a subprocess that quits and reopens another app; both
+    /// submenus grey out until it returns so it cannot be fired twice.
+    var accountSwitchInFlight = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         DEF.register(defaults: ["swapShortcutEnabled": true, "compactShortcutEnabled": true])
@@ -1418,6 +1504,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         installSwapHotKey()
         installCompactHotKey()
         installConfigWatch()
+        fetchAccountStatus()
     }
 
     /// Watch config.toml and hot-reload the vendor list when it changes on disk.
@@ -1480,6 +1567,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// from disk (nothing caches config.toml), so no invalidation is needed.
     @objc func configFileChanged() {
         rebuildVendorSubmenu()
+        // A new [[anthropic.accounts]] entry changes the Claude Code list.
+        fetchAccountStatus()
         if VENDOR == "overview" {
             if let ov = lastOverview { renderOverview(ov) }
         } else if let s = lastSnapshot {
@@ -1670,6 +1759,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.autoenablesItems = false
 
         menu.addItem(headerItem)
+        // Reads as a sub-line of the header, so it sits above the usage rows.
+        accountsInfoItem.isEnabled = false
+        accountsInfoItem.isHidden = true
+        menu.addItem(accountsInfoItem)
         // One hidden slot per built-in vendor for Overview mode. Named accounts
         // can take the total higher; renderOverview grows the pool on demand.
         for _ in 0..<VENDOR_AUTH.count {
@@ -1694,11 +1787,24 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         addAction(menu, "Abrir TUI", #selector(openTui), "t")
         vendorSubmenuItem.submenu = vendorSubmenu
         menu.addItem(vendorSubmenuItem)
+        for (item, submenu) in [(desktopAccountItem, desktopAccountSubmenu),
+                                (cliAccountItem, cliAccountSubmenu)] {
+            item.submenu = submenu
+            item.isHidden = true
+            menu.addItem(item)
+        }
         addAction(menu, "Preferências…", #selector(openPrefs), ",")
         menu.addItem(.separator())
         addAction(menu, "Sair", #selector(quit), "q")
 
+        // Catches a switch made elsewhere (a terminal, claude-acc) without
+        // polling for state that changes at most a few times a day.
+        menu.delegate = self
         statusItem.menu = menu
+    }
+
+    func menuWillOpen(_ menu: NSMenu) {
+        if Date().timeIntervalSince(accountStatusFetchedAt) >= 5 { fetchAccountStatus() }
     }
 
     func addAction(_ menu: NSMenu, _ title: String, _ sel: Selector, _ key: String) {
@@ -2250,6 +2356,165 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         DEF.set(id, forKey: "vendor")
     }
 
+    /// Ask the binary who each surface is signed in as. Same off-main shape as
+    /// `refresh()`; failures leave `lastAccountStatus` alone so a transient
+    /// hiccup doesn't blank a working menu.
+    func fetchAccountStatus() {
+        guard let bin = resolveBinary("ai-usagebar") else { return }
+        accountStatusFetchedAt = Date()
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: bin)
+            p.arguments = ["account", "status", "--json"]
+            let pipe = Pipe()
+            p.standardOutput = pipe
+            p.standardError = FileHandle.nullDevice
+
+            let watchdog = DispatchWorkItem { if p.isRunning { p.terminate() } }
+            DispatchQueue.global(qos: .utility)
+                .asyncAfter(deadline: .now() + REFRESH_TIMEOUT, execute: watchdog)
+            var data = Data()
+            do {
+                try p.run()
+                data = pipe.fileHandleForReading.readDataToEndOfFile()  // read before wait
+                p.waitUntilExit()
+            } catch {
+                watchdog.cancel()
+                return
+            }
+            watchdog.cancel()
+            guard let status = parseAccountStatus(data) else { return }
+            DispatchQueue.main.async { self?.applyAccountStatus(status) }
+        }
+    }
+
+    func applyAccountStatus(_ status: AccountStatus) {
+        lastAccountStatus = status
+        renderAccountMenus()
+    }
+
+    func renderAccountMenus() {
+        // Nil means the binary predates the subcommand: leave the menu exactly
+        // as it was before this feature existed.
+        guard let status = lastAccountStatus else {
+            accountsInfoItem.isHidden = true
+            desktopAccountItem.isHidden = true
+            cliAccountItem.isHidden = true
+            return
+        }
+        let line = accountsSummaryLine(status)
+        accountsInfoItem.isHidden = line.isEmpty
+        accountsInfoItem.attributedTitle = run(line, .secondaryLabelColor)
+
+        fill(desktopAccountSubmenu, status.desktopLabels, status.desktopActive,
+             #selector(switchDesktopAccount(_:)))
+        fill(cliAccountSubmenu, status.cliLabels, status.cliActive,
+             #selector(switchCliAccount(_:)))
+        // Both stay visible with an empty list — that is when "Adicionar
+        // conta…" matters most. Only a machine with no Claude Desktop app at
+        // all loses its submenu.
+        desktopAccountItem.isHidden = !status.desktopAvailable
+        cliAccountItem.isHidden = false
+        desktopAccountItem.isEnabled = !accountSwitchInFlight
+        cliAccountItem.isEnabled = !accountSwitchInFlight
+    }
+
+    private func fill(_ submenu: NSMenu, _ labels: [String], _ active: String?, _ action: Selector) {
+        submenu.removeAllItems()
+        for label in labels {
+            let it = NSMenuItem(title: label, action: action, keyEquivalent: "")
+            it.target = self
+            it.representedObject = label
+            it.state = (label == active) ? .on : .off
+            it.isEnabled = !accountSwitchInFlight && label != active
+            submenu.addItem(it)
+        }
+        submenu.addItem(.separator())
+        let add = NSMenuItem(title: "Adicionar conta…",
+                             action: #selector(addAccount(_:)), keyEquivalent: "")
+        add.target = self
+        add.representedObject = (submenu === desktopAccountSubmenu)
+        add.isEnabled = !accountSwitchInFlight
+        submenu.addItem(add)
+    }
+
+    /// Ask for a label, then hand the interactive part to Terminal: a Desktop
+    /// capture waits for a browser sign-in, a CLI one runs `claude`. Neither
+    /// belongs in a background subprocess the user cannot see or answer.
+    @objc func addAccount(_ sender: NSMenuItem) {
+        guard let desktop = sender.representedObject as? Bool,
+              let bin = resolveBinary("ai-usagebar") else { return }
+        let alert = NSAlert()
+        alert.messageText = desktop ? "Adicionar conta do Claude Desktop"
+                                    : "Adicionar conta do Claude Code"
+        alert.informativeText = desktop
+            ? "Escolha um nome. O app será fechado e reaberto na tela de login para você "
+                + "entrar com a conta nova; a atual é restaurada se você cancelar."
+            : "Escolha um nome. O `claude` abrirá no Terminal para você entrar; seu login "
+                + "padrão não é alterado."
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: 220, height: 24))
+        field.placeholderString = "trabalho"
+        alert.accessoryView = field
+        alert.addButton(withTitle: "Continuar")
+        alert.addButton(withTitle: "Cancelar")
+        NSApp.activate(ignoringOtherApps: true)
+        alert.window.initialFirstResponder = field
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let label = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !label.isEmpty else { return }
+        runInTerminal(addAccountScript(binary: bin, label: label, desktop: desktop))
+    }
+
+    /// Quits and reopens Claude.app, so confirm first — an unsent message or an
+    /// in-flight Cowork run would go with it. The CLI switch has no visible
+    /// side effect and needs no prompt.
+    @objc func switchDesktopAccount(_ sender: NSMenuItem) {
+        guard let label = sender.representedObject as? String else { return }
+        let alert = NSAlert()
+        alert.messageText = "Trocar a conta do Claude Desktop para «\(label)»?"
+        alert.informativeText = "O app será fechado e reaberto. Seu histórico local é "
+            + "mesclado nessa conta antes da troca, e uma cópia de segurança é gravada."
+        alert.addButton(withTitle: "Trocar e reiniciar")
+        alert.addButton(withTitle: "Cancelar")
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        runAccountSwitch(label: label, desktop: true)
+    }
+
+    @objc func switchCliAccount(_ sender: NSMenuItem) {
+        guard let label = sender.representedObject as? String else { return }
+        runAccountSwitch(label: label, desktop: false)
+    }
+
+    private func runAccountSwitch(label: String, desktop: Bool) {
+        guard let bin = resolveBinary("ai-usagebar"), !accountSwitchInFlight else { return }
+        accountSwitchInFlight = true
+        renderAccountMenus()
+        let args = switchArgs(label: label, desktop: desktop)
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            let p = Process()
+            p.executableURL = URL(fileURLWithPath: bin)
+            p.arguments = args
+            p.standardOutput = FileHandle.nullDevice
+            p.standardError = FileHandle.nullDevice
+            // A Desktop switch merges history, archives, quits and relaunches an
+            // app — far longer than a usage fetch, so it gets its own bound.
+            let watchdog = DispatchWorkItem { if p.isRunning { p.terminate() } }
+            DispatchQueue.global(qos: .utility)
+                .asyncAfter(deadline: .now() + ACCOUNT_SWITCH_TIMEOUT, execute: watchdog)
+            try? p.run()
+            p.waitUntilExit()
+            watchdog.cancel()
+            DispatchQueue.main.async {
+                guard let me = self else { return }
+                me.accountSwitchInFlight = false
+                me.fetchAccountStatus()
+                // The usage numbers belong to whoever is signed in now.
+                me.refresh()
+            }
+        }
+    }
+
     /// Toggle whether a provider appears in the Overview top-bar summary, from
     /// its dropdown row. The UserDefaults observer re-renders from the last
     /// fetch and consumes this presentation-only change without re-fetching.
@@ -2267,6 +2532,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         for (_, it) in rows { it.isHidden = true }
         for it in overviewRows { it.isHidden = true }
         compactItem.isHidden = true
+        accountsInfoItem.isHidden = true
     }
 }
 

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -497,6 +497,73 @@ func testSystemIntegrations() {
                 "nonzero OSStatus is registration failure")
 }
 
+/// `account status --json` parsing and the two strings built from it. Every
+/// field is optional in the schema, so the interesting cases are the missing
+/// ones: a Mac with no Claude Desktop app, and an older binary that doesn't
+/// know the subcommand at all.
+func testAccountStatus() {
+    let full = """
+    {"desktop":{"available":true,"data_dir":"/d","profiles_dir":"/p",
+      "active_label":"toptal","active_account_uuid":"u1",
+      "profiles":[{"label":"gmail","active":false},{"label":"toptal","active":true}]},
+     "cli":{"active_label":"struct","active_account_uuid":"u2",
+      "accounts":[{"label":"struct","active":true},{"label":"toptal","active":false}]}}
+    """
+    let s = parseAccountStatus(Data(full.utf8))
+    assertEqual(s?.desktopActive, "toptal", "desktop active label")
+    assertEqual(s?.cliActive, "struct", "cli active label")
+    assertEqual(s?.desktopLabels ?? [], ["gmail", "toptal"], "desktop labels keep file order")
+    assertEqual(s?.cliLabels ?? [], ["struct", "toptal"], "cli labels keep file order")
+    assertEqual(accountsSummaryLine(s!), "Desktop: toptal   ·   Code: struct", "summary line")
+
+    // No Claude Desktop app: the whole half is null, the CLI half still shows.
+    let linux = parseAccountStatus(Data("""
+        {"desktop":null,"cli":{"active_label":"work","accounts":[{"label":"work"}]}}
+        """.utf8))
+    assertNil(linux?.desktopActive, "null desktop has no active label")
+    assertEqual(linux?.desktopLabels ?? ["x"], [], "null desktop has no labels")
+    assertEqual(accountsSummaryLine(linux!), "Code: work", "summary drops the absent half")
+
+    // An account list with nobody active still renders, marked unknown.
+    let orphan = parseAccountStatus(Data(#"{"cli":{"accounts":[{"label":"work"}]}}"#.utf8))
+    assertEqual(accountsSummaryLine(orphan!), "Code: ?", "unknown active is shown, not hidden")
+    assertEqual(orphan?.cliLabels ?? [], ["work"], "an unmatched active still lists its accounts")
+
+    // A Mac with the app installed but nothing captured yet: no summary line,
+    // but `desktopAvailable` keeps the submenu (and "Adicionar conta…") alive.
+    let fresh = parseAccountStatus(Data(#"{"desktop":{"available":true,"profiles":[]}}"#.utf8))
+    assertEqual(fresh?.desktopAvailable, true, "an empty profile list is still available")
+    assertEqual(accountsSummaryLine(fresh!), "", "nothing captured renders no line")
+    assertEqual(linux?.desktopAvailable, false, "null desktop is unavailable")
+
+    // Nothing at all: no summary line, and no Desktop submenu.
+    let bare = parseAccountStatus(Data("{}".utf8))
+    assertEqual(bare?.desktopAvailable, false, "absent desktop key is unavailable")
+    assertEqual(accountsSummaryLine(bare!), "", "empty status renders no line")
+
+    // An older binary rejects the subcommand and prints usage on stderr, so
+    // stdout is empty or not JSON — must be nil, never a crash.
+    assertNil(parseAccountStatus(Data()), "empty output")
+    assertNil(parseAccountStatus(Data("error: unrecognized subcommand".utf8)), "non-JSON output")
+    assertNil(parseAccountStatus(Data("[1,2,3]".utf8)), "JSON that is not an object")
+
+    assertEqual(switchArgs(label: "work", desktop: true),
+                ["account", "switch", "work", "--desktop", "-y"], "desktop switch args")
+    assertEqual(switchArgs(label: "work", desktop: false),
+                ["account", "switch", "work", "--cli", "-y"], "cli switch args")
+
+    // The add script is shell text, so a label from a free-text field must not
+    // be able to end the quoted argument and run something else.
+    let script = addAccountScript(binary: "/usr/local/bin/ai-usagebar", label: "work", desktop: true)
+    assertEqual(script.contains("'/usr/local/bin/ai-usagebar' account add 'work' --desktop"), true,
+                "desktop add command")
+    assertEqual(addAccountScript(binary: "/b", label: "w", desktop: false)
+                    .contains("'/b' account add 'w'\n"), true, "cli add command has no --desktop")
+    let nasty = addAccountScript(binary: "/b", label: "a'; rm -rf ~; echo '", desktop: false)
+    assertEqual(nasty.contains("rm -rf ~;\n"), false, "injected command stays inside the quotes")
+    assertEqual(nasty.contains(#"'a'\''; rm -rf ~; echo '\'''"#), true, "label is escaped")
+}
+
 @main
 struct TestRunner {
     static func main() {
@@ -510,6 +577,7 @@ struct TestRunner {
         testCompactToggle()
         testShortReset()
         testOverviewProviderToggle()
+        testAccountStatus()
         testSystemIntegrations()
         if failures > 0 {
             print("\n\(failures) test(s) FAILED")

--- a/src/account.rs
+++ b/src/account.rs
@@ -31,7 +31,19 @@ impl Registered {
 #[must_use]
 pub fn run(action: &AccountAction) -> i32 {
     match action {
-        AccountAction::Add { label, no_login } => add(label, !no_login),
+        AccountAction::Add {
+            label,
+            no_login,
+            desktop,
+            email,
+            yes,
+        } => {
+            if *desktop {
+                add_desktop(label, email.as_deref(), *yes)
+            } else {
+                add(label, !no_login)
+            }
+        }
         AccountAction::Status { json } => status(*json),
         AccountAction::Switch {
             label,
@@ -236,6 +248,99 @@ fn active_tag(value: &serde_json::Value) -> &'static str {
     }
 }
 
+/// Capture a Claude Desktop account. Unlike the CLI half, this cannot happen
+/// quietly in the background: the app has one login slot, so the only way to
+/// obtain a second account's credential is to sign it out and have the user
+/// sign back in as the account being saved.
+fn add_desktop(label: &str, email: Option<&str>, assume_yes: bool) -> i32 {
+    let config = config_or_default();
+    let paths = match Paths::resolve(&config.anthropic) {
+        Ok(paths) if paths.available() => paths,
+        Ok(paths) => {
+            eprintln!(
+                "ai-usagebar account add: no Claude Desktop app data at {} (macOS only)",
+                paths.data_dir.display()
+            );
+            return 1;
+        }
+        Err(error) => {
+            eprintln!("ai-usagebar account add: {error}");
+            return 1;
+        }
+    };
+
+    let profiles = claude_desktop::load_profiles(&paths.profiles_dir);
+    let active = claude_desktop::active_account_uuid(&paths.config_json())
+        .and_then(|uuid| claude_desktop::label_for_uuid(&profiles, &uuid).map(str::to_string));
+
+    println!("Capturing a Claude Desktop account as {label:?}.");
+    println!("  The app will close and reopen at its login screen, where you sign in as the");
+    println!("  account you want to save. Nothing else on this machine is touched.");
+    match &active {
+        Some(previous) => println!(
+            "  Your current account ({previous:?}) is saved first, so switching back is intact."
+        ),
+        None => println!(
+            "  Your current login is copied to {} first and restored if you cancel.",
+            paths.prelogin_dir().display()
+        ),
+    }
+    if !assume_yes && !confirm("  Close Claude and start the login?") {
+        println!("Aborted (pass -y to skip this prompt).");
+        return 1;
+    }
+    // Cosmetic, and the only chance to ask: once the app is signed out this
+    // process is polling, not reading stdin.
+    let email = email
+        .map(str::to_string)
+        .or_else(|| ask("  E-mail for this account (optional, for display): "));
+
+    let mut notes = Vec::new();
+    let outcome = claude_desktop::capture::capture_profile(
+        &paths,
+        label,
+        email.as_deref(),
+        &claude_desktop::app::DesktopApp,
+        claude_desktop::capture::WaitOpts::default(),
+        &mut notes,
+    );
+    for note in &notes {
+        println!("  note: {note}");
+    }
+    match outcome {
+        Err(error) => {
+            eprintln!("ai-usagebar account add: {error}");
+            1
+        }
+        Ok(claude_desktop::capture::CaptureOutcome::TimedOut) => {
+            eprintln!(
+                "No login detected in time — your previous account was restored. \
+                 Re-run when you are ready to sign in."
+            );
+            1
+        }
+        Ok(claude_desktop::capture::CaptureOutcome::AlreadySaved(existing)) => {
+            println!(
+                "That account is already saved as {existing:?} — nothing new to add. \
+                 You are left signed into it."
+            );
+            0
+        }
+        Ok(claude_desktop::capture::CaptureOutcome::Captured(captured)) => {
+            println!(
+                "  seeded         {} session(s) and {} routine(s) from your other accounts",
+                captured.seeded_sessions, captured.seeded_routines
+            );
+            println!();
+            println!(
+                "Added Claude Desktop account {label:?}. Switch to it with:\n\
+                 \n  ai-usagebar account switch {label} --desktop\n"
+            );
+            0
+        }
+    }
+}
+
 struct SwitchArgs<'a> {
     label: &'a str,
     desktop: bool,
@@ -429,18 +534,29 @@ fn print_cli_capture(outgoing: Option<&str>) {
 }
 
 fn confirm(prompt: &str) -> bool {
+    matches!(
+        ask(&format!("{prompt} [y/N] "))
+            .unwrap_or_default()
+            .to_ascii_lowercase()
+            .as_str(),
+        "y" | "yes"
+    )
+}
+
+/// One line from the terminal, or `None` when there isn't one — piped input and
+/// the menu bar's subprocess both land here, and neither can answer.
+fn ask(prompt: &str) -> Option<String> {
     use std::io::IsTerminal;
 
     if !std::io::stdin().is_terminal() {
-        return false;
+        return None;
     }
-    print!("{prompt} [y/N] ");
+    print!("{prompt}");
     let _ = std::io::stdout().flush();
     let mut answer = String::new();
-    if std::io::stdin().read_line(&mut answer).is_err() {
-        return false;
-    }
-    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    std::io::stdin().read_line(&mut answer).ok()?;
+    let answer = answer.trim().to_string();
+    (!answer.is_empty()).then_some(answer)
 }
 
 fn add(label: &str, login: bool) -> i32 {

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,7 +1,10 @@
 //! Administrative commands for named Claude accounts.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use crate::anthropic::cli_account::{self, CliSwitchOpts, CliSwitchOutcome, KeychainStore};
+use crate::claude_desktop::{self, Paths, SwitchOpts, SwitchPlan};
 use crate::config::Config;
 use crate::error::{AppError, Result};
 use crate::widget::cli::AccountAction;
@@ -29,7 +32,415 @@ impl Registered {
 pub fn run(action: &AccountAction) -> i32 {
     match action {
         AccountAction::Add { label, no_login } => add(label, !no_login),
+        AccountAction::Status { json } => status(*json),
+        AccountAction::Switch {
+            label,
+            desktop,
+            cli,
+            dry_run,
+            yes,
+            force,
+            keep_bridge,
+            backup_sessions,
+            keep_backups,
+        } => switch(&SwitchArgs {
+            label,
+            desktop: *desktop,
+            cli: *cli,
+            dry_run: *dry_run,
+            yes: *yes,
+            force: *force,
+            opts: SwitchOpts {
+                keep_bridge: *keep_bridge,
+                backup_sessions: *backup_sessions,
+                keep_backups: *keep_backups,
+            },
+        }),
     }
+}
+
+/// A config that fails to parse must not blank out the account report: the
+/// menu bar polls `account status` while the file is being edited, and the
+/// Desktop half does not depend on config at all.
+fn config_or_default() -> Config {
+    Config::load().unwrap_or_else(|error| {
+        eprintln!("ai-usagebar account: using defaults, config.toml did not parse: {error}");
+        Config::default()
+    })
+}
+
+fn status(json: bool) -> i32 {
+    let config = config_or_default();
+    let accounts = config.anthropic.all_accounts();
+    let paths = Paths::resolve(&config.anthropic)
+        .ok()
+        .filter(Paths::available);
+
+    // A Desktop profile captured without an e-mail can still be named: the
+    // same account signed into the CLI records one, keyed by the same UUID.
+    let emails_by_uuid: Vec<(String, String)> = accounts
+        .iter()
+        .filter_map(|account| {
+            let marker = cli_account::marker_path(&account.config_dir());
+            Some((
+                cli_account::account_uuid_in(&marker)?,
+                cli_account::account_email_in(&marker)?,
+            ))
+        })
+        .collect();
+    let email_for = |uuid: &str| -> Option<&str> {
+        emails_by_uuid
+            .iter()
+            .find(|(known, _)| known == uuid)
+            .map(|(_, email)| email.as_str())
+    };
+
+    let desktop = paths.as_ref().map(|paths| {
+        let profiles = claude_desktop::load_profiles(&paths.profiles_dir);
+        let sessions_root = paths.sessions_root();
+        let active_uuid = claude_desktop::active_account_uuid(&paths.config_json());
+        let active_label = active_uuid
+            .as_deref()
+            .and_then(|uuid| claude_desktop::label_for_uuid(&profiles, uuid))
+            .map(str::to_string);
+        let rows: Vec<serde_json::Value> = profiles
+            .iter()
+            .map(|profile| {
+                serde_json::json!({
+                    "label": profile.label,
+                    "email": profile
+                        .email
+                        .as_deref()
+                        .or_else(|| email_for(&profile.account_uuid)),
+                    "account_uuid": profile.account_uuid,
+                    "org_uuid": profile.org_uuid,
+                    "has_credentials": profile.has_credentials,
+                    "has_desktop_state": profile.has_desktop_state,
+                    "sessions": claude_desktop::session_count(&sessions_root, profile),
+                    "active": Some(&profile.label) == active_label.as_ref(),
+                })
+            })
+            .collect();
+        serde_json::json!({
+            "available": true,
+            "data_dir": paths.data_dir,
+            "profiles_dir": paths.profiles_dir,
+            "active_label": active_label,
+            "active_account_uuid": active_uuid,
+            "profiles": rows,
+        })
+    });
+
+    let home = cli_account::home_claude_json().ok();
+    let cli_active = home
+        .as_deref()
+        .and_then(|home| cli_account::resolve_active_label(home, &accounts));
+    let cli_rows: Vec<serde_json::Value> = accounts
+        .iter()
+        .map(|account| {
+            let marker = cli_account::marker_path(&account.config_dir());
+            serde_json::json!({
+                "label": account.label,
+                "email": cli_account::account_email_in(&marker),
+                "account_uuid": cli_account::account_uuid_in(&marker),
+                "config_dir": account.config_dir(),
+                "active": Some(&account.label) == cli_active.as_ref(),
+            })
+        })
+        .collect();
+    let cli = serde_json::json!({
+        "active_label": cli_active,
+        "active_account_uuid": home.as_deref().and_then(cli_account::account_uuid_in),
+        "accounts": cli_rows,
+    });
+
+    let report = serde_json::json!({ "desktop": desktop, "cli": cli });
+    if json {
+        println!("{report}");
+        return 0;
+    }
+    print_status(&report);
+    0
+}
+
+fn print_status(report: &serde_json::Value) {
+    match &report["desktop"] {
+        serde_json::Value::Null => {
+            println!("Claude Desktop   not found (macOS only)");
+        }
+        desktop => {
+            println!(
+                "Claude Desktop   {}",
+                desktop["data_dir"].as_str().unwrap_or("?")
+            );
+            let profiles = desktop["profiles"]
+                .as_array()
+                .map_or(&[][..], Vec::as_slice);
+            if profiles.is_empty() {
+                println!(
+                    "  no saved accounts in {} — capture one with `claude-acc add <label>`",
+                    desktop["profiles_dir"].as_str().unwrap_or("?")
+                );
+            }
+            for profile in profiles {
+                println!(
+                    "  {:<12} {:<28} sessions={:<5} creds={:<4} state={:<4}{}",
+                    profile["label"].as_str().unwrap_or("?"),
+                    profile["email"].as_str().unwrap_or("(email unknown)"),
+                    profile["sessions"].as_u64().unwrap_or(0),
+                    yes_no(&profile["has_credentials"]),
+                    yes_no(&profile["has_desktop_state"]),
+                    active_tag(&profile["active"]),
+                );
+            }
+        }
+    }
+
+    println!();
+    println!("Claude Code      the `claude` CLI's default login");
+    let accounts = report["cli"]["accounts"]
+        .as_array()
+        .map_or(&[][..], Vec::as_slice);
+    if accounts.is_empty() {
+        println!("  no named accounts — add one with `ai-usagebar account add <label>`");
+    }
+    for account in accounts {
+        println!(
+            "  {:<12} {:<28}{}",
+            account["label"].as_str().unwrap_or("?"),
+            account["email"].as_str().unwrap_or("(email unknown)"),
+            active_tag(&account["active"]),
+        );
+    }
+    if report["cli"]["active_label"].is_null() && !accounts.is_empty() {
+        println!(
+            "  note: the live CLI login belongs to no account listed here, so its \
+             saved copies may be stale."
+        );
+    }
+}
+
+fn yes_no(value: &serde_json::Value) -> &'static str {
+    if value.as_bool().unwrap_or(false) {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn active_tag(value: &serde_json::Value) -> &'static str {
+    if value.as_bool().unwrap_or(false) {
+        "  [active]"
+    } else {
+        ""
+    }
+}
+
+struct SwitchArgs<'a> {
+    label: &'a str,
+    desktop: bool,
+    cli: bool,
+    dry_run: bool,
+    yes: bool,
+    force: bool,
+    opts: SwitchOpts,
+}
+
+fn switch(args: &SwitchArgs) -> i32 {
+    let config = config_or_default();
+    // Neither flag means both surfaces. A label that only exists on one side is
+    // then a skip, not a failure: the two namespaces are independent and may
+    // legitimately hold different sets of accounts.
+    let both = !args.desktop && !args.cli;
+    let mut failed = false;
+    let mut acted = false;
+
+    if args.desktop || both {
+        match switch_desktop(&config, args, both) {
+            Ok(true) => acted = true,
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!("ai-usagebar account switch: {error}");
+                failed = true;
+            }
+        }
+    }
+    if args.cli || both {
+        if acted {
+            println!();
+        }
+        match switch_cli(&config, args, both) {
+            Ok(true) => acted = true,
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!("ai-usagebar account switch: {error}");
+                failed = true;
+            }
+        }
+    }
+
+    if !acted && !failed {
+        eprintln!(
+            "ai-usagebar account switch: nothing to do for {:?}. \
+             Run `ai-usagebar account status` to see the known accounts.",
+            args.label
+        );
+        return 1;
+    }
+    i32::from(failed)
+}
+
+/// `Ok(false)` means "this surface does not know that label, and the other one
+/// might" — reported as a note rather than an error.
+fn switch_desktop(config: &Config, args: &SwitchArgs, tolerant: bool) -> Result<bool> {
+    let paths = Paths::resolve(&config.anthropic)?;
+    if !paths.available() {
+        if !tolerant {
+            return Err(AppError::Other(format!(
+                "no Claude Desktop app data at {} (macOS only)",
+                paths.data_dir.display()
+            )));
+        }
+        return Ok(false);
+    }
+
+    let plan = match claude_desktop::plan_switch(&paths, args.label, args.opts.clone()) {
+        Ok(plan) => plan,
+        Err(error) if tolerant => {
+            println!("Claude Desktop   skipped: {error}");
+            return Ok(false);
+        }
+        Err(error) => return Err(error),
+    };
+    print_plan(&plan);
+
+    if args.dry_run {
+        println!("  (dry run — nothing was changed)");
+        return Ok(true);
+    }
+    if !args.yes
+        && !confirm(&format!(
+            "  Quit and relaunch the Claude Desktop app as {:?}?",
+            plan.target.label
+        ))
+    {
+        println!("  aborted (pass -y to skip this prompt)");
+        return Ok(false);
+    }
+
+    let notes = claude_desktop::apply_switch(&paths, &plan, &claude_desktop::app::DesktopApp)?;
+    for note in &notes {
+        println!("  note: {note}");
+    }
+    println!(
+        "  switched — the app is reopening as {:?}.",
+        plan.target.label
+    );
+    Ok(true)
+}
+
+fn print_plan(plan: &SwitchPlan) {
+    let email = plan.target.email.as_deref().unwrap_or("email unknown");
+    println!("Claude Desktop   → {} ({email})", plan.target.label);
+    if let Some(outgoing) = &plan.outgoing {
+        println!("  saving          {outgoing}'s credential and browser state first");
+    }
+    match plan.target.org_uuid {
+        Some(_) => {
+            let routines = plan.scheduled.as_ref().map_or(0, |merge| merge.added);
+            println!(
+                "  history         {} new + {} refreshed session(s), {routines} routine(s)",
+                plan.sessions.copied.len(),
+                plan.sessions.updated.len(),
+            );
+        }
+        None => println!("  history         skipped (no org recorded for this account yet)"),
+    }
+    println!(
+        "  credential      {}",
+        if plan.tokens.is_some() {
+            "swap to the saved Desktop login"
+        } else {
+            "none saved yet — the app stays signed in as it is"
+        }
+    );
+    println!(
+        "  browser state   {}",
+        if plan.restores_desktop_state {
+            "restore this account's cookies and local storage"
+        } else {
+            "none saved yet"
+        }
+    );
+    if !plan.opts.keep_bridge {
+        println!("  remote bridge   clear (a stale session id breaks /remote-control)");
+    }
+    if !plan.archive_members.is_empty() {
+        println!("  rollback        {}", plan.archive.display());
+    }
+}
+
+fn switch_cli(config: &Config, args: &SwitchArgs, tolerant: bool) -> Result<bool> {
+    let accounts = config.anthropic.all_accounts();
+    if tolerant && !accounts.iter().any(|a| a.label == args.label) {
+        println!(
+            "Claude Code      skipped: no account {:?} configured",
+            args.label
+        );
+        return Ok(false);
+    }
+    let home = cli_account::home_claude_json()?;
+    let outcome = cli_account::switch_cli_account(
+        &home,
+        &accounts,
+        args.label,
+        CliSwitchOpts {
+            force: args.force,
+            dry_run: args.dry_run,
+        },
+        &KeychainStore,
+    )?;
+
+    println!("Claude Code      → {}", args.label);
+    match outcome {
+        CliSwitchOutcome::AlreadyActive => {
+            println!("  already the CLI's default login; nothing to do");
+        }
+        CliSwitchOutcome::WouldSwitch { outgoing } => {
+            print_cli_capture(outgoing.as_deref());
+            println!("  (dry run — nothing was changed)");
+        }
+        CliSwitchOutcome::Switched { outgoing } => {
+            print_cli_capture(outgoing.as_deref());
+            println!(
+                "  switched — plain `claude` now signs in as {:?}.",
+                args.label
+            );
+        }
+    }
+    Ok(true)
+}
+
+fn print_cli_capture(outgoing: Option<&str>) {
+    match outgoing {
+        Some(label) => println!("  saving          {label}'s credential back into its own account"),
+        None => println!("  saving          nothing to save (--force discarded the live login)"),
+    }
+}
+
+fn confirm(prompt: &str) -> bool {
+    use std::io::IsTerminal;
+
+    if !std::io::stdin().is_terminal() {
+        return false;
+    }
+    print!("{prompt} [y/N] ");
+    let _ = std::io::stdout().flush();
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return false;
+    }
+    matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes")
 }
 
 fn add(label: &str, login: bool) -> i32 {

--- a/src/anthropic/cli_account.rs
+++ b/src/anthropic/cli_account.rs
@@ -1,0 +1,547 @@
+//! Which Claude account the `claude` **CLI** is signed into, and moving that
+//! login between managed accounts.
+//!
+//! This is a separate identity from the Claude Desktop app's (see
+//! [`crate::claude_desktop`]) — the two drift apart constantly, which is most
+//! of why they are both worth reporting.
+//!
+//! The CLI keeps exactly **one** default login: `~/.claude/.credentials.json`
+//! on Linux, the login-Keychain item `Claude Code-credentials` on macOS. A
+//! named account instead lives under its own `CLAUDE_CONFIG_DIR`, in the
+//! per-directory Keychain item [`crate::anthropic::keychain`] resolves. Making
+//! a named account "the one plain `claude` uses" therefore means copying its
+//! credential into that single default slot.
+//!
+//! Both slots then hold the same *rotating* refresh token, and whichever
+//! client refreshes first invalidates the other's copy — the failure
+//! [`crate::anthropic::creds`] documents. Two things keep that from happening:
+//! the switch captures the outgoing credential back into its own account
+//! first, so the freshest lineage is never dropped; and
+//! [`crate::config::AnthropicConfig::account_target_with`] routes reads for
+//! whichever label is *currently* active to the default slot, so only one copy
+//! is ever live.
+//!
+//! Everything except [`KeychainStore`] is platform-agnostic and unit-tested
+//! against a fake store, so the logic stays under CI's linter on Linux.
+
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use crate::config::AnthropicAccount;
+use crate::error::{AppError, Result};
+
+/// The `claude` CLI's per-config-dir state file. Holds a plaintext
+/// `oauthAccount` identity marker (uuid, email, org) — never a token.
+const CLAUDE_JSON: &str = ".claude.json";
+
+/// Read/write access to the credential slots. Abstracted so the switch logic
+/// can be tested without a macOS Keychain.
+pub trait CredentialStore {
+    fn read_default(&self) -> Result<Option<String>>;
+    fn write_default(&self, blob: &str) -> Result<()>;
+    fn read_named(&self, config_dir: &Path) -> Result<Option<String>>;
+    fn write_named(&self, config_dir: &Path, blob: &str) -> Result<()>;
+}
+
+/// The real store. The `#[cfg]` pairs are confined here so no other logic in
+/// this module is invisible to a Linux build — the same shape
+/// [`crate::anthropic::creds::resolve`] uses.
+pub struct KeychainStore;
+
+/// Path to the home `.claude.json` that records the live CLI identity.
+pub fn home_claude_json() -> Result<std::path::PathBuf> {
+    Ok(crate::cache::home_dir()?.join(CLAUDE_JSON))
+}
+
+/// The identity marker inside an account's own `CLAUDE_CONFIG_DIR`.
+pub fn marker_path(config_dir: &Path) -> std::path::PathBuf {
+    config_dir.join(CLAUDE_JSON)
+}
+
+/// The account UUID recorded in a `.claude.json`, if any.
+pub fn account_uuid_in(claude_json: &Path) -> Option<String> {
+    oauth_account_in(claude_json)?
+        .get("accountUuid")?
+        .as_str()
+        .filter(|uuid| !uuid.is_empty())
+        .map(str::to_string)
+}
+
+/// The e-mail recorded alongside it, for display only.
+pub fn account_email_in(claude_json: &Path) -> Option<String> {
+    oauth_account_in(claude_json)?
+        .get("emailAddress")?
+        .as_str()
+        .filter(|email| !email.is_empty())
+        .map(str::to_string)
+}
+
+/// Which managed label the live CLI login belongs to.
+///
+/// `None` when the CLI is signed into something we do not manage — a plain
+/// `claude` login done by hand, say. Callers surface that as "unknown" rather
+/// than hiding it: it is exactly the case where the named copies may have gone
+/// stale behind our back.
+pub fn resolve_active_label(
+    home_claude_json: &Path,
+    accounts: &[AnthropicAccount],
+) -> Option<String> {
+    let live = account_uuid_in(home_claude_json)?;
+    accounts
+        .iter()
+        .find(|account| {
+            account_uuid_in(&account.config_dir().join(CLAUDE_JSON)) == Some(live.clone())
+        })
+        .map(|account| account.label.clone())
+}
+
+/// Set (or clear) the `oauthAccount` marker in a `.claude.json`, preserving
+/// every other key. That document is tens of kilobytes of unrelated CLI state,
+/// so it is merged into, never replaced.
+pub fn merge_oauth_account(existing: &[u8], oauth_account: Option<&Value>) -> Result<Vec<u8>> {
+    let mut document: Value = if existing.iter().all(u8::is_ascii_whitespace) {
+        Value::Object(Map::new())
+    } else {
+        serde_json::from_slice(existing)?
+    };
+    let object = document
+        .as_object_mut()
+        .ok_or_else(|| AppError::Other(format!("{CLAUDE_JSON} is not a JSON object")))?;
+    match oauth_account {
+        Some(account) => {
+            object.insert("oauthAccount".into(), account.clone());
+        }
+        // Better an absent marker than one that names the previous account.
+        None => {
+            object.remove("oauthAccount");
+        }
+    }
+    Ok(serde_json::to_vec(&document)?)
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CliSwitchOpts {
+    /// Overwrite the default slot even though the live login belongs to no
+    /// managed account. That login cannot be captured anywhere first, so this
+    /// genuinely destroys it.
+    pub force: bool,
+    /// Validate everything and report, without writing.
+    pub dry_run: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CliSwitchOutcome {
+    AlreadyActive,
+    /// `outgoing` is the label whose credential was captured back first, when
+    /// there was one.
+    Switched {
+        outgoing: Option<String>,
+    },
+    /// `dry_run` was set; nothing was written.
+    WouldSwitch {
+        outgoing: Option<String>,
+    },
+}
+
+/// Make `label` the account plain `claude` uses.
+///
+/// Ordering is deliberate. The outgoing credential is captured back **before**
+/// anything is overwritten — that is the only irreversible step, and a failure
+/// there aborts. The default slot is then written **before** the identity
+/// marker, because the credential is the source of truth: a marker claiming an
+/// account whose token is not there is worse than the reverse.
+pub fn switch_cli_account(
+    home_claude_json: &Path,
+    accounts: &[AnthropicAccount],
+    label: &str,
+    opts: CliSwitchOpts,
+    store: &dyn CredentialStore,
+) -> Result<CliSwitchOutcome> {
+    let target = accounts
+        .iter()
+        .find(|account| account.label == label)
+        .ok_or_else(|| {
+            let known: Vec<&str> = accounts.iter().map(|a| a.label.as_str()).collect();
+            AppError::Credentials(format!(
+                "no Claude CLI account {label:?} in [[anthropic.accounts]] or accounts_dir; \
+                 known: {known:?}"
+            ))
+        })?;
+
+    let active = resolve_active_label(home_claude_json, accounts);
+    if active.as_deref() == Some(label) {
+        return Ok(CliSwitchOutcome::AlreadyActive);
+    }
+    if active.is_none() && !opts.force {
+        return Err(AppError::Credentials(format!(
+            "the `claude` CLI is signed into an account that is not managed here, so \
+             switching to {label:?} would overwrite a login that cannot be saved first. \
+             Register it with `ai-usagebar account add <label>`, or pass --force to \
+             discard it."
+        )));
+    }
+
+    // Fail before touching anything if the target has never been signed in.
+    let target_blob = store.read_named(&target.config_dir())?.ok_or_else(|| {
+        AppError::Credentials(format!(
+            "no stored credential for {label:?}; sign it in once with \
+             `ai-usagebar account add {label}`"
+        ))
+    })?;
+    let oauth_account = oauth_account_in(&target.config_dir().join(CLAUDE_JSON));
+
+    if opts.dry_run {
+        return Ok(CliSwitchOutcome::WouldSwitch { outgoing: active });
+    }
+
+    if let Some(outgoing) = &active {
+        let outgoing_dir = accounts
+            .iter()
+            .find(|account| &account.label == outgoing)
+            .map(AnthropicAccount::config_dir);
+        if let (Some(dir), Some(blob)) = (outgoing_dir, store.read_default()?) {
+            store.write_named(&dir, &blob)?;
+        }
+    }
+    store.write_default(&target_blob)?;
+
+    let existing = std::fs::read(home_claude_json).unwrap_or_default();
+    let merged = merge_oauth_account(&existing, oauth_account.as_ref())?;
+    crate::cache::atomic_write(home_claude_json, &merged)?;
+
+    Ok(CliSwitchOutcome::Switched { outgoing: active })
+}
+
+fn oauth_account_in(claude_json: &Path) -> Option<Value> {
+    let bytes = std::fs::read(claude_json).ok()?;
+    let document: Value = serde_json::from_slice(&bytes).ok()?;
+    document
+        .get("oauthAccount")
+        .filter(|v| v.is_object())
+        .cloned()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn unsupported() -> AppError {
+    AppError::Credentials(
+        "switching the `claude` CLI login is supported on macOS only (elsewhere, run \
+         `CLAUDE_CONFIG_DIR=<account dir> claude` to use a specific account)"
+            .into(),
+    )
+}
+
+impl CredentialStore for KeychainStore {
+    fn read_default(&self) -> Result<Option<String>> {
+        #[cfg(target_os = "macos")]
+        return super::keychain::read_raw();
+        #[cfg(not(target_os = "macos"))]
+        Err(unsupported())
+    }
+
+    fn write_default(&self, blob: &str) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        return super::keychain::write_raw(blob);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = blob;
+            Err(unsupported())
+        }
+    }
+
+    fn read_named(&self, config_dir: &Path) -> Result<Option<String>> {
+        #[cfg(target_os = "macos")]
+        return super::keychain::read_raw_for(config_dir);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = config_dir;
+            Err(unsupported())
+        }
+    }
+
+    fn write_named(&self, config_dir: &Path, blob: &str) -> Result<()> {
+        #[cfg(target_os = "macos")]
+        return super::keychain::write_raw_for(config_dir, blob);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (config_dir, blob);
+            Err(unsupported())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    #[derive(Default)]
+    struct FakeStore {
+        default: RefCell<Option<String>>,
+        named: RefCell<BTreeMap<PathBuf, String>>,
+    }
+
+    impl CredentialStore for FakeStore {
+        fn read_default(&self) -> Result<Option<String>> {
+            Ok(self.default.borrow().clone())
+        }
+        fn write_default(&self, blob: &str) -> Result<()> {
+            *self.default.borrow_mut() = Some(blob.to_string());
+            Ok(())
+        }
+        fn read_named(&self, config_dir: &Path) -> Result<Option<String>> {
+            Ok(self.named.borrow().get(config_dir).cloned())
+        }
+        fn write_named(&self, config_dir: &Path, blob: &str) -> Result<()> {
+            self.named
+                .borrow_mut()
+                .insert(config_dir.to_path_buf(), blob.to_string());
+            Ok(())
+        }
+    }
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn marker(uuid: &str, email: &str) -> String {
+        format!(r#"{{"oauthAccount":{{"accountUuid":"{uuid}","emailAddress":"{email}"}}}}"#)
+    }
+
+    struct Fixture {
+        _root: tempfile::TempDir,
+        home: PathBuf,
+        accounts: Vec<AnthropicAccount>,
+        store: FakeStore,
+    }
+
+    /// Two accounts, `work` and `personal`; the CLI is signed into `personal`.
+    fn fixture() -> Fixture {
+        let root = tempfile::TempDir::new().unwrap();
+        let home = root.path().join("home").join(CLAUDE_JSON);
+        write(&home, &marker("uuid-personal", "me@personal.test"));
+
+        let accounts: Vec<AnthropicAccount> = ["work", "personal"]
+            .iter()
+            .map(|label| AnthropicAccount {
+                label: (*label).to_string(),
+                credentials_path: root
+                    .path()
+                    .join("accounts")
+                    .join(label)
+                    .join(".credentials.json"),
+            })
+            .collect();
+        write(
+            &accounts[0].config_dir().join(CLAUDE_JSON),
+            &marker("uuid-work", "me@work.test"),
+        );
+        write(
+            &accounts[1].config_dir().join(CLAUDE_JSON),
+            &marker("uuid-personal", "me@personal.test"),
+        );
+
+        let store = FakeStore::default();
+        *store.default.borrow_mut() = Some("personal-live".into());
+        store
+            .named
+            .borrow_mut()
+            .insert(accounts[0].config_dir(), "work-saved".into());
+        store
+            .named
+            .borrow_mut()
+            .insert(accounts[1].config_dir(), "personal-stale".into());
+
+        Fixture {
+            _root: root,
+            home,
+            accounts,
+            store,
+        }
+    }
+
+    #[test]
+    fn the_live_login_resolves_to_its_label() {
+        let f = fixture();
+        assert_eq!(
+            resolve_active_label(&f.home, &f.accounts).as_deref(),
+            Some("personal")
+        );
+        assert_eq!(
+            account_email_in(&f.home).as_deref(),
+            Some("me@personal.test")
+        );
+    }
+
+    #[test]
+    fn an_unmanaged_login_resolves_to_nothing() {
+        let f = fixture();
+        write(&f.home, &marker("uuid-stranger", "who@example.test"));
+        assert_eq!(resolve_active_label(&f.home, &f.accounts), None);
+    }
+
+    #[test]
+    fn a_missing_marker_file_is_not_an_error() {
+        let f = fixture();
+        std::fs::remove_file(&f.home).unwrap();
+        assert_eq!(resolve_active_label(&f.home, &f.accounts), None);
+        assert_eq!(account_uuid_in(&f.home), None);
+    }
+
+    #[test]
+    fn switching_captures_the_outgoing_credential_first() {
+        let f = fixture();
+
+        let outcome = switch_cli_account(
+            &f.home,
+            &f.accounts,
+            "work",
+            CliSwitchOpts::default(),
+            &f.store,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            CliSwitchOutcome::Switched {
+                outgoing: Some("personal".into())
+            }
+        );
+        // The freshest lineage was written back into personal's own slot before
+        // the default slot was overwritten.
+        assert_eq!(
+            f.store.named.borrow()[&f.accounts[1].config_dir()],
+            "personal-live"
+        );
+        assert_eq!(f.store.default.borrow().as_deref(), Some("work-saved"));
+        assert_eq!(
+            resolve_active_label(&f.home, &f.accounts).as_deref(),
+            Some("work")
+        );
+    }
+
+    #[test]
+    fn switching_is_idempotent() {
+        let f = fixture();
+        let outcome = switch_cli_account(
+            &f.home,
+            &f.accounts,
+            "personal",
+            CliSwitchOpts::default(),
+            &f.store,
+        )
+        .unwrap();
+        assert_eq!(outcome, CliSwitchOutcome::AlreadyActive);
+        assert_eq!(f.store.default.borrow().as_deref(), Some("personal-live"));
+    }
+
+    #[test]
+    fn a_dry_run_validates_without_writing() {
+        let f = fixture();
+        let before = std::fs::read(&f.home).unwrap();
+
+        let outcome = switch_cli_account(
+            &f.home,
+            &f.accounts,
+            "work",
+            CliSwitchOpts {
+                dry_run: true,
+                ..CliSwitchOpts::default()
+            },
+            &f.store,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            CliSwitchOutcome::WouldSwitch {
+                outgoing: Some("personal".into())
+            }
+        );
+        assert_eq!(f.store.default.borrow().as_deref(), Some("personal-live"));
+        assert_eq!(std::fs::read(&f.home).unwrap(), before);
+    }
+
+    #[test]
+    fn an_unmanaged_live_login_is_refused_without_force() {
+        let f = fixture();
+        write(&f.home, &marker("uuid-stranger", "who@example.test"));
+
+        let error = switch_cli_account(
+            &f.home,
+            &f.accounts,
+            "work",
+            CliSwitchOpts::default(),
+            &f.store,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--force"), "{error}");
+        assert_eq!(f.store.default.borrow().as_deref(), Some("personal-live"));
+
+        switch_cli_account(
+            &f.home,
+            &f.accounts,
+            "work",
+            CliSwitchOpts {
+                force: true,
+                ..CliSwitchOpts::default()
+            },
+            &f.store,
+        )
+        .unwrap();
+        assert_eq!(f.store.default.borrow().as_deref(), Some("work-saved"));
+    }
+
+    #[test]
+    fn switching_to_an_account_that_never_signed_in_changes_nothing() {
+        let f = fixture();
+        f.store
+            .named
+            .borrow_mut()
+            .remove(&f.accounts[0].config_dir());
+
+        let error = switch_cli_account(
+            &f.home,
+            &f.accounts,
+            "work",
+            CliSwitchOpts::default(),
+            &f.store,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("account add work"), "{error}");
+        assert_eq!(f.store.default.borrow().as_deref(), Some("personal-live"));
+    }
+
+    #[test]
+    fn merging_the_marker_preserves_unrelated_state() {
+        let existing = br#"{"firstStartTime":"2026-01-01","oauthAccount":{"accountUuid":"old"},
+            "projects":{"/tmp/x":{"allowedTools":[]}}}"#;
+        let replacement = serde_json::json!({"accountUuid": "new", "emailAddress": "a@b.test"});
+
+        let bytes = merge_oauth_account(existing, Some(&replacement)).unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["oauthAccount"]["accountUuid"], "new");
+        assert_eq!(value["firstStartTime"], "2026-01-01");
+        assert!(value["projects"]["/tmp/x"].is_object());
+    }
+
+    #[test]
+    fn merging_no_marker_clears_a_stale_one() {
+        let existing = br#"{"oauthAccount":{"accountUuid":"old"},"autoUpdates":true}"#;
+        let bytes = merge_oauth_account(existing, None).unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(value.get("oauthAccount").is_none());
+        assert_eq!(value["autoUpdates"], true);
+    }
+
+    #[test]
+    fn merging_into_an_absent_file_starts_a_fresh_document() {
+        let replacement = serde_json::json!({"accountUuid": "new"});
+        let bytes = merge_oauth_account(b"", Some(&replacement)).unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["oauthAccount"]["accountUuid"], "new");
+    }
+}

--- a/src/anthropic/mod.rs
+++ b/src/anthropic/mod.rs
@@ -4,6 +4,7 @@
 //! Mirrors `~/Projects/claudebar/claudebar` line-for-line; see individual
 //! submodule headers for the bash references.
 
+pub mod cli_account;
 pub mod creds;
 pub mod fetch;
 #[cfg(target_os = "macos")]

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -1,0 +1,117 @@
+//! The only part of a Claude Desktop switch that touches the outside world:
+//! stopping the app, restarting it, and writing the rollback archive.
+//!
+//! It sits behind a trait so the switch orchestration can be exercised against
+//! a recorder — the step *ordering* is the dangerous part (snapshotting the
+//! outgoing account must happen before `config.json` is rewritten, and the
+//! relaunch must happen even when an earlier step failed), and ordering is
+//! exactly what a test can pin down without a Mac.
+
+use std::cell::RefCell;
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::error::{AppError, Result};
+
+/// Host-level effects of a switch.
+pub trait AppControl {
+    /// Stop the Claude Desktop app. Must return only once it is really gone —
+    /// its SQLite and LevelDB stores cannot be copied while it is writing them.
+    fn quit(&self);
+    /// Start it again.
+    fn relaunch(&self);
+    /// Write `members` (relative to `root`) into a gzipped tar at `archive`.
+    fn archive(&self, archive: &Path, root: &Path, members: &[&str]) -> Result<()>;
+}
+
+/// The real thing. Every command is a macOS system binary at a fixed path, the
+/// same approach `anthropic::keychain` takes with `security(1)` and `shasum(1)`
+/// — no extra dependency, and nothing to resolve off `PATH`. On any other
+/// platform these simply fail, which is harmless: there is no Claude Desktop
+/// app to find there in the first place, so a switch never gets this far.
+pub struct DesktopApp;
+
+/// How long to give the app to shut down cleanly before insisting.
+const QUIT_GRACE: Duration = Duration::from_secs(2);
+
+impl AppControl for DesktopApp {
+    fn quit(&self) {
+        // Graceful first so the app tears down its own child processes; the
+        // signal is the fallback. Neither touches a `claude` CLI process —
+        // `-x` matches the executable name exactly.
+        let _ = Command::new("/usr/bin/osascript")
+            .args(["-e", "tell application \"Claude\" to quit"])
+            .output();
+        std::thread::sleep(QUIT_GRACE);
+        let _ = Command::new("/usr/bin/pkill")
+            .args(["-x", "Claude"])
+            .output();
+    }
+
+    fn relaunch(&self) {
+        let _ = Command::new("/usr/bin/open")
+            .args(["-a", "Claude"])
+            .output();
+    }
+
+    fn archive(&self, archive: &Path, root: &Path, members: &[&str]) -> Result<()> {
+        if let Some(parent) = archive.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| AppError::io_at(parent, e))?;
+        }
+        let output = Command::new("/usr/bin/tar")
+            .arg("-czf")
+            .arg(archive)
+            .arg("-C")
+            .arg(root)
+            .args(members)
+            .output()
+            .map_err(|e| AppError::Other(format!("could not run `tar`: {e}")))?;
+        if output.status.success() {
+            return Ok(());
+        }
+        let detail = String::from_utf8_lossy(&output.stderr);
+        Err(AppError::Other(format!(
+            "could not write the rollback archive {} (tar exited {}): {}",
+            archive.display(),
+            output.status.code().unwrap_or(-1),
+            detail.trim()
+        )))
+    }
+}
+
+/// Records what *would* happen instead of doing it. Backs `--dry-run`, and is
+/// the fixture the ordering tests assert against.
+#[derive(Debug, Default)]
+pub struct Recorder {
+    steps: RefCell<Vec<String>>,
+}
+
+impl Recorder {
+    pub fn steps(&self) -> Vec<String> {
+        self.steps.borrow().clone()
+    }
+
+    pub fn record(&self, step: impl Into<String>) {
+        self.steps.borrow_mut().push(step.into());
+    }
+}
+
+impl AppControl for Recorder {
+    fn quit(&self) {
+        self.record("quit");
+    }
+
+    fn relaunch(&self) {
+        self.record("relaunch");
+    }
+
+    fn archive(&self, archive: &Path, _root: &Path, members: &[&str]) -> Result<()> {
+        self.record(format!(
+            "archive {} [{}]",
+            archive.display(),
+            members.join(", ")
+        ));
+        Ok(())
+    }
+}

--- a/src/claude_desktop/capture.rs
+++ b/src/claude_desktop/capture.rs
@@ -1,0 +1,455 @@
+//! Capturing a **new** Claude Desktop account, so this machine can switch to
+//! it later.
+//!
+//! Unlike the `claude` CLI — where `CLAUDE_CONFIG_DIR=<dir> claude` isolates a
+//! login into its own directory — the Desktop app has exactly one login slot
+//! and no way to ask for a second. The only way to obtain a second account's
+//! credential is to sign the app out, have the user sign in as that account,
+//! and save what the app then writes. That is what this does, and why it is
+//! interactive and destructive-looking in the middle.
+//!
+//! It is safe to cancel. The live login is copied out **before** anything is
+//! cleared, and put straight back if the sign-in times out or the user walks
+//! away. The account that was active is also saved into its own profile first,
+//! so switching back to it afterwards restores exactly what it looked like.
+//!
+//! Ported from claude-acc's `add` (<https://github.com/ohmaseclaro/claude-acc>),
+//! along with the two empirical rules that make the polling reliable: a login
+//! only counts once *both* `lastKnownAccountUuid` and the token cache are
+//! written, and the org id has to be recovered from either the new session
+//! folder or the dxt allowlist keys.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use super::app::AppControl;
+use super::{Paths, merge};
+use crate::error::{AppError, Result};
+
+/// Everything the app remembers an account by. Backed up before a capture
+/// clears it, restored verbatim if the capture does not complete.
+const LOGIN_STATE_FILES: [&str; 4] = [
+    "config.json",
+    "Cookies",
+    "Cookies-journal",
+    "bridge-state.json",
+];
+const LOGIN_STATE_DIRS: [&str; 3] = ["Local Storage", "Session Storage", "IndexedDB"];
+
+/// How long to wait for each interactive step.
+#[derive(Debug, Clone, Copy)]
+pub struct WaitOpts {
+    pub login: Duration,
+    pub org: Duration,
+    pub poll: Duration,
+}
+
+impl Default for WaitOpts {
+    fn default() -> Self {
+        Self {
+            login: Duration::from_secs(300),
+            org: Duration::from_secs(120),
+            poll: Duration::from_secs(2),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Captured {
+    pub label: String,
+    pub account_uuid: String,
+    /// Absent when the app had not created a session folder yet; history is
+    /// then seeded on the first switch instead.
+    pub org_uuid: Option<String>,
+    pub seeded_sessions: usize,
+    pub seeded_routines: usize,
+}
+
+#[derive(Debug)]
+pub enum CaptureOutcome {
+    Captured(Box<Captured>),
+    /// The account signed in is one this machine already knows. Nothing was
+    /// saved and the app is left signed into it.
+    AlreadySaved(String),
+    /// Nobody signed in within the timeout; the previous login was restored.
+    TimedOut,
+}
+
+/// Sign the Desktop app out, wait for the user to sign in as a new account,
+/// and save it under `label`.
+pub fn capture_profile(
+    paths: &Paths,
+    label: &str,
+    email: Option<&str>,
+    app: &dyn AppControl,
+    wait: WaitOpts,
+    notes: &mut Vec<String>,
+) -> Result<CaptureOutcome> {
+    crate::config::validate_account_label(label)?;
+    let profiles = super::load_profiles(&paths.profiles_dir);
+    if profiles.iter().any(|profile| profile.label == label) {
+        return Err(AppError::Credentials(format!(
+            "a Claude Desktop account {label:?} already exists in {}; pick another name",
+            paths.profiles_dir.display()
+        )));
+    }
+    let known_accounts: Vec<String> = profiles.iter().map(|p| p.account_uuid.clone()).collect();
+    let known_orgs: Vec<String> = profiles.iter().filter_map(|p| p.org_uuid.clone()).collect();
+
+    let config_json = paths.config_json();
+    let outgoing = super::active_account_uuid(&config_json)
+        .and_then(|uuid| super::label_for_uuid(&profiles, &uuid).map(str::to_string));
+
+    app.quit();
+    // Save the account we are about to sign out, so switching back to it later
+    // restores its browser state rather than only its credential.
+    if let Some(previous) = &outgoing {
+        super::snapshot_profile(paths, previous, notes);
+    }
+    // The safety net runs regardless: the live login may belong to no profile
+    // at all, and it still has to survive a cancelled capture.
+    backup_login_state(paths, notes)?;
+    clear_login_state(paths, notes)?;
+    app.relaunch();
+
+    let Some(account_uuid) = poll_for_login(&config_json, wait) else {
+        app.quit();
+        restore_login_state(paths, notes);
+        app.relaunch();
+        return Ok(CaptureOutcome::TimedOut);
+    };
+    if let Some(existing) = super::label_for_uuid(&profiles, &account_uuid) {
+        return Ok(CaptureOutcome::AlreadySaved(existing.to_string()));
+    }
+    if known_accounts.iter().any(|known| known == &account_uuid) {
+        return Ok(CaptureOutcome::AlreadySaved(account_uuid));
+    }
+
+    let org_uuid = poll_for_org(paths, &account_uuid, &known_orgs, wait);
+    app.quit();
+    super::snapshot_profile(paths, label, notes);
+    write_meta(paths, label, email, &account_uuid, org_uuid.as_deref())?;
+
+    // Seed the new account with everything this machine already has, so its
+    // first login is not an empty sidebar.
+    let (seeded_sessions, seeded_routines) = match &org_uuid {
+        Some(org) => super::merge_history_into(paths, &account_uuid, org, notes),
+        None => {
+            notes.push(
+                "no organisation recorded yet, so history was not seeded — open one chat in \
+                 the app, then run `ai-usagebar account switch <label> --desktop` to pull it in"
+                    .into(),
+            );
+            (0, 0)
+        }
+    };
+    app.relaunch();
+
+    Ok(CaptureOutcome::Captured(Box::new(Captured {
+        label: label.to_string(),
+        account_uuid,
+        org_uuid,
+        seeded_sessions,
+        seeded_routines,
+    })))
+}
+
+fn poll_for_login(config_json: &Path, wait: WaitOpts) -> Option<String> {
+    let deadline = Instant::now() + wait.login;
+    while Instant::now() < deadline {
+        if let Ok(bytes) = std::fs::read(config_json)
+            && let Some(uuid) = merge::logged_in_account(&bytes)
+        {
+            return Some(uuid);
+        }
+        std::thread::sleep(wait.poll);
+    }
+    None
+}
+
+/// The account's own session folder is the reliable signal; the config's dxt
+/// allowlist keys are the fallback for an account that has not opened a chat.
+fn poll_for_org(
+    paths: &Paths,
+    account_uuid: &str,
+    known_orgs: &[String],
+    wait: WaitOpts,
+) -> Option<String> {
+    let deadline = Instant::now() + wait.org;
+    let account_dir = paths.sessions_root().join(account_uuid);
+    while Instant::now() < deadline {
+        if let Ok(entries) = std::fs::read_dir(&account_dir)
+            && let Some(org) = entries
+                .flatten()
+                .filter(|entry| entry.path().is_dir())
+                .find_map(|entry| entry.file_name().to_str().map(str::to_string))
+        {
+            return Some(org);
+        }
+        if let Ok(bytes) = std::fs::read(paths.config_json())
+            && let Some(org) = merge::new_org_in_config(&bytes, known_orgs)
+        {
+            return Some(org);
+        }
+        std::thread::sleep(wait.poll);
+    }
+    None
+}
+
+/// The one place that writes `meta.json`. A switch must never touch it — this
+/// is the file that says which account a profile *is*.
+fn write_meta(
+    paths: &Paths,
+    label: &str,
+    email: Option<&str>,
+    account_uuid: &str,
+    org_uuid: Option<&str>,
+) -> Result<()> {
+    let meta = serde_json::json!({
+        "label": label,
+        "email": email,
+        "accountUuid": account_uuid,
+        "orgUuid": org_uuid,
+        "savedAt": chrono::Local::now().timestamp(),
+    });
+    crate::cache::atomic_write(
+        &paths.profile_dir(label).join(super::META_JSON),
+        &serde_json::to_vec_pretty(&meta)?,
+    )
+}
+
+fn backup_login_state(paths: &Paths, notes: &mut Vec<String>) -> Result<()> {
+    let backup = paths.prelogin_dir();
+    if backup.exists() {
+        std::fs::remove_dir_all(&backup).map_err(|e| AppError::io_at(&backup, e))?;
+    }
+    std::fs::create_dir_all(&backup).map_err(|e| AppError::io_at(&backup, e))?;
+    super::restrict(&backup, 0o700, notes);
+    for name in LOGIN_STATE_FILES {
+        let source = paths.data_dir.join(name);
+        if source.is_file() {
+            super::copy_file(&source, &backup.join(name))?;
+        }
+    }
+    for name in LOGIN_STATE_DIRS {
+        let source = paths.data_dir.join(name);
+        if source.is_dir() {
+            super::replace_dir(&source, &backup.join(name))?;
+        }
+    }
+    Ok(())
+}
+
+/// Best-effort by design: this runs when the capture has already failed, and a
+/// partial restore reported plainly beats an error that hides what happened.
+fn restore_login_state(paths: &Paths, notes: &mut Vec<String>) {
+    let backup = paths.prelogin_dir();
+    if !backup.is_dir() {
+        notes.push("no pre-login backup to restore".into());
+        return;
+    }
+    for name in LOGIN_STATE_FILES {
+        let source = backup.join(name);
+        let live = paths.data_dir.join(name);
+        if source.is_file() {
+            if let Err(error) = super::copy_file(&source, &live) {
+                notes.push(format!("could not restore {name}: {error}"));
+            }
+        } else if live.is_file()
+            && let Err(error) = std::fs::remove_file(&live)
+        {
+            notes.push(format!("could not clear {name}: {error}"));
+        }
+    }
+    for name in LOGIN_STATE_DIRS {
+        let source = backup.join(name);
+        if source.is_dir()
+            && let Err(error) = super::replace_dir(&source, &paths.data_dir.join(name))
+        {
+            notes.push(format!("could not restore {name}: {error}"));
+        }
+    }
+}
+
+fn clear_login_state(paths: &Paths, notes: &mut Vec<String>) -> Result<()> {
+    let config_json = paths.config_json();
+    if let Ok(bytes) = std::fs::read(&config_json) {
+        match merge::clear_config_tokens(&bytes) {
+            Ok(cleared) => crate::cache::atomic_write(&config_json, &cleared)?,
+            Err(error) => notes.push(format!("could not clear the Desktop config: {error}")),
+        }
+    }
+    for name in LOGIN_STATE_FILES
+        .iter()
+        .filter(|name| **name != "config.json")
+    {
+        let live = paths.data_dir.join(name);
+        if live.is_file()
+            && let Err(error) = std::fs::remove_file(&live)
+        {
+            notes.push(format!("could not clear {name}: {error}"));
+        }
+    }
+    for name in LOGIN_STATE_DIRS {
+        let live = paths.data_dir.join(name);
+        if live.is_dir()
+            && let Err(error) = std::fs::remove_dir_all(&live)
+        {
+            notes.push(format!("could not clear {name}: {error}"));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claude_desktop::app::Recorder;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn fixture() -> (tempfile::TempDir, Paths) {
+        let root = tempfile::TempDir::new().unwrap();
+        let data = root.path().join("data");
+        write(
+            &data.join("config.json"),
+            r#"{"lastKnownAccountUuid":"uuid-here","oauth:tokenCache":"live-a",
+                "oauth:tokenCacheV2":"live-b","autoUpdates":true}"#,
+        );
+        write(&data.join("Cookies"), "live-cookies");
+        write(
+            &data.join("bridge-state.json"),
+            r#"{"remoteSessionId":"cse"}"#,
+        );
+        write(&data.join("Local Storage/leveldb/CURRENT"), "live-ldb");
+        let paths = Paths::at(
+            data,
+            root.path().join("profiles"),
+            root.path().join("backups"),
+        );
+        (root, paths)
+    }
+
+    /// The safety net: whatever a capture clears has to come back byte for byte.
+    #[test]
+    fn a_cleared_login_is_restored_exactly() {
+        let (_root, paths) = fixture();
+        let mut notes = Vec::new();
+
+        backup_login_state(&paths, &mut notes).unwrap();
+        clear_login_state(&paths, &mut notes).unwrap();
+
+        let cleared: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(paths.config_json()).unwrap()).unwrap();
+        assert!(cleared.get("oauth:tokenCacheV2").is_none());
+        assert!(cleared.get("lastKnownAccountUuid").is_none());
+        assert_eq!(cleared["autoUpdates"], true, "settings must survive");
+        assert!(!paths.data_dir.join("Cookies").exists());
+        assert!(!paths.data_dir.join("Local Storage").exists());
+
+        restore_login_state(&paths, &mut notes);
+
+        assert!(notes.is_empty(), "{notes:?}");
+        let restored: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(paths.config_json()).unwrap()).unwrap();
+        assert_eq!(restored["oauth:tokenCacheV2"], "live-b");
+        assert_eq!(restored["lastKnownAccountUuid"], "uuid-here");
+        assert_eq!(
+            std::fs::read_to_string(paths.data_dir.join("Cookies")).unwrap(),
+            "live-cookies"
+        );
+        assert_eq!(
+            std::fs::read_to_string(paths.data_dir.join("Local Storage/leveldb/CURRENT")).unwrap(),
+            "live-ldb"
+        );
+    }
+
+    /// A file the app created *after* the backup must not survive the restore,
+    /// or the new account's cookies would leak into the old one's session.
+    #[test]
+    fn restoring_clears_state_the_backup_does_not_have() {
+        let (_root, paths) = fixture();
+        let mut notes = Vec::new();
+        std::fs::remove_file(paths.data_dir.join("Cookies")).unwrap();
+
+        backup_login_state(&paths, &mut notes).unwrap();
+        write(&paths.data_dir.join("Cookies"), "someone else's");
+        restore_login_state(&paths, &mut notes);
+
+        assert!(!paths.data_dir.join("Cookies").exists(), "{notes:?}");
+    }
+
+    #[test]
+    fn a_timed_out_capture_puts_the_previous_login_back() {
+        let (_root, paths) = fixture();
+        let recorder = Recorder::default();
+        let mut notes = Vec::new();
+        let before = std::fs::read(paths.config_json()).unwrap();
+
+        let outcome = capture_profile(
+            &paths,
+            "work",
+            None,
+            &recorder,
+            WaitOpts {
+                login: Duration::from_millis(1),
+                org: Duration::from_millis(1),
+                poll: Duration::from_millis(1),
+            },
+            &mut notes,
+        )
+        .unwrap();
+
+        assert!(matches!(outcome, CaptureOutcome::TimedOut), "{outcome:?}");
+        assert_eq!(std::fs::read(paths.config_json()).unwrap(), before);
+        assert!(!paths.profile_dir("work").exists(), "nothing was saved");
+        // Quit, reopen at the login screen, quit again, reopen restored.
+        assert_eq!(recorder.steps(), ["quit", "relaunch", "quit", "relaunch"]);
+    }
+
+    #[test]
+    fn capturing_a_label_that_already_exists_is_refused_before_signing_out() {
+        let (_root, paths) = fixture();
+        write(
+            &paths.profile_dir("work").join("meta.json"),
+            r#"{"accountUuid":"uuid-work"}"#,
+        );
+        let recorder = Recorder::default();
+        let before = std::fs::read(paths.config_json()).unwrap();
+
+        let error = capture_profile(
+            &paths,
+            "work",
+            None,
+            &recorder,
+            WaitOpts::default(),
+            &mut Vec::new(),
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("already exists"), "{error}");
+        assert!(recorder.steps().is_empty(), "the app must not be touched");
+        assert_eq!(std::fs::read(paths.config_json()).unwrap(), before);
+    }
+
+    #[test]
+    fn an_unusable_label_is_refused() {
+        let (_root, paths) = fixture();
+        let recorder = Recorder::default();
+        assert!(
+            capture_profile(
+                &paths,
+                "../escape",
+                None,
+                &recorder,
+                WaitOpts::default(),
+                &mut Vec::new()
+            )
+            .is_err()
+        );
+        assert!(recorder.steps().is_empty());
+    }
+}

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -174,6 +174,58 @@ pub fn swap_config_tokens(
     Ok(serde_json::to_vec(&document)?)
 }
 
+/// Strip everything the Desktop app uses to remember an account, so it reopens
+/// at the login screen. Only the identity keys go: the dxt allowlists, window
+/// state and feature flags are the user's settings, not their session.
+pub fn clear_config_tokens(existing: &[u8]) -> Result<Vec<u8>> {
+    let mut document: Value = serde_json::from_slice(existing)?;
+    let object = document
+        .as_object_mut()
+        .ok_or_else(|| AppError::Other("Claude Desktop config.json is not a JSON object".into()))?;
+    for key in [
+        "oauth:tokenCache",
+        "oauth:tokenCacheV2",
+        "lastKnownAccountUuid",
+    ] {
+        object.remove(key);
+    }
+    Ok(serde_json::to_vec(&document)?)
+}
+
+/// The account the app has finished signing in as, or `None` while the login
+/// is still in progress. Both fields matter: `lastKnownAccountUuid` appears
+/// before the token cache is written, so keying on it alone captures a
+/// half-finished login.
+pub fn logged_in_account(config: &[u8]) -> Option<String> {
+    let document: Value = serde_json::from_slice(config).ok()?;
+    let has_token = document
+        .get("oauth:tokenCacheV2")
+        .and_then(Value::as_str)
+        .is_some_and(|token| !token.is_empty());
+    if !has_token {
+        return None;
+    }
+    document
+        .get("lastKnownAccountUuid")?
+        .as_str()
+        .filter(|uuid| !uuid.is_empty())
+        .map(str::to_string)
+}
+
+/// An organisation this machine has not seen before, recovered from the dxt
+/// allowlist keys the app writes per org (`dxt:allowlistEnabled:<org>`). The
+/// fallback for when the account's session folder has not appeared yet.
+pub fn new_org_in_config(config: &[u8], known: &[String]) -> Option<String> {
+    const PREFIX: &str = "dxt:allowlistEnabled:";
+    let document: Value = serde_json::from_slice(config).ok()?;
+    document
+        .as_object()?
+        .keys()
+        .filter_map(|key| key.strip_prefix(PREFIX))
+        .find(|org| !org.is_empty() && !known.iter().any(|seen| seen == org))
+        .map(str::to_string)
+}
+
 /// Fold a per-profile snapshot of `ant-device-registry.json` back into the live
 /// one. The file is a map of account UUID → device registration and already
 /// holds every account, so this is purely additive: **the live value wins every
@@ -427,6 +479,56 @@ mod tests {
     #[test]
     fn config_swap_rejects_a_non_object_document() {
         assert!(swap_config_tokens(b"[]", "a", "b", "u").is_err());
+    }
+
+    #[test]
+    fn clearing_tokens_keeps_the_users_settings() {
+        let existing = br#"{"lastKnownAccountUuid":"u","oauth:tokenCache":"a",
+            "oauth:tokenCacheV2":"b","dxt:allowlistEnabled:org-1":true,"autoUpdates":true}"#;
+
+        let bytes = clear_config_tokens(existing).unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(value.get("oauth:tokenCache").is_none());
+        assert!(value.get("oauth:tokenCacheV2").is_none());
+        assert!(value.get("lastKnownAccountUuid").is_none());
+        assert_eq!(value["dxt:allowlistEnabled:org-1"], true);
+        assert_eq!(value["autoUpdates"], true);
+    }
+
+    #[test]
+    fn a_login_counts_only_once_both_fields_are_written() {
+        assert_eq!(
+            logged_in_account(&clear_config_tokens(b"{}").unwrap()),
+            None
+        );
+        // The uuid lands before the token cache does; capturing here would
+        // save a profile with no credential in it.
+        assert_eq!(logged_in_account(br#"{"lastKnownAccountUuid":"u"}"#), None);
+        assert_eq!(
+            logged_in_account(br#"{"lastKnownAccountUuid":"u","oauth:tokenCacheV2":""}"#),
+            None
+        );
+        assert_eq!(
+            logged_in_account(br#"{"lastKnownAccountUuid":"u","oauth:tokenCacheV2":"t"}"#),
+            Some("u".into())
+        );
+        assert_eq!(logged_in_account(b"not json"), None);
+    }
+
+    #[test]
+    fn a_new_org_is_recovered_from_the_allowlist_keys() {
+        let config = br#"{"dxt:allowlistEnabled:org-old":true,
+            "dxt:allowlistEnabled:org-new":true,"unrelated":1}"#;
+
+        assert_eq!(
+            new_org_in_config(config, &["org-old".into()]),
+            Some("org-new".into())
+        );
+        assert_eq!(
+            new_org_in_config(config, &["org-old".into(), "org-new".into()]),
+            None
+        );
+        assert_eq!(new_org_in_config(b"{}", &[]), None);
     }
 
     #[test]

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -1,0 +1,452 @@
+//! The pure half of a Claude Desktop account switch: deciding which session
+//! indexes to copy, what the merged schedule registry looks like, and what the
+//! rewritten `config.json` / `ant-device-registry.json` contain.
+//!
+//! Nothing here touches `$HOME`, spawns a process, or writes a file — every
+//! function takes an explicit root or the file's bytes, which is what lets
+//! `--dry-run` be free (compute the plan, print it, stop) and lets the whole
+//! algorithm be unit-tested against a temporary directory on any platform.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde_json::{Map, Value};
+
+use crate::error::{AppError, Result};
+
+/// Per-account schedule registry, stored beside that account's session indexes.
+const SCHEDULED_TASKS: &str = "scheduled-tasks.json";
+
+/// Session-index files that a switch would bring into the target account's
+/// history folder, so it shows the union of everything rather than only the
+/// conversations that account happened to start.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SessionMerge {
+    /// `(source, destination)` for indexes the target has never seen.
+    pub copied: Vec<(PathBuf, PathBuf)>,
+    /// `(source, destination)` where the source is strictly newer. A resumed
+    /// chat's index advances, so a stale copy in the target folder *must* be
+    /// overwritten — otherwise the app reopens it at an old resume point and
+    /// the recent messages look like they vanished.
+    pub updated: Vec<(PathBuf, PathBuf)>,
+}
+
+impl SessionMerge {
+    pub fn is_empty(&self) -> bool {
+        self.copied.is_empty() && self.updated.is_empty()
+    }
+}
+
+/// The merged `scheduled-tasks.json` for the target account, rendered but not
+/// yet written.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ScheduledMerge {
+    pub target: PathBuf,
+    pub bytes: Vec<u8>,
+    /// Tasks the target did not already have.
+    pub added: usize,
+}
+
+/// Plan the session-index merge into `<sessions_root>/<account_uuid>/<org_uuid>`.
+///
+/// Infallible: an unreadable or absent tree simply means there is nothing to
+/// merge. Only the *writes* can fail, and those abort the switch before it
+/// touches the app or any credential.
+pub fn plan_session_merge(
+    sessions_root: &Path,
+    account_uuid: &str,
+    org_uuid: &str,
+) -> SessionMerge {
+    let target_dir = sessions_root.join(account_uuid).join(org_uuid);
+
+    // Keyed by destination so two source accounts holding the same index can't
+    // both queue a write — the newest one wins, exactly as it would if the
+    // copies were applied one at a time.
+    let mut best: BTreeMap<PathBuf, (PathBuf, i64)> = BTreeMap::new();
+    for source_dir in account_org_dirs(sessions_root) {
+        if source_dir == target_dir {
+            continue;
+        }
+        for source in local_session_files(&source_dir) {
+            let Some(name) = source.file_name() else {
+                continue;
+            };
+            let destination = target_dir.join(name);
+            let activity = last_activity(&source);
+            match best.get(&destination) {
+                Some((_, seen)) if *seen >= activity => {}
+                _ => {
+                    best.insert(destination, (source, activity));
+                }
+            }
+        }
+    }
+
+    let mut merge = SessionMerge::default();
+    for (destination, (source, activity)) in best {
+        if !destination.exists() {
+            merge.copied.push((source, destination));
+        } else if activity > last_activity(&destination) {
+            merge.updated.push((source, destination));
+        }
+    }
+    merge
+}
+
+/// Plan the routine/schedule merge: a union by task `id`, with the newer
+/// `createdAt` winning a conflict. The task *scripts* these point at live in
+/// `~/.claude/scheduled-tasks/<name>/` and are global already, so only the
+/// account-scoped registry needs merging.
+pub fn plan_scheduled_merge(
+    sessions_root: &Path,
+    account_uuid: &str,
+    org_uuid: &str,
+) -> Result<ScheduledMerge> {
+    let target = sessions_root
+        .join(account_uuid)
+        .join(org_uuid)
+        .join(SCHEDULED_TASKS);
+    let (target_tasks, mut skips) = load_scheduled(&target);
+
+    // A Vec rather than a map: registries hold a handful of entries, and the
+    // target's own tasks must keep their existing order.
+    let mut tasks: Vec<(String, Value)> = target_tasks
+        .into_iter()
+        .filter_map(|task| task_id(&task).map(|id| (id, task)))
+        .collect();
+    let mut added = 0usize;
+
+    for source in scheduled_task_files(sessions_root) {
+        if source == target {
+            continue;
+        }
+        let (source_tasks, source_skips) = load_scheduled(&source);
+        for task in source_tasks {
+            let Some(id) = task_id(&task) else {
+                continue;
+            };
+            match tasks.iter_mut().find(|(existing, _)| *existing == id) {
+                Some((_, existing)) => {
+                    if created_at(&task) > created_at(existing) {
+                        *existing = task;
+                    }
+                }
+                None => {
+                    tasks.push((id, task));
+                    added += 1;
+                }
+            }
+        }
+        for (key, value) in source_skips {
+            // First recorded skip wins; a later account's copy never overrides.
+            skips.entry(key).or_insert(value);
+        }
+    }
+
+    let merged = serde_json::json!({
+        "scheduledTasks": tasks.into_iter().map(|(_, task)| task).collect::<Vec<_>>(),
+        "recordedSkips": skips,
+    });
+    Ok(ScheduledMerge {
+        target,
+        bytes: serde_json::to_vec(&merged)?,
+        added,
+    })
+}
+
+/// Rewrite Claude Desktop's `config.json` so the app comes back as a different
+/// account: both OAuth token-cache blobs plus the `lastKnownAccountUuid`
+/// pointer that tells the app who it is. Every other key — the dxt allowlists,
+/// window state, feature flags — is carried through untouched.
+pub fn swap_config_tokens(
+    existing: &[u8],
+    token_cache: &str,
+    token_cache_v2: &str,
+    account_uuid: &str,
+) -> Result<Vec<u8>> {
+    let mut document: Value = serde_json::from_slice(existing)?;
+    let object = document
+        .as_object_mut()
+        .ok_or_else(|| AppError::Other("Claude Desktop config.json is not a JSON object".into()))?;
+    object.insert("oauth:tokenCache".into(), token_cache.into());
+    object.insert("oauth:tokenCacheV2".into(), token_cache_v2.into());
+    object.insert("lastKnownAccountUuid".into(), account_uuid.into());
+    Ok(serde_json::to_vec(&document)?)
+}
+
+/// Fold a per-profile snapshot of `ant-device-registry.json` back into the live
+/// one. The file is a map of account UUID → device registration and already
+/// holds every account, so this is purely additive: **the live value wins every
+/// conflict**, and the only thing a snapshot can contribute is a key the live
+/// file somehow lost. That makes it impossible for this step to be the cause of
+/// a broken browser pairing, which is the whole point of doing it at all.
+///
+/// A malformed snapshot returns the live file unchanged.
+pub fn merge_device_registry(live: &[u8], snapshot: &[u8]) -> Result<Vec<u8>> {
+    let mut merged: Map<String, Value> = serde_json::from_slice(live)?;
+    if let Ok(saved) = serde_json::from_slice::<Map<String, Value>>(snapshot) {
+        for (account_uuid, registration) in saved {
+            merged.entry(account_uuid).or_insert(registration);
+        }
+    }
+    Ok(serde_json::to_vec(&merged)?)
+}
+
+/// Every `<account>/<org>` directory under the session root.
+fn account_org_dirs(sessions_root: &Path) -> Vec<PathBuf> {
+    let Ok(accounts) = std::fs::read_dir(sessions_root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for account in accounts.flatten() {
+        let Ok(orgs) = std::fs::read_dir(account.path()) else {
+            continue;
+        };
+        out.extend(orgs.flatten().map(|org| org.path()).filter(|p| p.is_dir()));
+    }
+    out.sort();
+    out
+}
+
+/// `local_*.json` only — never an account-level file such as
+/// `scheduled-tasks.json`, which lives in the same folder but is merged by id.
+fn local_session_files(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("local_") && name.ends_with(".json"))
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn scheduled_task_files(sessions_root: &Path) -> Vec<PathBuf> {
+    account_org_dirs(sessions_root)
+        .into_iter()
+        .map(|dir| dir.join(SCHEDULED_TASKS))
+        .filter(|path| path.is_file())
+        .collect()
+}
+
+fn load_scheduled(path: &Path) -> (Vec<Value>, Map<String, Value>) {
+    let Ok(bytes) = std::fs::read(path) else {
+        return (Vec::new(), Map::new());
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+        return (Vec::new(), Map::new());
+    };
+    let tasks = value
+        .get("scheduledTasks")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let skips = value
+        .get("recordedSkips")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    (tasks, skips)
+}
+
+fn task_id(task: &Value) -> Option<String> {
+    task.get("id")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+}
+
+fn created_at(task: &Value) -> i64 {
+    task.get("createdAt").map_or(0, json_i64)
+}
+
+fn last_activity(path: &Path) -> i64 {
+    let Ok(bytes) = std::fs::read(path) else {
+        return 0;
+    };
+    serde_json::from_slice::<Value>(&bytes)
+        .ok()
+        .and_then(|value| value.get("lastActivityAt").map(json_i64))
+        .unwrap_or(0)
+}
+
+/// Timestamps arrive as JSON numbers, but a schema-tolerant read costs one line
+/// and a wrong `0` would silently make every merge decision "keep the target".
+fn json_i64(value: &Value) -> i64 {
+    value
+        .as_i64()
+        .or_else(|| value.as_f64().map(|seconds| seconds as i64))
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    fn session(activity: i64) -> String {
+        format!("{{\"lastActivityAt\":{activity},\"cwd\":\"/tmp/demo\"}}")
+    }
+
+    #[test]
+    fn session_merge_takes_the_newest_copy() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(&sessions.join("A/O1/local_x.json"), &session(100));
+        write(&sessions.join("B/O2/local_x.json"), &session(200));
+
+        let merge = plan_session_merge(sessions, "A", "O1");
+        assert!(merge.copied.is_empty());
+        assert_eq!(merge.updated.len(), 1);
+        assert_eq!(merge.updated[0].0, sessions.join("B/O2/local_x.json"));
+        assert_eq!(merge.updated[0].1, sessions.join("A/O1/local_x.json"));
+    }
+
+    #[test]
+    fn session_merge_keeps_a_newer_target() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(&sessions.join("A/O1/local_x.json"), &session(300));
+        write(&sessions.join("B/O2/local_x.json"), &session(200));
+
+        assert_eq!(
+            plan_session_merge(sessions, "A", "O1"),
+            SessionMerge::default()
+        );
+    }
+
+    #[test]
+    fn session_merge_copies_indexes_the_target_lacks() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(&sessions.join("A/O1/local_x.json"), &session(100));
+        write(&sessions.join("B/O2/local_y.json"), &session(50));
+
+        let merge = plan_session_merge(sessions, "A", "O1");
+        assert_eq!(merge.updated.len(), 0);
+        assert_eq!(merge.copied.len(), 1);
+        assert_eq!(merge.copied[0].1, sessions.join("A/O1/local_y.json"));
+    }
+
+    #[test]
+    fn session_merge_prefers_the_newest_of_several_sources() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(&sessions.join("A/O1/local_x.json"), &session(10));
+        write(&sessions.join("B/O2/local_x.json"), &session(200));
+        write(&sessions.join("C/O3/local_x.json"), &session(150));
+
+        let merge = plan_session_merge(sessions, "A", "O1");
+        assert_eq!(merge.updated.len(), 1);
+        assert_eq!(merge.updated[0].0, sessions.join("B/O2/local_x.json"));
+    }
+
+    #[test]
+    fn session_merge_never_touches_the_schedule_registry() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(&sessions.join("A/O1/local_x.json"), &session(100));
+        write(&sessions.join("B/O2/scheduled-tasks.json"), "{}");
+
+        let merge = plan_session_merge(sessions, "A", "O1");
+        assert!(merge.is_empty(), "{merge:?}");
+    }
+
+    #[test]
+    fn scheduled_merge_unions_by_id_with_the_newer_winning() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"name":"old"}],
+                "recordedSkips":{"t1":"target"}}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":200,"name":"new"},
+                                  {"id":"t2","createdAt":5,"name":"extra"}],
+                "recordedSkips":{"t1":"other","t2":"other"}}"#,
+        );
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        assert_eq!(merge.added, 1);
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+        let tasks = value["scheduledTasks"].as_array().unwrap();
+        assert_eq!(tasks.len(), 2);
+        assert_eq!(tasks[0]["name"], "new", "newer createdAt must win");
+        assert_eq!(tasks[1]["id"], "t2");
+        // setdefault semantics: the target's own skip is never overridden.
+        assert_eq!(value["recordedSkips"]["t1"], "target");
+        assert_eq!(value["recordedSkips"]["t2"], "other");
+    }
+
+    #[test]
+    fn scheduled_merge_keeps_the_target_when_it_is_newer() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":300,"name":"target"}]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"name":"other"}]}"#,
+        );
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        assert_eq!(merge.added, 0);
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+        assert_eq!(value["scheduledTasks"][0]["name"], "target");
+    }
+
+    #[test]
+    fn config_swap_preserves_every_unrelated_key() {
+        let existing = br#"{"lastKnownAccountUuid":"old","oauth:tokenCache":"a",
+            "oauth:tokenCacheV2":"b","dxt:allowlistEnabled:org-1":true,
+            "windowBounds":{"width":1200}}"#;
+
+        let bytes = swap_config_tokens(existing, "new-a", "new-b", "new-uuid").unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["oauth:tokenCache"], "new-a");
+        assert_eq!(value["oauth:tokenCacheV2"], "new-b");
+        assert_eq!(value["lastKnownAccountUuid"], "new-uuid");
+        assert_eq!(value["dxt:allowlistEnabled:org-1"], true);
+        assert_eq!(value["windowBounds"]["width"], 1200);
+    }
+
+    #[test]
+    fn config_swap_rejects_a_non_object_document() {
+        assert!(swap_config_tokens(b"[]", "a", "b", "u").is_err());
+    }
+
+    #[test]
+    fn device_registry_merge_lets_the_live_value_win() {
+        let live = br#"{"acct-a":{"deviceId":"live-a"},"acct-b":{"deviceId":"live-b"}}"#;
+        let snapshot = br#"{"acct-b":{"deviceId":"stale-b"},"acct-c":{"deviceId":"saved-c"}}"#;
+
+        let bytes = merge_device_registry(live, snapshot).unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["acct-a"]["deviceId"], "live-a");
+        assert_eq!(value["acct-b"]["deviceId"], "live-b", "live must win");
+        assert_eq!(value["acct-c"]["deviceId"], "saved-c");
+    }
+
+    #[test]
+    fn device_registry_merge_ignores_a_malformed_snapshot() {
+        let live = br#"{"acct-a":{"deviceId":"live-a"}}"#;
+        let bytes = merge_device_registry(live, b"not json at all").unwrap();
+        let value: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["acct-a"]["deviceId"], "live-a");
+        assert_eq!(value.as_object().unwrap().len(), 1);
+    }
+}

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -1,0 +1,994 @@
+//! Switching which Claude account the **Claude Desktop app** is signed in as,
+//! carrying local history along so the account you land on shows the union of
+//! everything rather than only its own conversations.
+//!
+//! The Claude Desktop internals this relies on — the data-directory layout, the
+//! `oauth:tokenCache` / `oauth:tokenCacheV2` / `lastKnownAccountUuid` fields in
+//! `config.json`, which cookie and LevelDB stores carry the renderer's "who am
+//! I", the newest-wins rule for session indexes, and the reason
+//! `bridge-state.json` must be deleted rather than restored — were
+//! reverse-engineered by **claude-acc** (<https://github.com/ohmaseclaro/claude-acc>,
+//! MIT). [`plan_switch`]/[`apply_switch`] are a port of its `cmd_switch`, and
+//! they read and write its profile store so the two tools stay interchangeable.
+//! claude-acc still owns capturing (`add`), forgetting (`remove`), and chat
+//! filtering (`only`/`reset`); this module deliberately covers read + switch.
+//!
+//! Nothing here is compiled out on Linux. Every path is injected through
+//! [`Paths`], the platform commands live behind [`app::AppControl`], and the
+//! whole thing simply finds no data directory on a machine with no Claude
+//! Desktop app — which keeps the logic under CI's clippy and its tests running
+//! everywhere.
+
+pub mod app;
+pub mod merge;
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::config::AnthropicConfig;
+use crate::error::{AppError, Result};
+
+use app::AppControl;
+use merge::{ScheduledMerge, SessionMerge};
+
+/// Claude Desktop's own state file: OAuth token caches plus the account pointer.
+const CONFIG_JSON: &str = "config.json";
+/// Root of the per-account session-index tree, `<root>/<account>/<org>/`.
+const SESSIONS_DIR: &str = "claude-code-sessions";
+/// Chromium-style cookie jar — part of the renderer's identity, not just
+/// `config.json`'s oauth fields.
+const COOKIE_FILES: [&str; 2] = ["Cookies", "Cookies-journal"];
+/// LevelDB stores that carry the rest of that identity.
+const LEVELDB_DIRS: [&str; 3] = ["Local Storage", "Session Storage", "IndexedDB"];
+/// Remote-control / cloud-session bridge. Holds a volatile `cse_…` session id
+/// that goes stale fast, so it is deleted on every switch and *never* saved
+/// into a profile: restoring a dead id makes `/remote-control` fail to
+/// disconnect.
+const BRIDGE_FILE: &str = "bridge-state.json";
+/// Account-keyed map of browser-extension device registrations. Additive only —
+/// see [`merge::merge_device_registry`].
+const DEVICE_REGISTRY: &str = "ant-device-registry.json";
+
+/// Profile-store filenames, owned by claude-acc's layout.
+const TOKEN_CACHE: &str = "config-tokenCache";
+const TOKEN_CACHE_V2: &str = "config-tokenCacheV2";
+const DESKTOP_STATE: &str = "desktop-state";
+const META_JSON: &str = "meta.json";
+
+/// Where the Claude Desktop app and the saved profiles live.
+///
+/// Constructed with [`Paths::at`] in tests so nothing reads a real `$HOME`.
+#[derive(Debug, Clone)]
+pub struct Paths {
+    pub data_dir: PathBuf,
+    pub profiles_dir: PathBuf,
+    pub backups_dir: PathBuf,
+}
+
+impl Paths {
+    /// Test seam: every root explicit.
+    pub fn at(data_dir: PathBuf, profiles_dir: PathBuf, backups_dir: PathBuf) -> Self {
+        Self {
+            data_dir,
+            profiles_dir,
+            backups_dir,
+        }
+    }
+
+    /// Production paths. `desktop_profiles_dir` overrides the claude-acc
+    /// default; rollback archives land beside the profile store.
+    pub fn resolve(anthropic: &AnthropicConfig) -> Result<Self> {
+        let home = crate::cache::home_dir()?;
+        let profiles_dir = anthropic
+            .desktop_profiles_dir
+            .clone()
+            .unwrap_or_else(|| home.join(".claude-acc").join("profiles"));
+        let backups_dir = profiles_dir
+            .parent()
+            .map_or_else(|| home.join(".claude-acc"), Path::to_path_buf)
+            .join("backups");
+        Ok(Self {
+            data_dir: home.join("Library/Application Support/Claude"),
+            profiles_dir,
+            backups_dir,
+        })
+    }
+
+    /// Whether there is a Claude Desktop app installation to act on at all.
+    /// False on Linux, and on a Mac where the app has never run.
+    pub fn available(&self) -> bool {
+        self.data_dir.is_dir()
+    }
+
+    pub fn config_json(&self) -> PathBuf {
+        self.data_dir.join(CONFIG_JSON)
+    }
+
+    pub fn sessions_root(&self) -> PathBuf {
+        self.data_dir.join(SESSIONS_DIR)
+    }
+
+    pub fn profile_dir(&self, label: &str) -> PathBuf {
+        self.profiles_dir.join(label)
+    }
+}
+
+/// One saved account in the profile store.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileMeta {
+    /// The profile directory's name — authoritative, so a hand-edited
+    /// `meta.json` can never make a profile answer to the wrong label.
+    pub label: String,
+    pub email: Option<String>,
+    pub account_uuid: String,
+    /// Absent until the app has created a session folder for the account;
+    /// without it the history merges are skipped but the credential swap
+    /// still works.
+    pub org_uuid: Option<String>,
+    pub has_credentials: bool,
+    pub has_desktop_state: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMeta {
+    email: Option<String>,
+    #[serde(rename = "accountUuid")]
+    account_uuid: Option<String>,
+    #[serde(rename = "orgUuid")]
+    org_uuid: Option<String>,
+}
+
+/// Every saved profile, sorted by label. Best-effort by design: one unreadable
+/// or hand-mangled `meta.json` is skipped rather than failing `account status`
+/// for every other account.
+pub fn load_profiles(profiles_dir: &Path) -> Vec<ProfileMeta> {
+    let Ok(entries) = std::fs::read_dir(profiles_dir) else {
+        return Vec::new();
+    };
+    let mut profiles: Vec<ProfileMeta> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let dir = entry.path();
+            let label = dir.file_name()?.to_str()?.to_string();
+            let raw: RawMeta =
+                serde_json::from_slice(&std::fs::read(dir.join(META_JSON)).ok()?).ok()?;
+            let account_uuid = raw.account_uuid.filter(|uuid| !uuid.is_empty())?;
+            Some(ProfileMeta {
+                label,
+                email: raw.email.filter(|email| !email.is_empty()),
+                account_uuid,
+                org_uuid: raw.org_uuid.filter(|uuid| !uuid.is_empty()),
+                has_credentials: dir.join(TOKEN_CACHE).is_file()
+                    && dir.join(TOKEN_CACHE_V2).is_file(),
+                has_desktop_state: dir.join(DESKTOP_STATE).is_dir(),
+            })
+        })
+        .collect();
+    profiles.sort_by(|a, b| a.label.cmp(&b.label));
+    profiles
+}
+
+/// Which account the Desktop app currently believes it is. This is the app's
+/// own pointer, not a guess from file timestamps.
+pub fn active_account_uuid(config_json: &Path) -> Option<String> {
+    let bytes = std::fs::read(config_json).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    value
+        .get("lastKnownAccountUuid")?
+        .as_str()
+        .filter(|uuid| !uuid.is_empty())
+        .map(str::to_string)
+}
+
+pub fn label_for_uuid<'a>(profiles: &'a [ProfileMeta], account_uuid: &str) -> Option<&'a str> {
+    profiles
+        .iter()
+        .find(|profile| profile.account_uuid == account_uuid)
+        .map(|profile| profile.label.as_str())
+}
+
+/// How many conversations the account's history folder holds.
+pub fn session_count(sessions_root: &Path, profile: &ProfileMeta) -> usize {
+    let Some(org) = &profile.org_uuid else {
+        return 0;
+    };
+    let Ok(entries) = std::fs::read_dir(sessions_root.join(&profile.account_uuid).join(org)) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .filter(|entry| {
+            entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "json")
+        })
+        .count()
+}
+
+/// Knobs that change what a switch does rather than which account it targets.
+#[derive(Debug, Clone)]
+pub struct SwitchOpts {
+    /// Keep `bridge-state.json` instead of deleting it. Off by default, so the
+    /// shipped behaviour matches claude-acc; on, it turns "does the remote
+    /// bridge cause the browser disconnect?" into a one-command experiment.
+    pub keep_bridge: bool,
+    /// Also archive the whole session tree. Off by default: the session merge
+    /// is additive (the older copy always survives in its source folder), so a
+    /// full-tree archive costs tens of megabytes per switch to protect against
+    /// nothing. On, it matches claude-acc byte for byte.
+    pub backup_sessions: bool,
+    /// Rollback archives to retain.
+    pub keep_backups: usize,
+}
+
+impl Default for SwitchOpts {
+    fn default() -> Self {
+        Self {
+            keep_bridge: false,
+            backup_sessions: false,
+            keep_backups: 10,
+        }
+    }
+}
+
+/// The saved OAuth token caches for the account being switched to. Opaque
+/// blobs; never logged or printed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SavedTokens {
+    pub token_cache: String,
+    pub token_cache_v2: String,
+}
+
+/// Everything a switch would do, decided before anything is touched.
+#[derive(Debug)]
+pub struct SwitchPlan {
+    pub target: ProfileMeta,
+    /// The account being switched away from, when it is one we manage.
+    pub outgoing: Option<String>,
+    pub sessions: SessionMerge,
+    /// Absent when the target has no known org yet, so there is no history
+    /// folder to merge into.
+    pub scheduled: Option<ScheduledMerge>,
+    /// Absent when the profile has no saved Desktop credential; the switch then
+    /// migrates history but leaves the app signed in as it was.
+    pub tokens: Option<SavedTokens>,
+    pub archive: PathBuf,
+    pub archive_members: Vec<String>,
+    pub restores_desktop_state: bool,
+    pub opts: SwitchOpts,
+}
+
+/// Decide the whole switch without performing any of it.
+///
+/// This is what makes `--dry-run` free, and a test asserts it leaves the data
+/// directory byte-identical.
+pub fn plan_switch(paths: &Paths, label: &str, opts: SwitchOpts) -> Result<SwitchPlan> {
+    let profiles = load_profiles(&paths.profiles_dir);
+    let target = profiles
+        .iter()
+        .find(|profile| profile.label == label)
+        .cloned()
+        .ok_or_else(|| {
+            let known: Vec<&str> = profiles.iter().map(|p| p.label.as_str()).collect();
+            AppError::Credentials(format!(
+                "no saved Claude Desktop account {label:?} in {}; known: {known:?}. \
+                 Capture one with `claude-acc add {label}` \
+                 (https://github.com/ohmaseclaro/claude-acc)",
+                paths.profiles_dir.display()
+            ))
+        })?;
+
+    let sessions_root = paths.sessions_root();
+    let (sessions, scheduled) = match &target.org_uuid {
+        Some(org) => (
+            merge::plan_session_merge(&sessions_root, &target.account_uuid, org),
+            Some(merge::plan_scheduled_merge(
+                &sessions_root,
+                &target.account_uuid,
+                org,
+            )?),
+        ),
+        None => (SessionMerge::default(), None),
+    };
+
+    let outgoing = active_account_uuid(&paths.config_json())
+        .and_then(|uuid| label_for_uuid(&profiles, &uuid).map(str::to_string));
+
+    let profile_dir = paths.profile_dir(label);
+    let tokens = match (
+        std::fs::read_to_string(profile_dir.join(TOKEN_CACHE)),
+        std::fs::read_to_string(profile_dir.join(TOKEN_CACHE_V2)),
+    ) {
+        (Ok(token_cache), Ok(token_cache_v2)) => Some(SavedTokens {
+            token_cache,
+            token_cache_v2,
+        }),
+        _ => None,
+    };
+
+    let stamp = crate::claude_desktop::timestamp();
+    Ok(SwitchPlan {
+        archive: paths
+            .backups_dir
+            .join(format!("switch-{stamp}-{label}.tar.gz")),
+        archive_members: archive_members(paths, &opts),
+        restores_desktop_state: profile_dir.join(DESKTOP_STATE).is_dir(),
+        target,
+        outgoing,
+        sessions,
+        scheduled,
+        tokens,
+        opts,
+    })
+}
+
+/// Perform a planned switch.
+///
+/// `Err` means the switch aborted **before** the app or any credential was
+/// touched. Once the app is down every remaining step is best-effort and
+/// reports through the returned notes: bailing out halfway would leave the user
+/// with a quit app and a half-swapped identity, which is worse than proceeding.
+pub fn apply_switch(paths: &Paths, plan: &SwitchPlan, app: &dyn AppControl) -> Result<Vec<String>> {
+    let mut notes = Vec::new();
+
+    // The rollback archive comes first: no backup, no mutation.
+    let members: Vec<&str> = plan
+        .archive_members
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    if !members.is_empty() {
+        app.archive(&plan.archive, &paths.data_dir, &members)?;
+        prune_archives(&paths.backups_dir, plan.opts.keep_backups, &mut notes);
+    }
+
+    // History merges abort too — a partial merge is recoverable, but doing it
+    // after the credential swap would strand the user on an account whose
+    // history never arrived.
+    for (source, destination) in plan.sessions.copied.iter().chain(&plan.sessions.updated) {
+        copy_file(source, destination)?;
+    }
+    if let Some(scheduled) = &plan.scheduled
+        && let Err(error) = crate::cache::atomic_write(&scheduled.target, &scheduled.bytes)
+    {
+        notes.push(format!("schedule merge skipped: {error}"));
+    }
+
+    // From here the app is down and nothing returns early — the relaunch in the
+    // tail must run whatever happens above it.
+    app.quit();
+
+    // Identify the outgoing account from the *live* config, after the quit:
+    // the app rewrites this file on shutdown. Snapshotting it must also happen
+    // strictly before the swap below, or the outgoing tokens get filed under
+    // the incoming label and an account is destroyed.
+    let live_config = paths.config_json();
+    let outgoing = active_account_uuid(&live_config).and_then(|uuid| {
+        label_for_uuid(&load_profiles(&paths.profiles_dir), &uuid).map(str::to_string)
+    });
+    if let Some(label) = &outgoing {
+        snapshot_profile(paths, label, &mut notes);
+    }
+
+    match &plan.tokens {
+        Some(tokens) => {
+            swap_credentials(&live_config, tokens, &plan.target.account_uuid, &mut notes)
+        }
+        None => notes.push(format!(
+            "no saved Desktop credential for {:?} yet — sign in once in the app, \
+             then switch again to capture it",
+            plan.target.label
+        )),
+    }
+
+    if plan.restores_desktop_state {
+        restore_desktop_state(paths, &plan.target.label, &mut notes);
+    } else {
+        notes.push(format!(
+            "no saved browser state for {:?} yet — the app may still show the previous account",
+            plan.target.label
+        ));
+    }
+
+    if !plan.opts.keep_bridge {
+        let bridge = paths.data_dir.join(BRIDGE_FILE);
+        if bridge.is_file()
+            && let Err(error) = std::fs::remove_file(&bridge)
+        {
+            notes.push(format!("could not clear {BRIDGE_FILE}: {error}"));
+        }
+    }
+    restore_device_registry(paths, &plan.target.label, &mut notes);
+
+    app.relaunch();
+    Ok(notes)
+}
+
+/// Save the outgoing account's live credential and browser state back into its
+/// profile, so switching to it later restores what it looked like just now.
+/// Only safe with the app fully quit — copying a live SQLite/LevelDB store
+/// risks grabbing it mid-write.
+///
+/// Deliberately never writes `meta.json`: that file belongs to `claude-acc add`,
+/// and two tools writing it is how the stores drift apart.
+fn snapshot_profile(paths: &Paths, label: &str, notes: &mut Vec<String>) {
+    let profile_dir = paths.profile_dir(label);
+    if let Err(error) = std::fs::create_dir_all(&profile_dir) {
+        notes.push(format!("could not snapshot {label:?}: {error}"));
+        return;
+    }
+    restrict(&profile_dir, 0o700, notes);
+
+    if let Ok(bytes) = std::fs::read(paths.config_json())
+        && let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes)
+    {
+        for (key, file) in [
+            ("oauth:tokenCache", TOKEN_CACHE),
+            ("oauth:tokenCacheV2", TOKEN_CACHE_V2),
+        ] {
+            if let Some(blob) = value.get(key).and_then(serde_json::Value::as_str) {
+                let path = profile_dir.join(file);
+                if let Err(error) = crate::cache::atomic_write(&path, blob.as_bytes()) {
+                    notes.push(format!("could not save {label:?}'s credential: {error}"));
+                } else {
+                    restrict(&path, 0o600, notes);
+                }
+            }
+        }
+    }
+
+    // The registry is account-keyed and shared, so it is snapshotted (never
+    // moved) purely so a lost key can be folded back in later.
+    let registry = paths.data_dir.join(DEVICE_REGISTRY);
+    if registry.is_file() {
+        let _ = copy_file(&registry, &profile_dir.join(DEVICE_REGISTRY));
+    }
+
+    let state_dir = profile_dir.join(DESKTOP_STATE);
+    if let Err(error) = std::fs::create_dir_all(&state_dir) {
+        notes.push(format!(
+            "could not snapshot {label:?}'s browser state: {error}"
+        ));
+        return;
+    }
+    restrict(&state_dir, 0o700, notes);
+    for name in COOKIE_FILES {
+        let source = paths.data_dir.join(name);
+        if source.is_file() {
+            let destination = state_dir.join(name);
+            if copy_file(&source, &destination).is_ok() {
+                restrict(&destination, 0o600, notes);
+            }
+        }
+    }
+    for name in LEVELDB_DIRS {
+        let source = paths.data_dir.join(name);
+        if source.is_dir()
+            && let Err(error) = replace_dir(&source, &state_dir.join(name))
+        {
+            notes.push(format!("could not snapshot {label:?}'s {name}: {error}"));
+        }
+    }
+    // bridge-state.json is deliberately not snapshotted — see BRIDGE_FILE.
+}
+
+fn swap_credentials(
+    config_json: &Path,
+    tokens: &SavedTokens,
+    account_uuid: &str,
+    notes: &mut Vec<String>,
+) {
+    let existing = match std::fs::read(config_json) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            notes.push(format!("could not read the Desktop config: {error}"));
+            return;
+        }
+    };
+    match merge::swap_config_tokens(
+        &existing,
+        &tokens.token_cache,
+        &tokens.token_cache_v2,
+        account_uuid,
+    ) {
+        // Atomic, unlike claude-acc's truncating write: a crash mid-write here
+        // would take every account's tokens with it.
+        Ok(bytes) => {
+            if let Err(error) = crate::cache::atomic_write(config_json, &bytes) {
+                notes.push(format!("could not write the Desktop config: {error}"));
+            }
+        }
+        Err(error) => notes.push(format!("could not swap the Desktop credential: {error}")),
+    }
+}
+
+fn restore_desktop_state(paths: &Paths, label: &str, notes: &mut Vec<String>) {
+    let state_dir = paths.profile_dir(label).join(DESKTOP_STATE);
+    for name in COOKIE_FILES {
+        let source = state_dir.join(name);
+        if source.is_file()
+            && let Err(error) = copy_file(&source, &paths.data_dir.join(name))
+        {
+            notes.push(format!("could not restore {name}: {error}"));
+        }
+    }
+    for name in LEVELDB_DIRS {
+        let source = state_dir.join(name);
+        if source.is_dir()
+            && let Err(error) = replace_dir(&source, &paths.data_dir.join(name))
+        {
+            notes.push(format!("could not restore {name}: {error}"));
+        }
+    }
+}
+
+/// Fold a snapshotted device registry back into the live one. Purely additive
+/// (live wins every conflict), so this can only ever restore a lost entry.
+fn restore_device_registry(paths: &Paths, label: &str, notes: &mut Vec<String>) {
+    let snapshot = paths.profile_dir(label).join(DEVICE_REGISTRY);
+    let live = paths.data_dir.join(DEVICE_REGISTRY);
+    let (Ok(saved), Ok(current)) = (std::fs::read(&snapshot), std::fs::read(&live)) else {
+        return;
+    };
+    match merge::merge_device_registry(&current, &saved) {
+        Ok(bytes) if bytes != current => {
+            if let Err(error) = crate::cache::atomic_write(&live, &bytes) {
+                notes.push(format!("could not merge {DEVICE_REGISTRY}: {error}"));
+            }
+        }
+        Ok(_) => {}
+        Err(error) => notes.push(format!("could not merge {DEVICE_REGISTRY}: {error}")),
+    }
+}
+
+/// What goes into the rollback archive, relative to the data directory.
+///
+/// Only what a switch can actually destroy: the credential pointer, the
+/// schedule registries it rewrites, and the device registry. Missing entries
+/// are dropped, because `tar` fails the whole archive on one of them.
+fn archive_members(paths: &Paths, opts: &SwitchOpts) -> Vec<String> {
+    let mut members = Vec::new();
+    for name in [CONFIG_JSON, DEVICE_REGISTRY] {
+        if paths.data_dir.join(name).exists() {
+            members.push(name.to_string());
+        }
+    }
+    if opts.backup_sessions {
+        if paths.sessions_root().is_dir() {
+            members.push(SESSIONS_DIR.to_string());
+        }
+        return members;
+    }
+    let sessions_root = paths.sessions_root();
+    let Ok(accounts) = std::fs::read_dir(&sessions_root) else {
+        return members;
+    };
+    let mut registries = Vec::new();
+    for account in accounts.flatten() {
+        let Ok(orgs) = std::fs::read_dir(account.path()) else {
+            continue;
+        };
+        for org in orgs.flatten() {
+            let path = org.path().join("scheduled-tasks.json");
+            if path.is_file()
+                && let Ok(relative) = path.strip_prefix(&paths.data_dir)
+            {
+                registries.push(relative.display().to_string());
+            }
+        }
+    }
+    registries.sort();
+    members.extend(registries);
+    members
+}
+
+fn prune_archives(backups_dir: &Path, keep: usize, notes: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(backups_dir) else {
+        return;
+    };
+    // The name embeds a sortable timestamp right after the constant prefix, so
+    // lexicographic order is chronological order.
+    let mut archives: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("switch-") && name.ends_with(".tar.gz"))
+        })
+        .collect();
+    if archives.len() <= keep {
+        return;
+    }
+    archives.sort();
+    let doomed = archives.len() - keep;
+    for path in archives.into_iter().take(doomed) {
+        if let Err(error) = std::fs::remove_file(&path) {
+            notes.push(format!("could not prune {}: {error}", path.display()));
+        }
+    }
+}
+
+fn copy_file(source: &Path, destination: &Path) -> Result<()> {
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AppError::io_at(parent, e))?;
+    }
+    std::fs::copy(source, destination).map_err(|e| AppError::io_at(source, e))?;
+    Ok(())
+}
+
+/// Replace `destination` with a fresh copy of `source`. LevelDB stores must not
+/// be merged file-by-file — a stale manifest beside fresh log files is a
+/// corrupt store — so the old directory goes first.
+fn replace_dir(source: &Path, destination: &Path) -> Result<()> {
+    if destination.exists() {
+        std::fs::remove_dir_all(destination).map_err(|e| AppError::io_at(destination, e))?;
+    }
+    copy_dir(source, destination)
+}
+
+fn copy_dir(source: &Path, destination: &Path) -> Result<()> {
+    std::fs::create_dir_all(destination).map_err(|e| AppError::io_at(destination, e))?;
+    let entries = std::fs::read_dir(source).map_err(|e| AppError::io_at(source, e))?;
+    for entry in entries.flatten() {
+        let child = entry.path();
+        let target = destination.join(entry.file_name());
+        if child.is_dir() {
+            copy_dir(&child, &target)?;
+        } else {
+            std::fs::copy(&child, &target).map_err(|e| AppError::io_at(&child, e))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict(path: &Path, mode: u32, notes: &mut Vec<String>) {
+    use std::os::unix::fs::PermissionsExt;
+
+    if let Err(error) = std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)) {
+        notes.push(format!("could not restrict {}: {error}", path.display()));
+    }
+}
+
+#[cfg(not(unix))]
+fn restrict(_path: &Path, _mode: u32, _notes: &mut Vec<String>) {}
+
+fn timestamp() -> String {
+    chrono::Local::now().format("%Y%m%d-%H%M%S").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use app::Recorder;
+
+    struct Fixture {
+        _root: tempfile::TempDir,
+        paths: Paths,
+    }
+
+    fn write(path: &Path, contents: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, contents).unwrap();
+    }
+
+    /// Two accounts: `here` (active) and `there` (fully captured).
+    fn fixture() -> Fixture {
+        let root = tempfile::TempDir::new().unwrap();
+        let data = root.path().join("data");
+        let profiles = root.path().join("profiles");
+        let backups = root.path().join("backups");
+
+        write(
+            &data.join(CONFIG_JSON),
+            r#"{"lastKnownAccountUuid":"uuid-here","oauth:tokenCache":"live-a",
+                "oauth:tokenCacheV2":"live-b","dxt:allowlistEnabled:org-1":true}"#,
+        );
+        write(
+            &data.join(DEVICE_REGISTRY),
+            r#"{"uuid-here":{"deviceId":"d1"}}"#,
+        );
+        write(
+            &data.join(BRIDGE_FILE),
+            r#"{"remoteSessionId":"cse_stale"}"#,
+        );
+        write(&data.join("Cookies"), "live-cookies");
+        write(&data.join("Local Storage/leveldb/CURRENT"), "live-ldb");
+        write(
+            &data.join(SESSIONS_DIR).join("uuid-here/org-1/local_x.json"),
+            r#"{"lastActivityAt":500}"#,
+        );
+        write(
+            &data
+                .join(SESSIONS_DIR)
+                .join("uuid-here/org-1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1}]}"#,
+        );
+
+        write(
+            &profiles.join("here/meta.json"),
+            r#"{"label":"here","email":"here@example.com","accountUuid":"uuid-here","orgUuid":"org-1"}"#,
+        );
+        write(
+            &profiles.join("there/meta.json"),
+            r#"{"label":"there","email":"there@example.com","accountUuid":"uuid-there","orgUuid":"org-2"}"#,
+        );
+        write(&profiles.join("there").join(TOKEN_CACHE), "saved-a");
+        write(&profiles.join("there").join(TOKEN_CACHE_V2), "saved-b");
+        write(
+            &profiles.join("there").join(DESKTOP_STATE).join("Cookies"),
+            "there-cookies",
+        );
+        write(
+            &profiles
+                .join("there")
+                .join(DESKTOP_STATE)
+                .join("Local Storage/leveldb/CURRENT"),
+            "there-ldb",
+        );
+
+        Fixture {
+            paths: Paths::at(data, profiles, backups),
+            _root: root,
+        }
+    }
+
+    /// `(relative path, length)` for every file under a root, so a test can
+    /// assert nothing changed.
+    fn manifest(root: &Path) -> Vec<(String, u64)> {
+        fn walk(dir: &Path, root: &Path, out: &mut Vec<(String, u64)>) {
+            let Ok(entries) = std::fs::read_dir(dir) else {
+                return;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, root, out);
+                } else if let Ok(meta) = entry.metadata() {
+                    let relative = path.strip_prefix(root).unwrap().display().to_string();
+                    out.push((relative, meta.len()));
+                }
+            }
+        }
+        let mut out = Vec::new();
+        walk(root, root, &mut out);
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn profiles_load_sorted_with_their_capture_state() {
+        let fixture = fixture();
+        let profiles = load_profiles(&fixture.paths.profiles_dir);
+
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].label, "here");
+        assert_eq!(profiles[0].email.as_deref(), Some("here@example.com"));
+        assert!(!profiles[0].has_credentials);
+        assert_eq!(profiles[1].label, "there");
+        assert!(profiles[1].has_credentials);
+        assert!(profiles[1].has_desktop_state);
+    }
+
+    #[test]
+    fn a_malformed_profile_is_skipped_not_fatal() {
+        let fixture = fixture();
+        write(
+            &fixture.paths.profiles_dir.join("broken/meta.json"),
+            "{ not json",
+        );
+        write(
+            &fixture.paths.profiles_dir.join("no-uuid/meta.json"),
+            r#"{"label":"x"}"#,
+        );
+
+        let profiles = load_profiles(&fixture.paths.profiles_dir);
+        let labels: Vec<&str> = profiles.iter().map(|p| p.label.as_str()).collect();
+        assert_eq!(labels, ["here", "there"]);
+    }
+
+    #[test]
+    fn the_active_account_resolves_to_its_label() {
+        let fixture = fixture();
+        let profiles = load_profiles(&fixture.paths.profiles_dir);
+        let uuid = active_account_uuid(&fixture.paths.config_json()).unwrap();
+
+        assert_eq!(label_for_uuid(&profiles, &uuid), Some("here"));
+        assert_eq!(label_for_uuid(&profiles, "uuid-nobody"), None);
+    }
+
+    #[test]
+    fn session_counts_come_from_the_accounts_own_folder() {
+        let fixture = fixture();
+        let profiles = load_profiles(&fixture.paths.profiles_dir);
+        let sessions_root = fixture.paths.sessions_root();
+
+        assert_eq!(session_count(&sessions_root, &profiles[0]), 2);
+        assert_eq!(session_count(&sessions_root, &profiles[1]), 0);
+    }
+
+    #[test]
+    fn planning_a_switch_changes_nothing_on_disk() {
+        let fixture = fixture();
+        let before = manifest(&fixture.paths.data_dir);
+
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+
+        assert_eq!(plan.outgoing.as_deref(), Some("here"));
+        assert!(plan.tokens.is_some());
+        assert!(plan.restores_desktop_state);
+        assert_eq!(plan.sessions.copied.len(), 1, "{:?}", plan.sessions);
+        assert_eq!(manifest(&fixture.paths.data_dir), before);
+        assert!(!fixture.paths.backups_dir.exists());
+    }
+
+    #[test]
+    fn planning_an_unknown_label_lists_the_known_ones() {
+        let fixture = fixture();
+        let error = plan_switch(&fixture.paths, "nope", SwitchOpts::default()).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("here"), "{message}");
+        assert!(message.contains("claude-acc"), "{message}");
+    }
+
+    #[test]
+    fn the_archive_skips_the_session_tree_by_default() {
+        let fixture = fixture();
+
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        assert!(plan.archive_members.contains(&CONFIG_JSON.to_string()));
+        assert!(plan.archive_members.contains(&DEVICE_REGISTRY.to_string()));
+        assert!(!plan.archive_members.contains(&SESSIONS_DIR.to_string()));
+        assert!(
+            plan.archive_members
+                .iter()
+                .any(|member| member.ends_with("scheduled-tasks.json"))
+        );
+
+        let full = plan_switch(
+            &fixture.paths,
+            "there",
+            SwitchOpts {
+                backup_sessions: true,
+                ..SwitchOpts::default()
+            },
+        )
+        .unwrap();
+        assert!(full.archive_members.contains(&SESSIONS_DIR.to_string()));
+    }
+
+    #[test]
+    fn applying_a_switch_archives_then_quits_then_relaunches() {
+        let fixture = fixture();
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        let recorder = Recorder::default();
+
+        apply_switch(&fixture.paths, &plan, &recorder).unwrap();
+
+        let steps = recorder.steps();
+        assert!(steps[0].starts_with("archive "), "{steps:?}");
+        assert_eq!(steps[1], "quit");
+        assert_eq!(steps[2], "relaunch");
+    }
+
+    #[test]
+    fn applying_a_switch_swaps_the_credential_and_carries_history() {
+        let fixture = fixture();
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+
+        apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
+
+        let config: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(fixture.paths.config_json()).unwrap()).unwrap();
+        assert_eq!(config["oauth:tokenCache"], "saved-a");
+        assert_eq!(config["oauth:tokenCacheV2"], "saved-b");
+        assert_eq!(config["lastKnownAccountUuid"], "uuid-there");
+        assert_eq!(config["dxt:allowlistEnabled:org-1"], true);
+
+        // History followed the switch, and the browser state came back.
+        assert!(
+            fixture
+                .paths
+                .sessions_root()
+                .join("uuid-there/org-2/local_x.json")
+                .is_file()
+        );
+        assert_eq!(
+            std::fs::read_to_string(fixture.paths.data_dir.join("Cookies")).unwrap(),
+            "there-cookies"
+        );
+        assert_eq!(
+            std::fs::read_to_string(fixture.paths.data_dir.join("Local Storage/leveldb/CURRENT"))
+                .unwrap(),
+            "there-ldb"
+        );
+        // The volatile remote-control bridge is cleared, never restored.
+        assert!(!fixture.paths.data_dir.join(BRIDGE_FILE).exists());
+    }
+
+    #[test]
+    fn the_outgoing_account_is_snapshotted_before_the_swap() {
+        let fixture = fixture();
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+
+        apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
+
+        // `here` must have captured the credential that was live *before* the
+        // swap. Reading it back as "saved-a" would mean we filed the incoming
+        // account's tokens under the outgoing label.
+        let here = fixture.paths.profile_dir("here");
+        assert_eq!(
+            std::fs::read_to_string(here.join(TOKEN_CACHE)).unwrap(),
+            "live-a"
+        );
+        assert_eq!(
+            std::fs::read_to_string(here.join(TOKEN_CACHE_V2)).unwrap(),
+            "live-b"
+        );
+        assert_eq!(
+            std::fs::read_to_string(here.join(DESKTOP_STATE).join("Cookies")).unwrap(),
+            "live-cookies"
+        );
+        // meta.json belongs to claude-acc; we must never rewrite it.
+        let meta = std::fs::read_to_string(here.join(META_JSON)).unwrap();
+        assert!(meta.contains("here@example.com"), "{meta}");
+    }
+
+    #[test]
+    fn the_app_is_relaunched_even_without_a_saved_credential() {
+        let fixture = fixture();
+        std::fs::remove_file(fixture.paths.profile_dir("there").join(TOKEN_CACHE)).unwrap();
+        std::fs::remove_dir_all(fixture.paths.profile_dir("there").join(DESKTOP_STATE)).unwrap();
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        assert!(plan.tokens.is_none());
+        let recorder = Recorder::default();
+
+        let notes = apply_switch(&fixture.paths, &plan, &recorder).unwrap();
+
+        assert_eq!(recorder.steps().last().unwrap(), "relaunch");
+        assert!(
+            notes
+                .iter()
+                .any(|note| note.contains("no saved Desktop credential")),
+            "{notes:?}"
+        );
+    }
+
+    #[test]
+    fn keeping_the_bridge_leaves_it_in_place() {
+        let fixture = fixture();
+        let plan = plan_switch(
+            &fixture.paths,
+            "there",
+            SwitchOpts {
+                keep_bridge: true,
+                ..SwitchOpts::default()
+            },
+        )
+        .unwrap();
+
+        apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
+        assert!(fixture.paths.data_dir.join(BRIDGE_FILE).is_file());
+    }
+
+    #[test]
+    fn archives_are_pruned_oldest_first() {
+        let dir = tempfile::TempDir::new().unwrap();
+        for stamp in ["20260101-000000", "20260102-000000", "20260103-000000"] {
+            std::fs::write(dir.path().join(format!("switch-{stamp}-x.tar.gz")), "z").unwrap();
+        }
+        std::fs::write(dir.path().join("unrelated.txt"), "keep me").unwrap();
+        let mut notes = Vec::new();
+
+        prune_archives(dir.path(), 2, &mut notes);
+
+        assert!(notes.is_empty(), "{notes:?}");
+        assert!(!dir.path().join("switch-20260101-000000-x.tar.gz").exists());
+        assert!(dir.path().join("switch-20260102-000000-x.tar.gz").exists());
+        assert!(dir.path().join("switch-20260103-000000-x.tar.gz").exists());
+        assert!(dir.path().join("unrelated.txt").exists());
+    }
+}

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -20,6 +20,7 @@
 //! everywhere.
 
 pub mod app;
+pub mod capture;
 pub mod merge;
 
 use std::path::{Path, PathBuf};
@@ -111,6 +112,12 @@ impl Paths {
 
     pub fn profile_dir(&self, label: &str) -> PathBuf {
         self.profiles_dir.join(label)
+    }
+
+    /// Where [`capture`] parks the live login before clearing it, so a
+    /// cancelled capture can put the account back. Sits beside the archives.
+    pub fn prelogin_dir(&self) -> PathBuf {
+        self.backups_dir.with_file_name("prelogin-backup")
     }
 }
 
@@ -404,6 +411,43 @@ pub fn apply_switch(paths: &Paths, plan: &SwitchPlan, app: &dyn AppControl) -> R
 
     app.relaunch();
     Ok(notes)
+}
+
+/// Copy every other account's history into this one's folder, so it shows the
+/// union of everything. Used when capturing a brand-new account, whose first
+/// login would otherwise open on an empty sidebar; a switch uses the
+/// pre-computed plan instead so `--dry-run` can report it.
+///
+/// Returns `(session indexes, routines)` brought in.
+fn merge_history_into(
+    paths: &Paths,
+    account_uuid: &str,
+    org_uuid: &str,
+    notes: &mut Vec<String>,
+) -> (usize, usize) {
+    let sessions_root = paths.sessions_root();
+    let sessions = merge::plan_session_merge(&sessions_root, account_uuid, org_uuid);
+    let mut copied = 0;
+    for (source, destination) in sessions.copied.iter().chain(&sessions.updated) {
+        match copy_file(source, destination) {
+            Ok(()) => copied += 1,
+            Err(error) => notes.push(format!("could not seed {}: {error}", destination.display())),
+        }
+    }
+    let routines = match merge::plan_scheduled_merge(&sessions_root, account_uuid, org_uuid) {
+        Ok(scheduled) => match crate::cache::atomic_write(&scheduled.target, &scheduled.bytes) {
+            Ok(()) => scheduled.added,
+            Err(error) => {
+                notes.push(format!("schedule seed skipped: {error}"));
+                0
+            }
+        },
+        Err(error) => {
+            notes.push(format!("schedule seed skipped: {error}"));
+            0
+        }
+    };
+    (copied, routines)
 }
 
 /// Save the outgoing account's live credential and browser state back into its

--- a/src/config.rs
+++ b/src/config.rs
@@ -296,7 +296,7 @@ impl AnthropicConfig {
 /// account's cache dir — so path separators, control characters, or reserved
 /// cache sidecar names would escape, spoof terminal output, or collide with the
 /// cache layout (`usage.json`, `.stale`, …).
-fn validate_account_label(label: &str) -> Result<()> {
+pub fn validate_account_label(label: &str) -> Result<()> {
     const RESERVED: [&str; 4] = ["usage.json", ".stale", ".last_error", ".fetch.lock"];
     let bad = label.is_empty()
         || label == "."

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,6 +152,12 @@ pub struct AnthropicConfig {
     /// Keychain/`~/.claude` login doesn't add a redundant "Claude" tab. Ignored
     /// when there are no named accounts, so Anthropic never loses its only tab.
     pub show_default_account: bool,
+    /// Where the Claude **Desktop app**'s saved account profiles live. Defaults
+    /// to `~/.claude-acc/profiles`, the store claude-acc
+    /// (<https://github.com/ohmaseclaro/claude-acc>) creates — `account switch`
+    /// reads and writes that layout so the two tools stay interchangeable.
+    /// Unrelated to `accounts_dir`, which is the `claude` CLI's own accounts.
+    pub desktop_profiles_dir: Option<PathBuf>,
 }
 
 impl Default for AnthropicConfig {
@@ -162,6 +168,7 @@ impl Default for AnthropicConfig {
             accounts: Vec::new(),
             accounts_dir: None,
             show_default_account: true,
+            desktop_profiles_dir: None,
         }
     }
 }
@@ -184,6 +191,18 @@ pub struct AnthropicAccount {
     /// writes). Token refreshes are written back here, so each account keeps
     /// itself alive independently.
     pub credentials_path: PathBuf,
+}
+
+impl AnthropicAccount {
+    /// The `CLAUDE_CONFIG_DIR` this account occupies — the credential file's
+    /// own directory. Claude Code hashes exactly this path for the account's
+    /// Keychain item, so it is also the account's identity for
+    /// [`crate::anthropic::keychain`].
+    pub fn config_dir(&self) -> PathBuf {
+        self.credentials_path
+            .parent()
+            .map_or_else(|| self.credentials_path.clone(), Path::to_path_buf)
+    }
 }
 
 impl AnthropicConfig {
@@ -231,18 +250,43 @@ impl AnthropicConfig {
     /// accounts identically; the widget layers its `--cache-dir` override on
     /// top of the cache returned here.
     pub fn account_target(&self, label: &str) -> Result<(CredsTarget, Cache)> {
+        let active = crate::anthropic::cli_account::home_claude_json()
+            .ok()
+            .and_then(|path| {
+                crate::anthropic::cli_account::resolve_active_label(&path, &self.all_accounts())
+            });
+        self.account_target_with(label, active.as_deref())
+    }
+
+    /// The pure half of [`account_target`](AnthropicConfig::account_target),
+    /// with "which account the `claude` CLI is signed into" injected — the same
+    /// shape as `Cli::resolve_vendor_with`.
+    ///
+    /// When `label` *is* the live CLI login, its credential lives in the
+    /// default slot as well as its own, and both hold the same rotating
+    /// refresh token. Reading the default one keeps exactly one live lineage,
+    /// so a refresh here can never invalidate the copy `claude` is using (or
+    /// the other way round). The cache directory is unchanged either way, so
+    /// the tab keeps its identity and its cached usage across a switch.
+    pub fn account_target_with(
+        &self,
+        label: &str,
+        cli_active: Option<&str>,
+    ) -> Result<(CredsTarget, Cache)> {
         let account = self.account(label)?;
-        let config_dir = account
-            .credentials_path
-            .parent()
-            .map(std::path::Path::to_path_buf)
-            .unwrap_or_else(|| account.credentials_path.clone());
+        let cache = Cache::for_vendor_account("anthropic", label)?;
+        if cli_active == Some(label) {
+            return Ok((
+                CredsTarget::Default(crate::anthropic::creds::default_path()?),
+                cache,
+            ));
+        }
         Ok((
             CredsTarget::Named {
+                config_dir: account.config_dir(),
                 path: account.credentials_path,
-                config_dir,
             },
-            Cache::for_vendor_account("anthropic", label)?,
+            cache,
         ))
     }
 }
@@ -683,6 +727,7 @@ impl Config {
         expand_tilde_opt(&mut self.context.projects_path);
         expand_tilde_opt(&mut self.anthropic.credentials_path);
         expand_tilde_opt(&mut self.anthropic.accounts_dir);
+        expand_tilde_opt(&mut self.anthropic.desktop_profiles_dir);
         expand_tilde_opt(&mut self.openai.codex_auth_path);
         expand_tilde_opt(&mut self.cursor.db_path);
         for account in &mut self.anthropic.accounts {
@@ -1492,6 +1537,51 @@ enabled = false
             c.anthropic.accounts_dir,
             Some(home.join(".config/ai-usagebar/accounts"))
         );
+    }
+
+    #[test]
+    fn the_live_cli_account_is_read_from_the_default_credential_slot() {
+        let cfg = AnthropicConfig {
+            accounts: vec![
+                AnthropicAccount {
+                    label: "work".into(),
+                    credentials_path: "/tmp/accounts/work/.credentials.json".into(),
+                },
+                AnthropicAccount {
+                    label: "personal".into(),
+                    credentials_path: "/tmp/accounts/personal/.credentials.json".into(),
+                },
+            ],
+            ..Default::default()
+        };
+
+        let (idle, idle_cache) = cfg.account_target_with("work", Some("personal")).unwrap();
+        assert!(
+            matches!(&idle, CredsTarget::Named { config_dir, .. }
+                if config_dir == std::path::Path::new("/tmp/accounts/work")),
+            "{idle:?}"
+        );
+
+        // Same label, but it is the login `claude` itself is using: one lineage.
+        let (live, live_cache) = cfg.account_target_with("work", Some("work")).unwrap();
+        assert!(matches!(live, CredsTarget::Default(_)), "{live:?}");
+
+        // The cache must not move, or a switch would silently orphan the tab's
+        // usage history and show "Loading…" until the next fetch.
+        assert_eq!(idle_cache.dir(), live_cache.dir());
+    }
+
+    #[test]
+    fn no_live_cli_account_keeps_every_account_on_its_own_slot() {
+        let cfg = AnthropicConfig {
+            accounts: vec![AnthropicAccount {
+                label: "work".into(),
+                credentials_path: "/tmp/accounts/work/.credentials.json".into(),
+            }],
+            ..Default::default()
+        };
+        let (target, _) = cfg.account_target_with("work", None).unwrap();
+        assert!(matches!(target, CredsTarget::Named { .. }), "{target:?}");
     }
 
     /// The shipped example, which `make install` puts in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod anthropic;
 pub mod anthropic_api;
 pub mod antigravity;
 pub mod cache;
+pub mod claude_desktop;
 pub mod config;
 pub mod context;
 pub mod countdown;

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -148,6 +148,55 @@ pub enum AccountAction {
         #[arg(long)]
         no_login: bool,
     },
+
+    /// Show which Claude account the Desktop app and the `claude` CLI use.
+    Status {
+        /// Machine-readable output, consumed by the macOS menu bar.
+        #[arg(long)]
+        json: bool,
+    },
+
+    /// Make <LABEL> the active Claude account (macOS).
+    Switch {
+        /// Account to switch to. Desktop profiles come from claude-acc's store;
+        /// CLI accounts from `[[anthropic.accounts]]` / `accounts_dir`.
+        label: String,
+
+        /// Only switch the Claude Desktop app. Neither flag switches both.
+        #[arg(long)]
+        desktop: bool,
+
+        /// Only switch the `claude` CLI's default login.
+        #[arg(long)]
+        cli: bool,
+
+        /// Report what would change and exit without touching anything.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Skip the confirmation before quitting the Claude Desktop app.
+        #[arg(short = 'y', long)]
+        yes: bool,
+
+        /// Overwrite a `claude` CLI login that belongs to no managed account.
+        /// That login cannot be saved first, so this discards it.
+        #[arg(long)]
+        force: bool,
+
+        /// Keep `bridge-state.json` rather than clearing it. Diagnostic only:
+        /// a stale remote-control session id breaks `/remote-control`.
+        #[arg(long)]
+        keep_bridge: bool,
+
+        /// Also archive the whole session tree, as claude-acc does. Off by
+        /// default because the history merge is additive.
+        #[arg(long)]
+        backup_sessions: bool,
+
+        /// Rollback archives to retain.
+        #[arg(long, default_value_t = 10)]
+        keep_backups: usize,
+    },
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq)]

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -145,8 +145,24 @@ pub enum AccountAction {
         label: String,
 
         /// Only register the account; do not launch interactive login.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "desktop")]
         no_login: bool,
+
+        /// Capture a Claude **Desktop app** account under this label instead
+        /// of a `claude` CLI one (macOS). The app has a single login slot, so
+        /// this signs it out, waits for you to sign in as the new account, and
+        /// saves what it writes. Your current login is restored if you cancel.
+        #[arg(long)]
+        desktop: bool,
+
+        /// E-mail to label a `--desktop` account with. Asked for at the prompt
+        /// if omitted; purely cosmetic, and skipped when not interactive.
+        #[arg(long, requires = "desktop")]
+        email: Option<String>,
+
+        /// Skip the confirmation before signing the Desktop app out.
+        #[arg(short = 'y', long, requires = "desktop")]
+        yes: bool,
     },
 
     /// Show which Claude account the Desktop app and the `claude` CLI use.
@@ -374,7 +390,73 @@ mod tests {
         assert!(matches!(
             cli.command,
             Some(Command::Account {
-                action: AccountAction::Add { ref label, no_login: true }
+                action: AccountAction::Add {
+                    ref label,
+                    no_login: true,
+                    desktop: false,
+                    ..
+                }
+            }) if label == "work"
+        ));
+    }
+
+    /// The two halves of `add` capture different things and cannot be combined:
+    /// `--no-login` skips a `claude` login the Desktop capture never runs.
+    #[test]
+    fn account_add_desktop_takes_an_email_and_rejects_no_login() {
+        let cli = Cli::parse_from([
+            "ai-usagebar",
+            "account",
+            "add",
+            "work",
+            "--desktop",
+            "--email",
+            "a@b.test",
+            "-y",
+        ]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Account {
+                action: AccountAction::Add {
+                    desktop: true,
+                    yes: true,
+                    email: Some(ref email),
+                    ..
+                }
+            }) if email == "a@b.test"
+        ));
+        assert!(
+            Cli::try_parse_from([
+                "ai-usagebar",
+                "account",
+                "add",
+                "w",
+                "--desktop",
+                "--no-login"
+            ])
+            .is_err()
+        );
+        // --email / -y only mean something for the Desktop capture.
+        assert!(
+            Cli::try_parse_from(["ai-usagebar", "account", "add", "w", "--email", "a@b.test"])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn account_switch_defaults_to_both_surfaces() {
+        let cli = Cli::parse_from(["ai-usagebar", "account", "switch", "work", "--dry-run"]);
+        assert!(matches!(
+            cli.command,
+            Some(Command::Account {
+                action: AccountAction::Switch {
+                    ref label,
+                    desktop: false,
+                    cli: false,
+                    dry_run: true,
+                    keep_backups: 10,
+                    ..
+                }
             }) if label == "work"
         ));
     }


### PR DESCRIPTION
**Stacked on #51 — merge that first.** This branch contains its commit plus one
more; the diff shown here collapses once #51 lands.

#51 made both Claude identities visible and switchable. This one completes the
story: a machine can now build its whole account list with nothing but this
binary, and drive it from the menu bar.

|              | Claude Code CLI                   | Claude Desktop                        |
|--------------|-----------------------------------|---------------------------------------|
| add          | `account add <label>` *(existing)* | `account add <label> --desktop` **new** |
| see          | `account status`                  | `account status`                      |
| switch       | `account switch <label> --cli`    | `account switch <label> --desktop`    |
| menu         | Claude Code ▸                     | Claude Desktop ▸                      |

## Capturing a Desktop account

The CLI half of `add` is easy — `CLAUDE_CONFIG_DIR` gives `claude` as many
isolated logins as you want, so it signs one in without disturbing anything.
The Desktop app has a **single** login slot and no way to ask for a second, so
the only way to obtain another account's credential is to sign the app out,
wait for the user to sign in as that account, and keep what it writes.

`account add <label> --desktop` does that: saves the current account into its
own profile, copies the live login aside, clears it, reopens the app at its
login screen, polls until the sign-in completes, resolves the organisation,
captures credential + browser state + `meta.json`, and seeds the new account
with this machine's history so its first login isn't an empty sidebar.

Two empirical details that make the polling reliable, both inherited from the
reference implementation and both pinned by tests:

- A login counts only once **both** `lastKnownAccountUuid` *and* the token cache
  are written. The uuid lands first, and capturing there saves a profile with no
  credential in it.
- The org id has to come from either the account's new session folder or the
  `dxt:allowlistEnabled:<org>` keys — whichever appears first.

**It is safe to cancel.** The live login is copied out before anything is
cleared and goes back byte for byte if the sign-in times out. Two tests cover
that, including the non-obvious half: state the app created *after* the backup
must not survive the restore, or the new account's cookies leak into the old
one's session.

## Menu bar

Two submenus listing each surface's accounts with a checkmark on the active one,
click to switch, plus **Adicionar conta…** which hands the interactive part to
Terminal (a Desktop capture waits for a browser sign-in; neither belongs in a
background subprocess the user can't answer). A dim line under the header shows
both active accounts at a glance.

- Both submenus stay visible when their list is empty — that is exactly when
  adding matters. Only a machine with no Claude Desktop app loses one.
- The Desktop switch confirms first (`NSAlert`, pt-BR to match the rest of the
  menu) since it quits and reopens Claude.app. The CLI switch has no visible
  side effect and just runs.
- Status is fetched off the main thread on launch, on a `config.toml` change,
  and on `menuWillOpen` debounced to 5 s — so a switch made in a terminal shows
  up without a restart, without polling for state that changes a few times a day.
- **An older binary that rejects the subcommand parses to `nil` and the menu
  looks exactly as it did before.** Every field in the JSON is optional; there
  are tests for `"desktop": null`, an absent `"cli"` key, empty output, and
  non-JSON output.
- The label for "Adicionar conta…" comes from a free-text field, so it is
  single-quoted with quotes doubled out before going into the shell script —
  with a test asserting an injected command stays inside the quotes.

## Scope

Removing an account and chat filtering (`only` / `reset`) are still
[claude-acc](https://github.com/ohmaseclaro/claude-acc)'s. Everything else now
works standalone — on that project's profile format, so existing users' profiles
carry over untouched and either tool can capture or switch them. Its
reverse-engineering of the Desktop internals is what both PRs build on; the
Desktop halves of `add` and `switch` are ports of its commands, credited in the
module docs, README, and CHANGELOG.

## Checks

`cargo test` (727 + 3 e2e), `cargo clippy --all-targets -D warnings`,
`cargo fmt --check`, `macos/run-tests.sh`, `macos/build.sh` — all clean. No new
dependencies. Linux is unaffected: the new Rust modules carry no `target_os`
gates and their tests run everywhere, hermetically.

Exercised against four real accounts on macOS 15.