### PR TITLE
feat(minimax): MiniMax Token Plan vendor (interval + weekly quota)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **MiniMax Token Plan vendor** (`--vendor minimax`, `[minimax]`, opt-in). Reads
+  the subscription quota from `GET /v1/token_plan/remains` (undocumented,
+  captured against the live global endpoint). The plan reports one row per model
+  bucket, each with a rolling interval window and a weekly window, so it renders
+  as a two-pool quota vendor: `general` (text/coding) drives the bar and the
+  generic `{session_pct}` / `{weekly_pct}` aliases, and `video` rides along in
+  the tooltip and TUI panel. `{vendor_short}` is `mmx`.
+  Four properties of this API are encoded deliberately, each with a test:
+  it answers **HTTP 200 even when auth fails** (the real status is
+  `base_resp.status_code`; the two credential codes map onto HTTP 401 so a bad
+  key reports as an auth problem, not schema drift); the percentages are what
+  **remains**, not what was consumed, and are inverted on the way in; the
+  interval length is **not fixed** (5h for `general`, 24h for `video`), so each
+  window's duration comes from its own start/end; and all timestamps are epoch
+  **milliseconds**. `[minimax] region` picks the *instance* rather than a unit —
+  the global and CN deployments issue separate keys and reject each other's, so
+  the endpoint is recorded in the cache payload and a mismatched cache is
+  discarded instead of being shown against the wrong account.
+
 ## [0.19.0] — 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth c
 | Novita | API key (`NOVITA_API_KEY` env or `[novita] api_key` in config) | Set either. Opt-in. |
 | Moonshot | API key (`MOONSHOT_API_KEY` env or `[moonshot] api_key` in config) | Set either. Opt-in. Set `[moonshot] region = "cn"` for `api.moonshot.cn` (balance in CNY); the default `"global"` uses `api.moonshot.ai` (USD). |
 | Grok (xAI) | **Management** key (`XAI_MANAGEMENT_KEY` env or `[grok] api_key` in config) | Set either. Opt-in. This is **not** the inference key — create it under xAI Console → Management keys. See the team note below. |
+| MiniMax | **Token Plan** key (`MINIMAX_API_KEY` env or `[minimax] api_key` in config) | Set either. Opt-in. Must be the Token Plan **subscription** key — a pay-as-you-go key has no plan quota to report. Set `[minimax] region = "cn"` for `api.minimaxi.com`; the default `"global"` uses `api.minimax.io`. The two are separate instances and reject each other's keys. |
 | Google Antigravity | None — read from the local Antigravity server | Opt-in. Quota is served only while Antigravity 2.0, the Antigravity IDE, or an interactive `agy` session is running; all three share one account-wide quota. |
 | Cursor | None — read from Cursor's local `state.vscdb` | Opt-in. Sign in to the Cursor IDE at least once; ai-usagebar reads the session token it already wrote there. No key of your own to create. |
 
@@ -110,7 +111,7 @@ rather than silently querying the wrong URL.
 ### Enabling a vendor
 
 `enabled = true` is what makes a vendor fetch. Anthropic (API), DeepSeek, Kimi,
-Kilo, Novita, Moonshot, Grok, Antigravity, and Cursor all default to **disabled** so that existing
+Kilo, Novita, Moonshot, Grok, Antigravity, Cursor, and MiniMax all default to **disabled** so that existing
 installs are unaffected until you opt in. Two ways to do it:
 
 - **Via the TUI Settings overlay** (`ai-usagebar-tui`, then `s`): saving a
@@ -194,6 +195,12 @@ api_key_env = "DEEPSEEK_API_KEY"
 enabled = true             # disabled by default; enable once you add an API key
 api_key_env = "KIMI_API_KEY"
 # api_key = "sk-..."       # used if KIMI_API_KEY is unset; chmod 600 the file!
+
+[minimax]
+enabled = true             # disabled by default; enable once you add an API key
+api_key_env = "MINIMAX_API_KEY"
+# api_key = "..."          # used if MINIMAX_API_KEY is unset; chmod 600 the file!
+# region = "global"        # global -> api.minimax.io | cn -> api.minimaxi.com
 
 # --- Account-balance vendors (all opt-in) ---
 
