### PR TITLE
Fix TUI refresh flicker with stale-while-revalidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ Each release is also published at
   Thin by construction: it reuses the TUI's existing tab enumeration, fetch, and
   snapshot-to-sections projection, so no vendor needs to know it exists.
 
+### Fixed
+
+- **TUI refresh flicker.** Auto-refresh and manual refresh now keep the last
+  successful vendor snapshot visible with a `↻` indicator while revalidating.
+  Initial loads still show `fetching…`; failed revalidation preserves the old
+  snapshot with an explicit stale warning instead of briefly or permanently
+  hiding useful data. Duplicate requests for the same tab are suppressed
+  (#64).
+
 ## [0.20.1] — 2026-07-30
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -725,7 +725,11 @@ make clippy                                        # cargo clippy -D warnings
 - `c` — open local Claude context sessions (only when `[context] enabled = true`); `v` cycles its layout
 - `q` / `Esc` / `Ctrl-C` — quit
 
-Auto-refresh runs every 60 seconds in the background. Vendors use the same layout. Here's OpenRouter showing the credit balance gauge (red because 98% is consumed), usage-by-period totals, and tier:
+Auto-refresh runs every 60 seconds in the background. Existing values stay
+visible with a `↻` indicator while a request is in flight; a failed refresh
+keeps the last snapshot visibly marked stale instead of clearing it. Vendors
+use the same layout. Here's OpenRouter showing the credit balance gauge (red
+because 98% is consumed), usage-by-period totals, and tier:
 
 ![ai-usagebar-tui showing the OpenRouter tab — Credit balance gauge at 98% in red ($13.67 left of $900), Usage by period with today/week/month, paid tier](screenshots/tui-openrouter.png)
 

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -446,13 +446,13 @@ fn spawn_one(
     tx: &mpsc::UnboundedSender<(u64, TabId, TabState)>,
     delay: Duration,
 ) {
+    if !app.begin_refresh(&tab) {
+        return;
+    }
     let tx = tx.clone();
     let client = client.clone();
     let cfg = config.clone();
     let generation = app.tab_generation;
-    if let Some(index) = app.tabs_meta.iter().position(|current| current == &tab) {
-        app.tabs[index] = TabState::Loading;
-    }
     tokio::spawn(async move {
         if !delay.is_zero() {
             tokio::time::sleep(delay).await;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,5 +1,6 @@
 //! TUI app state — vendors, tab selection, per-vendor snapshot cache.
 
+use std::collections::HashSet;
 use std::time::Duration;
 
 use chrono::Utc;
@@ -38,7 +39,7 @@ pub struct ReadyTab {
 /// Identity of one TUI tab. Usually a whole vendor; for Anthropic it can also
 /// name a specific configured account (issues #14 / #17). `account: None` is a
 /// plain vendor tab — the default Claude account, or any non-Anthropic vendor.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TabId {
     pub vendor: VendorId,
     pub account: Option<String>,
@@ -93,6 +94,9 @@ pub struct App {
     pub tabs_meta: Vec<TabId>,
     pub active: usize,
     pub tabs: Vec<TabState>,
+    /// Tab identities with a request currently in flight. Kept separate from
+    /// `tabs` so a successful snapshot remains visible while it is refreshed.
+    refreshing_tabs: HashSet<TabId>,
     /// Monotonically increasing identity for a complete tab-set replacement.
     /// Background fetches carry this with their tab identity so results from a
     /// previous Settings reload cannot land in a new tab at the old index.
@@ -136,6 +140,7 @@ impl App {
             tabs_meta,
             active: 0,
             tabs: vec![TabState::Loading; n],
+            refreshing_tabs: HashSet::new(),
             tab_generation: 0,
             overview: false,
             overview_vendors: None,
@@ -188,6 +193,33 @@ impl App {
             .unwrap_or(fallback);
         self.tabs = vec![TabState::Loading; tabs_meta.len()];
         self.tabs_meta = tabs_meta;
+        self.refreshing_tabs.clear();
+    }
+
+    /// Mark one tab as in flight. A ready snapshot stays in place; tabs that
+    /// have never succeeded still use the full `Loading` state. Returning
+    /// `false` suppresses duplicate requests for the same tab.
+    pub fn begin_refresh(&mut self, tab: &TabId) -> bool {
+        let Some(index) = self.tabs_meta.iter().position(|current| current == tab) else {
+            return false;
+        };
+        if !self.refreshing_tabs.insert(tab.clone()) {
+            return false;
+        }
+        if !matches!(self.tabs[index], TabState::Ready(_)) {
+            self.tabs[index] = TabState::Loading;
+        }
+        true
+    }
+
+    pub fn is_refreshing(&self, tab: &TabId) -> bool {
+        self.refreshing_tabs.contains(tab)
+    }
+
+    pub fn tab_is_refreshing(&self, index: usize) -> bool {
+        self.tabs_meta
+            .get(index)
+            .is_some_and(|tab| self.is_refreshing(tab))
     }
 
     /// Apply an asynchronous refresh only when it still belongs to this tab
@@ -201,7 +233,19 @@ impl App {
         let Some(index) = self.tabs_meta.iter().position(|current| current == tab) else {
             return false;
         };
-        self.tabs[index] = state;
+        let was_refreshing = self.refreshing_tabs.remove(tab);
+        // If revalidation fails after a successful snapshot, preserve the
+        // useful data but make the failure explicit. Initial failures still
+        // become the normal Error state because there is no data to preserve.
+        if was_refreshing
+            && let TabState::Ready(ready) = &mut self.tabs[index]
+            && let TabState::Error(message) = state
+        {
+            ready.stale = true;
+            ready.last_error = Some((0, message));
+        } else {
+            self.tabs[index] = state;
+        }
         true
     }
 
@@ -775,11 +819,14 @@ mod tests {
         );
         app.active = 2; // "personal"
         app.tabs[0] = TabState::Error("old".into());
+        let old_tab = app.tabs_meta[0].clone();
+        assert!(app.begin_refresh(&old_tab));
 
         app.set_tabs(tabs_from_config(&config_with_accounts(&[])));
         assert_eq!(app.tabs_meta, vec![TabId::vendor(VendorId::Anthropic)]);
         assert_eq!(app.active, 0, "selection clamped after shrink");
         assert!(matches!(app.tabs[0], TabState::Loading));
+        assert!(!app.is_refreshing(&old_tab));
     }
 
     #[test]
@@ -836,6 +883,7 @@ mod tests {
         let openai = TabId::vendor(VendorId::Openai);
         let mut app = App::with_theme(vec![anthropic.clone(), openai.clone()], Theme::default());
         let generation = app.tab_generation;
+        assert!(app.begin_refresh(&anthropic));
 
         // A reorder is safe because delivery resolves the captured identity,
         // not a stale positional index.
@@ -844,6 +892,7 @@ mod tests {
         assert!(app.apply_refresh(generation, &anthropic, TabState::Error("ready".into())));
         assert!(matches!(app.tabs[0], TabState::Loading));
         assert!(matches!(&app.tabs[1], TabState::Error(message) if message == "ready"));
+        assert!(!app.is_refreshing(&anthropic));
     }
 
     fn ready_at(fetched_at: chrono::DateTime<Utc>) -> TabState {
@@ -863,6 +912,103 @@ mod tests {
             last_error: None,
             fetched_at: Some(fetched_at),
         }))
+    }
+
+    #[test]
+    fn refresh_keeps_ready_snapshot_visible_and_suppresses_duplicates() {
+        let tab = TabId::vendor(VendorId::Openrouter);
+        let fetched_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap();
+        let mut app = App::with_theme(vec![tab.clone()], Theme::default());
+        app.tabs[0] = ready_at(fetched_at);
+
+        assert!(app.begin_refresh(&tab));
+        assert!(
+            !app.begin_refresh(&tab),
+            "duplicate request must be suppressed"
+        );
+        assert!(app.is_refreshing(&tab));
+        match &app.tabs[0] {
+            TabState::Ready(ready) => assert_eq!(ready.fetched_at, Some(fetched_at)),
+            other => panic!("ready snapshot disappeared during refresh: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn first_refresh_still_uses_loading_until_data_arrives() {
+        let tab = TabId::vendor(VendorId::Openrouter);
+        let mut app = App::with_theme(vec![tab.clone()], Theme::default());
+
+        assert!(app.begin_refresh(&tab));
+        assert!(app.is_refreshing(&tab));
+        assert!(matches!(app.tabs[0], TabState::Loading));
+
+        assert!(app.apply_refresh(
+            app.tab_generation,
+            &tab,
+            TabState::Error("not signed in".into()),
+        ));
+        assert!(!app.is_refreshing(&tab));
+        assert!(matches!(&app.tabs[0], TabState::Error(message) if message == "not signed in"));
+    }
+
+    #[test]
+    fn successful_revalidation_replaces_snapshot_and_clears_indicator() {
+        let tab = TabId::vendor(VendorId::Openrouter);
+        let old_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap();
+        let new_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 1, 0).unwrap();
+        let mut app = App::with_theme(vec![tab.clone()], Theme::default());
+        app.tabs[0] = ready_at(old_at);
+
+        assert!(app.begin_refresh(&tab));
+        assert!(app.apply_refresh(app.tab_generation, &tab, ready_at(new_at)));
+        assert!(!app.is_refreshing(&tab));
+        match &app.tabs[0] {
+            TabState::Ready(ready) => assert_eq!(ready.fetched_at, Some(new_at)),
+            other => panic!("expected replacement snapshot, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn failed_revalidation_preserves_snapshot_with_visible_warning() {
+        let tab = TabId::vendor(VendorId::Openrouter);
+        let fetched_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap();
+        let mut app = App::with_theme(vec![tab.clone()], Theme::default());
+        app.tabs[0] = ready_at(fetched_at);
+
+        assert!(app.begin_refresh(&tab));
+        assert!(app.apply_refresh(
+            app.tab_generation,
+            &tab,
+            TabState::Error("refresh failed".into()),
+        ));
+        assert!(!app.is_refreshing(&tab));
+        match &app.tabs[0] {
+            TabState::Ready(ready) => {
+                assert_eq!(ready.fetched_at, Some(fetched_at));
+                assert!(ready.stale);
+                assert_eq!(ready.last_error, Some((0, "refresh failed".into())));
+            }
+            other => panic!("last successful snapshot was lost: {other:?}"),
+        }
+        let sections = crate::tui::panels::sections_for(&app.tabs[0], Utc::now(), 5);
+        assert!(sections.iter().any(|section| matches!(
+            section,
+            crate::tui::panels::Section::Text { label, value }
+                if label == "Warning" && value == "refresh failed"
+        )));
+    }
+
+    #[test]
+    fn old_generation_result_does_not_clear_current_refresh() {
+        let tab = TabId::vendor(VendorId::Openrouter);
+        let mut app = App::with_theme(vec![tab.clone()], Theme::default());
+        let old_generation = app.tab_generation;
+        app.set_tabs(vec![tab.clone()]);
+        assert!(app.begin_refresh(&tab));
+
+        assert!(!app.apply_refresh(old_generation, &tab, TabState::Error("old result".into()),));
+        assert!(app.is_refreshing(&tab));
+        assert!(matches!(app.tabs[0], TabState::Loading));
     }
 
     #[test]

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -216,7 +216,10 @@ fn draw_sidebar(f: &mut Frame, app: &App, area: Rect) {
     // The Overview is the virtual first entry, before the per-vendor tabs.
     let mut items = vec![ListItem::new("Overview").description("all vendors")];
     items.extend(app.tabs_meta.iter().enumerate().map(|(index, tab)| {
-        ListItem::new(tab_label(tab)).description(tab_status(app.tabs.get(index)))
+        ListItem::new(tab_label(tab)).description(tab_status(
+            app.tabs.get(index),
+            app.tab_is_refreshing(index),
+        ))
     }));
     let mut list = SelectList::new(items).theme(theme);
     list.select(Some(if app.overview { 0 } else { app.active + 1 }));
@@ -262,7 +265,10 @@ fn draw_detail(f: &mut Frame, app: &App, area: Rect) {
         " Overview ".to_string()
     } else {
         app.active_tab_id()
-            .map(|tab| format!(" {} ", tab_label(tab)))
+            .map(|tab| {
+                let refreshing = if app.is_refreshing(tab) { " ↻" } else { "" };
+                format!(" {}{refreshing} ", tab_label(tab))
+            })
             .unwrap_or_else(|| " details ".to_string())
     };
     let block = theme.titled_block(title);
@@ -347,6 +353,12 @@ fn draw_overview(f: &mut Frame, app: &App, area: Rect) {
                 if r.stale {
                     spans.push(theme.muted("  ⏸"));
                 }
+                if r.last_error.is_some() {
+                    spans.push(theme.muted(" ⚠"));
+                }
+                if app.tab_is_refreshing(i) {
+                    spans.push(theme.muted("  ↻"));
+                }
             }
             Some(TabState::Error(_)) => spans.push(Span::styled(
                 "error",
@@ -360,8 +372,9 @@ fn draw_overview(f: &mut Frame, app: &App, area: Rect) {
     f.render_widget(Paragraph::new(lines), area);
 }
 
-fn tab_status(tab: Option<&TabState>) -> &'static str {
+fn tab_status(tab: Option<&TabState>, refreshing: bool) -> &'static str {
     match tab {
+        Some(TabState::Ready(_)) if refreshing => "refreshing",
         Some(TabState::Loading) => "fetching",
         Some(TabState::Error(_)) => "error",
         Some(TabState::Ready(ready)) if ready.stale => "stale cache",
@@ -478,6 +491,21 @@ mod tests {
         // passing off "now" as a response time.
         let app = app_with(vec![ready_at(None), TabState::Loading]);
         assert_eq!(header_refresh_text(&app), "last refresh —");
+    }
+
+    #[test]
+    fn overview_keeps_metrics_visible_while_refreshing() {
+        let fetched_at = Utc.with_ymd_and_hms(2026, 5, 23, 12, 0, 0).unwrap();
+        let mut app = app_with(vec![ready_at(Some(fetched_at)), ready_at(Some(fetched_at))]);
+        app.overview = true;
+        let tab = app.tabs_meta[0].clone();
+        assert!(app.begin_refresh(&tab));
+
+        let out = body_text(&app);
+        assert!(out.contains("$0.00"), "ready metrics disappeared: {out}");
+        assert!(out.contains('↻'), "refresh indicator missing: {out}");
+        assert!(!out.contains("fetching…"), "ready row flickered: {out}");
+        assert_eq!(tab_status(app.tabs.first(), true), "refreshing");
     }
 
     fn app_with_context(layout: crate::config::ContextLayout) -> App {


### PR DESCRIPTION
## Summary
- keep the last successful tab snapshot visible while refresh is in flight
- mark refreshing and stale/error states explicitly
- suppress duplicate per-tab requests while preserving generation and identity guards
- document the refresh behavior and add regression coverage

## Verification
- cargo fmt --all -- --check
- cargo clippy --all-targets --locked --offline -- -D warnings
- cargo test --all-targets --locked --offline
- cargo machete
- cargo audit --no-fetch
- cargo deny check advisories bans sources

Fixes #64