### PR TITLE
Add `ai-usagebar usage` — quota + time-to-reset for every configured entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,15 @@ Each release is also published at
   at a time, which is what a status bar needs and what a person checking on four
   Claude accounts does not. This walks the same set the TUI builds — every
   enabled vendor plus one entry per named Claude account — and prints each
-  window's percentage next to when it resets. `--json` gives the same thing with
-  the percentage as a number, keyed by a stable id (`anthropic@work`), for
-  scripting and logging. A vendor that fails to fetch reports inline instead of
-  hiding the rest, and the exit code is non-zero only when every entry failed.
+  window's percentage next to when it resets. `--json` keeps gauge rows in a
+  convenient `metrics` list and provides a lossless ordered `sections` list for
+  balance text and grouped breakdowns, keyed by a stable id
+  (`anthropic@work`), for scripting and logging. A vendor that fails to fetch
+  reports inline instead of hiding the rest, and the exit code is non-zero only
+  when every entry failed.
 
   Thin by construction: it reuses the TUI's existing tab enumeration, fetch, and
-  snapshot-to-metrics projection, so no vendor needs to know it exists.
+  snapshot-to-sections projection, so no vendor needs to know it exists.
 
 ## [0.20.1] — 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **`ai-usagebar usage` — quota and time-to-reset for everything in the config,
+  in one command.** The widget answers "how is *this* vendor doing" one process
+  at a time, which is what a status bar needs and what a person checking on four
+  Claude accounts does not. This walks the same set the TUI builds — every
+  enabled vendor plus one entry per named Claude account — and prints each
+  window's percentage next to when it resets. `--json` gives the same thing with
+  the percentage as a number, keyed by a stable id (`anthropic@work`), for
+  scripting and logging. A vendor that fails to fetch reports inline instead of
+  hiding the rest, and the exit code is non-zero only when every entry failed.
+
+  Thin by construction: it reuses the TUI's existing tab enumeration, fetch, and
+  snapshot-to-metrics projection, so no vendor needs to know it exists.
+
 ## [0.20.1] — 2026-07-30
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ ai-usagebar --vendor kimi
 # Force Waybar JSON (e.g. piping into jq).
 ai-usagebar --json
 
+# Everything at once: quota + time-to-reset for every configured vendor,
+# with one entry per named Claude account.
+ai-usagebar usage
+ai-usagebar usage --json | jq '.entries[] | {id, metrics}'
+
 # Live preview while iterating on --format / --tooltip-format.
 ai-usagebar --vendor openrouter --watch 5
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ ai-usagebar --json
 # Everything at once: quota + time-to-reset for every configured vendor,
 # with one entry per named Claude account.
 ai-usagebar usage
-ai-usagebar usage --json | jq '.entries[] | {id, metrics}'
+ai-usagebar usage --json | jq '.entries[] | {id, metrics, sections}'
 
 # Live preview while iterating on --format / --tooltip-format.
 ai-usagebar --vendor openrouter --watch 5