@@ -292,7 +299,7 @@ Use one bar item and scroll through your vendors. The TUI on-click still shows t
 }
 ```
 
-The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` / `gpt` / `zai` / `opr` / `dsk` / `kmi` / `klo` / `nvt` / `msh` / `grk` / `aac` / `agy` / `cur`), so the bar text tells you which vendor is active. The other usage placeholders (`{session_pct}` for Anthropic, `{oai_session_pct}` for OpenAI, etc.) are vendor-specific. If you want one format string for every cycled vendor, prefer the generic aliases: `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}` are implemented by all eight usage vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Antigravity, and Cursor; OpenRouter and DeepSeek use `0` / `—` for the windows they don't expose). Cursor has no time windows but two usage *pools*, so it maps them onto the two generic slots: `session_pct` = **Cursor Models** (Auto + Composer), `weekly_pct` = **Other Models** (named / API), both resetting on the billing cycle. Anthropic and OpenAI add `*_elapsed`, `*_pace`, and `*_bar` families; Antigravity adds `*_elapsed` for all four of its windows, plus `{session_model}` / `{weekly_model}` / `{scoped_model}` / `{extra_model}`, which name the model group each row belongs to (vendors with a single quota pool leave them empty). The established API-backed vendors also expose their own `{oai_*}` / `{zai_*}` / `{or_*}` / `{ds_*}` / `{kimi_*}` families, which expand to empty strings for vendors that don't define them.
+The `{vendor_short}` placeholder always expands to a 3-letter vendor ID (`cld` / `gpt` / `zai` / `opr` / `dsk` / `kmi` / `klo` / `nvt` / `msh` / `grk` / `aac` / `agy` / `cur` / `mmx`), so the bar text tells you which vendor is active. The other usage placeholders (`{session_pct}` for Anthropic, `{oai_session_pct}` for OpenAI, etc.) are vendor-specific. If you want one format string for every cycled vendor, prefer the generic aliases: `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}` are implemented by all eight usage vendors (Anthropic, OpenAI, Z.AI, OpenRouter, DeepSeek, Kimi, Antigravity, and Cursor; OpenRouter and DeepSeek use `0` / `—` for the windows they don't expose). Cursor has no time windows but two usage *pools*, so it maps them onto the two generic slots: `session_pct` = **Cursor Models** (Auto + Composer), `weekly_pct` = **Other Models** (named / API), both resetting on the billing cycle. Anthropic and OpenAI add `*_elapsed`, `*_pace`, and `*_bar` families; Antigravity adds `*_elapsed` for all four of its windows, plus `{session_model}` / `{weekly_model}` / `{scoped_model}` / `{extra_model}`, which name the model group each row belongs to (vendors with a single quota pool leave them empty). The established API-backed vendors also expose their own `{oai_*}` / `{zai_*}` / `{or_*}` / `{ds_*}` / `{kimi_*}` families, which expand to empty strings for vendors that don't define them.
 
 `signal: 13` lets the scroll-cycle commands refresh the bar instantly (via `SIGRTMIN+13`) instead of waiting for the next 300s interval.
 
@@ -520,6 +527,7 @@ Then `hyprctl reload` (no logout needed).
 | **OpenRouter** | `openrouter.ai/api/v1/{credits,key}` (documented) | Balance, today/week/month spend, free vs paid tier | Yes |
 | **DeepSeek** | `api.deepseek.com/user/balance` (documented) | Balance, granted, topped-up credits | Yes |
 | **Kimi** | `api.kimi.com/coding/v1/usages` (undocumented; community-confirmed) | Weekly subscription quota + 5h rolling rate-limit window | No — widget/TUI only; desktop protocol and marker parity are future work |
+| **MiniMax** | `api.minimax.io/v1/token_plan/remains` (undocumented) | Token Plan rolling interval window + weekly, per model bucket (text, video) | No — widget/TUI only |
 | **Kilo** | `api.kilo.ai/api/profile/balance` (undocumented; extension-internal) | Remaining credit balance ($) | No — widget/TUI only |
 | **Novita** | `api.novita.ai/openapi/v1/billing/balance/detail` (documented) | Remaining credit balance ($) | No — widget/TUI only |
 | **Moonshot** | `api.moonshot.ai\|.cn/v1/users/me/balance` (documented) | Account balance ($ on `.ai`, ¥ on `.cn`) | No — widget/TUI only |

--- a/config.example.toml
+++ b/config.example.toml
@@ -207,3 +207,18 @@ enabled = false
 #   Windows: %APPDATA%\Cursor\User\globalStorage\state.vscdb
 # Set this if you use a portable Cursor install or a renamed profile dir.
 # db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"
+
+[minimax]
+# Disabled by default — enable once you've set a key (env var or inline).
+# Saving a key in the Settings overlay writes the inline fallback AND flips
+# `enabled` to true; clearing the field removes the inline key again.
+# Token Plan subscription quota (rolling interval window + weekly) from the
+# undocumented /v1/token_plan/remains endpoint. Needs the Token Plan
+# SUBSCRIPTION key — a pay-as-you-go key has no plan quota to report.
+enabled = false
+api_key_env = "MINIMAX_API_KEY"    # checked first; if set + non-empty, used
+# api_key = "..."                  # fallback; chmod 600 the file if you use it
+# Region picks the INSTANCE, and the two issue separate keys — pointing this
+# at the wrong one reads as an invalid key, not an empty plan:
+#   global -> api.minimax.io   |   cn -> api.minimaxi.com
+# region = "global"

--- a/src/active.rs
+++ b/src/active.rs
@@ -112,6 +112,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "grok" => Some(VendorId::Grok),
         "antigravity" => Some(VendorId::Antigravity),
         "cursor" => Some(VendorId::Cursor),
+        "minimax" => Some(VendorId::Minimax),
         _ => None,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,7 @@ pub struct Config {
     pub grok: GrokConfig,
     pub antigravity: AntigravityConfig,
     pub cursor: CursorConfig,
+    pub minimax: MinimaxConfig,
 }
 
 /// UI / dispatch preferences. Currently just `primary` — which vendor the
@@ -517,6 +518,32 @@ impl Default for NovitaConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
+pub struct MinimaxConfig {
+    pub enabled: bool,
+    pub api_key_env: String,
+    pub api_key: Option<String>,
+    /// `"global"` → api.minimax.io; `"cn"` → api.minimaxi.com. Unlike
+    /// Moonshot's, this does not change the unit — MiniMax reports quota as a
+    /// percentage either way. It picks the *instance*: a key issued for one
+    /// host is rejected by the other (`status_code 2049`), so pointing this at
+    /// the wrong region reads as an invalid key rather than an empty plan.
+    pub region: String,
+}
+
+impl Default for MinimaxConfig {
+    fn default() -> Self {
+        // Opt-in like the other API-key vendors: needs an explicit key.
+        Self {
+            enabled: false,
+            api_key_env: "MINIMAX_API_KEY".to_string(),
+            api_key: None,
+            region: "global".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct MoonshotConfig {
     pub enabled: bool,
     pub api_key_env: String,
@@ -705,6 +732,7 @@ impl Config {
             VendorId::Grok => self.grok.enabled,
             VendorId::Antigravity => self.antigravity.enabled,
             VendorId::Cursor => self.cursor.enabled,
+            VendorId::Minimax => self.minimax.enabled,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod format;
 pub mod grok;
 pub mod kilo;
 pub mod kimi;
+pub mod minimax;
 pub mod moonshot;
 pub mod novita;
 pub mod openai;

--- a/src/minimax/fetch.rs
+++ b/src/minimax/fetch.rs
@@ -1,0 +1,487 @@
+//! MiniMax fetch — reads Token Plan quota from `/v1/token_plan/remains` under
+//! the shared cache + flock primitives.
+//!
+//! The host is region-dependent (`api.minimax.io` global, `api.minimaxi.com`
+//! CN) and, unlike Moonshot's regions, the two are *separate instances*: a key
+//! issued for one is rejected by the other. That makes a cached figure from the
+//! other region not merely stale but wrong, so the endpoint is recorded in the
+//! payload and a mismatched cache is discarded.
+
+use std::time::Duration;
+
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
+use crate::error::{AppError, Result};
+use crate::usage::{MinimaxSnapshot, UsageWindow};
+use crate::vendor::{MAX_BODY_BYTES, read_body_capped};
+
+use super::types::{RemainsEnvelope, is_auth_failure, to_snapshot};
+
+pub const BASE_GLOBAL: &str = "https://api.minimax.io";
+pub const BASE_CN: &str = "https://api.minimaxi.com";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Label shown as the plan name. The quota endpoint doesn't name the plan, and
+/// inventing a tier from the numbers would be a guess, so the product name is
+/// used as-is.
+pub const PLAN_LABEL: &str = "MiniMax Token Plan";
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub remains: String,
+}
+
+impl Endpoints {
+    /// Pick the host by region. `cn` → `api.minimaxi.com`, anything else →
+    /// `api.minimax.io`. No currency is implied: MiniMax reports quota as
+    /// percentages, not money.
+    pub fn for_region(region: &str) -> Self {
+        let base = if region.eq_ignore_ascii_case("cn") {
+            BASE_CN
+        } else {
+            BASE_GLOBAL
+        };
+        Self {
+            remains: format!("{base}/v1/token_plan/remains"),
+        }
+    }
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self::for_region("global")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchOutcome {
+    pub snapshot: MinimaxSnapshot,
+    pub stale: bool,
+    pub last_error: Option<(u16, String)>,
+    pub cache_age: Option<Duration>,
+}
+
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    api_key: &str,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+
+    let target = target_key(endpoints);
+
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse_cache(&bytes, cache, false, &target)
+    {
+        return Ok(outcome);
+    }
+
+    match fetch_live(client, endpoints, api_key).await {
+        Ok(snap) => {
+            let bytes = serde_json::to_vec(
+                &serde_json::json!({ "target": target, "snapshot": serde_repr(&snap) }),
+            )?;
+            cache.write_payload(&bytes)?;
+            Ok(FetchOutcome {
+                snapshot: snap,
+                stale: false,
+                last_error: None,
+                cache_age: Some(Duration::ZERO),
+            })
+        }
+        Err(e) if e.is_transient() => fallback_silent(cache, &target, e),
+        Err(AppError::Http { status, body }) => {
+            cache.mark_stale();
+            cache.write_last_error(status, &body);
+            let diag = (status, body.clone());
+            fallback_with_error(cache, Some(diag), &target, AppError::Http { status, body })
+        }
+        Err(e) => {
+            cache.mark_stale();
+            cache.write_last_error(0, &e.to_string());
+            let diag = (0, e.to_string());
+            fallback_with_error(cache, Some(diag), &target, e)
+        }
+    }
+}
+
+/// Identity of the instance the cached quota belongs to. The global and CN
+/// deployments are separate accounts, so a figure from one must never be shown
+/// after the user points the vendor at the other.
+fn target_key(endpoints: &Endpoints) -> String {
+    endpoints.remains.clone()
+}
+
+fn fallback_silent(cache: &Cache, target: &str, original: AppError) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
+        return Err(original);
+    };
+    reuse_cache(&bytes, cache, true, target)
+}
+
+/// On failure we show the last good figure with the error alongside it. With
+/// nothing usable cached there is nothing to show, so the **original** error is
+/// returned rather than a generic "no usable cache" that hides what went wrong.
+fn fallback_with_error(
+    cache: &Cache,
+    last_error: Option<(u16, String)>,
+    target: &str,
+    original: AppError,
+) -> Result<FetchOutcome> {
+    let Some(bytes) = cache.fallback_payload(MAX_STALE)? else {
+        return Err(original);
+    };
+    let Ok(mut outcome) = reuse_cache(&bytes, cache, true, target) else {
+        return Err(original);
+    };
+    outcome.last_error = last_error;
+    Ok(outcome)
+}
+
+fn reuse_cache(bytes: &[u8], cache: &Cache, stale: bool, target: &str) -> Result<FetchOutcome> {
+    let snap = parse_cache(bytes, target)?;
+    Ok(FetchOutcome {
+        snapshot: snap,
+        stale,
+        last_error: cache.read_last_error(),
+        cache_age: cache.payload_age(),
+    })
+}
+
+fn window_repr(w: &UsageWindow) -> serde_json::Value {
+    serde_json::json!({
+        "pct": w.utilization_pct,
+        "resets_at": w.resets_at.map(|t| t.to_rfc3339()),
+        "window_secs": w.window_duration.num_seconds(),
+    })
+}
+
+fn serde_repr(snap: &MinimaxSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "plan": snap.plan,
+        "session": window_repr(&snap.session),
+        "weekly": window_repr(&snap.weekly),
+        "video_session": snap.video_session.as_ref().map(window_repr),
+        "video_weekly": snap.video_weekly.as_ref().map(window_repr),
+    })
+}
+
+fn parse_window(v: &serde_json::Value, what: &str) -> Result<UsageWindow> {
+    let pct = v["pct"]
+        .as_i64()
+        .ok_or_else(|| AppError::Schema(format!("minimax cache missing '{what}.pct'")))?;
+    let resets_at = match v["resets_at"].as_str() {
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map_err(|e| AppError::Schema(format!("minimax cache '{what}.resets_at': {e}")))?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+    let secs = v["window_secs"]
+        .as_i64()
+        .ok_or_else(|| AppError::Schema(format!("minimax cache missing '{what}.window_secs'")))?;
+    Ok(UsageWindow {
+        utilization_pct: pct.clamp(0, 100) as i32,
+        resets_at,
+        window_duration: chrono::Duration::seconds(secs),
+    })
+}
+
+fn parse_cache(bytes: &[u8], target: &str) -> Result<MinimaxSnapshot> {
+    let v: serde_json::Value = serde_json::from_slice(bytes)?;
+    let cached_target = v.get("target").and_then(serde_json::Value::as_str);
+    if cached_target != Some(target) {
+        return Err(AppError::Schema(format!(
+            "minimax cache belongs to a different instance ({}); refetching",
+            cached_target.unwrap_or("unknown")
+        )));
+    }
+    let s = v
+        .get("snapshot")
+        .ok_or_else(|| AppError::Schema("minimax cache missing 'snapshot' field".into()))?;
+    let optional = |name: &str| -> Result<Option<UsageWindow>> {
+        match s.get(name) {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(w) => parse_window(w, name).map(Some),
+        }
+    };
+    Ok(MinimaxSnapshot {
+        plan: s["plan"].as_str().unwrap_or(PLAN_LABEL).to_string(),
+        session: parse_window(&s["session"], "session")?,
+        weekly: parse_window(&s["weekly"], "weekly")?,
+        video_session: optional("video_session")?,
+        video_weekly: optional("video_weekly")?,
+    })
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    endpoints: &Endpoints,
+    api_key: &str,
+) -> Result<MinimaxSnapshot> {
+    let resp = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(&endpoints.remains)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport(format!("minimax timeout: {}", endpoints.remains)))??;
+
+    let status = resp.status();
+    let bytes = read_body_capped(resp, MAX_BODY_BYTES).await?;
+
+    if !status.is_success() {
+        // Never surface upstream/proxy bodies: they can carry credentials or
+        // arbitrary markup. Keep the cached diagnostic useful but generic.
+        let body = if matches!(status.as_u16(), 401 | 403) {
+            "MiniMax authentication failed".to_string()
+        } else {
+            format!("MiniMax API returned HTTP {}", status.as_u16())
+        };
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let env: RemainsEnvelope = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Schema(format!("minimax {}: {e}", endpoints.remains)))?;
+
+    // MiniMax answers auth failures with HTTP 200 and the real status in the
+    // envelope. Those are reported as HTTP 401 so the UI says "authentication
+    // failed" instead of filing a wrong key under schema drift.
+    if is_auth_failure(env.base_resp.status_code) {
+        return Err(AppError::Http {
+            status: 401,
+            body: "MiniMax authentication failed".to_string(),
+        });
+    }
+    env.check_ok()?;
+    to_snapshot(env, PLAN_LABEL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const LIVE_BODY: &str = r#"{
+        "model_remains": [
+            {"start_time":1785164400000,"end_time":1785182400000,"model_name":"general",
+             "current_interval_remaining_percent":99,
+             "weekly_start_time":1785110400000,"weekly_end_time":1785715200000,
+             "current_weekly_remaining_percent":80},
+            {"start_time":1785110400000,"end_time":1785196800000,"model_name":"video",
+             "current_interval_remaining_percent":100,
+             "weekly_start_time":1785110400000,"weekly_end_time":1785715200000,
+             "current_weekly_remaining_percent":100}
+        ],
+        "base_resp": {"status_code":0,"status_msg":"success"}
+    }"#;
+
+    fn cache_fixture() -> (TempDir, Cache) {
+        let td = TempDir::new().unwrap();
+        let cache = Cache::at(td.path().join("minimax"));
+        cache.ensure_dir().unwrap();
+        (td, cache)
+    }
+
+    fn endpoints_for(server: &mockito::Server) -> Endpoints {
+        Endpoints {
+            remains: format!("{}/v1/token_plan/remains", server.url()),
+        }
+    }
+
+    #[test]
+    fn region_picks_the_instance_host() {
+        assert!(
+            Endpoints::for_region("global")
+                .remains
+                .starts_with(BASE_GLOBAL)
+        );
+        assert!(Endpoints::for_region("cn").remains.starts_with(BASE_CN));
+        assert!(Endpoints::for_region("CN").remains.starts_with(BASE_CN));
+        // Anything unrecognized stays on the global instance.
+        assert!(
+            Endpoints::for_region("")
+                .remains
+                .starts_with(BASE_GLOBAL)
+        );
+    }
+
+    #[tokio::test]
+    async fn live_fetch_reads_both_pools() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/token_plan/remains")
+            .match_header("authorization", "Bearer mm-test")
+            .with_status(200)
+            .with_body(LIVE_BODY)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mm-test",
+            &cache,
+            &endpoints_for(&server),
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(out.snapshot.session.utilization_pct, 1);
+        assert_eq!(out.snapshot.weekly.utilization_pct, 20);
+        assert_eq!(out.snapshot.video_session.unwrap().utilization_pct, 0);
+        assert!(!out.stale);
+        assert_eq!(out.snapshot.plan, PLAN_LABEL);
+    }
+
+    /// The whole point of the in-band check: a 200 carrying `2049` is an auth
+    /// failure, and must not be cached as a valid zero-usage plan.
+    #[tokio::test]
+    async fn in_band_auth_failure_is_reported_as_401() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/token_plan/remains")
+            .with_status(200)
+            .with_body(r#"{"base_resp":{"status_code":2049,"status_msg":"invalid api key"}}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let err = fetch_snapshot(
+            &reqwest::Client::new(),
+            "bad",
+            &cache,
+            &endpoints_for(&server),
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap_err();
+
+        match err {
+            AppError::Http { status, ref body } => {
+                assert_eq!(status, 401);
+                assert!(body.contains("authentication"), "body was {body:?}");
+            }
+            other => panic!("expected HTTP 401, got {other:?}"),
+        }
+    }
+
+    /// A cache written against the other instance is wrong, not merely stale.
+    #[tokio::test]
+    async fn cache_from_the_other_instance_is_rejected() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/token_plan/remains")
+            .with_status(200)
+            .with_body(LIVE_BODY)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let seed = serde_json::json!({
+            "target": format!("{BASE_CN}/v1/token_plan/remains"),
+            "snapshot": {
+                "plan": "MiniMax Token Plan",
+                "session": {"pct": 77, "resets_at": null, "window_secs": 18000},
+                "weekly":  {"pct": 77, "resets_at": null, "window_secs": 604800},
+            }
+        });
+        cache
+            .write_payload(&serde_json::to_vec(&seed).unwrap())
+            .unwrap();
+
+        // A long TTL would normally serve the cache; the target mismatch must
+        // force a refetch instead of showing the other instance's numbers.
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mm-test",
+            &cache,
+            &endpoints_for(&server),
+            Duration::from_secs(3600),
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.snapshot.session.utilization_pct, 1, "refetched, not 77");
+    }
+
+    #[tokio::test]
+    async fn http_error_falls_back_to_matching_cache() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/v1/token_plan/remains")
+            .with_status(500)
+            .with_body("upstream exploded")
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let endpoints = endpoints_for(&server);
+        let seed = serde_json::json!({
+            "target": target_key(&endpoints),
+            "snapshot": {
+                "plan": "MiniMax Token Plan",
+                "session": {"pct": 42, "resets_at": null, "window_secs": 18000},
+                "weekly":  {"pct": 43, "resets_at": null, "window_secs": 604800},
+            }
+        });
+        cache
+            .write_payload(&serde_json::to_vec(&seed).unwrap())
+            .unwrap();
+
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mm-test",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+
+        assert!(out.stale);
+        assert_eq!(out.snapshot.session.utilization_pct, 42);
+        let (code, body) = out.last_error.expect("error recorded alongside the figure");
+        assert_eq!(code, 500);
+        assert!(
+            !body.contains("exploded"),
+            "upstream body must not be surfaced: {body:?}"
+        );
+    }
+
+    #[test]
+    fn cache_round_trips_windows_including_reset_and_duration() {
+        let endpoints = Endpoints::default();
+        let snap = MinimaxSnapshot {
+            plan: PLAN_LABEL.to_string(),
+            session: UsageWindow {
+                utilization_pct: 12,
+                resets_at: chrono::DateTime::from_timestamp_millis(1785182400000),
+                window_duration: chrono::Duration::hours(5),
+            },
+            weekly: UsageWindow {
+                utilization_pct: 34,
+                resets_at: None,
+                window_duration: chrono::Duration::days(7),
+            },
+            video_session: None,
+            video_weekly: None,
+        };
+        let bytes = serde_json::to_vec(&serde_json::json!({
+            "target": target_key(&endpoints),
+            "snapshot": serde_repr(&snap),
+        }))
+        .unwrap();
+        let back = parse_cache(&bytes, &target_key(&endpoints)).unwrap();
+        assert_eq!(back, snap);
+    }
+}

