### PR TITLE
Fix schedule reconciliation and Desktop liveness; confirm deletions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ Each release is also published at
 
 ### Added
 
+- **Deleted routines are now confirmed instead of silently resurrected.** The
+  schedule merge is a union, so deleting a routine in one account meant it came
+  straight back from whichever account still held a copy — and there was no way
+  to tell that apart from a routine the account had simply never received.
+  ai-usagebar now records what each account held after the last merge
+  (`~/.claude-acc/synced.json`, shared with claude-acc) and uses it to detect a
+  genuine deletion, then asks: keep them all, delete them everywhere, or choose
+  individually. Confirming a deletion sweeps the routine from *every* account so
+  it stops returning. The macOS menu bar asks the same question in a dialog with
+  one checkbox per routine — checked keeps it — and passes the verdict through
+  as `--delete-routine <id>`; `account status --json` lists pending conflicts
+  under `routine_conflicts` so scripts can do the same.
+
+  Deleting is only ever reachable from an answered prompt: `-y` does not imply
+  it, and a switch with no terminal (the menu bar's subprocess, a pipe, a cron)
+  keeps everything and says so. With no record yet — the first run after
+  upgrading — nothing is reported as a deletion, so behaviour is unchanged until
+  there is real history to compare against.
+
+### Added
+
 - **`ai-usagebar usage` — quota and time-to-reset for everything in the config,
   in one command.** The widget answers "how is *this* vendor doing" one process
   at a time, which is what a status bar needs and what a person checking on four

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,15 +24,23 @@ Each release is also published at
   account-agnostic `~/.claude/projects/` is never touched, so the conversation
   stops following you between accounts without the text being destroyed. The
   macOS menu bar asks the same question in a dialog with one checkbox per item —
-  checked keeps it — and passes the verdict through as `--delete-conflict <id>`;
-  `account status --json` lists pending conflicts under `deletion_conflicts` so
-  scripts can do the same.
+  checked keeps it — and passes the verdict through as the type-scoped
+  `--delete-conflict <key>`; `account status --json` lists each pending
+  conflict's opaque `key` under `deletion_conflicts` so scripts can do the same
+  without confusing a routine id with a chat filename.
 
   Deleting is only ever reachable from an answered prompt: `-y` does not imply
   it, and a switch with no terminal (the menu bar's subprocess, a pipe, a cron)
   keeps everything and says so. With no record yet — the first run after
   upgrading — nothing is reported as a deletion, so behaviour is unchanged until
   there is real history to compare against.
+
+- **Routine edits now reconcile per task instead of per registry file.** The
+  sync record keeps a three-way baseline, so editing one routine in each of two
+  accounts preserves both edits. Concurrent edits to the same routine remain
+  local and are reported during the switch instead of silently choosing one;
+  editing the desired copy resolves it on the next switch. Existing sync files
+  remain readable and keep their flat claude-acc-compatible shape.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,22 @@ Each release is also published at
 
 ### Added
 
-- **Deleted routines are now confirmed instead of silently resurrected.** The
-  schedule merge is a union, so deleting a routine in one account meant it came
-  straight back from whichever account still held a copy — and there was no way
-  to tell that apart from a routine the account had simply never received.
+- **Deleted routines and chats are now confirmed instead of silently
+  resurrected.** The merge is a union, so deleting a routine or a conversation
+  in one account meant it came straight back from whichever account still held a
+  copy — and there was no way to tell that apart from something the account had
+  simply never received.
   ai-usagebar now records what each account held after the last merge
   (`~/.claude-acc/synced.json`, shared with claude-acc) and uses it to detect a
   genuine deletion, then asks: keep them all, delete them everywhere, or choose
-  individually. Confirming a deletion sweeps the routine from *every* account so
-  it stops returning. The macOS menu bar asks the same question in a dialog with
-  one checkbox per routine — checked keeps it — and passes the verdict through
-  as `--delete-routine <id>`; `account status --json` lists pending conflicts
-  under `routine_conflicts` so scripts can do the same.
+  individually. Confirming sweeps it from *every* account so it stops returning.
+  A confirmed chat loses only its **index** — the transcript in the
+  account-agnostic `~/.claude/projects/` is never touched, so the conversation
+  stops following you between accounts without the text being destroyed. The
+  macOS menu bar asks the same question in a dialog with one checkbox per item —
+  checked keeps it — and passes the verdict through as `--delete-conflict <id>`;
+  `account status --json` lists pending conflicts under `deletion_conflicts` so
+  scripts can do the same.
 
   Deleting is only ever reachable from an answered prompt: `-y` does not imply
   it, and a switch with no terminal (the menu bar's subprocess, a pipe, a cron)

--- a/README.md
+++ b/README.md
@@ -590,11 +590,16 @@ destroyed.
 A switch run without a terminal — the menu bar's subprocess, a script — always
 keeps everything and says so; deleting is only ever reachable from an answered
 prompt. The macOS menu bar asks the same question in a dialog with a checkbox
-per item, and passes the answer through as `--delete-conflict <id>`;
-`account status --json` lists the pending ones under `deletion_conflicts`.
+per item, and passes the answer through as `--delete-conflict <key>`;
+`account status --json` lists the pending ones under `deletion_conflicts`. Use
+the returned opaque `key`; the type scope
+prevents a routine id from authorizing deletion of a same-named chat index.
 
-Edits still reconcile independently of this: chats on `lastActivityAt` and
-routines on their registry's mtime, newest wins either way.
+Edits still reconcile independently of this: chats use `lastActivityAt`, while
+routines use a per-task three-way baseline in the sync record. Edits to
+different routines propagate independently. If two accounts edit the same
+routine concurrently, each local copy is preserved and the switch reports the
+conflict; edit the desired copy once more to resolve it on the next switch.
 
 **What this does not do.** Forgetting an account (`remove`) and chat filtering
 (`only` / `reset`) are not implemented — delete a profile directory by hand, or

--- a/README.md
+++ b/README.md
@@ -574,21 +574,27 @@ it cannot save (`--force` overrides, and genuinely discards it).
 claude-acc's format, so if you already use that tool your existing profiles work
 here untouched, and either tool can capture or switch them.
 
-**Deleted routines are confirmed, not silently resurrected.** The history merge
-is a union, so a routine you delete in one account would normally come straight
-back from whichever account still holds a copy. ai-usagebar records what each
-account held after the last merge, so it can tell a real deletion from a routine
-that account simply never received, and asks before acting: keep them all,
-delete them everywhere, or choose individually. Answering "delete" removes the
-routine from every account so it stops following you around. A switch run
-without a terminal — the menu bar's subprocess, a script — always keeps
-everything and says so; deleting is only ever reachable from an answered prompt.
-The macOS menu bar asks the same question in a dialog with a checkbox per
-routine, and passes the answer through as `--delete-routine <id>`;
-`account status --json` lists the pending ones under `routine_conflicts`.
+**Deletions are confirmed, not silently resurrected.** The history merge is a
+union, so a routine or chat you delete in one account would normally come
+straight back from whichever account still holds a copy. ai-usagebar records
+what each account held after the last merge, so it can tell a real deletion from
+something that account simply never received, and asks before acting: keep them
+all, delete them everywhere, or choose individually. Answering "delete" removes
+it from every account so it stops following you around.
 
-Conversations are not part of this: they reconcile on `lastActivityAt` (newest
-wins, so work in either account survives), and a deleted chat still reappears.
+Deleting a chat drops only its **index**. The transcript lives in the
+account-agnostic `~/.claude/projects/`, which is never touched — the
+conversation stops following you between accounts without the text being
+destroyed.
+
+A switch run without a terminal — the menu bar's subprocess, a script — always
+keeps everything and says so; deleting is only ever reachable from an answered
+prompt. The macOS menu bar asks the same question in a dialog with a checkbox
+per item, and passes the answer through as `--delete-conflict <id>`;
+`account status --json` lists the pending ones under `deletion_conflicts`.
+
+Edits still reconcile independently of this: chats on `lastActivityAt` and
+routines on their registry's mtime, newest wins either way.
 
 **What this does not do.** Forgetting an account (`remove`) and chat filtering
 (`only` / `reset`) are not implemented — delete a profile directory by hand, or

--- a/README.md
+++ b/README.md
@@ -574,6 +574,22 @@ it cannot save (`--force` overrides, and genuinely discards it).
 claude-acc's format, so if you already use that tool your existing profiles work
 here untouched, and either tool can capture or switch them.
 
+**Deleted routines are confirmed, not silently resurrected.** The history merge
+is a union, so a routine you delete in one account would normally come straight
+back from whichever account still holds a copy. ai-usagebar records what each
+account held after the last merge, so it can tell a real deletion from a routine
+that account simply never received, and asks before acting: keep them all,
+delete them everywhere, or choose individually. Answering "delete" removes the
+routine from every account so it stops following you around. A switch run
+without a terminal — the menu bar's subprocess, a script — always keeps
+everything and says so; deleting is only ever reachable from an answered prompt.
+The macOS menu bar asks the same question in a dialog with a checkbox per
+routine, and passes the answer through as `--delete-routine <id>`;
+`account status --json` lists the pending ones under `routine_conflicts`.
+
+Conversations are not part of this: they reconcile on `lastActivityAt` (newest
+wins, so work in either account survives), and a deleted chat still reappears.
+
 **What this does not do.** Forgetting an account (`remove`) and chat filtering
 (`only` / `reset`) are not implemented — delete a profile directory by hand, or
 use claude-acc. Cowork (agent-mode) sessions are not migrated by a switch and

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -901,17 +901,19 @@ struct AccountStatus: Equatable {
     var cliLabels: [String] = []
     /// Routines one account deleted that another still holds. A switch would
     /// hand them back, so the user is asked before it starts.
-    var routineConflicts: [RoutineConflict] = []
+    var deletionConflicts: [DeletionConflict] = []
 }
 
-struct RoutineConflict: Equatable {
+struct DeletionConflict: Equatable {
     var id: String
+    /// "routine" or "chat" — they are swept differently but answered together.
+    var kind: String
     var summary: String
     var deletedBy: String
     var stillIn: [String]
 
     /// One line for the dialog: what it is, and who dropped it.
-    var line: String { "\(summary) — deleted in \(deletedBy)" }
+    var line: String { "[\(kind)] \(summary) — deleted in \(deletedBy)" }
 }
 
 /// Parse `account status --json`. Every field is optional on purpose: a Mac
@@ -932,10 +934,11 @@ func parseAccountStatus(_ data: Data) -> AccountStatus? {
         (side as? [String: Any])?["active_label"] as? String
     }
     let desktop = root["desktop"], cli = root["cli"]
-    let conflicts = ((desktop as? [String: Any])?["routine_conflicts"] as? [[String: Any]] ?? [])
-        .compactMap { row -> RoutineConflict? in
+    let conflicts = ((desktop as? [String: Any])?["deletion_conflicts"] as? [[String: Any]] ?? [])
+        .compactMap { row -> DeletionConflict? in
             guard let id = row["id"] as? String else { return nil }
-            return RoutineConflict(id: id,
+            return DeletionConflict(id: id,
+                                   kind: row["kind"] as? String ?? "item",
                                    summary: row["summary"] as? String ?? id,
                                    deletedBy: row["deleted_by"] as? String ?? "?",
                                    stillIn: row["still_in"] as? [String] ?? [])
@@ -945,7 +948,7 @@ func parseAccountStatus(_ data: Data) -> AccountStatus? {
                          cliActive: active(cli),
                          desktopLabels: labels(desktop, "profiles"),
                          cliLabels: labels(cli, "accounts"),
-                         routineConflicts: conflicts)
+                         deletionConflicts: conflicts)
 }
 
 /// The one dim line under the header. Empty when neither surface resolved, so
@@ -961,15 +964,15 @@ func accountsSummaryLine(_ s: AccountStatus) -> String {
 /// on a stdin that is not a terminal and abort.
 func switchArgs(label: String, desktop: Bool, deleting: [String] = []) -> [String] {
     var args = ["account", "switch", label, desktop ? "--desktop" : "--cli", "-y"]
-    // Passing any --delete-routine also tells the binary the question was
+    // Passing any --delete-conflict also tells the binary the question was
     // already answered, so it never blocks on a prompt it cannot show here.
-    for id in deleting { args += ["--delete-routine", id] }
+    for id in deleting { args += ["--delete-conflict", id] }
     return args
 }
 
 /// The first few conflicts spelled out, the rest summarised — a switch after a
 /// big clean-up must not grow a dialog taller than the screen.
-func conflictPreview(_ conflicts: [RoutineConflict], limit: Int = 10) -> String {
+func conflictPreview(_ conflicts: [DeletionConflict], limit: Int = 10) -> String {
     var lines = conflicts.prefix(limit).map { "• \($0.line)" }
     if conflicts.count > limit {
         lines.append("… e mais \(conflicts.count - limit)")
@@ -2520,22 +2523,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         // Routines deleted in one account but alive in another would be handed
         // straight back by the merge. Decide before the switch starts, since a
         // background subprocess has no way to ask.
-        guard let doomed = resolveRoutineConflicts() else { return }
+        guard let doomed = resolveDeletionConflicts() else { return }
         runAccountSwitch(label: label, desktop: true, deleting: doomed)
     }
 
     /// Returns the routine ids to delete everywhere, or nil if the user backed
     /// out of the whole switch. An empty array means "keep them all".
-    private func resolveRoutineConflicts() -> [String]? {
-        let conflicts = lastAccountStatus?.routineConflicts ?? []
+    private func resolveDeletionConflicts() -> [String]? {
+        let conflicts = lastAccountStatus?.deletionConflicts ?? []
         if conflicts.isEmpty { return [] }
 
         let alert = NSAlert()
         alert.messageText = conflicts.count == 1
-            ? "1 rotina foi apagada em uma conta e ainda existe em outra"
-            : "\(conflicts.count) rotinas foram apagadas em uma conta e ainda existem em outra"
+            ? "1 item foi apagado em uma conta e ainda existe em outra"
+            : "\(conflicts.count) itens foram apagados em uma conta e ainda existem em outra"
         alert.informativeText = conflictPreview(conflicts)
-            + "\n\nMantê-las traz de volta as apagadas. Apagar remove de todas as contas."
+            + "\n\nManter traz de volta os apagados. Apagar remove de todas as contas — uma conversa perde só o índice, a transcrição permanece."
         alert.addButton(withTitle: "Manter todas")
         alert.addButton(withTitle: "Apagar em todas")
         alert.addButton(withTitle: "Escolher…")
@@ -2543,14 +2546,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         switch alert.runModal() {
         case .alertFirstButtonReturn: return []
         case .alertSecondButtonReturn: return conflicts.map { $0.id }
-        default: return chooseRoutineConflicts(conflicts)
+        default: return chooseDeletionConflicts(conflicts)
         }
     }
 
     /// A checkbox per conflict — checked means keep. Everything left unchecked
     /// is deleted everywhere, so the destructive outcome takes a deliberate
     /// uncheck rather than being the default.
-    private func chooseRoutineConflicts(_ conflicts: [RoutineConflict]) -> [String]? {
+    private func chooseDeletionConflicts(_ conflicts: [DeletionConflict]) -> [String]? {
         let rowHeight = 22
         let list = NSStackView(frame: NSRect(x: 0, y: 0, width: 420,
                                              height: rowHeight * conflicts.count))
@@ -2570,8 +2573,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         scroll.documentView = list
 
         let alert = NSAlert()
-        alert.messageText = "Quais rotinas manter?"
-        alert.informativeText = "Marcadas continuam. As desmarcadas são apagadas em todas as contas."
+        alert.messageText = "O que manter?"
+        alert.informativeText = "Marcados continuam. Os desmarcados são apagados em todas as contas."
         alert.accessoryView = scroll
         alert.addButton(withTitle: "Confirmar")
         alert.addButton(withTitle: "Cancelar")

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -899,6 +899,19 @@ struct AccountStatus: Equatable {
     var cliActive: String?
     var desktopLabels: [String] = []
     var cliLabels: [String] = []
+    /// Routines one account deleted that another still holds. A switch would
+    /// hand them back, so the user is asked before it starts.
+    var routineConflicts: [RoutineConflict] = []
+}
+
+struct RoutineConflict: Equatable {
+    var id: String
+    var summary: String
+    var deletedBy: String
+    var stillIn: [String]
+
+    /// One line for the dialog: what it is, and who dropped it.
+    var line: String { "\(summary) — deleted in \(deletedBy)" }
 }
 
 /// Parse `account status --json`. Every field is optional on purpose: a Mac
@@ -919,11 +932,20 @@ func parseAccountStatus(_ data: Data) -> AccountStatus? {
         (side as? [String: Any])?["active_label"] as? String
     }
     let desktop = root["desktop"], cli = root["cli"]
+    let conflicts = ((desktop as? [String: Any])?["routine_conflicts"] as? [[String: Any]] ?? [])
+        .compactMap { row -> RoutineConflict? in
+            guard let id = row["id"] as? String else { return nil }
+            return RoutineConflict(id: id,
+                                   summary: row["summary"] as? String ?? id,
+                                   deletedBy: row["deleted_by"] as? String ?? "?",
+                                   stillIn: row["still_in"] as? [String] ?? [])
+        }
     return AccountStatus(desktopAvailable: desktop is [String: Any],
                          desktopActive: active(desktop),
                          cliActive: active(cli),
                          desktopLabels: labels(desktop, "profiles"),
-                         cliLabels: labels(cli, "accounts"))
+                         cliLabels: labels(cli, "accounts"),
+                         routineConflicts: conflicts)
 }
 
 /// The one dim line under the header. Empty when neither surface resolved, so
@@ -937,8 +959,22 @@ func accountsSummaryLine(_ s: AccountStatus) -> String {
 
 /// `-y` because the menu has already asked; without it the binary would prompt
 /// on a stdin that is not a terminal and abort.
-func switchArgs(label: String, desktop: Bool) -> [String] {
-    ["account", "switch", label, desktop ? "--desktop" : "--cli", "-y"]
+func switchArgs(label: String, desktop: Bool, deleting: [String] = []) -> [String] {
+    var args = ["account", "switch", label, desktop ? "--desktop" : "--cli", "-y"]
+    // Passing any --delete-routine also tells the binary the question was
+    // already answered, so it never blocks on a prompt it cannot show here.
+    for id in deleting { args += ["--delete-routine", id] }
+    return args
+}
+
+/// The first few conflicts spelled out, the rest summarised — a switch after a
+/// big clean-up must not grow a dialog taller than the screen.
+func conflictPreview(_ conflicts: [RoutineConflict], limit: Int = 10) -> String {
+    var lines = conflicts.prefix(limit).map { "• \($0.line)" }
+    if conflicts.count > limit {
+        lines.append("… e mais \(conflicts.count - limit)")
+    }
+    return lines.joined(separator: "\n")
 }
 
 /// Adding an account is interactive — a Desktop capture waits for you to sign
@@ -2481,7 +2517,67 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         alert.addButton(withTitle: "Cancelar")
         NSApp.activate(ignoringOtherApps: true)
         guard alert.runModal() == .alertFirstButtonReturn else { return }
-        runAccountSwitch(label: label, desktop: true)
+        // Routines deleted in one account but alive in another would be handed
+        // straight back by the merge. Decide before the switch starts, since a
+        // background subprocess has no way to ask.
+        guard let doomed = resolveRoutineConflicts() else { return }
+        runAccountSwitch(label: label, desktop: true, deleting: doomed)
+    }
+
+    /// Returns the routine ids to delete everywhere, or nil if the user backed
+    /// out of the whole switch. An empty array means "keep them all".
+    private func resolveRoutineConflicts() -> [String]? {
+        let conflicts = lastAccountStatus?.routineConflicts ?? []
+        if conflicts.isEmpty { return [] }
+
+        let alert = NSAlert()
+        alert.messageText = conflicts.count == 1
+            ? "1 rotina foi apagada em uma conta e ainda existe em outra"
+            : "\(conflicts.count) rotinas foram apagadas em uma conta e ainda existem em outra"
+        alert.informativeText = conflictPreview(conflicts)
+            + "\n\nMantê-las traz de volta as apagadas. Apagar remove de todas as contas."
+        alert.addButton(withTitle: "Manter todas")
+        alert.addButton(withTitle: "Apagar em todas")
+        alert.addButton(withTitle: "Escolher…")
+        NSApp.activate(ignoringOtherApps: true)
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return []
+        case .alertSecondButtonReturn: return conflicts.map { $0.id }
+        default: return chooseRoutineConflicts(conflicts)
+        }
+    }
+
+    /// A checkbox per conflict — checked means keep. Everything left unchecked
+    /// is deleted everywhere, so the destructive outcome takes a deliberate
+    /// uncheck rather than being the default.
+    private func chooseRoutineConflicts(_ conflicts: [RoutineConflict]) -> [String]? {
+        let rowHeight = 22
+        let list = NSStackView(frame: NSRect(x: 0, y: 0, width: 420,
+                                             height: rowHeight * conflicts.count))
+        list.orientation = .vertical
+        list.alignment = .leading
+        list.spacing = 4
+        var boxes: [NSButton] = []
+        for conflict in conflicts {
+            let box = NSButton(checkboxWithTitle: conflict.line, target: nil, action: nil)
+            box.state = .on
+            boxes.append(box)
+            list.addArrangedSubview(box)
+        }
+        let scroll = NSScrollView(frame: NSRect(x: 0, y: 0, width: 420,
+                                                height: min(260, rowHeight * conflicts.count + 8)))
+        scroll.hasVerticalScroller = true
+        scroll.documentView = list
+
+        let alert = NSAlert()
+        alert.messageText = "Quais rotinas manter?"
+        alert.informativeText = "Marcadas continuam. As desmarcadas são apagadas em todas as contas."
+        alert.accessoryView = scroll
+        alert.addButton(withTitle: "Confirmar")
+        alert.addButton(withTitle: "Cancelar")
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return nil }
+        return zip(conflicts, boxes).filter { $0.1.state != .on }.map { $0.0.id }
     }
 
     @objc func switchCliAccount(_ sender: NSMenuItem) {
@@ -2489,11 +2585,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         runAccountSwitch(label: label, desktop: false)
     }
 
-    private func runAccountSwitch(label: String, desktop: Bool) {
+    private func runAccountSwitch(label: String, desktop: Bool, deleting: [String] = []) {
         guard let bin = resolveBinary("ai-usagebar"), !accountSwitchInFlight else { return }
         accountSwitchInFlight = true
         renderAccountMenus()
-        let args = switchArgs(label: label, desktop: desktop)
+        let args = switchArgs(label: label, desktop: desktop, deleting: deleting)
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let p = Process()
             p.executableURL = URL(fileURLWithPath: bin)

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -905,6 +905,8 @@ struct AccountStatus: Equatable {
 }
 
 struct DeletionConflict: Equatable {
+    /// Opaque, type-scoped value accepted by `--delete-conflict`.
+    var key: String
     var id: String
     /// "routine" or "chat" — they are swept differently but answered together.
     var kind: String
@@ -937,8 +939,11 @@ func parseAccountStatus(_ data: Data) -> AccountStatus? {
     let conflicts = ((desktop as? [String: Any])?["deletion_conflicts"] as? [[String: Any]] ?? [])
         .compactMap { row -> DeletionConflict? in
             guard let id = row["id"] as? String else { return nil }
-            return DeletionConflict(id: id,
-                                   kind: row["kind"] as? String ?? "item",
+            let kind = row["kind"] as? String ?? "item"
+            guard let key = row["key"] as? String else { return nil }
+            return DeletionConflict(key: key,
+                                   id: id,
+                                   kind: kind,
                                    summary: row["summary"] as? String ?? id,
                                    deletedBy: row["deleted_by"] as? String ?? "?",
                                    stillIn: row["still_in"] as? [String] ?? [])
@@ -2545,7 +2550,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         NSApp.activate(ignoringOtherApps: true)
         switch alert.runModal() {
         case .alertFirstButtonReturn: return []
-        case .alertSecondButtonReturn: return conflicts.map { $0.id }
+        case .alertSecondButtonReturn: return conflicts.map { $0.key }
         default: return chooseDeletionConflicts(conflicts)
         }
     }
@@ -2580,7 +2585,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         alert.addButton(withTitle: "Cancelar")
         NSApp.activate(ignoringOtherApps: true)
         guard alert.runModal() == .alertFirstButtonReturn else { return nil }
-        return zip(conflicts, boxes).filter { $0.1.state != .on }.map { $0.0.id }
+        return zip(conflicts, boxes).filter { $0.1.state != .on }.map { $0.0.key }
     }
 
     @objc func switchCliAccount(_ sender: NSMenuItem) {

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -550,11 +550,12 @@ func testAccountStatus() {
     // Routines deleted in one account but alive in another.
     let withConflicts = parseAccountStatus(Data("""
         {"desktop":{"available":true,"profiles":[{"label":"gmail"}],"deletion_conflicts":[
-          {"id":"t1","kind":"routine","summary":"0 5 * * *  (daily-report)","deleted_by":"hotmail",
+          {"key":"opaque-conflict-1","id":"t1","kind":"routine","summary":"0 5 * * *  (daily-report)","deleted_by":"hotmail",
            "still_in":["gmail","struct"]}]}}
         """.utf8))
     assertEqual(withConflicts?.deletionConflicts.count, 1, "conflict parsed")
     assertEqual(withConflicts?.deletionConflicts.first?.id, "t1", "conflict id")
+    assertEqual(withConflicts?.deletionConflicts.first?.key, "opaque-conflict-1", "typed conflict key")
     assertEqual(withConflicts?.deletionConflicts.first?.line,
                 "[routine] 0 5 * * *  (daily-report) — deleted in hotmail", "conflict line")
     // An older binary has no such key, and a status with none must stay empty
@@ -563,7 +564,7 @@ func testAccountStatus() {
                 "absent deletion_conflicts is empty")
 
     let many = (1...12).map {
-        DeletionConflict(id: "t\($0)", kind: "chat", summary: "s\($0)",
+        DeletionConflict(key: "opaque-\($0)", id: "t\($0)", kind: "chat", summary: "s\($0)",
                          deletedBy: "b", stillIn: ["a"])
     }
     assertEqual(conflictPreview(many).components(separatedBy: "\n").count, 11,
@@ -572,9 +573,11 @@ func testAccountStatus() {
     assertEqual(conflictPreview(Array(many.prefix(3))).contains("e mais"), false,
                 "a short list is not summarised")
 
-    assertEqual(switchArgs(label: "work", desktop: true, deleting: ["t1", "t2"]),
+    assertEqual(switchArgs(label: "work", desktop: true,
+                           deleting: ["opaque-1", "opaque-2"]),
                 ["account", "switch", "work", "--desktop", "-y",
-                 "--delete-conflict", "t1", "--delete-conflict", "t2"],
+                 "--delete-conflict", "opaque-1",
+                 "--delete-conflict", "opaque-2"],
                 "confirmed deletions are passed through")
     assertEqual(switchArgs(label: "work", desktop: true),
                 ["account", "switch", "work", "--desktop", "-y"], "desktop switch args")

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -547,6 +547,34 @@ func testAccountStatus() {
     assertNil(parseAccountStatus(Data("error: unrecognized subcommand".utf8)), "non-JSON output")
     assertNil(parseAccountStatus(Data("[1,2,3]".utf8)), "JSON that is not an object")
 
+    // Routines deleted in one account but alive in another.
+    let withConflicts = parseAccountStatus(Data("""
+        {"desktop":{"available":true,"profiles":[{"label":"gmail"}],"routine_conflicts":[
+          {"id":"t1","summary":"0 5 * * *  (daily-report)","deleted_by":"hotmail",
+           "still_in":["gmail","struct"]}]}}
+        """.utf8))
+    assertEqual(withConflicts?.routineConflicts.count, 1, "conflict parsed")
+    assertEqual(withConflicts?.routineConflicts.first?.id, "t1", "conflict id")
+    assertEqual(withConflicts?.routineConflicts.first?.line,
+                "0 5 * * *  (daily-report) — deleted in hotmail", "conflict line")
+    // An older binary has no such key, and a status with none must stay empty
+    // so the dialog never appears for nothing.
+    assertEqual(withConflicts.map { _ in fresh?.routineConflicts.isEmpty }, true,
+                "absent routine_conflicts is empty")
+
+    let many = (1...12).map {
+        RoutineConflict(id: "t\($0)", summary: "s\($0)", deletedBy: "b", stillIn: ["a"])
+    }
+    assertEqual(conflictPreview(many).components(separatedBy: "\n").count, 11,
+                "preview caps at 10 plus a summary line")
+    assertEqual(conflictPreview(many).hasSuffix("… e mais 2"), true, "preview counts the rest")
+    assertEqual(conflictPreview(Array(many.prefix(3))).contains("e mais"), false,
+                "a short list is not summarised")
+
+    assertEqual(switchArgs(label: "work", desktop: true, deleting: ["t1", "t2"]),
+                ["account", "switch", "work", "--desktop", "-y",
+                 "--delete-routine", "t1", "--delete-routine", "t2"],
+                "confirmed deletions are passed through")
     assertEqual(switchArgs(label: "work", desktop: true),
                 ["account", "switch", "work", "--desktop", "-y"], "desktop switch args")
     assertEqual(switchArgs(label: "work", desktop: false),

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -549,21 +549,22 @@ func testAccountStatus() {
 
     // Routines deleted in one account but alive in another.
     let withConflicts = parseAccountStatus(Data("""
-        {"desktop":{"available":true,"profiles":[{"label":"gmail"}],"routine_conflicts":[
-          {"id":"t1","summary":"0 5 * * *  (daily-report)","deleted_by":"hotmail",
+        {"desktop":{"available":true,"profiles":[{"label":"gmail"}],"deletion_conflicts":[
+          {"id":"t1","kind":"routine","summary":"0 5 * * *  (daily-report)","deleted_by":"hotmail",
            "still_in":["gmail","struct"]}]}}
         """.utf8))
-    assertEqual(withConflicts?.routineConflicts.count, 1, "conflict parsed")
-    assertEqual(withConflicts?.routineConflicts.first?.id, "t1", "conflict id")
-    assertEqual(withConflicts?.routineConflicts.first?.line,
-                "0 5 * * *  (daily-report) — deleted in hotmail", "conflict line")
+    assertEqual(withConflicts?.deletionConflicts.count, 1, "conflict parsed")
+    assertEqual(withConflicts?.deletionConflicts.first?.id, "t1", "conflict id")
+    assertEqual(withConflicts?.deletionConflicts.first?.line,
+                "[routine] 0 5 * * *  (daily-report) — deleted in hotmail", "conflict line")
     // An older binary has no such key, and a status with none must stay empty
     // so the dialog never appears for nothing.
-    assertEqual(withConflicts.map { _ in fresh?.routineConflicts.isEmpty }, true,
-                "absent routine_conflicts is empty")
+    assertEqual(withConflicts.map { _ in fresh?.deletionConflicts.isEmpty }, true,
+                "absent deletion_conflicts is empty")
 
     let many = (1...12).map {
-        RoutineConflict(id: "t\($0)", summary: "s\($0)", deletedBy: "b", stillIn: ["a"])
+        DeletionConflict(id: "t\($0)", kind: "chat", summary: "s\($0)",
+                         deletedBy: "b", stillIn: ["a"])
     }
     assertEqual(conflictPreview(many).components(separatedBy: "\n").count, 11,
                 "preview caps at 10 plus a summary line")
@@ -573,7 +574,7 @@ func testAccountStatus() {
 
     assertEqual(switchArgs(label: "work", desktop: true, deleting: ["t1", "t2"]),
                 ["account", "switch", "work", "--desktop", "-y",
-                 "--delete-routine", "t1", "--delete-routine", "t2"],
+                 "--delete-conflict", "t1", "--delete-conflict", "t2"],
                 "confirmed deletions are passed through")
     assertEqual(switchArgs(label: "work", desktop: true),
                 ["account", "switch", "work", "--desktop", "-y"], "desktop switch args")

--- a/src/account.rs
+++ b/src/account.rs
@@ -493,12 +493,16 @@ fn print_plan(plan: &SwitchPlan) {
     }
     match plan.target.org_uuid {
         Some(_) => {
-            let routines = plan.scheduled.as_ref().map_or(0, |merge| merge.added);
+            let (new_routines, edited_routines) = plan
+                .scheduled
+                .as_ref()
+                .map_or((0, 0), |merge| (merge.added, merge.updated));
             println!(
-                "  history         {} new + {} refreshed session(s), {routines} routine(s)",
+                "  history         {} new + {} refreshed session(s)",
                 plan.sessions.copied.len(),
                 plan.sessions.updated.len(),
             );
+            println!("  routines        {new_routines} new + {edited_routines} edited elsewhere");
         }
         None => println!("  history         skipped (no org recorded for this account yet)"),
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,6 +1,7 @@
 //! Administrative commands for named Claude accounts.
 
-use std::io::Write;
+use std::collections::BTreeSet;
+use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -56,6 +57,7 @@ pub fn run(action: &AccountAction) -> i32 {
             keep_bridge,
             backup_sessions,
             keep_backups,
+            delete_routine,
         } => switch(&SwitchArgs {
             label,
             desktop: *desktop,
@@ -63,6 +65,7 @@ pub fn run(action: &AccountAction) -> i32 {
             dry_run: *dry_run,
             yes: *yes,
             force: *force,
+            delete_routine: delete_routine.clone(),
             opts: SwitchOpts {
                 keep_bridge: *keep_bridge,
                 backup_sessions: *backup_sessions,
@@ -145,6 +148,28 @@ fn status(json: bool) -> i32 {
                 })
             })
             .collect();
+        // Routines one account deleted that another still holds. Reported here
+        // so the macOS menu bar can ask before it starts a switch, then pass
+        // the answer back with `--delete-routine`.
+        let named = |uuid: &str| {
+            claude_desktop::label_for_uuid(&profiles, uuid)
+                .unwrap_or(uuid)
+                .to_string()
+        };
+        let conflicts: Vec<serde_json::Value> = claude_desktop::merge::deletion_candidates(
+            &sessions_root,
+            &claude_desktop::load_synced(&paths.synced_path()),
+        )
+        .iter()
+        .map(|candidate| {
+            serde_json::json!({
+                "id": candidate.id,
+                "summary": candidate.summary,
+                "deleted_by": named(&candidate.deleted_by),
+                "still_in": candidate.still_in.iter().map(|uuid| named(uuid)).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
         serde_json::json!({
             "available": true,
             "data_dir": paths.data_dir,
@@ -152,6 +177,7 @@ fn status(json: bool) -> i32 {
             "active_label": active_label,
             "active_account_uuid": active_uuid,
             "profiles": rows,
+            "routine_conflicts": conflicts,
         })
     });
 
@@ -376,6 +402,9 @@ struct SwitchArgs<'a> {
     dry_run: bool,
     yes: bool,
     force: bool,
+    /// Routine ids an already-answered dialog confirmed for deletion. Non-empty
+    /// means the decision is made and nothing is prompted.
+    delete_routine: Vec<String>,
     opts: SwitchOpts,
 }
 
@@ -458,12 +487,17 @@ fn switch_desktop(config: &Config, args: &SwitchArgs, tolerant: bool) -> Result<
         }
         Err(error) => return Err(error),
     };
+    let mut plan = plan;
     print_plan(&plan);
 
     if args.dry_run {
+        // Report the conflicts, but never ask: a dry run must not leave the
+        // user having made a decision that was then thrown away.
+        resolve_deletions(&paths, &mut plan, args, false);
         println!("  (dry run — nothing was changed)");
         return Ok(true);
     }
+    resolve_deletions(&paths, &mut plan, args, std::io::stdin().is_terminal());
     if !args.yes
         && !confirm(&format!(
             "  Quit and relaunch the Claude Desktop app as {:?}?",
@@ -483,6 +517,139 @@ fn switch_desktop(config: &Config, args: &SwitchArgs, tolerant: bool) -> Result<
         plan.target.label
     );
     Ok(true)
+}
+
+/// How many conflicts to spell out before summarising the rest. A switch after
+/// a big clean-up should not scroll the decision off the screen.
+const DELETION_PREVIEW: usize = 10;
+
+/// Ask what to do about schedules an account deleted that others still hold.
+///
+/// Deleting is deliberately reachable only from an answered prompt: `-y` skips
+/// the quit confirmation, but must not silently erase routines, and a
+/// non-interactive run (the menu bar's subprocess, a pipe) keeps everything and
+/// says so. Keeping is always the recoverable choice — the task simply comes
+/// back, and the prompt returns next time.
+fn resolve_deletions(paths: &Paths, plan: &mut SwitchPlan, args: &SwitchArgs, interactive: bool) {
+    if plan.deletions.is_empty() {
+        return;
+    }
+    if !args.delete_routine.is_empty() {
+        // The caller already asked — the macOS menu bar's dialog, or a script
+        // that listed `routine_conflicts` from `account status --json`. Only
+        // ids actually in conflict are honoured, so a stale dialog answered
+        // against an older list cannot delete something new.
+        let known: BTreeSet<&str> = plan.deletions.iter().map(|c| c.id.as_str()).collect();
+        plan.confirmed_deletions = args
+            .delete_routine
+            .iter()
+            .filter(|id| known.contains(id.as_str()))
+            .cloned()
+            .collect();
+        println!(
+            "  routines        deleting {} of {} conflict(s) everywhere, as chosen",
+            plan.confirmed_deletions.len(),
+            plan.deletions.len()
+        );
+        return;
+    }
+    let profiles = claude_desktop::load_profiles(&paths.profiles_dir);
+    let name = |uuid: &str| {
+        claude_desktop::label_for_uuid(&profiles, uuid)
+            .unwrap_or(uuid)
+            .to_string()
+    };
+
+    println!();
+    println!(
+        "Routine conflicts  {} deleted in one account, still present in another",
+        plan.deletions.len()
+    );
+    for (index, candidate) in plan.deletions.iter().take(DELETION_PREVIEW).enumerate() {
+        let others: Vec<String> = candidate.still_in.iter().map(|uuid| name(uuid)).collect();
+        println!(
+            "  {:>2}. {:<34} deleted in {}, still in {}",
+            index + 1,
+            candidate.summary,
+            name(&candidate.deleted_by),
+            others.join(", ")
+        );
+    }
+    if plan.deletions.len() > DELETION_PREVIEW {
+        println!(
+            "      … and {} more",
+            plan.deletions.len() - DELETION_PREVIEW
+        );
+    }
+
+    if !interactive {
+        println!(
+            "  Keeping all of them (no terminal to ask). Re-run the switch from a \
+             terminal to decide."
+        );
+        return;
+    }
+
+    println!();
+    println!("  [k] keep them all (default)      — they stay, and this asks again next time");
+    println!("  [d] delete them everywhere       — removed from every account");
+    println!("  [c] choose individually");
+    let answer = ask("> ").unwrap_or_default().to_ascii_lowercase();
+    match answer.as_str() {
+        "d" | "delete" => {
+            plan.confirmed_deletions = plan.deletions.iter().map(|c| c.id.clone()).collect();
+            println!(
+                "  deleting {} routine(s) everywhere",
+                plan.confirmed_deletions.len()
+            );
+        }
+        "c" | "choose" => choose_deletions_individually(plan, &name),
+        _ => println!("  keeping all of them"),
+    }
+}
+
+/// Pick which to keep by number; everything unlisted goes. Asking for the
+/// keepers rather than the doomed makes the destructive answer the one you have
+/// to type deliberately, and a blank line the harmless one.
+fn choose_deletions_individually(plan: &mut SwitchPlan, name: &impl Fn(&str) -> String) {
+    println!();
+    for (index, candidate) in plan.deletions.iter().enumerate() {
+        println!(
+            "  {:>2}. {:<34} deleted in {}",
+            index + 1,
+            candidate.summary,
+            name(&candidate.deleted_by)
+        );
+    }
+    println!();
+    println!("  Numbers to KEEP, space separated (blank = keep none, deletes all):");
+    let picked = ask("> ").unwrap_or_default();
+    let keep: BTreeSet<usize> = picked
+        .split_whitespace()
+        .filter_map(|token| token.parse::<usize>().ok())
+        .collect();
+    let valid = 1..=plan.deletions.len();
+    let unknown: Vec<&str> = picked
+        .split_whitespace()
+        .filter(|token| !matches!(token.parse::<usize>(), Ok(n) if valid.contains(&n)))
+        .collect();
+    if !unknown.is_empty() {
+        // Guessing which routine a typo meant is not worth erasing one over.
+        println!("  {unknown:?} is not in the list — keeping everything instead.");
+        return;
+    }
+    plan.confirmed_deletions = plan
+        .deletions
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| !keep.contains(&(index + 1)))
+        .map(|(_, candidate)| candidate.id.clone())
+        .collect();
+    println!(
+        "  keeping {}, deleting {} everywhere",
+        keep.len(),
+        plan.confirmed_deletions.len()
+    );
 }
 
 fn print_plan(plan: &SwitchPlan) {

--- a/src/account.rs
+++ b/src/account.rs
@@ -1,6 +1,6 @@
 //! Administrative commands for named Claude accounts.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -163,6 +163,7 @@ fn status(json: bool) -> i32 {
         .iter()
         .map(|candidate| {
             serde_json::json!({
+                "key": candidate.external_key(),
                 "id": candidate.id,
                 "kind": candidate.kind.label(),
                 "summary": candidate.summary,
@@ -538,17 +539,21 @@ fn resolve_deletions(paths: &Paths, plan: &mut SwitchPlan, args: &SwitchArgs, in
     if !args.delete_conflict.is_empty() {
         // The caller already asked — the macOS menu bar's dialog, or a script
         // that listed `deletion_conflicts` from `account status --json`. Only
-        // ids actually in conflict are honoured, so a stale dialog answered
-        // against an older list cannot delete something new.
-        let known: BTreeSet<&str> = plan.deletions.iter().map(|c| c.id.as_str()).collect();
+        // exact opaque keys actually in conflict are honoured, so a stale
+        // dialog answered against an older observation cannot delete a later
+        // item that happens to reuse the same id.
+        let known: BTreeMap<String, claude_desktop::merge::DeletionKey> = plan
+            .deletions
+            .iter()
+            .map(|candidate| (candidate.external_key(), candidate.key()))
+            .collect();
         plan.confirmed_deletions = args
             .delete_conflict
             .iter()
-            .filter(|id| known.contains(id.as_str()))
-            .cloned()
+            .filter_map(|key| known.get(key).cloned())
             .collect();
         println!(
-            "  routines        deleting {} of {} conflict(s) everywhere, as chosen",
+            "  deletions       deleting {} of {} conflict(s) everywhere, as chosen",
             plan.confirmed_deletions.len(),
             plan.deletions.len()
         );
@@ -603,9 +608,9 @@ fn resolve_deletions(paths: &Paths, plan: &mut SwitchPlan, args: &SwitchArgs, in
     let answer = ask("> ").unwrap_or_default().to_ascii_lowercase();
     match answer.as_str() {
         "d" | "delete" => {
-            plan.confirmed_deletions = plan.deletions.iter().map(|c| c.id.clone()).collect();
+            plan.confirmed_deletions = plan.deletions.iter().map(|c| c.key()).collect();
             println!(
-                "  deleting {} routine(s) everywhere",
+                "  deleting {} item(s) everywhere",
                 plan.confirmed_deletions.len()
             );
         }
@@ -649,7 +654,7 @@ fn choose_deletions_individually(plan: &mut SwitchPlan, name: &impl Fn(&str) -> 
         .iter()
         .enumerate()
         .filter(|(index, _)| !keep.contains(&(index + 1)))
-        .map(|(_, candidate)| candidate.id.clone())
+        .map(|(_, candidate)| candidate.key())
         .collect();
     println!(
         "  keeping {}, deleting {} everywhere",
@@ -666,16 +671,21 @@ fn print_plan(plan: &SwitchPlan) {
     }
     match plan.target.org_uuid {
         Some(_) => {
-            let (new_routines, edited_routines) = plan
-                .scheduled
-                .as_ref()
-                .map_or((0, 0), |merge| (merge.added, merge.updated));
+            let (new_routines, edited_routines, conflicts) =
+                plan.scheduled.as_ref().map_or((0, 0, 0), |merge| {
+                    (merge.added, merge.updated, merge.conflicts)
+                });
             println!(
                 "  history         {} new + {} refreshed session(s)",
                 plan.sessions.copied.len(),
                 plan.sessions.updated.len(),
             );
             println!("  routines        {new_routines} new + {edited_routines} edited elsewhere");
+            if conflicts > 0 {
+                println!(
+                    "  routine conflicts {conflicts} kept local (edit the desired copy to resolve)"
+                );
+            }
         }
         None => println!("  history         skipped (no org recorded for this account yet)"),
     }

--- a/src/account.rs
+++ b/src/account.rs
@@ -57,7 +57,7 @@ pub fn run(action: &AccountAction) -> i32 {
             keep_bridge,
             backup_sessions,
             keep_backups,
-            delete_routine,
+            delete_conflict,
         } => switch(&SwitchArgs {
             label,
             desktop: *desktop,
@@ -65,7 +65,7 @@ pub fn run(action: &AccountAction) -> i32 {
             dry_run: *dry_run,
             yes: *yes,
             force: *force,
-            delete_routine: delete_routine.clone(),
+            delete_conflict: delete_conflict.clone(),
             opts: SwitchOpts {
                 keep_bridge: *keep_bridge,
                 backup_sessions: *backup_sessions,
@@ -150,7 +150,7 @@ fn status(json: bool) -> i32 {
             .collect();
         // Routines one account deleted that another still holds. Reported here
         // so the macOS menu bar can ask before it starts a switch, then pass
-        // the answer back with `--delete-routine`.
+        // the answer back with `--delete-conflict`.
         let named = |uuid: &str| {
             claude_desktop::label_for_uuid(&profiles, uuid)
                 .unwrap_or(uuid)
@@ -164,6 +164,7 @@ fn status(json: bool) -> i32 {
         .map(|candidate| {
             serde_json::json!({
                 "id": candidate.id,
+                "kind": candidate.kind.label(),
                 "summary": candidate.summary,
                 "deleted_by": named(&candidate.deleted_by),
                 "still_in": candidate.still_in.iter().map(|uuid| named(uuid)).collect::<Vec<_>>(),
@@ -177,7 +178,7 @@ fn status(json: bool) -> i32 {
             "active_label": active_label,
             "active_account_uuid": active_uuid,
             "profiles": rows,
-            "routine_conflicts": conflicts,
+            "deletion_conflicts": conflicts,
         })
     });
 
@@ -404,7 +405,7 @@ struct SwitchArgs<'a> {
     force: bool,
     /// Routine ids an already-answered dialog confirmed for deletion. Non-empty
     /// means the decision is made and nothing is prompted.
-    delete_routine: Vec<String>,
+    delete_conflict: Vec<String>,
     opts: SwitchOpts,
 }
 
@@ -534,14 +535,14 @@ fn resolve_deletions(paths: &Paths, plan: &mut SwitchPlan, args: &SwitchArgs, in
     if plan.deletions.is_empty() {
         return;
     }
-    if !args.delete_routine.is_empty() {
+    if !args.delete_conflict.is_empty() {
         // The caller already asked — the macOS menu bar's dialog, or a script
-        // that listed `routine_conflicts` from `account status --json`. Only
+        // that listed `deletion_conflicts` from `account status --json`. Only
         // ids actually in conflict are honoured, so a stale dialog answered
         // against an older list cannot delete something new.
         let known: BTreeSet<&str> = plan.deletions.iter().map(|c| c.id.as_str()).collect();
         plan.confirmed_deletions = args
-            .delete_routine
+            .delete_conflict
             .iter()
             .filter(|id| known.contains(id.as_str()))
             .cloned()
@@ -562,14 +563,15 @@ fn resolve_deletions(paths: &Paths, plan: &mut SwitchPlan, args: &SwitchArgs, in
 
     println!();
     println!(
-        "Routine conflicts  {} deleted in one account, still present in another",
+        "Deleted elsewhere  {} item(s) deleted in one account, still present in another",
         plan.deletions.len()
     );
     for (index, candidate) in plan.deletions.iter().take(DELETION_PREVIEW).enumerate() {
         let others: Vec<String> = candidate.still_in.iter().map(|uuid| name(uuid)).collect();
         println!(
-            "  {:>2}. {:<34} deleted in {}, still in {}",
+            "  {:>2}. {:<7} {:<34} deleted in {}, still in {}",
             index + 1,
+            candidate.kind.label(),
             candidate.summary,
             name(&candidate.deleted_by),
             others.join(", ")
@@ -594,6 +596,10 @@ fn resolve_deletions(paths: &Paths, plan: &mut SwitchPlan, args: &SwitchArgs, in
     println!("  [k] keep them all (default)      — they stay, and this asks again next time");
     println!("  [d] delete them everywhere       — removed from every account");
     println!("  [c] choose individually");
+    println!(
+        "      (a deleted chat loses only its index — the transcript in \
+         ~/.claude/projects stays)"
+    );
     let answer = ask("> ").unwrap_or_default().to_ascii_lowercase();
     match answer.as_str() {
         "d" | "delete" => {

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -66,13 +66,40 @@ fn set_private_mode(_path: &Path, _mode: u32) -> Result<()> {
 ///
 /// AppleScript answers correctly, and asking whether an application `is
 /// running` does not launch it.
-fn is_running() -> bool {
-    Command::new("/usr/bin/osascript")
+fn query_running_with(program: &Path) -> Result<bool> {
+    let output = Command::new(program)
         .args(["-e", "application \"Claude\" is running"])
         .output()
-        .is_ok_and(|output| {
-            output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
-        })
+        .map_err(|error| {
+            AppError::Other(format!(
+                "could not determine whether Claude Desktop is running: {error}"
+            ))
+        })?;
+    parse_running_output(
+        output.status.success(),
+        output.status.code(),
+        &output.stdout,
+    )
+}
+
+fn parse_running_output(success: bool, code: Option<i32>, stdout: &[u8]) -> Result<bool> {
+    if !success {
+        return Err(AppError::Other(format!(
+            "could not determine whether Claude Desktop is running (osascript exited {})",
+            code.unwrap_or(-1)
+        )));
+    }
+    match String::from_utf8_lossy(stdout).trim() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        value => Err(AppError::Other(format!(
+            "could not determine whether Claude Desktop is running (unexpected response {value:?})"
+        ))),
+    }
+}
+
+fn is_running() -> Result<bool> {
+    query_running_with(Path::new("/usr/bin/osascript"))
 }
 
 /// The app's main process id, for the force-quit fallbacks. `pkill -x Claude`
@@ -103,14 +130,21 @@ fn signal_main(signal: &str) {
     }
 }
 
-fn wait_until_stopped() -> bool {
+fn wait_until_stopped_with(
+    mut probe: impl FnMut() -> Result<bool>,
+    mut pause: impl FnMut(),
+) -> Result<bool> {
     for _ in 0..QUIT_POLLS {
-        if !is_running() {
-            return true;
+        if !probe()? {
+            return Ok(true);
         }
-        std::thread::sleep(QUIT_POLL);
+        pause();
     }
-    !is_running()
+    Ok(!probe()?)
+}
+
+fn wait_until_stopped() -> Result<bool> {
+    wait_until_stopped_with(is_running, || std::thread::sleep(QUIT_POLL))
 }
 
 impl AppControl for DesktopApp {
@@ -123,15 +157,15 @@ impl AppControl for DesktopApp {
             .args(["-e", "tell application \"Claude\" to quit"])
             .output();
         std::thread::sleep(QUIT_GRACE);
-        if wait_until_stopped() {
+        if wait_until_stopped()? {
             return Ok(());
         }
         signal_main("-TERM");
-        if wait_until_stopped() {
+        if wait_until_stopped()? {
             return Ok(());
         }
         signal_main("-KILL");
-        if wait_until_stopped() {
+        if wait_until_stopped()? {
             Ok(())
         } else {
             Err(AppError::Other(
@@ -262,6 +296,34 @@ impl AppControl for Recorder {
             members.join(", ")
         ));
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod liveness_tests {
+    use super::*;
+
+    #[test]
+    fn liveness_accepts_only_explicit_boolean_output() {
+        assert!(parse_running_output(true, Some(0), b"true\n").unwrap());
+        assert!(!parse_running_output(true, Some(0), b"false\n").unwrap());
+        assert!(parse_running_output(true, Some(0), b"unknown\n").is_err());
+        assert!(parse_running_output(false, Some(1), b"false\n").is_err());
+    }
+
+    #[test]
+    fn a_probe_launch_failure_is_not_treated_as_stopped() {
+        let missing = Path::new("/definitely/not/an/osascript/binary");
+        assert!(query_running_with(missing).is_err());
+    }
+
+    #[test]
+    fn wait_aborts_on_an_unknown_liveness_state() {
+        let result = wait_until_stopped_with(
+            || Err(AppError::Other("probe failed".into())),
+            || panic!("an unknown state must abort before sleeping"),
+        );
+        assert!(result.is_err());
     }
 }
 

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -53,11 +53,54 @@ fn set_private_mode(_path: &Path, _mode: u32) -> Result<()> {
     Ok(())
 }
 
+/// Whether Claude Desktop is up.
+///
+/// **Not** `pgrep -x Claude`: that matches nothing while the app is running
+/// (verified against a live install — `ps` lists
+/// `/Applications/Claude.app/Contents/MacOS/Claude`, but neither `pgrep -x
+/// Claude` nor `pgrep -f <full path>` finds it). Every liveness check therefore
+/// answered "stopped" instantly, so [`AppControl::quit`] reported success
+/// without ever confirming the app had exited — and would then let a switch
+/// copy live SQLite and LevelDB stores, the exact corruption this guards
+/// against.
+///
+/// AppleScript answers correctly, and asking whether an application `is
+/// running` does not launch it.
 fn is_running() -> bool {
-    Command::new("/usr/bin/pgrep")
-        .args(["-x", "Claude"])
+    Command::new("/usr/bin/osascript")
+        .args(["-e", "application \"Claude\" is running"])
         .output()
-        .is_ok_and(|output| output.status.success())
+        .is_ok_and(|output| {
+            output.status.success() && String::from_utf8_lossy(&output.stdout).trim() == "true"
+        })
+}
+
+/// The app's main process id, for the force-quit fallbacks. `pkill -x Claude`
+/// misses it for the same reason `pgrep` does, so match the executable path
+/// out of `ps` instead — the helper processes have distinct paths and are
+/// deliberately left alone, since quitting the main process takes them with it.
+fn main_pid() -> Option<String> {
+    const MAIN_EXECUTABLE: &str = "/Claude.app/Contents/MacOS/Claude";
+
+    let output = Command::new("/bin/ps")
+        .args(["-Ao", "pid=,comm="])
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .find_map(|line| {
+            let (pid, command) = line.trim().split_once(char::is_whitespace)?;
+            command
+                .trim()
+                .ends_with(MAIN_EXECUTABLE)
+                .then(|| pid.to_string())
+        })
+}
+
+fn signal_main(signal: &str) {
+    if let Some(pid) = main_pid() {
+        let _ = Command::new("/bin/kill").args([signal, &pid]).output();
+    }
 }
 
 fn wait_until_stopped() -> bool {
@@ -73,8 +116,9 @@ fn wait_until_stopped() -> bool {
 impl AppControl for DesktopApp {
     fn quit(&self) -> Result<()> {
         // Graceful first so the app tears down its own child processes; the
-        // signal is the fallback. Neither touches a `claude` CLI process —
-        // `-x` matches the executable name exactly.
+        // signals are the fallback for a hung app. Neither touches a `claude`
+        // CLI process: the AppleScript targets the Claude application, and the
+        // signals go to one pid matched on the app bundle's executable path.
         let _ = Command::new("/usr/bin/osascript")
             .args(["-e", "tell application \"Claude\" to quit"])
             .output();
@@ -82,15 +126,11 @@ impl AppControl for DesktopApp {
         if wait_until_stopped() {
             return Ok(());
         }
-        let _ = Command::new("/usr/bin/pkill")
-            .args(["-x", "Claude"])
-            .output();
+        signal_main("-TERM");
         if wait_until_stopped() {
             return Ok(());
         }
-        let _ = Command::new("/usr/bin/pkill")
-            .args(["-KILL", "-x", "Claude"])
-            .output();
+        signal_main("-KILL");
         if wait_until_stopped() {
             Ok(())
         } else {

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -7,6 +7,7 @@
 //! `--dry-run` be free (compute the plan, print it, stop) and lets the whole
 //! algorithm be unit-tested against a temporary directory on any platform.
 
+use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -45,6 +46,9 @@ pub struct ScheduledMerge {
     pub bytes: Vec<u8>,
     /// Tasks the target did not already have.
     pub added: usize,
+    /// Tasks the target already had, whose definition a more recently edited
+    /// registry replaced — an edit made while signed into another account.
+    pub updated: usize,
 }
 
 /// Plan the session-index merge into `<sessions_root>/<account_uuid>/<org_uuid>`.
@@ -107,32 +111,53 @@ pub fn plan_scheduled_merge(
         .join(org_uuid)
         .join(SCHEDULED_TASKS);
     let (target_tasks, mut skips) = load_scheduled(&target);
+    let target_mtime = modified_at(&target);
 
     // A Vec rather than a map: registries hold a handful of entries, and the
-    // target's own tasks must keep their existing order.
-    let mut tasks: Vec<(String, Value)> = target_tasks
+    // target's own tasks must keep their existing order. The third element is
+    // how fresh the registry each task came from is — see the comparison below.
+    let mut tasks: Vec<(String, Value, i64)> = target_tasks
         .into_iter()
-        .filter_map(|task| task_id(&task).map(|id| (id, task)))
+        .filter_map(|task| task_id(&task).map(|id| (id, task, target_mtime)))
         .collect();
     let mut added = 0usize;
+    let mut updated = 0usize;
 
     for source in scheduled_task_files(sessions_root) {
         if source == target {
             continue;
         }
+        let source_mtime = modified_at(&source);
         let (source_tasks, source_skips) = load_scheduled(&source);
         for task in source_tasks {
             let Some(id) = task_id(&task) else {
                 continue;
             };
-            match tasks.iter_mut().find(|(existing, _)| *existing == id) {
-                Some((_, existing)) => {
-                    if created_at(&task) > created_at(existing) {
+            match tasks.iter_mut().find(|(existing, ..)| *existing == id) {
+                Some((_, existing, existing_mtime)) => {
+                    // A scheduled task has no `updatedAt`: editing its cron,
+                    // model, or `enabled` flag leaves `createdAt` untouched.
+                    // Comparing `createdAt` alone therefore drops *every* edit
+                    // made after the task first synced to another account —
+                    // both copies tie, and a tie kept the incumbent. The
+                    // registry file's mtime is the only "who wrote last" signal
+                    // the format offers, and the account just worked in owns
+                    // the freshest one, so it breaks the tie.
+                    let fresher = match created_at(&task).cmp(&created_at(existing)) {
+                        Ordering::Greater => true,
+                        Ordering::Equal => source_mtime > *existing_mtime,
+                        Ordering::Less => false,
+                    };
+                    if fresher {
+                        if *existing != task {
+                            updated += 1;
+                        }
                         *existing = task;
+                        *existing_mtime = source_mtime;
                     }
                 }
                 None => {
-                    tasks.push((id, task));
+                    tasks.push((id, task, source_mtime));
                     added += 1;
                 }
             }
@@ -144,13 +169,14 @@ pub fn plan_scheduled_merge(
     }
 
     let merged = serde_json::json!({
-        "scheduledTasks": tasks.into_iter().map(|(_, task)| task).collect::<Vec<_>>(),
+        "scheduledTasks": tasks.into_iter().map(|(_, task, _)| task).collect::<Vec<_>>(),
         "recordedSkips": skips,
     });
     Ok(ScheduledMerge {
         target,
         bytes: serde_json::to_vec(&merged)?,
         added,
+        updated,
     })
 }
 
@@ -341,6 +367,19 @@ fn created_at(task: &Value) -> i64 {
     task.get("createdAt").map_or(0, json_i64)
 }
 
+/// When a registry file was last written, in epoch milliseconds. Absent or
+/// unreadable counts as the beginning of time, so a file we cannot stat never
+/// wins a tie against one we can.
+fn modified_at(path: &Path) -> i64 {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |since| {
+            i64::try_from(since.as_millis()).unwrap_or(i64::MAX)
+        })
+}
+
 fn last_activity(path: &Path) -> i64 {
     let Ok(bytes) = std::fs::read(path) else {
         return 0;
@@ -463,6 +502,117 @@ mod tests {
         // setdefault semantics: the target's own skip is never overridden.
         assert_eq!(value["recordedSkips"]["t1"], "target");
         assert_eq!(value["recordedSkips"]["t2"], "other");
+    }
+
+    /// Set a file's mtime so a test can say which registry was written last.
+    fn touch(path: &Path, millis_since_epoch: u64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(millis_since_epoch);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(time))
+            .unwrap();
+    }
+
+    /// A schedule edited while signed into another account: same `id`, same
+    /// `createdAt` (the format has no `updatedAt`), different cron. Comparing
+    /// `createdAt` alone ties, and a tie used to keep the incumbent — silently
+    /// discarding the edit on every switch back.
+    #[test]
+    fn scheduled_merge_takes_an_edit_that_did_not_change_created_at() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let target = sessions.join("A/O1/scheduled-tasks.json");
+        let source = sessions.join("B/O2/scheduled-tasks.json");
+        write(
+            &target,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *","enabled":true}]}"#,
+        );
+        write(
+            &source,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"30 9 * * *","enabled":false}]}"#,
+        );
+        touch(&target, 1_000);
+        touch(&source, 2_000); // edited more recently
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+
+        assert_eq!(merge.added, 0);
+        assert_eq!(merge.updated, 1, "the edit must be carried across");
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+        assert_eq!(value["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
+        assert_eq!(value["scheduledTasks"][0]["enabled"], false);
+    }
+
+    /// The mirror image: the target holds the fresher registry, so an older
+    /// copy sitting in another account must not overwrite it.
+    #[test]
+    fn scheduled_merge_keeps_the_target_when_its_registry_is_fresher() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let target = sessions.join("A/O1/scheduled-tasks.json");
+        let source = sessions.join("B/O2/scheduled-tasks.json");
+        write(
+            &target,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"30 9 * * *"}]}"#,
+        );
+        write(
+            &source,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *"}]}"#,
+        );
+        touch(&target, 2_000); // target edited more recently
+        touch(&source, 1_000);
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+
+        assert_eq!(merge.updated, 0);
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+        assert_eq!(value["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
+    }
+
+    /// mtime only breaks ties. A genuinely newer `createdAt` — the task was
+    /// deleted and recreated — still wins even from a staler file.
+    #[test]
+    fn a_newer_created_at_wins_regardless_of_file_mtime() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let target = sessions.join("A/O1/scheduled-tasks.json");
+        let source = sessions.join("B/O2/scheduled-tasks.json");
+        write(
+            &target,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"name":"old"}]}"#,
+        );
+        write(
+            &source,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":500,"name":"recreated"}]}"#,
+        );
+        touch(&target, 9_000); // target file is much fresher…
+        touch(&source, 1_000); // …but the task itself is older
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+        assert_eq!(value["scheduledTasks"][0]["name"], "recreated");
+    }
+
+    /// An identical copy in a fresher file is not an edit; reporting it as one
+    /// would make every switch claim to have changed something.
+    #[test]
+    fn an_identical_copy_is_not_counted_as_an_edit() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let target = sessions.join("A/O1/scheduled-tasks.json");
+        let source = sessions.join("B/O2/scheduled-tasks.json");
+        let same =
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *"}]}"#;
+        write(&target, same);
+        write(&source, same);
+        touch(&target, 1_000);
+        touch(&source, 2_000);
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        assert_eq!(merge.added, 0);
+        assert_eq!(merge.updated, 0);
     }
 
     #[test]

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -8,7 +8,7 @@
 //! algorithm be unit-tested against a temporary directory on any platform.
 
 use std::cmp::Ordering;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value};
@@ -95,6 +95,146 @@ pub fn plan_session_merge(
         }
     }
     merge
+}
+
+/// What each account held the last time a merge wrote its registry, keyed by
+/// account UUID. Union-merging is additive, so this record is the only way to
+/// tell "this account deleted the task" from "this account never had it".
+pub type SyncedTasks = BTreeMap<String, BTreeSet<String>>;
+
+/// A task an account deleted that other accounts still hold, so the next merge
+/// would hand it straight back. Only the user can say which they meant, so the
+/// merge surfaces these rather than guessing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletionCandidate {
+    pub id: String,
+    /// Account UUID that had it and no longer does.
+    pub deleted_by: String,
+    /// Account UUIDs that still hold a copy.
+    pub still_in: Vec<String>,
+    /// Short human description — schedule and task file, for the prompt.
+    pub summary: String,
+}
+
+/// Every account's current task ids, for refreshing [`SyncedTasks`] after a
+/// merge lands.
+pub fn current_task_ids(sessions_root: &Path) -> SyncedTasks {
+    let mut out = SyncedTasks::new();
+    for (account, path) in scheduled_registries(sessions_root) {
+        let (tasks, _) = load_scheduled(&path);
+        out.entry(account)
+            .or_default()
+            .extend(tasks.iter().filter_map(task_id));
+    }
+    out
+}
+
+/// Tasks that an account dropped since its last recorded sync but that survive
+/// in another account. Sorted by id so prompts and tests are deterministic.
+///
+/// A task absent from `synced` was never recorded as reaching that account, so
+/// it is simply new and never reported — which also means the very first run,
+/// before any manifest exists, reports nothing and behaves exactly as before.
+pub fn deletion_candidates(sessions_root: &Path, synced: &SyncedTasks) -> Vec<DeletionCandidate> {
+    let mut holders: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut summaries: BTreeMap<String, String> = BTreeMap::new();
+    let mut present: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    for (account, path) in scheduled_registries(sessions_root) {
+        let (tasks, _) = load_scheduled(&path);
+        for task in &tasks {
+            let Some(id) = task_id(task) else { continue };
+            holders.entry(id.clone()).or_default().push(account.clone());
+            summaries
+                .entry(id.clone())
+                .or_insert_with(|| describe(task));
+            present.entry(account.clone()).or_default().insert(id);
+        }
+        present.entry(account).or_default();
+    }
+
+    let mut out = Vec::new();
+    for (account, had) in synced {
+        let holds = present.get(account);
+        for id in had {
+            if holds.is_some_and(|ids| ids.contains(id)) {
+                continue; // still there — not deleted
+            }
+            let Some(still_in) = holders.get(id) else {
+                continue; // gone everywhere; nothing would resurrect it
+            };
+            out.push(DeletionCandidate {
+                id: id.clone(),
+                deleted_by: account.clone(),
+                still_in: still_in.clone(),
+                summary: summaries.get(id).cloned().unwrap_or_default(),
+            });
+        }
+    }
+    out.sort_by(|a, b| a.id.cmp(&b.id).then(a.deleted_by.cmp(&b.deleted_by)));
+    out.dedup_by(|a, b| a.id == b.id);
+    out
+}
+
+/// Remove `doomed` task ids from every account's registry, so a deletion the
+/// user confirmed actually sticks instead of returning on the next switch.
+/// Returns the files to write; nothing is touched here.
+pub fn plan_deletion_sweep(
+    sessions_root: &Path,
+    doomed: &BTreeSet<String>,
+) -> Result<Vec<(PathBuf, Vec<u8>)>> {
+    let mut writes = Vec::new();
+    if doomed.is_empty() {
+        return Ok(writes);
+    }
+    for (_, path) in scheduled_registries(sessions_root) {
+        let (tasks, skips) = load_scheduled(&path);
+        let before = tasks.len();
+        let kept: Vec<Value> = tasks
+            .into_iter()
+            .filter(|task| task_id(task).is_none_or(|id| !doomed.contains(&id)))
+            .collect();
+        if kept.len() == before {
+            continue; // this registry held none of them
+        }
+        let merged = serde_json::json!({ "scheduledTasks": kept, "recordedSkips": skips });
+        writes.push((path, serde_json::to_vec(&merged)?));
+    }
+    Ok(writes)
+}
+
+/// One line naming a task in the confirmation prompt. The id alone is opaque.
+fn describe(task: &Value) -> String {
+    let cron = task
+        .get("cronExpression")
+        .and_then(Value::as_str)
+        .unwrap_or("no schedule");
+    match task.get("filePath").and_then(Value::as_str) {
+        Some(path) => {
+            let name = Path::new(path)
+                .parent()
+                .and_then(Path::file_name)
+                .and_then(|name| name.to_str())
+                .unwrap_or(path);
+            format!("{cron}  ({name})")
+        }
+        None => cron.to_string(),
+    }
+}
+
+/// `(account uuid, registry path)` for every account on this machine.
+fn scheduled_registries(sessions_root: &Path) -> Vec<(String, PathBuf)> {
+    account_org_dirs(sessions_root)
+        .into_iter()
+        .filter_map(|dir| {
+            let path = dir.join(SCHEDULED_TASKS);
+            if !path.is_file() {
+                return None;
+            }
+            let account = dir.parent()?.file_name()?.to_str()?.to_string();
+            Some((account, path))
+        })
+        .collect()
 }
 
 /// Plan the routine/schedule merge: a union by task `id`, with the newer
@@ -613,6 +753,162 @@ mod tests {
         let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
         assert_eq!(merge.added, 0);
         assert_eq!(merge.updated, 0);
+    }
+
+    fn synced(pairs: &[(&str, &[&str])]) -> SyncedTasks {
+        pairs
+            .iter()
+            .map(|(account, ids)| {
+                (
+                    (*account).to_string(),
+                    ids.iter().map(|id| (*id).to_string()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    /// A task B once had and no longer does, while A still holds it: the next
+    /// merge into B would hand it straight back, so it needs confirming.
+    #[test]
+    fn a_task_dropped_by_one_account_is_reported_as_a_deletion() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1,"cronExpression":"0 5 * * *",
+                "filePath":"/x/daily-report/SKILL.md"},{"id":"t2","createdAt":2}]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t2","createdAt":2}]}"#,
+        );
+
+        let found = deletion_candidates(sessions, &synced(&[("B", &["t1", "t2"])]));
+
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].id, "t1");
+        assert_eq!(found[0].deleted_by, "B");
+        assert_eq!(found[0].still_in, ["A"]);
+        assert_eq!(found[0].summary, "0 5 * * *  (daily-report)");
+    }
+
+    /// The safe-rollout property: with no manifest yet, nothing is a deletion,
+    /// so an upgrade never opens a prompt about tasks it has no history for.
+    #[test]
+    fn nothing_is_a_deletion_without_a_recorded_sync() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1}]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[]}"#,
+        );
+
+        assert!(deletion_candidates(sessions, &SyncedTasks::new()).is_empty());
+        // …and a brand-new account that simply never received it is not a
+        // deletion either.
+        assert!(deletion_candidates(sessions, &synced(&[("B", &[])])).is_empty());
+    }
+
+    /// Deleted in every account is just deleted — nothing would resurrect it,
+    /// so there is nothing to ask about.
+    #[test]
+    fn a_task_gone_everywhere_is_not_a_conflict() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[]}"#,
+        );
+
+        let found = deletion_candidates(sessions, &synced(&[("A", &["t1"]), ("B", &["t1"])]));
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    #[test]
+    fn a_confirmed_deletion_is_swept_from_every_registry() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1},{"id":"t2","createdAt":2}],
+                "recordedSkips":{"t1":"keep me"}}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1}]}"#,
+        );
+        write(
+            &sessions.join("C/O3/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t2","createdAt":2}]}"#,
+        );
+
+        let doomed: BTreeSet<String> = ["t1".to_string()].into_iter().collect();
+        let writes = plan_deletion_sweep(sessions, &doomed).unwrap();
+
+        // C never held t1, so it is not rewritten at all.
+        assert_eq!(writes.len(), 2, "{writes:?}");
+        for (path, bytes) in &writes {
+            let value: Value = serde_json::from_slice(bytes).unwrap();
+            let ids: Vec<&str> = value["scheduledTasks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|task| task["id"].as_str().unwrap())
+                .collect();
+            assert!(!ids.contains(&"t1"), "{path:?} still has t1");
+        }
+        // Unrelated state in a rewritten registry survives the sweep.
+        let (_, a_bytes) = writes
+            .iter()
+            .find(|(p, _)| p.ends_with("A/O1/scheduled-tasks.json"))
+            .unwrap();
+        let a: Value = serde_json::from_slice(a_bytes).unwrap();
+        assert_eq!(a["recordedSkips"]["t1"], "keep me");
+        assert_eq!(a["scheduledTasks"][0]["id"], "t2");
+    }
+
+    #[test]
+    fn keeping_everything_rewrites_nothing() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1}]}"#,
+        );
+        assert!(
+            plan_deletion_sweep(sessions, &BTreeSet::new())
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn current_task_ids_records_every_account() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1"},{"id":"t2"}]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t2"}]}"#,
+        );
+
+        let ids = current_task_ids(sessions);
+        assert_eq!(
+            ids["A"],
+            ["t1".to_string(), "t2".to_string()].into_iter().collect()
+        );
+        assert_eq!(ids["B"], ["t2".to_string()].into_iter().collect());
     }
 
     #[test]

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -97,95 +97,223 @@ pub fn plan_session_merge(
     merge
 }
 
-/// What each account held the last time a merge wrote its registry, keyed by
-/// account UUID. Union-merging is additive, so this record is the only way to
-/// tell "this account deleted the task" from "this account never had it".
-pub type SyncedTasks = BTreeMap<String, BTreeSet<String>>;
+/// What one account held the last time a merge touched it.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SyncedAccount {
+    #[serde(default)]
+    pub routines: BTreeSet<String>,
+    /// Session-index filenames (`local_<id>.json`), not transcripts.
+    #[serde(default)]
+    pub sessions: BTreeSet<String>,
+}
 
-/// A task an account deleted that other accounts still hold, so the next merge
-/// would hand it straight back. Only the user can say which they meant, so the
-/// merge surfaces these rather than guessing.
+/// What every account held after the last merge, keyed by account UUID.
+/// Union-merging is additive, so this record is the only way to tell "this
+/// account deleted it" from "this account never had it".
+pub type Synced = BTreeMap<String, SyncedAccount>;
+
+/// Kept for the record written before conversations were covered: a bare list
+/// was routines only. Reading it as such means an existing file keeps working
+/// instead of being silently discarded and re-learned.
+pub fn parse_synced(bytes: &[u8]) -> Synced {
+    if let Ok(current) = serde_json::from_slice::<Synced>(bytes) {
+        return current;
+    }
+    serde_json::from_slice::<BTreeMap<String, BTreeSet<String>>>(bytes)
+        .map(|old| {
+            old.into_iter()
+                .map(|(account, routines)| {
+                    (
+                        account,
+                        SyncedAccount {
+                            routines,
+                            sessions: BTreeSet::new(),
+                        },
+                    )
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Which of the two things a conflict is about. They live in different files
+/// and are swept differently, but the user answers one question about both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictKind {
+    Routine,
+    Chat,
+}
+
+impl ConflictKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Routine => "routine",
+            Self::Chat => "chat",
+        }
+    }
+}
+
+/// Something an account deleted that other accounts still hold, so the next
+/// merge would hand it straight back. Only the user can say which they meant,
+/// so the merge surfaces these rather than guessing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeletionCandidate {
+    pub kind: ConflictKind,
+    /// Task id for a routine; session-index filename for a chat.
     pub id: String,
     /// Account UUID that had it and no longer does.
     pub deleted_by: String,
     /// Account UUIDs that still hold a copy.
     pub still_in: Vec<String>,
-    /// Short human description — schedule and task file, for the prompt.
+    /// Short human description for the prompt — the id alone is opaque.
     pub summary: String,
 }
 
-/// Every account's current task ids, for refreshing [`SyncedTasks`] after a
-/// merge lands.
-pub fn current_task_ids(sessions_root: &Path) -> SyncedTasks {
-    let mut out = SyncedTasks::new();
+/// Every account's current contents, for refreshing [`Synced`] after a merge.
+pub fn current_state(sessions_root: &Path) -> Synced {
+    let mut out = Synced::new();
     for (account, path) in scheduled_registries(sessions_root) {
         let (tasks, _) = load_scheduled(&path);
         out.entry(account)
             .or_default()
+            .routines
             .extend(tasks.iter().filter_map(task_id));
+    }
+    for (account, dir) in account_dirs(sessions_root) {
+        out.entry(account).or_default().sessions.extend(
+            local_session_files(&dir)
+                .iter()
+                .filter_map(|path| file_name(path)),
+        );
     }
     out
 }
 
-/// Tasks that an account dropped since its last recorded sync but that survive
-/// in another account. Sorted by id so prompts and tests are deterministic.
+/// Routines and chats an account dropped since its last recorded sync that
+/// survive in another account. Sorted for deterministic prompts and tests.
 ///
-/// A task absent from `synced` was never recorded as reaching that account, so
-/// it is simply new and never reported — which also means the very first run,
-/// before any manifest exists, reports nothing and behaves exactly as before.
-pub fn deletion_candidates(sessions_root: &Path, synced: &SyncedTasks) -> Vec<DeletionCandidate> {
-    let mut holders: BTreeMap<String, Vec<String>> = BTreeMap::new();
-    let mut summaries: BTreeMap<String, String> = BTreeMap::new();
-    let mut present: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+/// Anything absent from `synced` was never recorded as reaching that account,
+/// so it is simply new and never reported — which also means the very first
+/// run, before any record exists, reports nothing and behaves exactly as
+/// before.
+pub fn deletion_candidates(sessions_root: &Path, synced: &Synced) -> Vec<DeletionCandidate> {
+    let mut out = Vec::new();
+    let mut routines: Index = Index::default();
+    let mut chats: Index = Index::default();
 
     for (account, path) in scheduled_registries(sessions_root) {
         let (tasks, _) = load_scheduled(&path);
+        routines.seen(&account);
         for task in &tasks {
             let Some(id) = task_id(task) else { continue };
-            holders.entry(id.clone()).or_default().push(account.clone());
-            summaries
-                .entry(id.clone())
-                .or_insert_with(|| describe(task));
-            present.entry(account.clone()).or_default().insert(id);
+            routines.record(&account, id, || describe_task(task));
         }
-        present.entry(account).or_default();
+    }
+    for (account, dir) in account_dirs(sessions_root) {
+        chats.seen(&account);
+        for path in local_session_files(&dir) {
+            let Some(name) = file_name(&path) else {
+                continue;
+            };
+            chats.record(&account, name, || describe_session(&path));
+        }
     }
 
-    let mut out = Vec::new();
     for (account, had) in synced {
-        let holds = present.get(account);
+        routines.collect(ConflictKind::Routine, account, &had.routines, &mut out);
+        chats.collect(ConflictKind::Chat, account, &had.sessions, &mut out);
+    }
+    out.sort_by(|a, b| {
+        a.kind
+            .label()
+            .cmp(b.kind.label())
+            .then(a.id.cmp(&b.id))
+            .then(a.deleted_by.cmp(&b.deleted_by))
+    });
+    out.dedup_by(|a, b| a.kind == b.kind && a.id == b.id);
+    out
+}
+
+/// Who holds what, built once per kind so the deletion scan is a lookup rather
+/// than a rescan per account.
+#[derive(Default)]
+struct Index {
+    holders: BTreeMap<String, Vec<String>>,
+    summaries: BTreeMap<String, String>,
+    present: BTreeMap<String, BTreeSet<String>>,
+}
+
+impl Index {
+    fn seen(&mut self, account: &str) {
+        self.present.entry(account.to_string()).or_default();
+    }
+
+    fn record(&mut self, account: &str, id: String, summary: impl FnOnce() -> String) {
+        self.holders
+            .entry(id.clone())
+            .or_default()
+            .push(account.to_string());
+        self.summaries.entry(id.clone()).or_insert_with(summary);
+        self.present
+            .entry(account.to_string())
+            .or_default()
+            .insert(id);
+    }
+
+    fn collect(
+        &self,
+        kind: ConflictKind,
+        account: &str,
+        had: &BTreeSet<String>,
+        out: &mut Vec<DeletionCandidate>,
+    ) {
+        let holds = self.present.get(account);
         for id in had {
             if holds.is_some_and(|ids| ids.contains(id)) {
                 continue; // still there — not deleted
             }
-            let Some(still_in) = holders.get(id) else {
+            let Some(still_in) = self.holders.get(id) else {
                 continue; // gone everywhere; nothing would resurrect it
             };
             out.push(DeletionCandidate {
+                kind,
                 id: id.clone(),
-                deleted_by: account.clone(),
+                deleted_by: account.to_string(),
                 still_in: still_in.clone(),
-                summary: summaries.get(id).cloned().unwrap_or_default(),
+                summary: self.summaries.get(id).cloned().unwrap_or_default(),
             });
         }
     }
-    out.sort_by(|a, b| a.id.cmp(&b.id).then(a.deleted_by.cmp(&b.deleted_by)));
-    out.dedup_by(|a, b| a.id == b.id);
-    out
 }
 
-/// Remove `doomed` task ids from every account's registry, so a deletion the
-/// user confirmed actually sticks instead of returning on the next switch.
-/// Returns the files to write; nothing is touched here.
+/// Registry rewrites and session-index removals a confirmed deletion implies.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct DeletionSweep {
+    pub rewrites: Vec<(PathBuf, Vec<u8>)>,
+    pub removals: Vec<PathBuf>,
+}
+
+impl DeletionSweep {
+    pub fn is_empty(&self) -> bool {
+        self.rewrites.is_empty() && self.removals.is_empty()
+    }
+}
+
+/// Remove `doomed` from every account, so a deletion the user confirmed sticks
+/// instead of returning on the next switch. Returns the work; nothing is
+/// touched here.
+///
+/// A chat is removed by dropping its *index* file. The transcript itself lives
+/// in the account-agnostic `~/.claude/projects/`, which this never touches — so
+/// the conversation stops following you between accounts without the text
+/// being destroyed.
 pub fn plan_deletion_sweep(
     sessions_root: &Path,
     doomed: &BTreeSet<String>,
-) -> Result<Vec<(PathBuf, Vec<u8>)>> {
-    let mut writes = Vec::new();
+) -> Result<DeletionSweep> {
+    let mut sweep = DeletionSweep::default();
     if doomed.is_empty() {
-        return Ok(writes);
+        return Ok(sweep);
     }
     for (_, path) in scheduled_registries(sessions_root) {
         let (tasks, skips) = load_scheduled(&path);
@@ -198,13 +326,60 @@ pub fn plan_deletion_sweep(
             continue; // this registry held none of them
         }
         let merged = serde_json::json!({ "scheduledTasks": kept, "recordedSkips": skips });
-        writes.push((path, serde_json::to_vec(&merged)?));
+        sweep.rewrites.push((path, serde_json::to_vec(&merged)?));
     }
-    Ok(writes)
+    for (_, dir) in account_dirs(sessions_root) {
+        for path in local_session_files(&dir) {
+            if file_name(&path).is_some_and(|name| doomed.contains(&name)) {
+                sweep.removals.push(path);
+            }
+        }
+    }
+    Ok(sweep)
+}
+
+/// `(account uuid, org dir)` for every account/org folder.
+fn account_dirs(sessions_root: &Path) -> Vec<(String, PathBuf)> {
+    account_org_dirs(sessions_root)
+        .into_iter()
+        .filter_map(|dir| {
+            let account = dir.parent()?.file_name()?.to_str()?.to_string();
+            Some((account, dir))
+        })
+        .collect()
+}
+
+fn file_name(path: &Path) -> Option<String> {
+    path.file_name()?.to_str().map(str::to_string)
+}
+
+/// One line naming a chat: its title and the project it ran in.
+fn describe_session(path: &Path) -> String {
+    let Ok(bytes) = std::fs::read(path) else {
+        return file_name(path).unwrap_or_default();
+    };
+    let Ok(value) = serde_json::from_slice::<Value>(&bytes) else {
+        return file_name(path).unwrap_or_default();
+    };
+    let title = value
+        .get("title")
+        .and_then(Value::as_str)
+        .filter(|title| !title.is_empty())
+        .unwrap_or("untitled");
+    match value.get("cwd").and_then(Value::as_str) {
+        Some(cwd) => {
+            let project = Path::new(cwd)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or(cwd);
+            format!("{title}  ({project})")
+        }
+        None => title.to_string(),
+    }
 }
 
 /// One line naming a task in the confirmation prompt. The id alone is opaque.
-fn describe(task: &Value) -> String {
+fn describe_task(task: &Value) -> String {
     let cron = task
         .get("cronExpression")
         .and_then(Value::as_str)
@@ -755,13 +930,31 @@ mod tests {
         assert_eq!(merge.updated, 0);
     }
 
-    fn synced(pairs: &[(&str, &[&str])]) -> SyncedTasks {
+    fn synced(pairs: &[(&str, &[&str])]) -> Synced {
         pairs
             .iter()
             .map(|(account, ids)| {
                 (
                     (*account).to_string(),
-                    ids.iter().map(|id| (*id).to_string()).collect(),
+                    SyncedAccount {
+                        routines: ids.iter().map(|id| (*id).to_string()).collect(),
+                        sessions: BTreeSet::new(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn synced_chats(pairs: &[(&str, &[&str])]) -> Synced {
+        pairs
+            .iter()
+            .map(|(account, names)| {
+                (
+                    (*account).to_string(),
+                    SyncedAccount {
+                        routines: BTreeSet::new(),
+                        sessions: names.iter().map(|name| (*name).to_string()).collect(),
+                    },
                 )
             })
             .collect()
@@ -807,7 +1000,7 @@ mod tests {
             r#"{"scheduledTasks":[]}"#,
         );
 
-        assert!(deletion_candidates(sessions, &SyncedTasks::new()).is_empty());
+        assert!(deletion_candidates(sessions, &Synced::new()).is_empty());
         // …and a brand-new account that simply never received it is not a
         // deletion either.
         assert!(deletion_candidates(sessions, &synced(&[("B", &[])])).is_empty());
@@ -851,7 +1044,7 @@ mod tests {
         );
 
         let doomed: BTreeSet<String> = ["t1".to_string()].into_iter().collect();
-        let writes = plan_deletion_sweep(sessions, &doomed).unwrap();
+        let writes = plan_deletion_sweep(sessions, &doomed).unwrap().rewrites;
 
         // C never held t1, so it is not rewritten at all.
         assert_eq!(writes.len(), 2, "{writes:?}");
@@ -873,6 +1066,104 @@ mod tests {
         let a: Value = serde_json::from_slice(a_bytes).unwrap();
         assert_eq!(a["recordedSkips"]["t1"], "keep me");
         assert_eq!(a["scheduledTasks"][0]["id"], "t2");
+    }
+
+    /// A chat B once had and no longer does, while A still holds it — the same
+    /// resurrection a routine suffers, in the other file.
+    #[test]
+    fn a_chat_dropped_by_one_account_is_reported_as_a_deletion() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/local_x.json"),
+            r#"{"lastActivityAt":1,"title":"Refactor the parser","cwd":"/w/ai-usagebar"}"#,
+        );
+        write(
+            &sessions.join("B/O2/local_y.json"),
+            r#"{"lastActivityAt":2}"#,
+        );
+
+        let found = deletion_candidates(sessions, &synced_chats(&[("B", &["local_x.json"])]));
+
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].kind, ConflictKind::Chat);
+        assert_eq!(found[0].id, "local_x.json");
+        assert_eq!(found[0].deleted_by, "B");
+        assert_eq!(found[0].summary, "Refactor the parser  (ai-usagebar)");
+    }
+
+    /// Both kinds surface from one scan, so the user answers a single question.
+    #[test]
+    fn routines_and_chats_are_reported_together() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","cronExpression":"0 5 * * *"}]}"#,
+        );
+        write(&sessions.join("A/O1/local_x.json"), r#"{"title":"Chat"}"#);
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[]}"#,
+        );
+
+        let mut had = synced(&[("B", &["t1"])]);
+        had.get_mut("B")
+            .unwrap()
+            .sessions
+            .insert("local_x.json".into());
+        let found = deletion_candidates(sessions, &had);
+
+        let kinds: Vec<&str> = found.iter().map(|c| c.kind.label()).collect();
+        assert_eq!(kinds, ["chat", "routine"], "{found:?}");
+    }
+
+    /// Confirming a chat removes its index from every account — and only the
+    /// index, since the transcript lives outside this tree entirely.
+    #[test]
+    fn a_confirmed_chat_deletion_removes_every_index_copy() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(&sessions.join("A/O1/local_x.json"), r#"{"title":"Doomed"}"#);
+        write(&sessions.join("B/O2/local_x.json"), r#"{"title":"Doomed"}"#);
+        write(
+            &sessions.join("B/O2/local_keep.json"),
+            r#"{"title":"Innocent"}"#,
+        );
+
+        let doomed: BTreeSet<String> = ["local_x.json".to_string()].into_iter().collect();
+        let sweep = plan_deletion_sweep(sessions, &doomed).unwrap();
+
+        assert!(sweep.rewrites.is_empty(), "no registry is involved");
+        assert_eq!(sweep.removals.len(), 2, "{:?}", sweep.removals);
+        assert!(sweep.removals.iter().all(|p| p.ends_with("local_x.json")));
+    }
+
+    /// The record written before chats were covered was a bare id list. It has
+    /// to keep working, or upgrading would silently forget every routine and
+    /// re-learn them as new.
+    #[test]
+    fn the_previous_record_format_is_still_understood() {
+        let old = br#"{"acct-a":["t1","t2"]}"#;
+        let parsed = parse_synced(old);
+        assert_eq!(
+            parsed["acct-a"].routines,
+            BTreeSet::from(["t1".to_string(), "t2".to_string()])
+        );
+        assert!(parsed["acct-a"].sessions.is_empty());
+
+        let current = br#"{"acct-a":{"routines":["t1"],"sessions":["local_x.json"]}}"#;
+        let parsed = parse_synced(current);
+        assert_eq!(
+            parsed["acct-a"].routines,
+            BTreeSet::from(["t1".to_string()])
+        );
+        assert_eq!(
+            parsed["acct-a"].sessions,
+            BTreeSet::from(["local_x.json".to_string()])
+        );
+
+        assert!(parse_synced(b"not json").is_empty());
     }
 
     #[test]
@@ -903,12 +1194,12 @@ mod tests {
             r#"{"scheduledTasks":[{"id":"t2"}]}"#,
         );
 
-        let ids = current_task_ids(sessions);
+        let ids = current_state(sessions);
         assert_eq!(
-            ids["A"],
-            ["t1".to_string(), "t2".to_string()].into_iter().collect()
+            ids["A"].routines,
+            BTreeSet::from(["t1".to_string(), "t2".to_string()])
         );
-        assert_eq!(ids["B"], ["t2".to_string()].into_iter().collect());
+        assert_eq!(ids["B"].routines, BTreeSet::from(["t2".to_string()]));
     }
 
     #[test]

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -7,7 +7,6 @@
 //! `--dry-run` be free (compute the plan, print it, stop) and lets the whole
 //! algorithm be unit-tested against a temporary directory on any platform.
 
-use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 
@@ -49,6 +48,12 @@ pub struct ScheduledMerge {
     /// Tasks the target already had, whose definition a more recently edited
     /// registry replaced — an edit made while signed into another account.
     pub updated: usize,
+    /// Same-id definitions changed independently, so the target's local copy
+    /// was preserved instead of guessing and discarding one side.
+    pub conflicts: usize,
+    /// Last successfully reconciled definition per task. Missing entries are
+    /// deliberate unresolved conflicts and must not be propagated later.
+    pub canonical_routines: BTreeMap<String, Value>,
 }
 
 /// Plan the session-index merge into `<sessions_root>/<account_uuid>/<org_uuid>`.
@@ -105,12 +110,40 @@ pub struct SyncedAccount {
     /// Session-index filenames (`local_<id>.json`), not transcripts.
     #[serde(default)]
     pub sessions: BTreeSet<String>,
+    /// Exact definitions observed the last time a switch completed. This is a
+    /// three-way merge baseline, not an authoritative copy.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub routine_definitions: BTreeMap<String, Value>,
+    /// Successfully reconciled definitions, duplicated in every account row
+    /// so the established flat claude-acc-compatible file shape stays intact.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub canonical_routines: BTreeMap<String, Value>,
 }
 
-/// What every account held after the last merge, keyed by account UUID.
-/// Union-merging is additive, so this record is the only way to tell "this
-/// account deleted it" from "this account never had it".
+/// What every account held after the last merge, keyed by account UUID. The
+/// flat shape is shared with claude-acc; new fields on each row are additive.
 pub type Synced = BTreeMap<String, SyncedAccount>;
+
+/// Accept a canonical definition only when every recorded account agrees. An
+/// older writer dropping the additive field therefore fails safe instead of
+/// making a stale definition authoritative.
+pub fn canonical_routines(synced: &Synced) -> BTreeMap<String, Value> {
+    let mut accounts = synced.values();
+    let Some(first) = accounts.next() else {
+        return BTreeMap::new();
+    };
+    let mut canonical = first.canonical_routines.clone();
+    for account in accounts {
+        canonical.retain(|id, task| account.canonical_routines.get(id) == Some(task));
+    }
+    canonical
+}
+
+pub fn set_canonical_routines(synced: &mut Synced, canonical: &BTreeMap<String, Value>) {
+    for account in synced.values_mut() {
+        account.canonical_routines.clone_from(canonical);
+    }
+}
 
 /// Kept for the record written before conversations were covered: a bare list
 /// was routines only. Reading it as such means an existing file keeps working
@@ -128,6 +161,8 @@ pub fn parse_synced(bytes: &[u8]) -> Synced {
                         SyncedAccount {
                             routines,
                             sessions: BTreeSet::new(),
+                            routine_definitions: BTreeMap::new(),
+                            canonical_routines: BTreeMap::new(),
                         },
                     )
                 })
@@ -138,10 +173,39 @@ pub fn parse_synced(bytes: &[u8]) -> Synced {
 
 /// Which of the two things a conflict is about. They live in different files
 /// and are swept differently, but the user answers one question about both.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ConflictKind {
     Routine,
     Chat,
+}
+
+/// Stable, type-scoped identity for a destructive conflict decision.
+///
+/// Routine ids and chat-index filenames are both arbitrary strings and can
+/// collide. Keeping the kind beside the id all the way to the sweep prevents a
+/// verdict about one namespace from authorizing deletion in the other.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DeletionKey {
+    pub kind: ConflictKind,
+    pub id: String,
+    pub deleted_by: String,
+    pub still_in: Vec<String>,
+}
+
+impl DeletionKey {
+    pub fn external(&self) -> String {
+        // JSON is only an opaque transport token here. Length-aware encoding
+        // avoids delimiter collisions in arbitrary ids, and including the
+        // observed account topology makes stale dialogs fail closed.
+        serde_json::to_string(&(
+            1,
+            self.kind.label(),
+            &self.id,
+            &self.deleted_by,
+            &self.still_in,
+        ))
+        .expect("a tuple of strings is always JSON-serializable")
+    }
 }
 
 impl ConflictKind {
@@ -169,15 +233,32 @@ pub struct DeletionCandidate {
     pub summary: String,
 }
 
+impl DeletionCandidate {
+    pub fn key(&self) -> DeletionKey {
+        DeletionKey {
+            kind: self.kind,
+            id: self.id.clone(),
+            deleted_by: self.deleted_by.clone(),
+            still_in: self.still_in.clone(),
+        }
+    }
+
+    pub fn external_key(&self) -> String {
+        self.key().external()
+    }
+}
+
 /// Every account's current contents, for refreshing [`Synced`] after a merge.
 pub fn current_state(sessions_root: &Path) -> Synced {
     let mut out = Synced::new();
     for (account, path) in scheduled_registries(sessions_root) {
         let (tasks, _) = load_scheduled(&path);
-        out.entry(account)
-            .or_default()
-            .routines
-            .extend(tasks.iter().filter_map(task_id));
+        let account = out.entry(account).or_default();
+        for task in tasks {
+            let Some(id) = task_id(&task) else { continue };
+            account.routines.insert(id.clone());
+            account.routine_definitions.insert(id, task);
+        }
     }
     for (account, dir) in account_dirs(sessions_root) {
         out.entry(account).or_default().sessions.extend(
@@ -219,7 +300,7 @@ pub fn deletion_candidates(sessions_root: &Path, synced: &Synced) -> Vec<Deletio
         }
     }
 
-    for (account, had) in synced {
+    for (account, had) in synced.iter() {
         routines.collect(ConflictKind::Routine, account, &had.routines, &mut out);
         chats.collect(ConflictKind::Chat, account, &had.sessions, &mut out);
     }
@@ -309,18 +390,28 @@ impl DeletionSweep {
 /// being destroyed.
 pub fn plan_deletion_sweep(
     sessions_root: &Path,
-    doomed: &BTreeSet<String>,
+    doomed: &BTreeSet<DeletionKey>,
 ) -> Result<DeletionSweep> {
     let mut sweep = DeletionSweep::default();
     if doomed.is_empty() {
         return Ok(sweep);
     }
+    let routine_ids: BTreeSet<&str> = doomed
+        .iter()
+        .filter(|key| key.kind == ConflictKind::Routine)
+        .map(|key| key.id.as_str())
+        .collect();
+    let chat_names: BTreeSet<&str> = doomed
+        .iter()
+        .filter(|key| key.kind == ConflictKind::Chat)
+        .map(|key| key.id.as_str())
+        .collect();
     for (_, path) in scheduled_registries(sessions_root) {
         let (tasks, skips) = load_scheduled(&path);
         let before = tasks.len();
         let kept: Vec<Value> = tasks
             .into_iter()
-            .filter(|task| task_id(task).is_none_or(|id| !doomed.contains(&id)))
+            .filter(|task| task_id(task).is_none_or(|id| !routine_ids.contains(id.as_str())))
             .collect();
         if kept.len() == before {
             continue; // this registry held none of them
@@ -330,7 +421,7 @@ pub fn plan_deletion_sweep(
     }
     for (_, dir) in account_dirs(sessions_root) {
         for path in local_session_files(&dir) {
-            if file_name(&path).is_some_and(|name| doomed.contains(&name)) {
+            if file_name(&path).is_some_and(|name| chat_names.contains(name.as_str())) {
                 sweep.removals.push(path);
             }
         }
@@ -412,70 +503,90 @@ fn scheduled_registries(sessions_root: &Path) -> Vec<(String, PathBuf)> {
         .collect()
 }
 
-/// Plan the routine/schedule merge: a union by task `id`, with the newer
-/// `createdAt` winning a conflict. The task *scripts* these point at live in
+#[derive(Debug)]
+struct RoutineCandidate {
+    account: String,
+    task: Value,
+    target: bool,
+}
+
+/// Whether `task` changed since that account was last observed. `None` means
+/// there is no trustworthy baseline (first run or a pre-definition record).
+fn task_changed(synced: &Synced, account: &str, id: &str, task: &Value) -> Option<bool> {
+    let state = synced.get(account)?;
+    match state.routine_definitions.get(id) {
+        Some(previous) => Some(previous != task),
+        None if state.routines.contains(id) => None,
+        None => Some(true),
+    }
+}
+
+fn unique_values<'a>(values: impl Iterator<Item = &'a Value>) -> Vec<Value> {
+    let mut unique = Vec::new();
+    for value in values {
+        if !unique.contains(value) {
+            unique.push(value.clone());
+        }
+    }
+    unique
+}
+
+/// Plan the routine/schedule merge as a three-way reconciliation by task `id`.
+/// The task *scripts* these point at live in
 /// `~/.claude/scheduled-tasks/<name>/` and are global already, so only the
 /// account-scoped registry needs merging.
+///
+/// The sync record holds both the last observation per account and the last
+/// successfully reconciled definition. An edit in one account therefore
+/// propagates to stale copies without treating an unrelated registry write as
+/// an edit to every task. Concurrent edits to the same task are kept local and
+/// reported as a conflict; the user can resolve one by editing the desired
+/// copy, which becomes the sole change against the next baseline.
 pub fn plan_scheduled_merge(
     sessions_root: &Path,
     account_uuid: &str,
     org_uuid: &str,
+    synced: &Synced,
 ) -> Result<ScheduledMerge> {
     let target = sessions_root
         .join(account_uuid)
         .join(org_uuid)
         .join(SCHEDULED_TASKS);
     let (target_tasks, mut skips) = load_scheduled(&target);
-    let target_mtime = modified_at(&target);
+    let prior_canonical = canonical_routines(synced);
 
-    // A Vec rather than a map: registries hold a handful of entries, and the
-    // target's own tasks must keep their existing order. The third element is
-    // how fresh the registry each task came from is — see the comparison below.
-    let mut tasks: Vec<(String, Value, i64)> = target_tasks
-        .into_iter()
-        .filter_map(|task| task_id(&task).map(|id| (id, task, target_mtime)))
-        .collect();
-    let mut added = 0usize;
-    let mut updated = 0usize;
+    let mut candidates: BTreeMap<String, Vec<RoutineCandidate>> = BTreeMap::new();
+    let mut order = Vec::new();
+    let mut seen = BTreeSet::new();
+    for task in target_tasks {
+        let Some(id) = task_id(&task) else { continue };
+        if seen.insert(id.clone()) {
+            order.push(id.clone());
+        }
+        candidates.entry(id).or_default().push(RoutineCandidate {
+            account: account_uuid.to_string(),
+            task,
+            target: true,
+        });
+    }
 
-    for source in scheduled_task_files(sessions_root) {
+    for (account, source) in scheduled_registries(sessions_root) {
         if source == target {
             continue;
         }
-        let source_mtime = modified_at(&source);
         let (source_tasks, source_skips) = load_scheduled(&source);
         for task in source_tasks {
             let Some(id) = task_id(&task) else {
                 continue;
             };
-            match tasks.iter_mut().find(|(existing, ..)| *existing == id) {
-                Some((_, existing, existing_mtime)) => {
-                    // A scheduled task has no `updatedAt`: editing its cron,
-                    // model, or `enabled` flag leaves `createdAt` untouched.
-                    // Comparing `createdAt` alone therefore drops *every* edit
-                    // made after the task first synced to another account —
-                    // both copies tie, and a tie kept the incumbent. The
-                    // registry file's mtime is the only "who wrote last" signal
-                    // the format offers, and the account just worked in owns
-                    // the freshest one, so it breaks the tie.
-                    let fresher = match created_at(&task).cmp(&created_at(existing)) {
-                        Ordering::Greater => true,
-                        Ordering::Equal => source_mtime > *existing_mtime,
-                        Ordering::Less => false,
-                    };
-                    if fresher {
-                        if *existing != task {
-                            updated += 1;
-                        }
-                        *existing = task;
-                        *existing_mtime = source_mtime;
-                    }
-                }
-                None => {
-                    tasks.push((id, task, source_mtime));
-                    added += 1;
-                }
+            if seen.insert(id.clone()) {
+                order.push(id.clone());
             }
+            candidates.entry(id).or_default().push(RoutineCandidate {
+                account: account.clone(),
+                task,
+                target: false,
+            });
         }
         for (key, value) in source_skips {
             // First recorded skip wins; a later account's copy never overrides.
@@ -483,8 +594,70 @@ pub fn plan_scheduled_merge(
         }
     }
 
+    let mut tasks = Vec::new();
+    let mut canonical_routines = BTreeMap::new();
+    let mut added = 0usize;
+    let mut updated = 0usize;
+    let mut conflicts = 0usize;
+
+    for id in order {
+        let choices = &candidates[&id];
+        let target_task = choices
+            .iter()
+            .find(|candidate| candidate.target)
+            .map(|candidate| &candidate.task);
+        let changed = unique_values(choices.iter().filter_map(|candidate| {
+            task_changed(synced, &candidate.account, &id, &candidate.task)
+                .is_some_and(|changed| changed)
+                .then_some(&candidate.task)
+        }));
+
+        let (selected, resolved) = if let Some(canonical) = prior_canonical.get(&id) {
+            let unknown_divergence = choices.iter().any(|candidate| {
+                task_changed(synced, &candidate.account, &id, &candidate.task).is_none()
+                    && candidate.task != *canonical
+            });
+            if changed.len() == 1 && !unknown_divergence {
+                (changed[0].clone(), true)
+            } else if changed.is_empty() && !unknown_divergence {
+                (canonical.clone(), true)
+            } else {
+                (target_task.unwrap_or(&choices[0].task).clone(), false)
+            }
+        } else if changed.len() == 1 {
+            (changed[0].clone(), true)
+        } else if changed.len() > 1 {
+            (target_task.unwrap_or(&choices[0].task).clone(), false)
+        } else {
+            let max_created = choices
+                .iter()
+                .map(|candidate| created_at(&candidate.task))
+                .max();
+            let newest = unique_values(choices.iter().filter_map(|candidate| {
+                (Some(created_at(&candidate.task)) == max_created).then_some(&candidate.task)
+            }));
+            if newest.len() == 1 {
+                (newest[0].clone(), true)
+            } else {
+                (target_task.unwrap_or(&choices[0].task).clone(), false)
+            }
+        };
+
+        match target_task {
+            None => added += 1,
+            Some(existing) if *existing != selected => updated += 1,
+            Some(_) => {}
+        }
+        if resolved {
+            canonical_routines.insert(id, selected.clone());
+        } else {
+            conflicts += 1;
+        }
+        tasks.push(selected);
+    }
+
     let merged = serde_json::json!({
-        "scheduledTasks": tasks.into_iter().map(|(_, task, _)| task).collect::<Vec<_>>(),
+        "scheduledTasks": tasks,
         "recordedSkips": skips,
     });
     Ok(ScheduledMerge {
@@ -492,6 +665,8 @@ pub fn plan_scheduled_merge(
         bytes: serde_json::to_vec(&merged)?,
         added,
         updated,
+        conflicts,
+        canonical_routines,
     })
 }
 
@@ -643,14 +818,6 @@ fn local_session_files(dir: &Path) -> Vec<PathBuf> {
     out
 }
 
-fn scheduled_task_files(sessions_root: &Path) -> Vec<PathBuf> {
-    account_org_dirs(sessions_root)
-        .into_iter()
-        .map(|dir| dir.join(SCHEDULED_TASKS))
-        .filter(|path| path.is_file())
-        .collect()
-}
-
 fn load_scheduled(path: &Path) -> (Vec<Value>, Map<String, Value>) {
     let Ok(bytes) = std::fs::read(path) else {
         return (Vec::new(), Map::new());
@@ -680,19 +847,6 @@ fn task_id(task: &Value) -> Option<String> {
 
 fn created_at(task: &Value) -> i64 {
     task.get("createdAt").map_or(0, json_i64)
-}
-
-/// When a registry file was last written, in epoch milliseconds. Absent or
-/// unreadable counts as the beginning of time, so a file we cannot stat never
-/// wins a tie against one we can.
-fn modified_at(path: &Path) -> i64 {
-    std::fs::metadata(path)
-        .and_then(|meta| meta.modified())
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |since| {
-            i64::try_from(since.as_millis()).unwrap_or(i64::MAX)
-        })
 }
 
 fn last_activity(path: &Path) -> i64 {
@@ -807,7 +961,7 @@ mod tests {
                 "recordedSkips":{"t1":"other","t2":"other"}}"#,
         );
 
-        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &Synced::default()).unwrap();
         assert_eq!(merge.added, 1);
         let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
         let tasks = value["scheduledTasks"].as_array().unwrap();
@@ -819,15 +973,28 @@ mod tests {
         assert_eq!(value["recordedSkips"]["t2"], "other");
     }
 
-    /// Set a file's mtime so a test can say which registry was written last.
-    fn touch(path: &Path, millis_since_epoch: u64) {
-        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(millis_since_epoch);
-        std::fs::OpenOptions::new()
-            .write(true)
-            .open(path)
-            .unwrap()
-            .set_times(std::fs::FileTimes::new().set_modified(time))
-            .unwrap();
+    fn sync_baseline(sessions: &Path) -> Synced {
+        let mut synced = current_state(sessions);
+        let mut canonical = BTreeMap::new();
+        let mut conflicts = BTreeSet::new();
+        for account in synced.values() {
+            for (id, task) in &account.routine_definitions {
+                match canonical.get(id) {
+                    Some(existing) if existing != task => {
+                        conflicts.insert(id.clone());
+                    }
+                    Some(_) => {}
+                    None => {
+                        canonical.insert(id.clone(), task.clone());
+                    }
+                }
+            }
+        }
+        for id in conflicts {
+            canonical.remove(&id);
+        }
+        set_canonical_routines(&mut synced, &canonical);
+        synced
     }
 
     /// A schedule edited while signed into another account: same `id`, same
@@ -840,18 +1007,16 @@ mod tests {
         let sessions = root.path();
         let target = sessions.join("A/O1/scheduled-tasks.json");
         let source = sessions.join("B/O2/scheduled-tasks.json");
-        write(
-            &target,
-            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *","enabled":true}]}"#,
-        );
+        let old = r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *","enabled":true}]}"#;
+        write(&target, old);
+        write(&source, old);
+        let synced = sync_baseline(sessions);
         write(
             &source,
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"30 9 * * *","enabled":false}]}"#,
         );
-        touch(&target, 1_000);
-        touch(&source, 2_000); // edited more recently
 
-        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &synced).unwrap();
 
         assert_eq!(merge.added, 0);
         assert_eq!(merge.updated, 1, "the edit must be carried across");
@@ -860,34 +1025,111 @@ mod tests {
         assert_eq!(value["scheduledTasks"][0]["enabled"], false);
     }
 
-    /// The mirror image: the target holds the fresher registry, so an older
-    /// copy sitting in another account must not overwrite it.
+    /// The mirror image: only the target changed against the shared baseline,
+    /// so the source's stale copy must not overwrite it.
     #[test]
     fn scheduled_merge_keeps_the_target_when_its_registry_is_fresher() {
         let root = tempfile::TempDir::new().unwrap();
         let sessions = root.path();
         let target = sessions.join("A/O1/scheduled-tasks.json");
         let source = sessions.join("B/O2/scheduled-tasks.json");
+        let old =
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *"}]}"#;
+        write(&target, old);
+        write(&source, old);
+        let synced = sync_baseline(sessions);
         write(
             &target,
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"30 9 * * *"}]}"#,
         );
-        write(
-            &source,
-            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *"}]}"#,
-        );
-        touch(&target, 2_000); // target edited more recently
-        touch(&source, 1_000);
 
-        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &synced).unwrap();
 
         assert_eq!(merge.updated, 0);
         let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
         assert_eq!(value["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
     }
 
-    /// mtime only breaks ties. A genuinely newer `createdAt` — the task was
-    /// deleted and recreated — still wins even from a staler file.
+    /// Editing different tasks in different accounts is the case a file-level
+    /// mtime cannot represent: whichever file wins overwrites one valid edit.
+    #[test]
+    fn independent_task_edits_are_both_reconciled() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let a = sessions.join("A/O1/scheduled-tasks.json");
+        let b = sessions.join("B/O2/scheduled-tasks.json");
+        let old = r#"{"scheduledTasks":[
+            {"id":"t1","createdAt":100,"name":"old-t1"},
+            {"id":"t2","createdAt":100,"name":"old-t2"}
+        ]}"#;
+        write(&a, old);
+        write(&b, old);
+        let synced = sync_baseline(sessions);
+        write(
+            &a,
+            r#"{"scheduledTasks":[
+                {"id":"t1","createdAt":100,"name":"A-edited"},
+                {"id":"t2","createdAt":100,"name":"old-t2"}
+            ]}"#,
+        );
+        write(
+            &b,
+            r#"{"scheduledTasks":[
+                {"id":"t1","createdAt":100,"name":"old-t1"},
+                {"id":"t2","createdAt":100,"name":"B-edited"}
+            ]}"#,
+        );
+
+        let merge = plan_scheduled_merge(sessions, "B", "O2", &synced).unwrap();
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+        let tasks = value["scheduledTasks"].as_array().unwrap();
+
+        assert_eq!(tasks[0]["name"], "A-edited");
+        assert_eq!(tasks[1]["name"], "B-edited");
+        assert_eq!(merge.updated, 1);
+        assert_eq!(merge.conflicts, 0);
+
+        // After B receives A's edit, the canonical t2 edit must still flow
+        // back to A on the next switch; recording actual observations must not
+        // accidentally declare A's stale copy authoritative.
+        write(&b, std::str::from_utf8(&merge.bytes).unwrap());
+        let mut next = current_state(sessions);
+        set_canonical_routines(&mut next, &merge.canonical_routines);
+        let into_a = plan_scheduled_merge(sessions, "A", "O1", &next).unwrap();
+        let value: Value = serde_json::from_slice(&into_a.bytes).unwrap();
+        let tasks = value["scheduledTasks"].as_array().unwrap();
+        assert_eq!(tasks[0]["name"], "A-edited");
+        assert_eq!(tasks[1]["name"], "B-edited");
+        assert_eq!(into_a.updated, 1);
+    }
+
+    /// Without a baseline, equal-createdAt divergent definitions are
+    /// ambiguous. Preserve the target and leave the canonical entry absent so
+    /// a later switch cannot silently overwrite either side.
+    #[test]
+    fn an_unresolved_same_task_edit_is_kept_local() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"name":"A"}]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"name":"B"}]}"#,
+        );
+
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &Synced::default()).unwrap();
+        let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
+
+        assert_eq!(value["scheduledTasks"][0]["name"], "A");
+        assert_eq!(merge.updated, 0);
+        assert_eq!(merge.conflicts, 1);
+        assert!(!merge.canonical_routines.contains_key("t1"));
+    }
+
+    /// A genuinely newer `createdAt` means the task was deleted and recreated,
+    /// so it still wins before a three-way baseline exists.
     #[test]
     fn a_newer_created_at_wins_regardless_of_file_mtime() {
         let root = tempfile::TempDir::new().unwrap();
@@ -902,16 +1144,13 @@ mod tests {
             &source,
             r#"{"scheduledTasks":[{"id":"t1","createdAt":500,"name":"recreated"}]}"#,
         );
-        touch(&target, 9_000); // target file is much fresher…
-        touch(&source, 1_000); // …but the task itself is older
-
-        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &Synced::default()).unwrap();
         let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
         assert_eq!(value["scheduledTasks"][0]["name"], "recreated");
     }
 
-    /// An identical copy in a fresher file is not an edit; reporting it as one
-    /// would make every switch claim to have changed something.
+    /// An identical copy is not an edit; reporting it as one would make every
+    /// switch claim to have changed something.
     #[test]
     fn an_identical_copy_is_not_counted_as_an_edit() {
         let root = tempfile::TempDir::new().unwrap();
@@ -922,10 +1161,7 @@ mod tests {
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *"}]}"#;
         write(&target, same);
         write(&source, same);
-        touch(&target, 1_000);
-        touch(&source, 2_000);
-
-        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &Synced::default()).unwrap();
         assert_eq!(merge.added, 0);
         assert_eq!(merge.updated, 0);
     }
@@ -939,6 +1175,8 @@ mod tests {
                     SyncedAccount {
                         routines: ids.iter().map(|id| (*id).to_string()).collect(),
                         sessions: BTreeSet::new(),
+                        routine_definitions: BTreeMap::new(),
+                        canonical_routines: BTreeMap::new(),
                     },
                 )
             })
@@ -954,6 +1192,8 @@ mod tests {
                     SyncedAccount {
                         routines: BTreeSet::new(),
                         sessions: names.iter().map(|name| (*name).to_string()).collect(),
+                        routine_definitions: BTreeMap::new(),
+                        canonical_routines: BTreeMap::new(),
                     },
                 )
             })
@@ -1043,7 +1283,12 @@ mod tests {
             r#"{"scheduledTasks":[{"id":"t2","createdAt":2}]}"#,
         );
 
-        let doomed: BTreeSet<String> = ["t1".to_string()].into_iter().collect();
+        let doomed = BTreeSet::from([DeletionKey {
+            kind: ConflictKind::Routine,
+            id: "t1".to_string(),
+            deleted_by: "A".to_string(),
+            still_in: vec!["B".to_string()],
+        }]);
         let writes = plan_deletion_sweep(sessions, &doomed).unwrap().rewrites;
 
         // C never held t1, so it is not rewritten at all.
@@ -1131,12 +1376,60 @@ mod tests {
             r#"{"title":"Innocent"}"#,
         );
 
-        let doomed: BTreeSet<String> = ["local_x.json".to_string()].into_iter().collect();
+        let doomed = BTreeSet::from([DeletionKey {
+            kind: ConflictKind::Chat,
+            id: "local_x.json".to_string(),
+            deleted_by: "A".to_string(),
+            still_in: vec!["B".to_string()],
+        }]);
         let sweep = plan_deletion_sweep(sessions, &doomed).unwrap();
 
         assert!(sweep.rewrites.is_empty(), "no registry is involved");
         assert_eq!(sweep.removals.len(), 2, "{:?}", sweep.removals);
         assert!(sweep.removals.iter().all(|p| p.ends_with("local_x.json")));
+    }
+
+    /// Routine ids and chat filenames share no namespace. A verdict for one
+    /// must never authorize deleting the other even when the strings collide.
+    #[test]
+    fn a_deletion_verdict_is_scoped_to_its_conflict_kind() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"local_x.json","createdAt":1}]}"#,
+        );
+        write(
+            &sessions.join("A/O1/local_x.json"),
+            r#"{"title":"Keep chat"}"#,
+        );
+
+        let doomed = BTreeSet::from([DeletionKey {
+            kind: ConflictKind::Routine,
+            id: "local_x.json".to_string(),
+            deleted_by: "A".to_string(),
+            still_in: vec!["B".to_string()],
+        }]);
+        let sweep = plan_deletion_sweep(sessions, &doomed).unwrap();
+
+        assert_eq!(sweep.rewrites.len(), 1, "the routine is removed");
+        assert!(sweep.removals.is_empty(), "the colliding chat must survive");
+    }
+
+    #[test]
+    fn a_conflict_key_is_bound_to_the_observed_deletion() {
+        let original = DeletionCandidate {
+            kind: ConflictKind::Routine,
+            id: "t1".to_string(),
+            deleted_by: "A".to_string(),
+            still_in: vec!["B".to_string()],
+            summary: "daily".to_string(),
+        };
+        let mut later = original.clone();
+        later.deleted_by = "B".to_string();
+        later.still_in = vec!["A".to_string()];
+
+        assert_ne!(original.external_key(), later.external_key());
     }
 
     /// The record written before chats were covered was a bare id list. It has
@@ -1162,6 +1455,15 @@ mod tests {
             parsed["acct-a"].sessions,
             BTreeSet::from(["local_x.json".to_string()])
         );
+
+        let v2 = br#"{
+            "acct-a":{"routines":["t1"],"sessions":[],
+                "routine_definitions":{"t1":{"id":"t1","enabled":true}},
+                "canonical_routines":{"t1":{"id":"t1","enabled":true}}}
+        }"#;
+        let parsed = parse_synced(v2);
+        assert_eq!(parsed["acct-a"].routine_definitions["t1"]["enabled"], true);
+        assert_eq!(canonical_routines(&parsed)["t1"]["enabled"], true);
 
         assert!(parse_synced(b"not json").is_empty());
     }
@@ -1215,7 +1517,7 @@ mod tests {
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"name":"other"}]}"#,
         );
 
-        let merge = plan_scheduled_merge(sessions, "A", "O1").unwrap();
+        let merge = plan_scheduled_merge(sessions, "A", "O1", &Synced::default()).unwrap();
         assert_eq!(merge.added, 0);
         let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
         assert_eq!(value["scheduledTasks"][0]["name"], "target");

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -294,9 +294,12 @@ pub struct SwitchPlan {
     /// resurrect them. The caller decides — a terminal prompt or the menu bar —
     /// and records the verdict in `confirmed_deletions`.
     pub deletions: Vec<merge::DeletionCandidate>,
-    /// Task ids the user confirmed should go everywhere. Empty means keep them
-    /// all, which is also what a non-interactive switch must do.
-    pub confirmed_deletions: BTreeSet<String>,
+    /// Type-scoped items the user confirmed should go everywhere. Empty means
+    /// keep them all, which is also what a non-interactive switch must do.
+    pub confirmed_deletions: BTreeSet<merge::DeletionKey>,
+    /// Baseline used to plan this switch. Apply combines it with the actual
+    /// post-write state so unresolved definitions remain unresolved safely.
+    pub prior_synced: merge::Synced,
 }
 
 /// Decide the whole switch without performing any of it.
@@ -320,6 +323,7 @@ pub fn plan_switch(paths: &Paths, label: &str, opts: SwitchOpts) -> Result<Switc
         })?;
 
     let sessions_root = paths.sessions_root();
+    let synced = load_synced(&paths.synced_path());
     let (sessions, scheduled) = match &target.org_uuid {
         Some(org) => (
             merge::plan_session_merge(&sessions_root, &target.account_uuid, org),
@@ -327,11 +331,12 @@ pub fn plan_switch(paths: &Paths, label: &str, opts: SwitchOpts) -> Result<Switc
                 &sessions_root,
                 &target.account_uuid,
                 org,
+                &synced,
             )?),
         ),
         None => (SessionMerge::default(), None),
     };
-    let deletions = merge::deletion_candidates(&sessions_root, &load_synced(&paths.synced_path()));
+    let deletions = merge::deletion_candidates(&sessions_root, &synced);
 
     let outgoing = active_account_uuid(&paths.config_json())
         .and_then(|uuid| label_for_uuid(&profiles, &uuid).map(str::to_string));
@@ -380,6 +385,7 @@ pub fn plan_switch(paths: &Paths, label: &str, opts: SwitchOpts) -> Result<Switc
         opts,
         deletions,
         confirmed_deletions: BTreeSet::new(),
+        prior_synced: synced,
     })
 }
 
@@ -393,7 +399,18 @@ pub fn apply_switch(paths: &Paths, plan: &SwitchPlan, app: &dyn AppControl) -> R
     let members: Vec<&str> = plan.archive_members.iter().map(String::as_str).collect();
 
     // Stop before archiving so SQLite/LevelDB and config.json are quiescent.
-    app.quit()?;
+    if let Err(error) = app.quit() {
+        // A fail-closed liveness probe can report an error after the graceful
+        // quit request already stopped Claude. Relaunch is harmless if it was
+        // still running and preserves the invariant that an attempted switch
+        // never leaves the app closed solely because verification failed.
+        return match app.relaunch() {
+            Ok(()) => Err(error),
+            Err(relaunch) => Err(AppError::Other(format!(
+                "{error}; Claude Desktop also could not be relaunched: {relaunch}"
+            ))),
+        };
+    }
     let mut archived = false;
     let mut result = (|| {
         if !members.is_empty() {
@@ -473,10 +490,24 @@ fn apply_switch_while_stopped(
     }
     // Record what every account holds now, so the next switch can tell an
     // intentional deletion from a task that account simply never received.
-    if let Err(error) = save_synced(
-        &paths.synced_path(),
-        &merge::current_state(&paths.sessions_root()),
-    ) {
+    let mut synced = merge::current_state(&paths.sessions_root());
+    let mut canonical = plan
+        .scheduled
+        .as_ref()
+        .map(|scheduled| scheduled.canonical_routines.clone())
+        .unwrap_or_else(|| merge::canonical_routines(&plan.prior_synced));
+    for key in &plan.confirmed_deletions {
+        if key.kind == merge::ConflictKind::Routine {
+            canonical.remove(&key.id);
+        }
+    }
+    let present: BTreeSet<String> = synced
+        .values()
+        .flat_map(|account| account.routines.iter().cloned())
+        .collect();
+    canonical.retain(|id, _| present.contains(id));
+    merge::set_canonical_routines(&mut synced, &canonical);
+    if let Err(error) = save_synced(&paths.synced_path(), &synced) {
         notes.push(format!("could not record the schedule sync: {error}"));
     }
 
@@ -530,7 +561,12 @@ fn merge_history_into(
             Err(error) => notes.push(format!("could not seed {}: {error}", destination.display())),
         }
     }
-    let routines = match merge::plan_scheduled_merge(&sessions_root, account_uuid, org_uuid) {
+    let routines = match merge::plan_scheduled_merge(
+        &sessions_root,
+        account_uuid,
+        org_uuid,
+        &load_synced(&paths.synced_path()),
+    ) {
         Ok(scheduled) => match crate::cache::atomic_write(&scheduled.target, &scheduled.bytes) {
             Ok(()) => scheduled.added + scheduled.updated,
             Err(error) => {
@@ -903,10 +939,36 @@ fn timestamp() -> String {
 mod tests {
     use super::*;
     use app::Recorder;
+    use std::cell::RefCell;
 
     struct Fixture {
         _root: tempfile::TempDir,
         paths: Paths,
+    }
+
+    #[derive(Default)]
+    struct QuitFailure {
+        steps: RefCell<Vec<&'static str>>,
+    }
+
+    impl AppControl for QuitFailure {
+        fn quit(&self) -> Result<()> {
+            self.steps.borrow_mut().push("quit");
+            Err(AppError::Other("liveness probe failed".into()))
+        }
+
+        fn relaunch(&self) -> Result<()> {
+            self.steps.borrow_mut().push("relaunch");
+            Ok(())
+        }
+
+        fn archive(&self, _archive: &Path, _root: &Path, _members: &[&str]) -> Result<()> {
+            panic!("archive must not run after an unconfirmed quit")
+        }
+
+        fn restore(&self, _archive: &Path, _root: &Path, _members: &[&str]) -> Result<()> {
+            panic!("restore must not run before a switch starts")
+        }
     }
 
     fn write(path: &Path, contents: &str) {
@@ -1116,6 +1178,20 @@ mod tests {
         assert_eq!(steps[2], "relaunch");
     }
 
+    #[test]
+    fn a_failed_liveness_probe_relaunches_without_touching_account_data() {
+        let fixture = fixture();
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        let before = std::fs::read(fixture.paths.config_json()).unwrap();
+        let app = QuitFailure::default();
+
+        let error = apply_switch(&fixture.paths, &plan, &app).unwrap_err();
+
+        assert!(error.to_string().contains("liveness probe failed"));
+        assert_eq!(*app.steps.borrow(), ["quit", "relaunch"]);
+        assert_eq!(std::fs::read(fixture.paths.config_json()).unwrap(), before);
+    }
+
     /// The wiring, not the pieces: a confirmed deletion must actually reach
     /// every registry through `apply_switch`, and the sync record must be
     /// written so the next switch can tell deletions from new tasks. Testing
@@ -1135,7 +1211,14 @@ mod tests {
         );
 
         let mut plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
-        plan.confirmed_deletions = ["t1".to_string()].into_iter().collect();
+        plan.confirmed_deletions = [merge::DeletionKey {
+            kind: merge::ConflictKind::Routine,
+            id: "t1".to_string(),
+            deleted_by: "uuid-here".to_string(),
+            still_in: vec!["uuid-there".to_string()],
+        }]
+        .into_iter()
+        .collect();
         apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
 
         for registry in [

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -188,16 +188,15 @@ pub fn load_profiles(profiles_dir: &Path) -> Vec<ProfileMeta> {
 /// Read the schedule sync record. Absent or malformed reads as empty, which
 /// makes every task look new — so a first run, or a corrupted record, reports
 /// no deletions rather than inventing them.
-pub fn load_synced(path: &Path) -> merge::SyncedTasks {
+pub fn load_synced(path: &Path) -> merge::Synced {
     std::fs::read(path)
-        .ok()
-        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .map(|bytes| merge::parse_synced(&bytes))
         .unwrap_or_default()
 }
 
 /// Record what every account holds now, so the next switch can tell a deletion
 /// from a task that account never had.
-pub fn save_synced(path: &Path, synced: &merge::SyncedTasks) -> Result<()> {
+pub fn save_synced(path: &Path, synced: &merge::Synced) -> Result<()> {
     crate::cache::atomic_write(path, &serde_json::to_vec(synced)?)
 }
 
@@ -451,13 +450,22 @@ fn apply_switch_while_stopped(
     // prompt returns forever. Runs after the merge so it also strips anything
     // the merge just re-added.
     match merge::plan_deletion_sweep(&paths.sessions_root(), &plan.confirmed_deletions) {
-        Ok(writes) => {
-            for (path, bytes) in writes {
+        Ok(sweep) => {
+            for (path, bytes) in sweep.rewrites {
                 if let Err(error) = crate::cache::atomic_write(&path, &bytes) {
                     notes.push(format!(
                         "could not apply deletion to {}: {error}",
                         path.display()
                     ));
+                }
+            }
+            // Only the chat's *index* goes. Its transcript lives in the
+            // account-agnostic `~/.claude/projects/` and is never touched, so a
+            // confirmed chat stops following you between accounts without the
+            // conversation itself being destroyed.
+            for path in sweep.removals {
+                if let Err(error) = std::fs::remove_file(&path) {
+                    notes.push(format!("could not remove {}: {error}", path.display()));
                 }
             }
         }
@@ -467,7 +475,7 @@ fn apply_switch_while_stopped(
     // intentional deletion from a task that account simply never received.
     if let Err(error) = save_synced(
         &paths.synced_path(),
-        &merge::current_task_ids(&paths.sessions_root()),
+        &merge::current_state(&paths.sessions_root()),
     ) {
         notes.push(format!("could not record the schedule sync: {error}"));
     }
@@ -1160,7 +1168,9 @@ mod tests {
         let recorded = load_synced(&fixture.paths.synced_path());
         assert!(!recorded.is_empty(), "the sync record was never written");
         assert!(
-            recorded.values().all(|ids| !ids.contains("t1")),
+            recorded
+                .values()
+                .all(|state| !state.routines.contains("t1")),
             "{recorded:?} still lists the deleted task"
         );
     }

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -1108,6 +1108,85 @@ mod tests {
         assert_eq!(steps[2], "relaunch");
     }
 
+    /// The wiring, not the pieces: a confirmed deletion must actually reach
+    /// every registry through `apply_switch`, and the sync record must be
+    /// written so the next switch can tell deletions from new tasks. Testing
+    /// `plan_deletion_sweep` alone would pass even if nothing called it.
+    #[test]
+    fn a_confirmed_deletion_reaches_every_account_and_updates_the_record() {
+        let fixture = fixture();
+        let sessions = fixture.paths.sessions_root();
+        // Both accounts hold t1; only `there` holds t2.
+        write(
+            &sessions.join("uuid-here/org-1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1}]}"#,
+        );
+        write(
+            &sessions.join("uuid-there/org-2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1},{"id":"t2","createdAt":2}]}"#,
+        );
+
+        let mut plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        plan.confirmed_deletions = ["t1".to_string()].into_iter().collect();
+        apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
+
+        for registry in [
+            sessions.join("uuid-here/org-1/scheduled-tasks.json"),
+            sessions.join("uuid-there/org-2/scheduled-tasks.json"),
+        ] {
+            let value: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(&registry).unwrap()).unwrap();
+            let ids: Vec<&str> = value["scheduledTasks"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|task| task["id"].as_str())
+                .collect();
+            assert!(
+                !ids.contains(&"t1"),
+                "{registry:?} still holds the deleted task"
+            );
+        }
+        // The unrelated task survives, so the sweep is targeted rather than a
+        // blanket wipe of the registry.
+        let there: serde_json::Value = serde_json::from_slice(
+            &std::fs::read(sessions.join("uuid-there/org-2/scheduled-tasks.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(there["scheduledTasks"][0]["id"], "t2");
+
+        // And the record now reflects reality, so t1 is not reported as a
+        // deletion for ever after.
+        let recorded = load_synced(&fixture.paths.synced_path());
+        assert!(!recorded.is_empty(), "the sync record was never written");
+        assert!(
+            recorded.values().all(|ids| !ids.contains("t1")),
+            "{recorded:?} still lists the deleted task"
+        );
+    }
+
+    /// Keeping everything must leave *other* accounts' registries untouched —
+    /// the safe answer has to be genuinely inert, not "delete nothing but
+    /// rewrite everything anyway". The switch target is excluded because the
+    /// ordinary merge rewrites it either way.
+    #[test]
+    fn keeping_every_conflict_leaves_other_accounts_untouched() {
+        let fixture = fixture();
+        let sessions = fixture.paths.sessions_root();
+        let bystander = sessions.join("uuid-here/org-1/scheduled-tasks.json");
+        write(
+            &bystander,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1}]}"#,
+        );
+        let before = std::fs::read(&bystander).unwrap();
+
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        assert!(plan.confirmed_deletions.is_empty());
+        apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
+
+        assert_eq!(std::fs::read(&bystander).unwrap(), before);
+    }
+
     #[test]
     fn applying_a_switch_swaps_the_credential_and_carries_history() {
         let fixture = fixture();

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -23,6 +23,7 @@ pub mod app;
 pub mod capture;
 pub mod merge;
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -119,6 +120,14 @@ impl Paths {
     pub fn prelogin_dir(&self) -> PathBuf {
         self.backups_dir.with_file_name("prelogin-backup")
     }
+
+    /// What each account's schedule registry held after the last merge, keyed
+    /// by account UUID. Kept beside the profile store rather than inside a
+    /// profile so both this tool and claude-acc read and write one record, and
+    /// so accounts without a captured profile are still tracked.
+    pub fn synced_path(&self) -> PathBuf {
+        self.backups_dir.with_file_name("synced.json")
+    }
 }
 
 /// One saved account in the profile store.
@@ -174,6 +183,22 @@ pub fn load_profiles(profiles_dir: &Path) -> Vec<ProfileMeta> {
         .collect();
     profiles.sort_by(|a, b| a.label.cmp(&b.label));
     profiles
+}
+
+/// Read the schedule sync record. Absent or malformed reads as empty, which
+/// makes every task look new — so a first run, or a corrupted record, reports
+/// no deletions rather than inventing them.
+pub fn load_synced(path: &Path) -> merge::SyncedTasks {
+    std::fs::read(path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or_default()
+}
+
+/// Record what every account holds now, so the next switch can tell a deletion
+/// from a task that account never had.
+pub fn save_synced(path: &Path, synced: &merge::SyncedTasks) -> Result<()> {
+    crate::cache::atomic_write(path, &serde_json::to_vec(synced)?)
 }
 
 /// Which account the Desktop app currently believes it is. This is the app's
@@ -266,6 +291,13 @@ pub struct SwitchPlan {
     pub archive_members: Vec<String>,
     pub restores_desktop_state: bool,
     pub opts: SwitchOpts,
+    /// Schedules an account deleted that others still hold, so this merge would
+    /// resurrect them. The caller decides — a terminal prompt or the menu bar —
+    /// and records the verdict in `confirmed_deletions`.
+    pub deletions: Vec<merge::DeletionCandidate>,
+    /// Task ids the user confirmed should go everywhere. Empty means keep them
+    /// all, which is also what a non-interactive switch must do.
+    pub confirmed_deletions: BTreeSet<String>,
 }
 
 /// Decide the whole switch without performing any of it.
@@ -300,6 +332,7 @@ pub fn plan_switch(paths: &Paths, label: &str, opts: SwitchOpts) -> Result<Switc
         ),
         None => (SessionMerge::default(), None),
     };
+    let deletions = merge::deletion_candidates(&sessions_root, &load_synced(&paths.synced_path()));
 
     let outgoing = active_account_uuid(&paths.config_json())
         .and_then(|uuid| label_for_uuid(&profiles, &uuid).map(str::to_string));
@@ -346,6 +379,8 @@ pub fn plan_switch(paths: &Paths, label: &str, opts: SwitchOpts) -> Result<Switc
         scheduled,
         tokens,
         opts,
+        deletions,
+        confirmed_deletions: BTreeSet::new(),
     })
 }
 
@@ -410,6 +445,31 @@ fn apply_switch_while_stopped(
     }
     if let Some(scheduled) = &plan.scheduled {
         crate::cache::atomic_write(&scheduled.target, &scheduled.bytes)?;
+    }
+    // A confirmed deletion has to leave every registry, or the copy still
+    // sitting in another account hands it back on the next switch and the same
+    // prompt returns forever. Runs after the merge so it also strips anything
+    // the merge just re-added.
+    match merge::plan_deletion_sweep(&paths.sessions_root(), &plan.confirmed_deletions) {
+        Ok(writes) => {
+            for (path, bytes) in writes {
+                if let Err(error) = crate::cache::atomic_write(&path, &bytes) {
+                    notes.push(format!(
+                        "could not apply deletion to {}: {error}",
+                        path.display()
+                    ));
+                }
+            }
+        }
+        Err(error) => notes.push(format!("deletion sweep skipped: {error}")),
+    }
+    // Record what every account holds now, so the next switch can tell an
+    // intentional deletion from a task that account simply never received.
+    if let Err(error) = save_synced(
+        &paths.synced_path(),
+        &merge::current_task_ids(&paths.sessions_root()),
+    ) {
+        notes.push(format!("could not record the schedule sync: {error}"));
     }
 
     // Identify the outgoing account from the *live* config, after the quit:

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -464,7 +464,7 @@ fn merge_history_into(
     }
     let routines = match merge::plan_scheduled_merge(&sessions_root, account_uuid, org_uuid) {
         Ok(scheduled) => match crate::cache::atomic_write(&scheduled.target, &scheduled.bytes) {
-            Ok(()) => scheduled.added,
+            Ok(()) => scheduled.added + scheduled.updated,
             Err(error) => {
                 notes.push(format!("schedule seed skipped: {error}"));
                 0

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -220,12 +220,13 @@ pub enum AccountAction {
         #[arg(long, default_value_t = 10)]
         keep_backups: usize,
 
-        /// Confirm that this routine id, deleted in one account but still held
-        /// by another, should be removed everywhere. Repeatable. Supplying any
-        /// suppresses the interactive prompt — ids not listed are kept — which
-        /// is how the macOS menu bar passes an answered dialog through.
+        /// Confirm that this type-scoped conflict key, deleted in one account
+        /// but still held by another, should be removed everywhere. Repeatable.
+        /// Supplying any suppresses the interactive prompt — keys not listed
+        /// are kept — which is how the macOS menu bar passes an answered dialog
+        /// through.
         /// `account status --json` lists the candidates as `deletion_conflicts`.
-        #[arg(long, value_name = "ID")]
+        #[arg(long, value_name = "KEY")]
         delete_conflict: Vec<String>,
     },
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -224,9 +224,9 @@ pub enum AccountAction {
         /// by another, should be removed everywhere. Repeatable. Supplying any
         /// suppresses the interactive prompt — ids not listed are kept — which
         /// is how the macOS menu bar passes an answered dialog through.
-        /// `account status --json` lists the candidates as `routine_conflicts`.
+        /// `account status --json` lists the candidates as `deletion_conflicts`.
         #[arg(long, value_name = "ID")]
-        delete_routine: Vec<String>,
+        delete_conflict: Vec<String>,
     },
 }
 

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -219,6 +219,14 @@ pub enum AccountAction {
         /// Rollback archives to retain.
         #[arg(long, default_value_t = 10)]
         keep_backups: usize,
+
+        /// Confirm that this routine id, deleted in one account but still held
+        /// by another, should be removed everywhere. Repeatable. Supplying any
+        /// suppresses the interactive prompt — ids not listed are kept — which
+        /// is how the macOS menu bar passes an answered dialog through.
+        /// `account status --json` lists the candidates as `routine_conflicts`.
+        #[arg(long, value_name = "ID")]
+        delete_routine: Vec<String>,
     },
 }
 


### PR DESCRIPTION
Three problems in the Claude Desktop support that shipped in v0.20.1, all found
by testing against a live install rather than by review. None is visible from
reading the code alone.

## 1. Schedule edits were silently discarded on switch-back

`plan_scheduled_merge` reconciled tasks on `createdAt`, keeping the incumbent on
a tie. But a scheduled task has **no `updatedAt`**. The real schema is:

```
approvedPermissions, createdAt, cronExpression, cwd, enabled, filePath,
id, lastRunAt, lastScheduledFor, model, permissionMode, useWorktree
```

Editing a task's cron, model, or `enabled` flag leaves `createdAt` untouched, so
both copies tie and the edit is dropped:

1. account A has task T, `createdAt = 100`
2. switch to B — T is copied, still `createdAt = 100`
3. edit T's cron while on B
4. switch back to A — A already has T at `100`; the source is also `100`;
   `100 > 100` is false → **the edit is gone**

The registry file's mtime is the only "who wrote last" signal the format offers,
and the account you just worked in owns the freshest one — so it now breaks the
tie. A newer `createdAt` still wins outright, so delete-and-recreate is
unaffected.

The regression test **fails against the old rule and passes against the new
one** (verified by reverting the comparison, not assumed). Identical copies are
not counted as edits, so a switch never claims a change it did not make.

## 2. Deleted routines and chats came back, with no way to tell a deletion from something new

The merge is a union, so deleting a routine or a conversation in one account
meant it returned from whichever account still held a copy — and the merge kept **no history**, so
it could not distinguish that from a routine the account had simply never
received. Confirming with the user was impossible without first closing that
gap.

`~/.claude-acc/synced.json` now records what each account held after the last
merge — shared with claude-acc, so both tools agree on one history. A genuine
deletion is *"this account had it, no longer does, and another still holds it"*,
which is exactly the case a merge would undo. Everything else stays additive and
silent.

The switch then asks: **keep them all / delete them everywhere / choose
individually**. Confirming sweeps the item from every registry — after the
merge, so it also strips what the merge just re-added; otherwise the surviving
copy hands it back next time and the same question returns forever.

```
Deleted elsewhere  2 item(s) deleted in one account, still present in another
   1. routine 0 5 * * *  (daily-report)         deleted in hotmail, still in gmail, struct
   2. chat    Refactor the parser  (ai-usagebar)  deleted in gmail, still in hotmail

  [k] keep them all (default)      — they stay, and this asks again next time
  [d] delete them everywhere       — removed from every account
  [c] choose individually
```

Each row carries its kind (`routine` / `chat`), since the same flow now covers
both. The macOS menu bar asks the same question before starting the switch (a
background subprocess cannot prompt): an `NSAlert` with the three options, and a
checkbox per item for the individual case, where **checked means keep**. The
verdict rides through as `--delete-conflict <id>`, which also tells the binary the
question was already answered. `account status --json` lists pending conflicts
under `deletion_conflicts` so scripts can do the same. Ids not currently in
conflict are ignored, so a dialog answered against a stale list cannot delete
something new.

**Deleting is only ever reachable from an answered prompt.** `-y` skips the quit
confirmation but deliberately does not imply deletion, and a switch with no
terminal — the menu bar's subprocess, a pipe, a cron — keeps everything and says
so. In the individual picker you type the numbers to **keep**, so the
destructive answer takes deliberate input and a blank line is harmless; an
out-of-range entry keeps everything rather than guessing at a typo.

**Safe rollout by construction:** with no record yet — the first run after
upgrading — nothing is reported as a deletion, so behaviour is unchanged until
there is real history to compare against.

## 3. The liveness check never matched, disabling every force-quit fallback

```
$ pgrep -x Claude                                   # while the app is running
$ pgrep -f /Applications/Claude.app/…/MacOS/Claude
$ ps -Ao pid,comm | grep Claude.app
  79408 /Applications/Claude.app/Contents/MacOS/Claude
$ osascript -e 'application "Claude" is running'
true
```

`pgrep` matches nothing while Claude Desktop is up. So `is_running()` always
answered "stopped", `wait_until_stopped()` returned `true` on the first poll,
and **`quit()` reported success without ever confirming the app had exited** —
leaving a switch free to copy live SQLite and LevelDB stores, precisely the
corruption the surrounding comments warn about. Both `pkill -x Claude` fallbacks
were dead code for the same reason.

The graceful AppleScript quit does work, which is why switches have functioned
in practice — but the safety net underneath was not there. Liveness now uses
`application "Claude" is running` (correct, and asking does not launch the app),
and the fallbacks signal the single pid matched on the bundle's executable path
out of `ps`. Helper processes have distinct paths and are left alone, since
quitting the main process takes them with it.

## Scope

**Conversations are covered too.** A confirmed chat loses only its *index* file;
the transcript lives in the account-agnostic `~/.claude/projects/`, which this
never touches — so it stops following you between accounts without the text
being destroyed. The prompt says so, since "delete everywhere" would otherwise
read as far more destructive than it is.

Edits reconcile independently of deletion: chats on `lastActivityAt`, routines
on their registry mtime, newest wins either way.

The sync record moved from a bare id list to `{routines, sessions}`, and the
older shape is still parsed as routines-only so an existing file keeps its
history rather than being re-learned from scratch.

## Checks

`cargo test` (816), `cargo clippy --all-targets -D warnings`, `cargo fmt
--check` — clean. `macos/run-tests.sh` and `macos/build.sh` pass. No new
dependencies.

Tests are hermetic: mtimes are set explicitly via `FileTimes` rather than
depending on wall-clock timing, and the deletion flow is pinned **through
`apply_switch`** rather than only at the pure-function level — testing
`plan_deletion_sweep` alone would keep passing even if nothing called it.

All three fixes are also going into
[claude-acc](https://github.com/ohmaseclaro/claude-acc), which has the same bugs
in its Python original and shares the sync record.


## Renamed routines now converge to one title

A scheduled task has no `updatedAt`, so renaming one leaves `createdAt` untouched
— both copies tie, and the merge breaks the tie by registry-file mtime while only
writing the account you switch *to*. So a routine's `displayName` never settled:
it propagated one direction at a time, by coarse file mtime, and an unrelated
edit could drag a stale name back.

A switch now runs a name-convergence pass after the merge and deletion sweep: for
each routine id it takes the `displayName` from the copy the merge itself would
keep (freshest by `createdAt`, then mtime) and writes that one title into *every*
registry. Name-only — no other field is touched — and there is no prompt, matching
how every other merged field already reconciles silently, so both the terminal and
the menu bar get it through the one switch path. Pinned by unit tests on the pure
pass plus a wiring test through `apply_switch`, and mirrored in claude-acc.