@@ -262,6 +262,10 @@ ai-usagebar --vendor openrouter --watch 5
 # Interactive TUI with tabs.
 ai-usagebar-tui
 ```
+
+In JSON, `metrics` contains only percentage gauges. The ordered `sections`
+array is the lossless view and also includes balance text, grouped breakdowns,
+and visual spacers; non-percentage rows never invent a numeric percentage.
 
 ## Standalone TUI — no Waybar required
 

--- a/src/bin/ai-usagebar.rs
+++ b/src/bin/ai-usagebar.rs
@@ -23,6 +23,12 @@ fn main() {
             std::process::exit(0);
         }
     };
+    // An administrative report, not the widget: it needs the runtime but must
+    // not go through the always-exit-0 Waybar contract — a script piping this
+    // deserves a real exit code.
+    if let Some(Command::Usage { json }) = &cli.command {
+        std::process::exit(rt.block_on(ai_usagebar::report::run(*json)));
+    }
     let code = rt.block_on(run(cli));
     std::process::exit(code);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod openai;
 pub mod openrouter;
 pub mod pacing;
 pub mod pango;
+pub mod report;
 pub mod theme;
 pub mod tooltip;
 pub mod tui;

--- a/src/report.rs
+++ b/src/report.rs
@@ -10,11 +10,12 @@
 //! Deliberately thin: [`crate::tui::app::tabs_from_config`] already decides
 //! what is configured, [`crate::tui::app::refresh_one`] already fetches and
 //! parses it, and [`crate::tui::panels::sections_for`] already projects any
-//! vendor's snapshot into labelled metrics carrying both the percentage and
-//! the reset. So this file only enumerates, flattens, and formats — no vendor
+//! vendor's snapshot into labelled sections carrying every reported value.
+//! So this file only enumerates, projects, and formats — no vendor
 //! ever needs to know it exists.
 
 use chrono::Utc;
+use serde::Serialize;
 use serde_json::json;
 
 use crate::config::Config;
@@ -30,15 +31,42 @@ struct Entry {
     id: String,
     name: String,
     plan: Option<String>,
-    metrics: Vec<Metric>,
+    sections: Vec<ReportSection>,
     error: Option<String>,
 }
 
-struct Metric {
-    label: String,
-    pct: u16,
-    value: String,
-    detail: String,
+/// Lossless machine-readable projection of a TUI panel row. `metrics` remains
+/// available in JSON as a convenience view over only the gauge rows; callers
+/// that need every reported value should consume this ordered list.
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ReportSection {
+    Metric {
+        label: String,
+        percent: u16,
+        value: String,
+        detail: String,
+    },
+    Text {
+        label: String,
+        value: String,
+    },
+    Block {
+        label: String,
+        body: Vec<String>,
+    },
+    Spacer,
+}
+
+impl ReportSection {
+    fn label(&self) -> Option<&str> {
+        match self {
+            Self::Metric { label, .. } | Self::Text { label, .. } | Self::Block { label, .. } => {
+                Some(label)
+            }
+            Self::Spacer => None,
+        }
+    }
 }
 
 pub async fn run(json: bool) -> i32 {
@@ -79,22 +107,31 @@ pub async fn run(json: bool) -> i32 {
     } else {
         print!("{}", render_text(&entries));
     }
-    i32::from(entries.iter().all(|entry| entry.error.is_some()))
+    report_exit_code(&entries)
 }
 
 async fn entry_for(client: &reqwest::Client, config: &Config, tab: &TabId) -> Entry {
     let state = refresh_one(client, config, tab).await;
+    entry_from_state(tab, &state, Utc::now())
+}
+
+fn entry_from_state(tab: &TabId, state: &TabState, now: chrono::DateTime<Utc>) -> Entry {
     let mut entry = Entry {
         id: tab_id(tab),
         name: tab_name(tab),
         plan: None,
-        metrics: Vec::new(),
+        sections: Vec::new(),
         error: match &state {
             TabState::Error(message) => Some(message.clone()),
             _ => None,
         },
     };
-    for section in sections_for(&state, Utc::now(), PACE_TOLERANCE) {
+    // The error is already a first-class entry field. Do not duplicate the
+    // TUI's interactive retry instructions as report data.
+    if entry.error.is_some() {
+        return entry;
+    }
+    for section in sections_for(state, now, PACE_TOLERANCE) {
         match section {
             Section::Title { left, .. } => entry.plan = Some(left),
             Section::Metric {
@@ -103,25 +140,26 @@ async fn entry_for(client: &reqwest::Client, config: &Config, tab: &TabId) -> En
                 value_label,
                 footnote,
                 ..
-            } => entry.metrics.push(Metric {
+            } => entry.sections.push(ReportSection::Metric {
                 label,
-                pct,
+                percent: pct,
                 value: value_label,
                 detail: footnote,
             }),
-            // Balance-only vendors report through Text rows rather than a
-            // gauge; keep them, since a credit balance is the whole answer
-            // for those.
-            Section::Text { label, value } => entry.metrics.push(Metric {
-                label,
-                pct: 0,
-                value,
-                detail: String::new(),
-            }),
-            Section::Block { .. } | Section::Spacer => {}
+            Section::Text { label, value } => {
+                entry.sections.push(ReportSection::Text { label, value });
+            }
+            Section::Block { label, body } => {
+                entry.sections.push(ReportSection::Block { label, body });
+            }
+            Section::Spacer => entry.sections.push(ReportSection::Spacer),
         }
     }
     entry
+}
+
+fn report_exit_code(entries: &[Entry]) -> i32 {
+    i32::from(entries.iter().all(|entry| entry.error.is_some()))
 }
 
 /// Stable machine id, matching the `anthropic@<label>` convention the macOS
@@ -144,17 +182,31 @@ fn render_json(entries: &[Entry]) -> String {
     let rows: Vec<serde_json::Value> = entries
         .iter()
         .map(|entry| {
+            let metrics = entry
+                .sections
+                .iter()
+                .filter_map(|section| match section {
+                    ReportSection::Metric {
+                        label,
+                        percent,
+                        value,
+                        detail,
+                    } => Some(json!({
+                        "label": label,
+                        "percent": percent,
+                        "value": value,
+                        "detail": detail,
+                    })),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
             json!({
                 "id": entry.id,
                 "name": entry.name,
                 "plan": entry.plan,
                 "error": entry.error,
-                "metrics": entry.metrics.iter().map(|metric| json!({
-                    "label": metric.label,
-                    "percent": metric.pct,
-                    "value": metric.value,
-                    "detail": metric.detail,
-                })).collect::<Vec<_>>(),
+                "metrics": metrics,
+                "sections": entry.sections,
             })
         })
         .collect();
@@ -166,8 +218,9 @@ fn render_text(entries: &[Entry]) -> String {
     // whole report rather than per-section.
     let width = entries
         .iter()
-        .flat_map(|entry| entry.metrics.iter())
-        .map(|metric| metric.label.chars().count())
+        .flat_map(|entry| entry.sections.iter())
+        .filter_map(ReportSection::label)
+        .map(|label| label.chars().count())
         .max()
         .unwrap_or(0);
 
@@ -182,19 +235,59 @@ fn render_text(entries: &[Entry]) -> String {
             out.push_str(&format!("  ! {error}\n\n"));
             continue;
         }
-        if entry.metrics.is_empty() {
+        if !entry
+            .sections
+            .iter()
+            .any(|section| !matches!(section, ReportSection::Spacer))
+        {
             out.push_str("  (nothing reported)\n\n");
             continue;
         }
-        for metric in &entry.metrics {
-            let label = format!("{:width$}", metric.label, width = width);
-            let value = format!("{:>9}", metric.value);
-            if metric.detail.is_empty() {
-                out.push_str(&format!("  {label}  {value}\n"));
-            } else {
-                out.push_str(&format!("  {label}  {value}   {}\n", metric.detail));
+        let mut body = String::new();
+        let mut pending_spacer = false;
+        for section in &entry.sections {
+            if matches!(section, ReportSection::Spacer) {
+                pending_spacer |= !body.is_empty();
+                continue;
+            }
+            if pending_spacer {
+                body.push('\n');
+                pending_spacer = false;
+            }
+            match section {
+                ReportSection::Metric {
+                    label,
+                    value,
+                    detail,
+                    ..
+                } => {
+                    let label = format!("{label:width$}");
+                    let value = format!("{value:>9}");
+                    if detail.is_empty() {
+                        body.push_str(&format!("  {label}  {value}\n"));
+                    } else {
+                        body.push_str(&format!("  {label}  {value}   {detail}\n"));
+                    }
+                }
+                ReportSection::Text { label, value } => {
+                    if label.is_empty() {
+                        body.push_str(&format!("  {}\n", value.trim_start()));
+                    } else if value.is_empty() {
+                        body.push_str(&format!("  {label}\n"));
+                    } else {
+                        body.push_str(&format!("  {label:width$}  {value}\n"));
+                    }
+                }
+                ReportSection::Block { label, body: lines } => {
+                    body.push_str(&format!("  {label}\n"));
+                    for line in lines {
+                        body.push_str(&format!("    {line}\n"));
+                    }
+                }
+                ReportSection::Spacer => unreachable!(),
             }
         }
+        out.push_str(&body);
         out.push('\n');
     }
     out
@@ -203,22 +296,24 @@ fn render_text(entries: &[Entry]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tui::app::ReadyTab;
+    use crate::usage::{DeepseekSnapshot, OpenRouterSnapshot, VendorSnapshot};
     use crate::vendor::VendorId;
 
-    fn entry(name: &str, metrics: Vec<Metric>) -> Entry {
+    fn entry(name: &str, sections: Vec<ReportSection>) -> Entry {
         Entry {
             id: name.into(),
             name: name.into(),
             plan: Some("Claude Max 20x".into()),
-            metrics,
+            sections,
             error: None,
         }
     }
 
-    fn metric(label: &str, pct: u16, value: &str, detail: &str) -> Metric {
-        Metric {
+    fn metric(label: &str, percent: u16, value: &str, detail: &str) -> ReportSection {
+        ReportSection::Metric {
             label: label.into(),
-            pct,
+            percent,
             value: value.into(),
             detail: detail.into(),
         }
@@ -298,5 +393,116 @@ mod tests {
         assert_eq!(first["metrics"][0]["percent"], 29);
         assert_eq!(first["metrics"][0]["detail"], "Resets in 0h 50m");
         assert!(first["error"].is_null());
+    }
+
+    #[test]
+    fn json_preserves_non_metric_sections_without_fabricating_percentages() {
+        let rendered = render_json(&[entry(
+            "openrouter",
+            vec![
+                metric("Credit balance", 25, "$75.00", "$25.00 used"),
+                ReportSection::Spacer,
+                ReportSection::Text {
+                    label: "Resets".into(),
+                    value: "in 9d".into(),
+                },
+                ReportSection::Block {
+                    label: "Usage by period".into(),
+                    body: vec!["today $1.00 · week $5.00".into()],
+                },
+            ],
+        )]);
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let first = &value["entries"][0];
+        assert_eq!(first["metrics"].as_array().unwrap().len(), 1);
+        assert_eq!(first["sections"][1]["type"], "spacer");
+        assert_eq!(first["sections"][2]["type"], "text");
+        assert!(first["sections"][2].get("percent").is_none());
+        assert_eq!(first["sections"][3]["type"], "block");
+        assert_eq!(first["sections"][3]["body"][0], "today $1.00 · week $5.00");
+    }
+
+    #[test]
+    fn real_panel_projection_keeps_openrouter_blocks() {
+        let state = TabState::Ready(Box::new(ReadyTab {
+            snapshot: VendorSnapshot::Openrouter(OpenRouterSnapshot {
+                label: "OR".into(),
+                total_credits: 100.0,
+                total_usage: 25.0,
+                usage_daily: 1.0,
+                usage_weekly: 5.0,
+                usage_monthly: 25.0,
+                is_free_tier: false,
+                limit: None,
+                limit_remaining: None,
+            }),
+            stale: false,
+            last_error: None,
+            fetched_at: None,
+        }));
+        let projected = entry_from_state(&TabId::vendor(VendorId::Openrouter), &state, Utc::now());
+        assert!(projected.sections.iter().any(|section| matches!(
+            section,
+            ReportSection::Block { label, .. } if label == "Usage by period"
+        )));
+        assert!(projected.sections.iter().any(|section| matches!(
+            section,
+            ReportSection::Block { label, .. } if label == "Tier"
+        )));
+        let text = render_text(&[projected]);
+        assert!(text.contains("Usage by period"), "{text}");
+        assert!(
+            text.contains("today $1.00 · week $5.00 · month $25.00"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn real_balance_text_is_not_exposed_as_a_percentage_metric() {
+        let state = TabState::Ready(Box::new(ReadyTab {
+            snapshot: VendorSnapshot::Deepseek(DeepseekSnapshot {
+                is_available: true,
+                balance: 12.5,
+                granted: 2.5,
+                topped_up: 10.0,
+                currency: "USD".into(),
+            }),
+            stale: false,
+            last_error: None,
+            fetched_at: None,
+        }));
+        let projected = entry_from_state(&TabId::vendor(VendorId::Deepseek), &state, Utc::now());
+        assert!(projected.sections.iter().any(|section| matches!(
+            section,
+            ReportSection::Text { label, value } if label == "Balance" && value == "$12.50"
+        )));
+        assert!(
+            !projected
+                .sections
+                .iter()
+                .any(|section| matches!(section, ReportSection::Metric { .. }))
+        );
+    }
+
+    #[test]
+    fn failed_entries_do_not_duplicate_tui_retry_rows() {
+        let failed = entry_from_state(
+            &TabId::vendor(VendorId::Openai),
+            &TabState::Error("not signed in".into()),
+            Utc::now(),
+        );
+        assert_eq!(failed.error.as_deref(), Some("not signed in"));
+        assert!(failed.sections.is_empty());
+    }
+
+    #[test]
+    fn exit_is_nonzero_only_when_every_entry_failed() {
+        let mut failed = entry("openai", Vec::new());
+        failed.error = Some("not signed in".into());
+        assert_eq!(report_exit_code(&[failed]), 1);
+
+        let mut failed = entry("openai", Vec::new());
+        failed.error = Some("not signed in".into());
+        assert_eq!(report_exit_code(&[failed, entry("cursor", Vec::new())]), 0);
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,302 @@
+//! `ai-usagebar usage` — quota and time-to-reset for everything in the config,
+//! in one pass.
+//!
+//! The widget answers "how is *this* vendor doing" one process at a time, which
+//! is what a status bar needs and what a person checking on four Claude
+//! accounts does not. This walks the same tab set the TUI builds — every
+//! enabled vendor, plus one entry per named Claude account — and prints what
+//! each one has left.
+//!
+//! Deliberately thin: [`crate::tui::app::tabs_from_config`] already decides
+//! what is configured, [`crate::tui::app::refresh_one`] already fetches and
+//! parses it, and [`crate::tui::panels::sections_for`] already projects any
+//! vendor's snapshot into labelled metrics carrying both the percentage and
+//! the reset. So this file only enumerates, flattens, and formats — no vendor
+//! ever needs to know it exists.
+
+use chrono::Utc;
+use serde_json::json;
+
+use crate::config::Config;
+use crate::tui::app::{TabId, TabState, refresh_one, tabs_from_config};
+use crate::tui::panels::{Section, sections_for};
+
+/// Matches the widget's `--pace-tolerance` default; only affects the pacing
+/// note appended to a metric's detail line.
+const PACE_TOLERANCE: u32 = 5;
+
+/// One configured vendor or account.
+struct Entry {
+    id: String,
+    name: String,
+    plan: Option<String>,
+    metrics: Vec<Metric>,
+    error: Option<String>,
+}
+
+struct Metric {
+    label: String,
+    pct: u16,
+    value: String,
+    detail: String,
+}
+
+pub async fn run(json: bool) -> i32 {
+    let config = match Config::load() {
+        Ok(config) => config,
+        Err(error) => {
+            eprintln!("ai-usagebar usage: {error}");
+            return 1;
+        }
+    };
+    let client = match crate::widget::run::http_client() {
+        Ok(client) => client,
+        Err(error) => {
+            eprintln!("ai-usagebar usage: {error}");
+            return 1;
+        }
+    };
+
+    let tabs = tabs_from_config(&config);
+    if tabs.is_empty() {
+        eprintln!(
+            "ai-usagebar usage: no vendors enabled in {}",
+            crate::config::config_path_hint()
+        );
+        return 1;
+    }
+
+    // Sequential on purpose: several of these share a per-vendor cache lock,
+    // and firing every account at Anthropic at once is a good way to get
+    // rate-limited for no gain on a handful of entries.
+    let mut entries = Vec::with_capacity(tabs.len());
+    for tab in &tabs {
+        entries.push(entry_for(&client, &config, tab).await);
+    }
+
+    if json {
+        println!("{}", render_json(&entries));
+    } else {
+        print!("{}", render_text(&entries));
+    }
+    i32::from(entries.iter().all(|entry| entry.error.is_some()))
+}
+
+async fn entry_for(client: &reqwest::Client, config: &Config, tab: &TabId) -> Entry {
+    let state = refresh_one(client, config, tab).await;
+    let mut entry = Entry {
+        id: tab_id(tab),
+        name: tab_name(tab),
+        plan: None,
+        metrics: Vec::new(),
+        error: match &state {
+            TabState::Error(message) => Some(message.clone()),
+            _ => None,
+        },
+    };
+    for section in sections_for(&state, Utc::now(), PACE_TOLERANCE) {
+        match section {
+            Section::Title { left, .. } => entry.plan = Some(left),
+            Section::Metric {
+                label,
+                pct,
+                value_label,
+                footnote,
+                ..
+            } => entry.metrics.push(Metric {
+                label,
+                pct,
+                value: value_label,
+                detail: footnote,
+            }),
+            // Balance-only vendors report through Text rows rather than a
+            // gauge; keep them, since a credit balance is the whole answer
+            // for those.
+            Section::Text { label, value } => entry.metrics.push(Metric {
+                label,
+                pct: 0,
+                value,
+                detail: String::new(),
+            }),
+            Section::Block { .. } | Section::Spacer => {}
+        }
+    }
+    entry
+}
+
+/// Stable machine id, matching the `anthropic@<label>` convention the macOS
+/// menu bar already uses for accounts.
+fn tab_id(tab: &TabId) -> String {
+    match &tab.account {
+        Some(account) => format!("{}@{account}", tab.vendor.slug()),
+        None => tab.vendor.slug().to_string(),
+    }
+}
+
+fn tab_name(tab: &TabId) -> String {
+    match &tab.account {
+        Some(account) => format!("{} · {account}", tab.vendor.slug()),
+        None => tab.vendor.slug().to_string(),
+    }
+}
+
+fn render_json(entries: &[Entry]) -> String {
+    let rows: Vec<serde_json::Value> = entries
+        .iter()
+        .map(|entry| {
+            json!({
+                "id": entry.id,
+                "name": entry.name,
+                "plan": entry.plan,
+                "error": entry.error,
+                "metrics": entry.metrics.iter().map(|metric| json!({
+                    "label": metric.label,
+                    "percent": metric.pct,
+                    "value": metric.value,
+                    "detail": metric.detail,
+                })).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    json!({ "entries": rows }).to_string()
+}
+
+fn render_text(entries: &[Entry]) -> String {
+    // Widest label across every entry, so the value column lines up down the
+    // whole report rather than per-section.
+    let width = entries
+        .iter()
+        .flat_map(|entry| entry.metrics.iter())
+        .map(|metric| metric.label.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    let mut out = String::new();
+    for entry in entries {
+        out.push_str(&entry.name);
+        if let Some(plan) = &entry.plan {
+            out.push_str(&format!("   {plan}"));
+        }
+        out.push('\n');
+        if let Some(error) = &entry.error {
+            out.push_str(&format!("  ! {error}\n\n"));
+            continue;
+        }
+        if entry.metrics.is_empty() {
+            out.push_str("  (nothing reported)\n\n");
+            continue;
+        }
+        for metric in &entry.metrics {
+            let label = format!("{:width$}", metric.label, width = width);
+            let value = format!("{:>9}", metric.value);
+            if metric.detail.is_empty() {
+                out.push_str(&format!("  {label}  {value}\n"));
+            } else {
+                out.push_str(&format!("  {label}  {value}   {}\n", metric.detail));
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vendor::VendorId;
+
+    fn entry(name: &str, metrics: Vec<Metric>) -> Entry {
+        Entry {
+            id: name.into(),
+            name: name.into(),
+            plan: Some("Claude Max 20x".into()),
+            metrics,
+            error: None,
+        }
+    }
+
+    fn metric(label: &str, pct: u16, value: &str, detail: &str) -> Metric {
+        Metric {
+            label: label.into(),
+            pct,
+            value: value.into(),
+            detail: detail.into(),
+        }
+    }
+
+    #[test]
+    fn accounts_get_a_stable_id_and_a_readable_name() {
+        let account = TabId::account("gmail");
+        assert_eq!(tab_id(&account), "anthropic@gmail");
+        assert_eq!(tab_name(&account), "anthropic · gmail");
+
+        let plain = TabId::vendor(VendorId::Cursor);
+        assert_eq!(tab_id(&plain), "cursor");
+        assert_eq!(tab_name(&plain), "cursor");
+    }
+
+    #[test]
+    fn every_metric_reports_its_quota_and_its_reset() {
+        let text = render_text(&[entry(
+            "anthropic · gmail",
+            vec![
+                metric("Session (5h)", 29, "29%", "Resets in 0h 50m"),
+                metric("Weekly (7d)", 32, "32%", "Resets in 4d 2h"),
+            ],
+        )]);
+
+        assert!(
+            text.contains("anthropic · gmail   Claude Max 20x"),
+            "{text}"
+        );
+        assert!(text.contains("29%   Resets in 0h 50m"), "{text}");
+        assert!(text.contains("32%   Resets in 4d 2h"), "{text}");
+    }
+
+    /// Labels are padded to one width across the whole report, so the columns
+    /// still line up when a later entry has a longer label than the first.
+    #[test]
+    fn value_columns_align_across_entries() {
+        let text = render_text(&[
+            entry("a", vec![metric("S", 1, "1%", "")]),
+            entry("b", vec![metric("A very long label", 2, "2%", "")]),
+        ]);
+        let columns: Vec<usize> = text
+            .lines()
+            .filter(|line| line.starts_with("  ") && line.contains('%'))
+            .map(|line| line.find('%').unwrap())
+            .collect();
+        assert_eq!(columns.len(), 2);
+        assert_eq!(columns[0], columns[1], "{text}");
+    }
+
+    /// One dead vendor must not hide the others — it reports inline and the
+    /// rest still print.
+    #[test]
+    fn a_failing_entry_is_reported_without_dropping_the_rest() {
+        let mut broken = entry("openai", Vec::new());
+        broken.error = Some("credentials error: not signed in".into());
+        let text = render_text(&[broken, entry("cursor", vec![metric("Auto", 5, "5%", "")])]);
+
+        assert!(
+            text.contains("! credentials error: not signed in"),
+            "{text}"
+        );
+        assert!(text.contains("cursor"), "{text}");
+        assert!(text.contains("5%"), "{text}");
+    }
+
+    #[test]
+    fn json_carries_the_percentage_as_a_number() {
+        let rendered = render_json(&[entry(
+            "anthropic · gmail",
+            vec![metric("Session (5h)", 29, "29%", "Resets in 0h 50m")],
+        )]);
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        let first = &value["entries"][0];
+        assert_eq!(first["plan"], "Claude Max 20x");
+        assert_eq!(first["metrics"][0]["percent"], 29);
+        assert_eq!(first["metrics"][0]["detail"], "Resets in 0h 50m");
+        assert!(first["error"].is_null());
+    }
+}

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -373,6 +373,12 @@ mod tests {
     use clap::Parser;
 
     #[test]
+    fn usage_subcommand_parses_machine_readable_mode() {
+        let cli = Cli::parse_from(["ai-usagebar", "usage", "--json"]);
+        assert!(matches!(cli.command, Some(Command::Usage { json: true })));
+    }
+
+    #[test]
     fn defaults_match_claudebar() {
         let cli = Cli::parse_from(["ai-usagebar"]);
         assert_eq!(cli.vendor, None);

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -135,6 +135,13 @@ pub enum Command {
         #[command(subcommand)]
         action: AccountAction,
     },
+
+    /// Quota and time-to-reset for every configured vendor and account.
+    Usage {
+        /// Machine-readable output.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(clap::Subcommand, Debug, Clone)]

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -625,7 +625,7 @@ fn render_with_theme(outcome: &FetchOutcome, theme: &Theme, cli: &Cli) -> Waybar
     render_anthropic(&input)
 }
 
-fn http_client() -> Result<Client> {
+pub fn http_client() -> Result<Client> {
     Client::builder()
         .timeout(HTTP_CLIENT_TIMEOUT)
         .redirect(crate::vendor::same_origin_redirect_policy())

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -625,7 +625,7 @@ fn render_with_theme(outcome: &FetchOutcome, theme: &Theme, cli: &Cli) -> Waybar
     render_anthropic(&input)
 }
 
-pub fn http_client() -> Result<Client> {
+pub(crate) fn http_client() -> Result<Client> {
     Client::builder()
         .timeout(HTTP_CLIENT_TIMEOUT)
         .redirect(crate::vendor::same_origin_redirect_policy())


### PR DESCRIPTION
The widget answers "how is *this* vendor doing", one process at a time. That is
exactly right for a status bar, and wrong for a person checking on several
accounts — today that means running `--vendor anthropic --account <label>` once
per account and reading N separate renders.

```
$ ai-usagebar usage
anthropic · struct   Claude Max 20x
  Session (5h)          1%   Resets in 1h 16m · 74% elapsed · 73pts under
  Weekly (7d)           1%   Resets in 6d 3h · 12% elapsed · 11pts under
  Fable (7d)            0%   Resets in —