--- a/src/minimax/mod.rs
+++ b/src/minimax/mod.rs
@@ -1,0 +1,10 @@
+//! MiniMax Token Plan vendor — subscription quota from
+//! `/v1/token_plan/remains` over an API key. The key is instance-scoped:
+//! `api.minimax.io` (global) and `api.minimaxi.com` (CN) reject each other's
+//! keys, so the region is configured rather than probed.
+
+pub mod fetch;
+pub mod types;
+pub mod vendor;
+
+pub use fetch::{FetchOutcome, fetch_snapshot};

--- a/src/minimax/types.rs
+++ b/src/minimax/types.rs
@@ -1,0 +1,341 @@
+//! Wire types for MiniMax's Token Plan quota endpoint,
+//! `GET /v1/token_plan/remains`.
+//!
+//! Captured against the live global endpoint (`api.minimax.io`); MiniMax does
+//! not publish a schema for it, so every field here is one observed on the
+//! wire. The response is `{ model_remains: [...], base_resp: { … } }` with one
+//! row per model bucket (`general` for text/coding, `video`), each carrying a
+//! rolling interval window and a weekly window.
+//!
+//! Four properties of this API drive the code below, and all four are easy to
+//! get backwards:
+//!
+//! 1. **HTTP 200 always.** Auth failures come back `200` with the real status
+//!    in `base_resp.status_code` (`1004` no key, `2049` invalid key). The HTTP
+//!    status must never be read as success.
+//! 2. **The percentages are what REMAINS**, not what was consumed. They are
+//!    inverted here so the rest of the app keeps its consumed-% convention.
+//! 3. **The interval length is not fixed** — `general` rolls every 5h but
+//!    `video` rolls every 24h — so the window duration comes from each row's
+//!    own `start_time`/`end_time` instead of a constant.
+//! 4. **All timestamps are epoch milliseconds**, not seconds.
+
+use serde::Deserialize;
+
+use crate::error::{AppError, Result};
+use crate::usage::{MinimaxSnapshot, UsageWindow};
+
+/// Bucket name of the text/coding pool — the one that drives the bars.
+const BUCKET_GENERAL: &str = "general";
+/// Bucket name of the video-generation pool, rendered as the secondary pool.
+const BUCKET_VIDEO: &str = "video";
+
+/// Fallbacks used only when a row's own start/end can't yield a positive
+/// duration (a malformed row); the pacing math needs a non-zero window.
+const DEFAULT_INTERVAL: chrono::Duration = chrono::Duration::hours(5);
+const DEFAULT_WEEKLY: chrono::Duration = chrono::Duration::days(7);
+
+/// MiniMax's standard envelope. Present on every response, including the ones
+/// that carry no data because authentication failed.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BaseResp {
+    pub status_code: i64,
+    #[serde(default)]
+    pub status_msg: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RemainsEnvelope {
+    /// Absent (not merely empty) on failure responses.
+    #[serde(default)]
+    pub model_remains: Vec<ModelRemains>,
+    pub base_resp: BaseResp,
+}
+
+impl RemainsEnvelope {
+    /// Reject the in-band failure shape before any field is read as a quota.
+    /// `status_code == 0` is the documented success value; everything else —
+    /// including the auth failures that arrive as HTTP 200 — is an error.
+    pub fn check_ok(&self) -> Result<()> {
+        if self.base_resp.status_code == 0 {
+            return Ok(());
+        }
+        Err(AppError::Schema(format!(
+            "minimax: API reported failure (status_code {}, {})",
+            self.base_resp.status_code,
+            if self.base_resp.status_msg.is_empty() {
+                "no message"
+            } else {
+                &self.base_resp.status_msg
+            }
+        )))
+    }
+}
+
+/// Envelope codes that mean "the credential was rejected" rather than "the
+/// service failed": `1004` no key supplied, `2049` the key is not valid for
+/// this instance (the code a global key gets from the CN host, and vice versa).
+/// The caller maps these onto an HTTP 401 so the UI reports an auth problem
+/// instead of filing a wrong key under schema drift.
+pub fn is_auth_failure(status_code: i64) -> bool {
+    matches!(status_code, 1004 | 2049)
+}
+
+/// One model bucket's quota. The `*_count` fields are request counters that
+/// only some buckets populate (`general` reports zeros and is governed by the
+/// percentages), so they are not part of the snapshot.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelRemains {
+    pub model_name: String,
+    /// Rolling interval window, epoch **milliseconds**.
+    pub start_time: i64,
+    pub end_time: i64,
+    /// Percentage of the interval quota still available (0..=100).
+    pub current_interval_remaining_percent: i64,
+    /// Weekly window, epoch **milliseconds**.
+    pub weekly_start_time: i64,
+    pub weekly_end_time: i64,
+    /// Percentage of the weekly quota still available (0..=100).
+    pub current_weekly_remaining_percent: i64,
+}
+
+/// Consumed percent from MiniMax's remaining percent, clamped to the 0..=100
+/// the renderers expect. An out-of-range value upstream would otherwise paint
+/// a bar past its track.
+fn consumed_pct(remaining: i64) -> i32 {
+    (100 - remaining.clamp(0, 100)) as i32
+}
+
+/// Epoch milliseconds to a UTC instant. Non-positive values mean "unreported"
+/// rather than 1970, so they become `None` and the row simply shows no reset.
+fn at_millis(ms: i64) -> Option<chrono::DateTime<chrono::Utc>> {
+    if ms <= 0 {
+        return None;
+    }
+    chrono::DateTime::from_timestamp_millis(ms)
+}
+
+/// Window length from the row's own bounds, falling back to `default` when the
+/// pair is unusable — never zero, which would make the pace marker divide by
+/// nothing.
+fn span(start_ms: i64, end_ms: i64, default: chrono::Duration) -> chrono::Duration {
+    let delta = end_ms.saturating_sub(start_ms);
+    if delta > 0 {
+        chrono::Duration::milliseconds(delta)
+    } else {
+        default
+    }
+}
+
+fn interval_window(row: &ModelRemains) -> UsageWindow {
+    UsageWindow {
+        utilization_pct: consumed_pct(row.current_interval_remaining_percent),
+        resets_at: at_millis(row.end_time),
+        window_duration: span(row.start_time, row.end_time, DEFAULT_INTERVAL),
+    }
+}
+
+fn weekly_window(row: &ModelRemains) -> UsageWindow {
+    UsageWindow {
+        utilization_pct: consumed_pct(row.current_weekly_remaining_percent),
+        resets_at: at_millis(row.weekly_end_time),
+        window_duration: span(row.weekly_start_time, row.weekly_end_time, DEFAULT_WEEKLY),
+    }
+}
+
+/// Build the snapshot from the parsed rows.
+///
+/// The `general` bucket is required — it is what the bars represent. If a plan
+/// ever names its text bucket something else, the first non-video row is used
+/// rather than failing outright; only a payload with no usable row at all is an
+/// error, because rendering a plan as 0% used would be a silent lie.
+pub fn to_snapshot(env: RemainsEnvelope, plan: &str) -> Result<MinimaxSnapshot> {
+    let rows = &env.model_remains;
+    let general = rows
+        .iter()
+        .find(|r| r.model_name == BUCKET_GENERAL)
+        .or_else(|| rows.iter().find(|r| r.model_name != BUCKET_VIDEO))
+        .ok_or_else(|| {
+            AppError::Schema("minimax: response carried no usable model bucket".to_string())
+        })?;
+    let video = rows.iter().find(|r| r.model_name == BUCKET_VIDEO);
+
+    Ok(MinimaxSnapshot {
+        plan: plan.to_string(),
+        session: interval_window(general),
+        weekly: weekly_window(general),
+        video_session: video.map(interval_window),
+        video_weekly: video.map(weekly_window),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Verbatim shape of a live successful response (values from a real Token
+    /// Plan account; `general` at 99% remaining on a 5h window, `video` at
+    /// 100% on a 24h one).
+    const LIVE: &str = r#"{
+        "model_remains": [
+            {
+                "start_time": 1785164400000,
+                "end_time": 1785182400000,
+                "remains_time": 1877492,
+                "current_interval_total_count": 0,
+                "current_interval_usage_count": 0,
+                "model_name": "general",
+                "current_weekly_total_count": 0,
+                "current_weekly_usage_count": 0,
+                "weekly_start_time": 1785110400000,
+                "weekly_end_time": 1785715200000,
+                "weekly_remains_time": 534677492,
+                "current_interval_status": 1,
+                "current_interval_remaining_percent": 99,
+                "current_weekly_status": 1,
+                "current_weekly_remaining_percent": 99
+            },
+            {
+                "start_time": 1785110400000,
+                "end_time": 1785196800000,
+                "remains_time": 16277492,
+                "current_interval_total_count": 3,
+                "current_interval_usage_count": 0,
+                "model_name": "video",
+                "current_weekly_total_count": 21,
+                "current_weekly_usage_count": 0,
+                "weekly_start_time": 1785110400000,
+                "weekly_end_time": 1785715200000,
+                "weekly_remains_time": 534677492,
+                "current_interval_status": 1,
+                "current_interval_remaining_percent": 100,
+                "current_weekly_status": 1,
+                "current_weekly_remaining_percent": 100
+            }
+        ],
+        "base_resp": { "status_code": 0, "status_msg": "success" }
+    }"#;
+
+    fn parse(raw: &str) -> RemainsEnvelope {
+        serde_json::from_str(raw).expect("envelope parses")
+    }
+
+    #[test]
+    fn parses_live_envelope() {
+        let env = parse(LIVE);
+        env.check_ok().expect("status_code 0 is success");
+        assert_eq!(env.model_remains.len(), 2);
+        assert_eq!(env.model_remains[0].model_name, "general");
+    }
+
+    /// The API reports what is LEFT; the app renders what was USED. A snapshot
+    /// that echoed 99 here would show a nearly-exhausted plan as nearly-full.
+    #[test]
+    fn inverts_remaining_percent_into_consumed() {
+        let snap = to_snapshot(parse(LIVE), "Token Plan").unwrap();
+        assert_eq!(snap.session.utilization_pct, 1);
+        assert_eq!(snap.weekly.utilization_pct, 1);
+        assert_eq!(snap.video_session.unwrap().utilization_pct, 0);
+    }
+
+    /// The interval length differs per bucket, so it must come from the row.
+    #[test]
+    fn derives_window_length_from_the_row_not_a_constant() {
+        let snap = to_snapshot(parse(LIVE), "Token Plan").unwrap();
+        assert_eq!(snap.session.window_duration, chrono::Duration::hours(5));
+        assert_eq!(snap.weekly.window_duration, chrono::Duration::days(7));
+        assert_eq!(
+            snap.video_session.unwrap().window_duration,
+            chrono::Duration::hours(24),
+            "video rolls daily, not on general's 5h cadence"
+        );
+    }
+
+    #[test]
+    fn reset_comes_from_end_time_in_milliseconds() {
+        let snap = to_snapshot(parse(LIVE), "Token Plan").unwrap();
+        assert_eq!(
+            snap.session.resets_at,
+            chrono::DateTime::from_timestamp_millis(1785182400000)
+        );
+    }
+
+    /// Auth failures arrive as HTTP 200 — the envelope is the only signal.
+    #[test]
+    fn rejects_in_band_auth_failure() {
+        for raw in [
+            r#"{"base_resp":{"status_code":1004,"status_msg":"login fail: Please carry the API secret key in the 'Authorization' field of the request header"}}"#,
+            r#"{"base_resp":{"status_code":2049,"status_msg":"invalid api key"}}"#,
+        ] {
+            let env = parse(raw);
+            assert!(env.model_remains.is_empty());
+            let err = env.check_ok().unwrap_err();
+            assert!(
+                matches!(err, AppError::Schema(ref m) if m.contains("minimax")),
+                "unexpected error: {err:?}"
+            );
+        }
+    }
+
+    /// A plan without video quota is normal, not an error.
+    #[test]
+    fn video_bucket_is_optional() {
+        let raw = r#"{
+            "model_remains": [{
+                "start_time": 1785164400000, "end_time": 1785182400000,
+                "model_name": "general",
+                "current_interval_remaining_percent": 40,
+                "weekly_start_time": 1785110400000, "weekly_end_time": 1785715200000,
+                "current_weekly_remaining_percent": 55
+            }],
+            "base_resp": {"status_code": 0, "status_msg": "success"}
+        }"#;
+        let snap = to_snapshot(parse(raw), "Token Plan").unwrap();
+        assert_eq!(snap.session.utilization_pct, 60);
+        assert_eq!(snap.weekly.utilization_pct, 45);
+        assert!(snap.video_session.is_none());
+        assert!(snap.video_weekly.is_none());
+    }
+
+    /// A response whose only row is `video` has no bar to draw — surfacing that
+    /// beats rendering an empty general pool as 0% used.
+    #[test]
+    fn errors_when_no_text_bucket_is_present() {
+        let raw = r#"{
+            "model_remains": [{
+                "start_time": 1, "end_time": 2, "model_name": "video",
+                "current_interval_remaining_percent": 100,
+                "weekly_start_time": 1, "weekly_end_time": 2,
+                "current_weekly_remaining_percent": 100
+            }],
+            "base_resp": {"status_code": 0, "status_msg": "success"}
+        }"#;
+        assert!(to_snapshot(parse(raw), "Token Plan").is_err());
+    }
+
+    /// Degenerate bounds must not produce a zero-length window: the pace marker
+    /// divides by it.
+    #[test]
+    fn falls_back_to_a_positive_window_on_degenerate_bounds() {
+        let raw = r#"{
+            "model_remains": [{
+                "start_time": 0, "end_time": 0, "model_name": "general",
+                "current_interval_remaining_percent": 100,
+                "weekly_start_time": 0, "weekly_end_time": 0,
+                "current_weekly_remaining_percent": 100
+            }],
+            "base_resp": {"status_code": 0, "status_msg": "success"}
+        }"#;
+        let snap = to_snapshot(parse(raw), "Token Plan").unwrap();
+        assert_eq!(snap.session.window_duration, DEFAULT_INTERVAL);
+        assert_eq!(snap.weekly.window_duration, DEFAULT_WEEKLY);
+        assert_eq!(snap.session.resets_at, None, "epoch 0 is unreported");
+    }
+
+    /// Upstream sending something outside 0..=100 must not paint past the track.
+    #[test]
+    fn clamps_out_of_range_percentages() {
+        assert_eq!(consumed_pct(150), 0);
+        assert_eq!(consumed_pct(-5), 100);
+    }
+}

--- a/src/minimax/vendor.rs
+++ b/src/minimax/vendor.rs
@@ -1,0 +1,346 @@
+//! MiniMax renderer — bar text + bordered Pango tooltip.
+//!
+//! MiniMax reports quota per model bucket, so its rows are labeled by pool the
+//! same way Antigravity labels its Gemini / third-party groups. The text pool
+//! is what the bar shows; the video pool, when the plan has one, appears in the
+//! tooltip rather than competing for space on the bar.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::pacing::PaceSeverity;
+use crate::pango::{color_span, escape, severity_color, severity_for};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::usage::{MinimaxSnapshot, UsageWindow};
+use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+
+/// The text & coding pool (`general` on the wire) — what the bars represent.
+pub const POOL_GENERAL: &str = "Text";
+/// The video-generation pool (`video` on the wire), shown when the plan has it.
+pub const POOL_VIDEO: &str = "Video";
+
+pub const DEFAULT_FORMAT: &str = "{minimax_session_pct}% · {minimax_session_reset}";
+
+pub fn build_placeholders(
+    snap: &MinimaxSnapshot,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
+    let session_pct = snap.session.utilization_pct;
+    let weekly_pct = snap.weekly.utilization_pct;
+    let session_reset = countdown::format(snap.session.resets_at, now);
+    let weekly_reset = countdown::format(snap.weekly.resets_at, now);
+    // The video pool is optional; its placeholders resolve to an em dash rather
+    // than vanishing, so a user format referencing them never leaves a gap.
+    let video = |w: &Option<UsageWindow>, pct: bool| -> String {
+        match w {
+            Some(w) if pct => w.utilization_pct.to_string(),
+            Some(w) => countdown::format(w.resets_at, now),
+            None => "—".to_string(),
+        }
+    };
+
+    placeholders(vec![
+        ("icon", "󰚩".to_string()),
+        ("vendor_short", "mmx".to_string()),
+        // Cross-vendor aliases — what the desktop surfaces read.
+        ("plan", snap.plan.clone()),
+        ("session_pct", session_pct.to_string()),
+        ("session_reset", session_reset.clone()),
+        ("weekly_pct", weekly_pct.to_string()),
+        ("weekly_reset", weekly_reset.clone()),
+        // MiniMax-specific placeholders.
+        ("minimax_plan", snap.plan.clone()),
+        ("minimax_session_pct", session_pct.to_string()),
+        ("minimax_session_reset", session_reset),
+        ("minimax_weekly_pct", weekly_pct.to_string()),
+        ("minimax_weekly_reset", weekly_reset),
+        ("minimax_video_pct", video(&snap.video_session, true)),
+        ("minimax_video_reset", video(&snap.video_session, false)),
+        ("minimax_video_weekly_pct", video(&snap.video_weekly, true)),
+    ])
+}
+
+/// Worst of the two text-pool windows. The video pool deliberately does not
+/// drive the bar color: running out of video quota should not paint the coding
+/// bar red.
+pub fn severity(snap: &MinimaxSnapshot) -> PaceSeverity {
+    severity_for(
+        snap.session
+            .utilization_pct
+            .max(snap.weekly.utilization_pct),
+    )
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &MinimaxSnapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let class = Class::from(severity(snap));
+    let format = opts
+        .format
+        .clone()
+        .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
+    let values = build_placeholders(snap, now);
+    // User formats are Pango markup after Waybar renders them. Escape API
+    // strings there, while retaining raw values for the default tooltip (which
+    // escapes exactly once at its markup insertion point).
+    let mut pango_values = values.clone();
+    for key in ["plan", "minimax_plan"] {
+        if let Some(value) = pango_values.get_mut(key) {
+            *value = escape(value);
+        }
+    }
+
+    let mut text = substitute(&format, &pango_values);
+    if outcome.stale {
+        text.push_str(" ⏸");
+    }
+
+    let wrapper_color = severity_color(severity(snap), theme).to_string();
+    let icon_prefix = match opts.icon.as_deref() {
+        Some(ic) if !ic.is_empty() => format!("{ic} "),
+        _ => String::new(),
+    };
+    let bar_text = color_span(&wrapper_color, &format!("{icon_prefix}{text}"));
+
+    let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
+        substitute(fmt, &pango_values)
+    } else {
+        render_tooltip(outcome, snap, theme, now)
+    };
+
+    WaybarOutput {
+        text: bar_text,
+        tooltip,
+        class,
+    }
+}
+
+fn render_tooltip(
+    outcome: &VendorOutcome,
+    snap: &MinimaxSnapshot,
+    theme: &Theme,
+    now: DateTime<Utc>,
+) -> String {
+    let blue = &theme.blue;
+    let dim = &theme.dim;
+    let fg = &theme.fg;
+
+    let mut lines: Vec<TooltipLine> = Vec::new();
+    lines.push(TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{blue}'>{}</span>",
+        escape(&snap.plan)
+    )));
+    lines.push(TooltipLine::Sep);
+
+    let mut pool = |label: &str, icon: &str, session: &UsageWindow, weekly: &UsageWindow| {
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{fg}'>  {icon}  {label}</span>"
+        )));
+        for (what, w) in [("Session", session), ("Weekly", weekly)] {
+            let color = severity_color(severity_for(w.utilization_pct), theme);
+            lines.push(TooltipLine::Body(format!(
+                "   <span foreground='{dim}'>{what}</span>  \
+                 <span font_weight='bold' foreground='{color}'>{pct}%</span>",
+                pct = w.utilization_pct
+            )));
+            lines.push(TooltipLine::Body(format!(
+                " <span foreground='{dim}'>     reset {}</span>",
+                escape(&countdown::format(w.resets_at, now))
+            )));
+        }
+    };
+
+    pool(POOL_GENERAL, "󰅄", &snap.session, &snap.weekly);
+    if let (Some(vs), Some(vw)) = (&snap.video_session, &snap.video_weekly) {
+        pool(POOL_VIDEO, "󰕧", vs, vw);
+    }
+
+    if let Some((code, msg)) = outcome.last_error.as_ref() {
+        let (label, icon, ecolor) = if *code == 0 {
+            ("MiniMax error".to_string(), "󰅚", theme.red.as_str())
+        } else if *code >= 500 {
+            (format!("HTTP {code}"), "󰅚", theme.red.as_str())
+        } else {
+            (format!("HTTP {code}"), "󰀪", theme.orange.as_str())
+        };
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{ecolor}'>  {icon}  {label}</span>"
+        )));
+        if msg != &label {
+            lines.push(TooltipLine::Body(format!(
+                "     <span foreground='{dim}'>{}</span>",
+                escape(msg)
+            )));
+        }
+    }
+
+    let updated = updated_at_hm(now, outcome.cache_age);
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  󰅐  Updated {updated}</span>"
+    )));
+
+    render_bordered(&lines, theme)
+}
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(o: FetchOutcome) -> Self {
+        Self {
+            snapshot: crate::usage::VendorSnapshot::Minimax(o.snapshot),
+            stale: o.stale,
+            last_error: o.last_error,
+            cache_age: o.cache_age,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 7, 27, 12, 0, 0).unwrap()
+    }
+
+    fn window(pct: i32, mins_ahead: i64, dur: chrono::Duration) -> UsageWindow {
+        UsageWindow {
+            utilization_pct: pct,
+            resets_at: Some(now() + chrono::Duration::minutes(mins_ahead)),
+            window_duration: dur,
+        }
+    }
+
+    fn snap() -> MinimaxSnapshot {
+        MinimaxSnapshot {
+            plan: "MiniMax Token Plan".to_string(),
+            session: window(31, 45, chrono::Duration::hours(5)),
+            weekly: window(62, 3000, chrono::Duration::days(7)),
+            video_session: Some(window(5, 200, chrono::Duration::hours(24))),
+            video_weekly: Some(window(9, 3000, chrono::Duration::days(7))),
+        }
+    }
+
+    fn opts() -> RenderOpts {
+        RenderOpts {
+            format: None,
+            tooltip_format: None,
+            icon: None,
+            pace_tolerance: 5,
+            format_pace_color: false,
+            tooltip_pace_pts: false,
+        }
+    }
+
+    fn outcome(s: &MinimaxSnapshot) -> VendorOutcome {
+        VendorOutcome {
+            snapshot: crate::usage::VendorSnapshot::Minimax(s.clone()),
+            stale: false,
+            last_error: None,
+            cache_age: Some(std::time::Duration::ZERO),
+        }
+    }
+
+    #[test]
+    fn default_format_shows_session_percent_and_reset() {
+        let s = snap();
+        let out = render(&outcome(&s), &s, &Theme::default(), &opts(), now());
+        assert!(out.text.contains("31%"), "bar text was {:?}", out.text);
+    }
+
+    /// Cross-vendor aliases are what the GNOME/macOS surfaces read; without
+    /// them MiniMax would render blank rows on the desktop.
+    #[test]
+    fn exposes_cross_vendor_aliases() {
+        let v = build_placeholders(&snap(), now());
+        assert_eq!(v.get("session_pct").map(String::as_str), Some("31"));
+        assert_eq!(v.get("weekly_pct").map(String::as_str), Some("62"));
+        assert_eq!(v.get("vendor_short").map(String::as_str), Some("mmx"));
+        assert!(v.contains_key("session_reset"));
+    }
+
+    /// The video pool must not drag the coding bar into red.
+    #[test]
+    fn severity_ignores_the_video_pool() {
+        let mut s = snap();
+        s.session.utilization_pct = 10;
+        s.weekly.utilization_pct = 10;
+        s.video_session = Some(window(99, 10, chrono::Duration::hours(24)));
+        s.video_weekly = Some(window(99, 10, chrono::Duration::days(7)));
+        assert_eq!(severity(&s), severity_for(10));
+    }
+
+    #[test]
+    fn video_placeholders_degrade_to_a_dash_without_the_pool() {
+        let mut s = snap();
+        s.video_session = None;
+        s.video_weekly = None;
+        let v = build_placeholders(&s, now());
+        assert_eq!(v.get("minimax_video_pct").map(String::as_str), Some("—"));
+        assert_eq!(
+            v.get("minimax_video_weekly_pct").map(String::as_str),
+            Some("—")
+        );
+    }
+
+    #[test]
+    fn tooltip_lists_both_pools_when_present() {
+        let s = snap();
+        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), now());
+        assert!(tip.contains(POOL_GENERAL));
+        assert!(tip.contains(POOL_VIDEO));
+    }
+
+    #[test]
+    fn tooltip_omits_the_video_pool_when_absent() {
+        let mut s = snap();
+        s.video_session = None;
+        s.video_weekly = None;
+        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), now());
+        assert!(tip.contains(POOL_GENERAL));
+        assert!(!tip.contains(POOL_VIDEO));
+    }
+
+    /// Plan text reaches Pango exactly once escaped, from both paths.
+    #[test]
+    fn escapes_the_plan_name_exactly_once() {
+        let mut s = snap();
+        s.plan = "Plan <b>&</b>".to_string();
+        let out = render(
+            &outcome(&s),
+            &s,
+            &Theme::default(),
+            &RenderOpts {
+                format: Some("{minimax_plan}".to_string()),
+                ..opts()
+            },
+            now(),
+        );
+        assert!(out.text.contains("&lt;b&gt;&amp;&lt;/b&gt;"), "{:?}", out.text);
+        assert!(!out.text.contains("&amp;lt;"), "double-escaped: {:?}", out.text);
+    }
+
+    #[test]
+    fn stale_marks_the_bar() {
+        let s = snap();
+        let mut o = outcome(&s);
+        o.stale = true;
+        let out = render(&o, &s, &Theme::default(), &opts(), now());
+        assert!(out.text.contains('⏸'));
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -491,6 +491,19 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             let outcome = crate::antigravity::fetch_snapshot(client, &cache, DEFAULT_TTL).await?;
             Ok(outcome.into())
         }