anthropic · gmail   Claude Max 20x
  Session (5h)         26%   Resets in 3h 16m · 34% elapsed · 8pts under
  Weekly (7d)          47%   Resets in 4d 16h · 33% elapsed · 14pts ahead
  Fable (7d)            9%   Resets in 4d 16h

cursor   Cursor Ultra
  Cursor Models       100%   Auto + Composer
  Other Models        100%   Named / API models · on-demand off
  Resets            4d 11h
```

`--json` emits the same data with the percentage as a number and a stable id per
entry, so it can be logged or graphed over time:

```json
{"entries":[{"id":"anthropic@gmail","name":"anthropic · gmail","plan":"Claude Max 20x",
  "error":null,"metrics":[{"label":"Session (5h)","percent":26,"value":"26%",
  "detail":"Resets in 3h 16m · 34% elapsed · 8pts under"}]}]}
```

The id format (`anthropic@gmail`) is the convention the macOS menu bar already
uses for accounts.

## Why it's small

Everything it needs already exists, it just was not reachable from one command:

- `tui::app::tabs_from_config` already decides what is configured, including one
  entry per named Claude account and honouring `show_default_account`.
- `tui::app::refresh_one` already fetches and parses a tab.
- `tui::panels::sections_for` already projects *any* vendor's snapshot into
  labelled metrics that carry both the percentage and the reset.

So `report.rs` only enumerates, flattens, and formats. **No vendor knows it
exists, and a new vendor is picked up for free** — that was the main design
constraint, since a 13-arm match here would be a second place to update forever.

## Behaviour notes

- **Sequential fetch.** Several entries share a per-vendor cache lock, and
  firing every account at Anthropic at once earns a rate-limit for no gain
  across a handful of entries. Same reasoning the macOS Overview already uses.
- **A failing entry reports inline** rather than aborting the run, so one
  expired credential cannot hide the other five.
- **Exit code is real.** Non-zero only when *every* entry failed. This
  deliberately does not follow the widget's always-exit-0 Waybar contract — that
  rule exists because Waybar hides modules that exit non-zero, which does not
  apply to a report a human or a script invokes. Dispatched before `run()` in
  `main` for that reason.
- Cache behaviour is unchanged: the existing 60 s TTL fast-path applies, so
  back-to-back runs do not re-hit the APIs.

## Checks

`cargo test` (732 + 3 e2e), `cargo clippy --all-targets -D warnings`,
`cargo fmt --check` — clean. No new dependencies, no vendor files touched. Five
unit tests cover the id/name mapping, that every metric renders its quota next
to its reset, column alignment across entries, that a failing entry does not
drop the others, and that the JSON percentage is a number rather than a string.

Independent of #51 and #52 — this branches off `main` and can merge in any order.