+        VendorId::Minimax => {
+            let api_key = crate::config::resolve_api_key(
+                "MiniMax",
+                &config.minimax.api_key_env,
+                config.minimax.api_key.as_deref(),
+            )?;
+            let cache = crate::cache::Cache::for_vendor("minimax")?;
+            let endpoints = crate::minimax::fetch::Endpoints::for_region(&config.minimax.region);
+            let outcome =
+                crate::minimax::fetch_snapshot(client, &api_key, &cache, &endpoints, DEFAULT_TTL)
+                    .await?;
+            Ok(outcome.into())
+        }
         VendorId::Cursor => {
             let cache = crate::cache::Cache::for_vendor("cursor")?;
             let db_path = config

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -132,6 +132,13 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
             s.plan.clone(),
             vec![pct("auto", s.auto_pct), pct("premium", s.api_pct)],
         ),
+        VendorSnapshot::Minimax(s) => (
+            s.plan.clone(),
+            vec![
+                pct("S", s.session.utilization_pct),
+                pct("W", s.weekly.utilization_pct),
+            ],
+        ),
     }
 }
 
@@ -169,6 +176,9 @@ pub fn headline_pct(snapshot: &VendorSnapshot) -> Option<i32> {
             Some(s.session.utilization_pct.max(s.weekly.utilization_pct))
         }
         VendorSnapshot::Cursor(s) => (!s.unlimited).then_some(s.total_pct),
+        VendorSnapshot::Minimax(s) => {
+            Some(s.session.utilization_pct.max(s.weekly.utilization_pct))
+        }
         VendorSnapshot::Openrouter(_)
         | VendorSnapshot::Deepseek(_)
         | VendorSnapshot::Kilo(_)
@@ -217,6 +227,7 @@ pub fn sections_for(tab: &TabState, now: DateTime<Utc>, pace_tolerance: u32) -> 
                 VendorSnapshot::Grok(s) => grok_sections(s),
                 VendorSnapshot::Antigravity(s) => antigravity_sections(s, now),
                 VendorSnapshot::Cursor(s) => cursor_sections(s, now),
+                VendorSnapshot::Minimax(s) => minimax_sections(s, now, pace_tolerance),
             };
             // Inject the (already-absolute) fetched-at instant into the title
             // row, right-aligned. Pre-snapshotted in app::refresh_one so it
@@ -535,6 +546,38 @@ fn cursor_sections(s: &crate::usage::CursorSnapshot, now: DateTime<Utc>) -> Vec<
         label: "Resets".into(),
         value: countdown::format(s.reset_at, now),
     });
+    v
+}
+
+/// MiniMax groups quota by model bucket, so the panel is laid out by window
+/// (Session, Weekly) with one row per pool — the same shape as Antigravity's
+/// two-group panel. Pacing is shown: both windows report a real duration, so
+/// the marker is meaningful.
+fn minimax_sections(
+    s: &crate::usage::MinimaxSnapshot,
+    now: DateTime<Utc>,
+    tol: u32,
+) -> Vec<Section> {
+    use crate::minimax::vendor::{POOL_GENERAL, POOL_VIDEO};
+
+    let mut v = vec![Section::Title {
+        left: s.plan.clone(),
+        right: None,
+    }];
+    for (heading, general, video) in [
+        ("Session", &s.session, s.video_session.as_ref()),
+        ("Weekly", &s.weekly, s.video_weekly.as_ref()),
+    ] {
+        v.push(Section::Spacer);
+        v.push(Section::Text {
+            label: heading.into(),
+            value: String::new(),
+        });
+        push_window(&mut v, POOL_GENERAL, general, now, tol, true);
+        if let Some(w) = video {
+            push_window(&mut v, POOL_VIDEO, w, now, tol, true);
+        }
+    }
     v
 }
 

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -102,6 +102,13 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         section: "grok",
         note: "management key, not the inference key",
     },
+    KeyVendor {
+        id: VendorId::Minimax,
+        label: "MiniMax",
+        env: "MINIMAX_API_KEY",
+        section: "minimax",
+        note: "Token Plan subscription key",
+    },
 ];
 
 /// Read the inline `api_key` currently in config for a given section, so the
@@ -117,6 +124,7 @@ fn config_inline_key<'a>(cfg: &'a Config, section: &str) -> Option<&'a str> {
         "novita" => cfg.novita.api_key.as_deref(),
         "moonshot" => cfg.moonshot.api_key.as_deref(),
         "grok" => cfg.grok.api_key.as_deref(),
+        "minimax" => cfg.minimax.api_key.as_deref(),
         _ => None,
     }
 }
@@ -745,6 +753,7 @@ fn vendor_label(v: VendorId) -> &'static str {
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
         VendorId::Cursor => "Cursor",
+        VendorId::Minimax => "MiniMax",
     }
 }
 

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -84,6 +84,7 @@ fn vendor_label(id: VendorId) -> &'static str {
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
         VendorId::Cursor => "Cursor",
+        VendorId::Minimax => "MiniMax",
     }
 }
 
@@ -102,6 +103,7 @@ fn compact_vendor_label(id: VendorId) -> &'static str {
         VendorId::Grok => "Grok",
         VendorId::Antigravity => "Antigravity",
         VendorId::Cursor => "Cursor",
+        VendorId::Minimax => "MiniMax",
     }
 }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -318,6 +318,7 @@ pub enum VendorSnapshot {
     AnthropicApi(AnthropicApiSnapshot),
     Antigravity(AntigravitySnapshot),
     Cursor(CursorSnapshot),
+    Minimax(MinimaxSnapshot),
 }
 
 /// Google Antigravity 2.0 / CLI snapshot. The API groups models into Gemini
@@ -340,6 +341,27 @@ pub struct AntigravitySnapshot {
 }
 
 impl Eq for AntigravitySnapshot {}
+
+/// MiniMax Token Plan — `/v1/token_plan/remains` returns one row per model
+/// bucket (`general` for text/coding, `video`), and each row carries its own
+/// rolling interval window plus a weekly window.
+///
+/// Two things the payload dictates rather than convention: the interval length
+/// is **not fixed** (`general` rolls every 5h, `video` every 24h), so the
+/// duration is derived from the row's own start/end rather than assumed; and
+/// the API reports the percentage **remaining**, which is inverted on the way
+/// in so these windows carry consumed-% like every other vendor's.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MinimaxSnapshot {
+    pub plan: String,
+    /// `general` bucket — rolling interval window (5h on the observed plans).
+    pub session: UsageWindow,
+    /// `general` bucket — weekly window.
+    pub weekly: UsageWindow,
+    /// `video` bucket, `None` on plans that carry no video quota.
+    pub video_session: Option<UsageWindow>,
+    pub video_weekly: Option<UsageWindow>,
+}
 
 /// Anthropic Admin API — month-to-date spend (USD) from the cost report. The
 /// monthly `limit` is supplied from config (the API exposes neither the limit

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -71,6 +71,7 @@ pub enum VendorId {
     Grok,
     Antigravity,
     Cursor,
+    Minimax,
 }
 
 impl VendorId {
@@ -89,6 +90,7 @@ impl VendorId {
             VendorId::Grok => "grok",
             VendorId::Antigravity => "antigravity",
             VendorId::Cursor => "cursor",
+            VendorId::Minimax => "minimax",
         }
     }
 
@@ -107,6 +109,7 @@ impl VendorId {
             VendorId::Grok,
             VendorId::Antigravity,
             VendorId::Cursor,
+            VendorId::Minimax,
         ]
     }
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -166,6 +166,7 @@ pub enum Vendor {
     Grok,
     Antigravity,
     Cursor,
+    Minimax,
 }
 
 impl Vendor {
@@ -184,6 +185,7 @@ impl Vendor {
             Vendor::Grok => crate::vendor::VendorId::Grok,
             Vendor::Antigravity => crate::vendor::VendorId::Antigravity,
             Vendor::Cursor => crate::vendor::VendorId::Cursor,
+            Vendor::Minimax => crate::vendor::VendorId::Minimax,
         }
     }
 }
@@ -269,6 +271,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::Grok => Vendor::Grok,
         crate::vendor::VendorId::Antigravity => Vendor::Antigravity,
         crate::vendor::VendorId::Cursor => Vendor::Cursor,
+        crate::vendor::VendorId::Minimax => Vendor::Minimax,
     }
 }
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -19,6 +19,7 @@ use crate::error::{AppError, Result};
 use crate::grok;
 use crate::kilo;
 use crate::kimi;
+use crate::minimax;
 use crate::moonshot;
 use crate::novita;
 use crate::openai;
@@ -151,6 +152,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::Grok => grok_output(cli, &config).await,
         Vendor::Antigravity => antigravity_output(cli, &config).await,
         Vendor::Cursor => cursor_output(cli, &config).await,
+        Vendor::Minimax => minimax_output(cli, &config).await,
     }
 }
 
@@ -283,6 +285,35 @@ async fn moonshot_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     let vendor_outcome: VendorOutcome = outcome.into();
     let opts = RenderOpts::from_cli(cli);
     Ok(moonshot::vendor::render(
+        &vendor_outcome,
+        &snap,
+        &theme,
+        &opts,
+        chrono::Utc::now(),
+    ))
+}
+
+async fn minimax_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let api_key = crate::config::resolve_api_key(
+        "MiniMax",
+        &config.minimax.api_key_env,
+        config.minimax.api_key.as_deref(),
+    )?;
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "minimax")?;
+    let endpoints = minimax::fetch::Endpoints::for_region(&config.minimax.region);
+    let outcome =
+        match minimax::fetch_snapshot(&client, &api_key, &cache, &endpoints, DEFAULT_TTL).await {
+            Ok(o) => o,
+            Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
+            Err(e) => return Err(e),
+        };
+
+    let theme = theme_from_cli(cli);
+    let snap = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    let opts = RenderOpts::from_cli(cli);
+    Ok(minimax::vendor::render(
         &vendor_outcome,
         &snap,
         &theme,

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -51,6 +51,7 @@ use ai_usagebar::cache::Cache;
 use ai_usagebar::cursor;
 use ai_usagebar::error::AppError;
 use ai_usagebar::kimi;
+use ai_usagebar::minimax;
 use ai_usagebar::openai;
 use ai_usagebar::openrouter;
 use ai_usagebar::zai;
@@ -377,5 +378,58 @@ async fn cursor_live() {
         out.snapshot.total_pct,
         out.snapshot.on_demand_enabled,
         out.snapshot.reset_at,
+    );
+}
+
+/// MiniMax Token Plan — optional: skipped unless a subscription key is present.
+///
+/// The endpoint answers HTTP 200 even for auth failures, so a green run here is
+/// what proves the in-band `base_resp.status_code` check is still doing its job:
+/// a wrong key surfaces as an error rather than an all-zero plan.
+#[tokio::test]
+#[ignore = "live API; run with --ignored"]
+async fn minimax_live() {
+    let Ok(api_key) = std::env::var("MINIMAX_API_KEY") else {
+        eprintln!("minimax_live: MINIMAX_API_KEY is unset — skipping optional MiniMax smoke test");
+        return;
+    };
+    if api_key.trim().is_empty() {
+        eprintln!("minimax_live: MINIMAX_API_KEY is empty — skipping optional MiniMax smoke test");
+        return;
+    }
+    let cache = xdg_cache_for("minimax");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let endpoints = minimax::fetch::Endpoints::default();
+    let out = minimax::fetch_snapshot(
+        &client,
+        &api_key,
+        &cache,
+        &endpoints,
+        Duration::from_secs(0),
+    )
+    .await
+    .expect("minimax fetch should succeed against the real API");
+
+    assert_pct("minimax.session", out.snapshot.session.utilization_pct);
+    assert_pct("minimax.weekly", out.snapshot.weekly.utilization_pct);
+    // The interval length is read from the payload rather than assumed: it has
+    // been observed at both 4h and 5h on the same account. A non-positive one
+    // would divide the pace math by nothing.
+    assert!(
+        out.snapshot.session.window_duration > chrono::Duration::zero(),
+        "minimax: interval window has no length — payload shape changed?"
+    );
+    if let Some(v) = out.snapshot.video_session.as_ref() {
+        assert_pct("minimax.video", v.utilization_pct);
+    }
+    println!(
+        "✅ minimax: {} · session {}% · weekly {}% · video {:?}",
+        out.snapshot.plan,
+        out.snapshot.session.utilization_pct,
+        out.snapshot.weekly.utilization_pct,
+        out.snapshot.video_session.as_ref().map(|w| w.utilization_pct),
     );
 }


### PR DESCRIPTION
## What changed

Adds **MiniMax** as an opt-in vendor (`--vendor minimax`, `[minimax]`), reading
the Token Plan subscription quota from `GET /v1/token_plan/remains`.

The endpoint is undocumented — MiniMax's public docs describe the Token Plan's
5-hour and weekly windows but publish no schema for reading them — so every
field here was captured against the live global endpoint and is covered by a
parse test built from a real response.

The plan reports **one row per model bucket**, each carrying its own rolling
interval window plus a weekly window. That maps onto the existing two-pool
shape Antigravity established: `general` (text/coding) drives the bar and the
generic `{session_pct}` / `{weekly_pct}` aliases, and `video` rides along in the
tooltip, the TUI panel, and the Overview. `{vendor_short}` is `mmx`.

## Why these four things are done the way they are

Each one is a property of the API that is easy to get backwards, and each has a
test that fails if it regresses:

1. **The endpoint answers HTTP 200 even when authentication fails.** The real
   status is `base_resp.status_code`. The two credential codes — `1004` (no key)
   and `2049` (key not valid for this instance) — are mapped onto HTTP 401, so a
   wrong key reports as an auth problem instead of being filed under schema
   drift. Reading the HTTP status alone would cache an auth failure as a valid
   all-zero plan.

2. **The percentages are what REMAINS, not what was consumed.** They are
   inverted on the way in. Echoing them straight through would paint a
   barely-used plan as nearly exhausted.

3. **The interval length is not fixed.** `general` rolls every 5h and `video`
   every 24h, and `general` itself has been observed at both 4h and 5h on the
   same account — so each window's duration comes from its own `start_time` /
   `end_time` rather than a constant.

4. **All timestamps are epoch milliseconds**, not seconds.

`[minimax] region` picks the **instance**, not a unit: `api.minimax.io` (global)
and `api.minimaxi.com` (CN) issue separate keys and reject each other's
(`status_code 2049`). A cached figure from one is therefore wrong rather than
merely stale, so the endpoint is recorded in the cache payload and a mismatched
cache is discarded instead of being shown against the wrong account. This
differs from Moonshot's `region`, which selects a currency.

## Test plan

- [x] `cargo test` — 704 passing (23 new: wire parsing, the inversion, the
      derived window length, the in-band auth mapping, cache round-trip,
      cross-instance cache rejection, HTTP fallback with body redaction,
      renderer and placeholder coverage)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `minimax_live` in `tests/live.rs`, green against a real Token Plan key:
      `✅ minimax: MiniMax Token Plan · session 1% · weekly 1% · video Some(0)`.
      It skips with a diagnostic when `MINIMAX_API_KEY` is unset, and uses the
      throwaway `xdg_cache_for` cache like the other live tests.
- [x] Unit tests are hermetic — no real `$HOME`/`$XDG` reads, `Cache::at` only.

## Notes for reviewers

- **Widget and TUI only** — no GNOME or macOS surface, same as Kimi. The
  vendor is registered in the Overview (`overview_cells` and `headline_pct`) so
  it participates there on both surfaces that already read them.
- **Opt-in**, defaults to `enabled = false`; it needs the Token Plan
  **subscription** key (a pay-as-you-go key has no plan quota to report).
- Docs updated: README credential table, the opt-in list, the `{vendor_short}`
  list, the endpoint table, the example config block, plus `config.example.toml`
  and a `## [Unreleased]` CHANGELOG entry.
- The upstream response body is never surfaced on error (401/403 and 5xx get
  generic messages), and `read_body_capped` is used rather than `resp.bytes()`.
