### PR TITLE
Read Claude Desktop account usage without a CLI login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ Each release is also published at
 
 ### Added
 
+- **Claude Desktop accounts now report usage with no `claude` CLI login.** A
+  saved Desktop account (`account add <label> --desktop`) previously needed a
+  *second*, separate `claude` login before its quota could show — because usage
+  came only from a CLI credential. It turns out the Desktop app stores its own
+  token under the same public OAuth client as Claude Code, and that token is
+  accepted by the usage endpoint, so ai-usagebar now reads it directly. Every
+  saved Desktop profile appears as a Claude account in `ai-usagebar usage`, the
+  TUI, the macOS menu-bar overview, and (via the shared cache) `claude-acc
+  list` — labelled `· <label> (desktop)` — with zero CLI involvement.
+
+  The token lives in the app's encrypted `safeStorage` blob; ai-usagebar
+  decrypts it with the login-Keychain key (macOS), picks the
+  `user:inference`-scoped entry, and maps it onto the existing OAuth path so
+  refresh, cache and rendering are unchanged. The **active** account is read
+  from the live `config.json` the running app keeps fresh, and is refreshed by
+  ai-usagebar only while the app is stopped — never rotating the credential out
+  from under it; every other account is read from its own profile snapshot and
+  refreshed freely, with the rotation written back so a later switch stays
+  valid. A half-finished CLI `account add <label>` no longer masks a working
+  Desktop profile of the same name: the Desktop source takes over when the CLI
+  credential can't authenticate. macOS-only (the Desktop app and its Keychain
+  key exist nowhere else).
+
 - **Deleted routines and chats are now confirmed instead of silently
   resurrected.** The merge is a union, so deleting a routine or a conversation
   in one account meant it came straight back from whichever account still held a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,21 +18,23 @@ Each release is also published at
   token under the same public OAuth client as Claude Code, and that token is
   accepted by the usage endpoint, so ai-usagebar now reads it directly. Every
   saved Desktop profile appears as a Claude account in `ai-usagebar usage`, the
-  TUI, the macOS menu-bar overview, and (via the shared cache) `claude-acc
-  list` — labelled `· <label> (desktop)` — with zero CLI involvement.
+  TUI, and the macOS menu-bar overview — labelled `· <label> (desktop)` — with
+  zero CLI involvement.
 
   The token lives in the app's encrypted `safeStorage` blob; ai-usagebar
   decrypts it with the login-Keychain key (macOS), picks the
   `user:inference`-scoped entry, and maps it onto the existing OAuth path so
-  refresh, cache and rendering are unchanged. The **active** account is read
-  from the live `config.json` the running app keeps fresh, and is refreshed by
-  ai-usagebar only while the app is stopped — never rotating the credential out
-  from under it; every other account is read from its own profile snapshot and
-  refreshed freely, with the rotation written back so a later switch stays
-  valid. A half-finished CLI `account add <label>` no longer masks a working
-  Desktop profile of the same name: the Desktop source takes over when the CLI
-  credential can't authenticate. macOS-only (the Desktop app and its Keychain
-  key exist nowhere else).
+  rendering are unchanged. The **active** account is read-only from the live
+  `config.json` the app keeps fresh; ai-usagebar never rotates that credential,
+  even while the app happens to be stopped. Every other account is read from
+  its profile snapshot and refreshed under the same lock as account switching,
+  with the rotation written back before a switch can install it. Desktop caches
+  are isolated by account UUID, so a reused label cannot expose another CLI or
+  Desktop account's usage. A half-finished CLI `account add <label>` no longer
+  masks a working Desktop profile of the same name: the Desktop source takes
+  over when the CLI credential can't authenticate. The menu bar consumes this
+  same Rust-resolved list, including a configured `desktop_profiles_dir`.
+  macOS-only (the Desktop app and its Keychain key exist nowhere else).
 
 - **Deleted routines and chats are now confirmed instead of silently
   resurrected.** The merge is a union, so deleting a routine or a conversation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15,7 +26,9 @@ dependencies = [
 name = "ai-usagebar"
 version = "0.20.1"
 dependencies = [
+ "aes",
  "base64 0.23.0",
+ "cbc",
  "chrono",
  "clap",
  "ctrlc",
@@ -23,6 +36,7 @@ dependencies = [
  "fs2",
  "insta",
  "mockito",
+ "pbkdf2",
  "pretty_assertions",
  "ratatui",
  "ratatui-bubbletea-components",
@@ -31,6 +45,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -198,6 +213,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +264,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +306,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -529,6 +572,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -873,6 +917,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1189,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1552,6 +1615,16 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
 ]
 
 [[package]]
@@ -2229,6 +2302,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,14 @@ directories = "5"
 thiserror = "2"
 ctrlc = "3"
 base64 = "0.23"
+# Electron/Chromium `safeStorage` crypto, used only to read the Claude Desktop
+# app's own OAuth token out of its encrypted `config.json` (macOS). AES-128-CBC
+# with a PBKDF2-HMAC-SHA1 key derived from a login-Keychain secret — the pure
+# transform is cross-platform so it stays unit-testable on Linux CI.
+aes = "0.8"
+cbc = { version = "0.1", features = ["alloc"] }
+pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
+sha1 = "0.10"
 ratatui = "0.30.1"
 ratatui-bubbletea-components = "0.2"
 ratatui-bubbletea-theme = "0.2"

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -812,9 +812,32 @@ func showDefaultClaudeAccount(configValue: String?, hasAccounts: Bool) -> Bool {
 
 /// Pseudo-id mapping: `anthropic@<label>` selects a named account.
 let ACCOUNT_ID_PREFIX = "anthropic@"
+// A Claude account whose usage comes from the Desktop app's own token (a saved
+// ~/.claude-acc/profiles/<label>), fetched with the widget's `--desktop` flag.
+// Distinct prefix so `vendorArgs` knows to pass it; every other helper treats it
+// as a Claude account via `accountLabel(of:)`.
+let DESKTOP_ACCOUNT_ID_PREFIX = "anthropic-desktop@"
 
 func accountLabel(of id: String) -> String? {
-    id.hasPrefix(ACCOUNT_ID_PREFIX) ? String(id.dropFirst(ACCOUNT_ID_PREFIX.count)) : nil
+    if id.hasPrefix(DESKTOP_ACCOUNT_ID_PREFIX) {
+        return String(id.dropFirst(DESKTOP_ACCOUNT_ID_PREFIX.count))
+    }
+    return id.hasPrefix(ACCOUNT_ID_PREFIX) ? String(id.dropFirst(ACCOUNT_ID_PREFIX.count)) : nil
+}
+
+func isDesktopAccountId(_ id: String) -> Bool { id.hasPrefix(DESKTOP_ACCOUNT_ID_PREFIX) }
+
+/// Saved Claude Desktop profiles with usable credentials (both encrypted token
+/// caches present), mirroring the Rust `has_credentials` check. Read straight
+/// from the claude-acc profile store so the menu bar needs no extra subprocess.
+func desktopProfileLabels() -> [String] {
+    let dir = "\(NSHomeDirectory())/.claude-acc/profiles"
+    guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dir) else { return [] }
+    let fm = FileManager.default
+    return entries.filter { label in
+        fm.fileExists(atPath: "\(dir)/\(label)/config-tokenCache")
+            && fm.fileExists(atPath: "\(dir)/\(label)/config-tokenCacheV2")
+    }.sorted()
 }
 
 func baseVendorId(_ id: String) -> String {
@@ -824,7 +847,9 @@ func baseVendorId(_ id: String) -> String {
 /// The subprocess arguments that select `id` (base vendor or named account).
 func vendorArgs(for id: String) -> [String] {
     if let label = accountLabel(of: id) {
-        return ["--vendor", "anthropic", "--account", label]
+        var args = ["--vendor", "anthropic", "--account", label]
+        if isDesktopAccountId(id) { args.append("--desktop") }
+        return args
     }
     return ["--vendor", id]
 }
@@ -860,14 +885,22 @@ func vendorEntries(active: String) -> [MenuEntry] {
     for v in VENDOR_AUTH where vendorEnabled(v) {
         if v.id == "anthropic" {
             let labels = claudeAccountLabels()
+            // Desktop accounts the CLI config doesn't already name — same
+            // dedup as the Rust `tabs_with_desktop` (a configured CLI account
+            // wins its label).
+            let desktop = desktopProfileLabels().filter { !labels.contains($0) }
             let showDefault = showDefaultClaudeAccount(
                 configValue: configValueTOML("anthropic", "show_default_account"),
-                hasAccounts: !labels.isEmpty)
+                hasAccounts: !(labels.isEmpty && desktop.isEmpty))
             if showDefault && (v.id == active || vendorConfigured(v)) {
                 out.append(MenuEntry(id: v.id, name: v.name))
             }
             for label in labels {
                 out.append(MenuEntry(id: ACCOUNT_ID_PREFIX + label, name: "Claude · \(label)"))
+            }
+            for label in desktop {
+                out.append(MenuEntry(id: DESKTOP_ACCOUNT_ID_PREFIX + label,
+                                     name: "Claude · \(label)"))
             }
         } else if v.id == active || vendorConfigured(v) {
             out.append(MenuEntry(id: v.id, name: v.name))

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -827,19 +827,6 @@ func accountLabel(of id: String) -> String? {
 
 func isDesktopAccountId(_ id: String) -> Bool { id.hasPrefix(DESKTOP_ACCOUNT_ID_PREFIX) }
 
-/// Saved Claude Desktop profiles with usable credentials (both encrypted token
-/// caches present), mirroring the Rust `has_credentials` check. Read straight
-/// from the claude-acc profile store so the menu bar needs no extra subprocess.
-func desktopProfileLabels() -> [String] {
-    let dir = "\(NSHomeDirectory())/.claude-acc/profiles"
-    guard let entries = try? FileManager.default.contentsOfDirectory(atPath: dir) else { return [] }
-    let fm = FileManager.default
-    return entries.filter { label in
-        fm.fileExists(atPath: "\(dir)/\(label)/config-tokenCache")
-            && fm.fileExists(atPath: "\(dir)/\(label)/config-tokenCacheV2")
-    }.sorted()
-}
-
 func baseVendorId(_ id: String) -> String {
     accountLabel(of: id) != nil ? "anthropic" : id
 }
@@ -858,6 +845,13 @@ func vendorArgs(for id: String) -> [String] {
 struct MenuEntry {
     let id: String    // "cursor", "anthropic", or "anthropic@<label>"
     let name: String  // display: "Cursor", "Claude · <label>"
+}
+
+func claudeAccountMenuEntries(_ accounts: [UsageAccount]) -> [MenuEntry] {
+    accounts.map { account in
+        let prefix = account.desktop ? DESKTOP_ACCOUNT_ID_PREFIX : ACCOUNT_ID_PREFIX
+        return MenuEntry(id: prefix + account.label, name: "Claude · \(account.label)")
+    }
 }
 
 /// Apply `[ui] overview_vendors` with the same semantics as the TUI: preserve
@@ -880,28 +874,23 @@ func filterOverviewEntries(_ entries: [MenuEntry], requested: [String]?) -> [Men
 /// with Anthropic expanded into its named accounts (the default entry kept
 /// only per `show_default_account`). `active` stays listed even when
 /// unconfigured — same rule the per-vendor list always had.
-func vendorEntries(active: String) -> [MenuEntry] {
+func vendorEntries(active: String, usageAccounts: [UsageAccount]? = nil) -> [MenuEntry] {
     var out: [MenuEntry] = []
     for v in VENDOR_AUTH where vendorEnabled(v) {
         if v.id == "anthropic" {
-            let labels = claudeAccountLabels()
-            // Desktop accounts the CLI config doesn't already name — same
-            // dedup as the Rust `tabs_with_desktop` (a configured CLI account
-            // wins its label).
-            let desktop = desktopProfileLabels().filter { !labels.contains($0) }
+            // Once account status is available, Rust owns profile-directory
+            // resolution and CLI/Desktop dedup. The nil fallback preserves
+            // configured CLI accounts with an older binary.
+            let accounts = usageAccounts ?? claudeAccountLabels().map {
+                UsageAccount(label: $0, desktop: false)
+            }
             let showDefault = showDefaultClaudeAccount(
                 configValue: configValueTOML("anthropic", "show_default_account"),
-                hasAccounts: !(labels.isEmpty && desktop.isEmpty))
+                hasAccounts: !accounts.isEmpty)
             if showDefault && (v.id == active || vendorConfigured(v)) {
                 out.append(MenuEntry(id: v.id, name: v.name))
             }
-            for label in labels {
-                out.append(MenuEntry(id: ACCOUNT_ID_PREFIX + label, name: "Claude · \(label)"))
-            }
-            for label in desktop {
-                out.append(MenuEntry(id: DESKTOP_ACCOUNT_ID_PREFIX + label,
-                                     name: "Claude · \(label)"))
-            }
+            out.append(contentsOf: claudeAccountMenuEntries(accounts))
         } else if v.id == active || vendorConfigured(v) {
             out.append(MenuEntry(id: v.id, name: v.name))
         }
@@ -932,9 +921,17 @@ struct AccountStatus: Equatable {
     var cliActive: String?
     var desktopLabels: [String] = []
     var cliLabels: [String] = []
+    /// Canonical Rust/TUI usage enumeration. Nil means an older binary, so the
+    /// menu falls back to configured CLI labels; an empty array is authoritative.
+    var usageAccounts: [UsageAccount]?
     /// Routines one account deleted that another still holds. A switch would
     /// hand them back, so the user is asked before it starts.
     var deletionConflicts: [DeletionConflict] = []
+}
+
+struct UsageAccount: Equatable {
+    var label: String
+    var desktop: Bool
 }
 
 struct DeletionConflict: Equatable {
@@ -969,6 +966,16 @@ func parseAccountStatus(_ data: Data) -> AccountStatus? {
         (side as? [String: Any])?["active_label"] as? String
     }
     let desktop = root["desktop"], cli = root["cli"]
+    let usageAccounts: [UsageAccount]?
+    if let rows = root["usage_accounts"] as? [[String: Any]] {
+        usageAccounts = rows.compactMap { row in
+            guard let label = row["label"] as? String,
+                  let desktop = row["desktop"] as? Bool else { return nil }
+            return UsageAccount(label: label, desktop: desktop)
+        }
+    } else {
+        usageAccounts = nil
+    }
     let conflicts = ((desktop as? [String: Any])?["deletion_conflicts"] as? [[String: Any]] ?? [])
         .compactMap { row -> DeletionConflict? in
             guard let id = row["id"] as? String else { return nil }
@@ -986,6 +993,7 @@ func parseAccountStatus(_ data: Data) -> AccountStatus? {
                          cliActive: active(cli),
                          desktopLabels: labels(desktop, "profiles"),
                          cliLabels: labels(cli, "accounts"),
+                         usageAccounts: usageAccounts,
                          deletionConflicts: conflicts)
 }
 
@@ -1824,7 +1832,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     /// The swap-shortcut ring: every configured entry (vendors *and* Claude
     /// accounts) plus the synthetic "overview" target, so ⌥⌘\ cycles them all.
     func swapCycleIds() -> [String] {
-        var ids = vendorEntries(active: VENDOR).map { $0.id }
+        var ids = vendorEntries(active: VENDOR,
+                                usageAccounts: lastAccountStatus?.usageAccounts).map { $0.id }
         ids.append("overview")
         return ids
     }
@@ -2103,7 +2112,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func refreshOverview(bin: String, generation: Int) {
         // vendorEntries(active: "") keeps only configured entries — the
         // active-vendor courtesy slot has no place in an all-vendors sweep.
-        let entries = filterOverviewEntries(vendorEntries(active: ""),
+        let entries = filterOverviewEntries(vendorEntries(
+                                                active: "",
+                                                usageAccounts: lastAccountStatus?.usageAccounts),
                                             requested: configuredOverviewVendorIds())
         DispatchQueue.global(qos: .utility).async { [weak self] in
             var results: [(name: String, id: String, snap: Snapshot?)] = []
@@ -2401,7 +2412,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func rebuildVendorSubmenu() {
         vendorSubmenu.removeAllItems()
         let active = VENDOR
-        let entries = vendorEntries(active: active)
+        let entries = vendorEntries(active: active,
+                                    usageAccounts: lastAccountStatus?.usageAccounts)
         if entries.isEmpty {
             let none = NSMenuItem(title: "Nenhum configurado", action: nil, keyEquivalent: "")
             none.isEnabled = false
@@ -2471,6 +2483,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     func applyAccountStatus(_ status: AccountStatus) {
         lastAccountStatus = status
         renderAccountMenus()
+        rebuildVendorSubmenu()
     }
 
     func renderAccountMenus() {

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -507,13 +507,19 @@ func testAccountStatus() {
       "active_label":"toptal","active_account_uuid":"u1",
       "profiles":[{"label":"gmail","active":false},{"label":"toptal","active":true}]},
      "cli":{"active_label":"struct","active_account_uuid":"u2",
-      "accounts":[{"label":"struct","active":true},{"label":"toptal","active":false}]}}
+      "accounts":[{"label":"struct","active":true},{"label":"toptal","active":false}]},
+     "usage_accounts":[{"label":"struct","desktop":false},
+                       {"label":"gmail","desktop":true}]}
     """
     let s = parseAccountStatus(Data(full.utf8))
     assertEqual(s?.desktopActive, "toptal", "desktop active label")
     assertEqual(s?.cliActive, "struct", "cli active label")
     assertEqual(s?.desktopLabels ?? [], ["gmail", "toptal"], "desktop labels keep file order")
     assertEqual(s?.cliLabels ?? [], ["struct", "toptal"], "cli labels keep file order")
+    assertEqual(s?.usageAccounts ?? [],
+                [UsageAccount(label: "struct", desktop: false),
+                 UsageAccount(label: "gmail", desktop: true)],
+                "usage accounts preserve Rust source selection")
     assertEqual(accountsSummaryLine(s!), "Desktop: toptal   ·   Code: struct", "summary line")
 
     // No Claude Desktop app: the whole half is null, the CLI half still shows.
@@ -611,6 +617,14 @@ func testDesktopAccounts() {
     assertEqual(vendorArgs(for: ACCOUNT_ID_PREFIX + "gmail"),
                 ["--vendor", "anthropic", "--account", "gmail"],
                 "cli account omits --desktop")
+
+    let shared = claudeAccountMenuEntries([
+        UsageAccount(label: "work", desktop: true),
+        UsageAccount(label: "personal", desktop: false),
+    ])
+    assertEqual(shared.map { $0.id },
+                [DESKTOP_ACCOUNT_ID_PREFIX + "work", ACCOUNT_ID_PREFIX + "personal"],
+                "menu uses the source selected by Rust status")
 }
 
 @main

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -593,6 +593,23 @@ func testAccountStatus() {
     assertEqual(nasty.contains(#"'a'\''; rm -rf ~; echo '\'''"#), true, "label is escaped")
 }
 
+func testDesktopAccounts() {
+    // A Desktop account id round-trips through accountLabel (so display, dedup
+    // and baseVendorId treat it as Claude) but is flagged for --desktop.
+    let id = DESKTOP_ACCOUNT_ID_PREFIX + "gmail"
+    assertEqual(accountLabel(of: id), "gmail", "desktop id yields its label")
+    assertEqual(baseVendorId(id), "anthropic", "desktop id is an anthropic entry")
+    assertEqual(isDesktopAccountId(id), true, "desktop id detected")
+    assertEqual(isDesktopAccountId(ACCOUNT_ID_PREFIX + "gmail"), false, "cli id is not desktop")
+
+    // vendorArgs adds --desktop only for a desktop account.
+    assertEqual(vendorArgs(for: id), ["--vendor", "anthropic", "--account", "gmail", "--desktop"],
+                "desktop account passes --desktop")
+    assertEqual(vendorArgs(for: ACCOUNT_ID_PREFIX + "gmail"),
+                ["--vendor", "anthropic", "--account", "gmail"],
+                "cli account omits --desktop")
+}
+
 @main
 struct TestRunner {
     static func main() {
@@ -603,6 +620,7 @@ struct TestRunner {
         testOverviewHeadline()
         testVendorCycle()
         testClaudeAccounts()
+        testDesktopAccounts()
         testCompactToggle()
         testShortReset()
         testOverviewProviderToggle()

--- a/src/account.rs
+++ b/src/account.rs
@@ -3,7 +3,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Write};
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use crate::anthropic::cli_account::{self, CliSwitchOpts, CliSwitchOutcome, KeychainStore};
 use crate::claude_desktop::{self, Paths, SwitchOpts, SwitchPlan};
@@ -206,7 +205,23 @@ fn status(json: bool) -> i32 {
         "accounts": cli_rows,
     });
 
-    let report = serde_json::json!({ "desktop": desktop, "cli": cli });
+    // The menu bar consumes this exact TUI enumeration instead of duplicating
+    // profile paths and CLI/Desktop dedup policy in Swift.
+    let usage_accounts: Vec<serde_json::Value> = crate::tui::app::tabs_with_desktop(&config)
+        .into_iter()
+        .filter(|tab| tab.vendor == crate::vendor::VendorId::Anthropic)
+        .filter_map(|tab| {
+            Some(serde_json::json!({
+                "label": tab.account?,
+                "desktop": tab.desktop,
+            }))
+        })
+        .collect();
+    let report = serde_json::json!({
+        "desktop": desktop,
+        "cli": cli,
+        "usage_accounts": usage_accounts,
+    });
     if json {
         println!("{report}");
         return 0;
@@ -477,8 +492,8 @@ fn switch_desktop(config: &Config, args: &SwitchArgs, tolerant: bool) -> Result<
     // Keep planning and mutation in one process-wide transaction. Two menu or
     // terminal switches planned against the same live identity must not race.
     let _lock = crate::cache::acquire_lock(
-        &paths.backups_dir.join(".account-switch.lock"),
-        Duration::from_secs(2),
+        &paths.account_switch_lock(),
+        claude_desktop::ACCOUNT_LOCK_TIMEOUT,
     )?;
 
     let plan = match claude_desktop::plan_switch(&paths, args.label, args.opts.clone()) {

--- a/src/anthropic/creds.rs
+++ b/src/anthropic/creds.rs
@@ -143,13 +143,23 @@ pub enum CredsTarget {
     /// fallback would be: the Keychain item is hashed from `config_dir`, so
     /// it can never resolve to a *different* account's credentials.
     Named { path: PathBuf, config_dir: PathBuf },
+    /// The Claude **Desktop app's** own encrypted token store — no `claude` CLI
+    /// login required. Read/decrypt/write-back all live in
+    /// [`super::desktop_creds`]; this variant just carries the resolved source.
+    Desktop(super::desktop_creds::DesktopCreds),
 }
 
 impl CredsTarget {
+    /// Filesystem path backing this target, for diagnostics. A [`Desktop`]
+    /// source has no single credential file (it decrypts a blob), so its
+    /// blob path stands in.
+    ///
+    /// [`Desktop`]: CredsTarget::Desktop
     pub fn path(&self) -> &Path {
         match self {
             CredsTarget::Default(p) | CredsTarget::Explicit(p) => p,
             CredsTarget::Named { path, .. } => path,
+            CredsTarget::Desktop(d) => d.blob_path(),
         }
     }
 }
@@ -168,6 +178,10 @@ pub enum CredsSource {
     /// Code-credentials-<hash>`), keyed by the account's config dir so
     /// write-backs land in the same per-account item they were read from.
     NamedKeychain(PathBuf),
+    /// The Claude Desktop token store; the handle re-encrypts a refreshed token
+    /// back into the same blob it was read from (a no-op for a read-only
+    /// active account).
+    Desktop(super::desktop_creds::Writeback),
 }
 
 /// Credentials that can't possibly authenticate anything: no access token, no
@@ -197,6 +211,10 @@ pub fn resolve(target: &CredsTarget) -> Result<(CredentialsFile, CredsSource)> {
             return read_named_with(path, config_dir, keychain::read_raw_for);
             #[cfg(not(target_os = "macos"))]
             read_named_with(path, config_dir, |_| Ok(None))
+        }
+        CredsTarget::Desktop(desktop) => {
+            let (creds, writeback) = desktop.read()?;
+            Ok((creds, CredsSource::Desktop(writeback)))
         }
     }
 }
@@ -336,6 +354,7 @@ pub fn write_back_to(source: &CredsSource, new_oauth: &OauthCreds) -> Result<()>
         CredsSource::NamedKeychain(_) => Err(AppError::Other(
             "Keychain credentials source is macOS-only".into(),
         )),
+        CredsSource::Desktop(writeback) => writeback.write(new_oauth),
     }
 }
 

--- a/src/anthropic/desktop_creds.rs
+++ b/src/anthropic/desktop_creds.rs
@@ -1,0 +1,436 @@
+//! Read (and refresh-write-back) the **Claude Desktop app's own** OAuth token so
+//! its usage shows up with no `claude` CLI login at all.
+//!
+//! The Desktop app stores its token under the same public OAuth client id as
+//! Claude Code (`oauth::CLIENT_ID`) — proven by the token being accepted at the
+//! usage endpoint — so once we lift it into an [`OauthCreds`] the entire
+//! existing fetch/refresh/cache/render path works unchanged. The only new work
+//! is getting it out of, and back into, the encrypted [`crate::safe_storage`]
+//! blob.
+//!
+//! Two blob locations, same encryption and inner shape:
+//!   - the live `config.json` (`oauth:tokenCacheV2` / `oauth:tokenCache` values)
+//!     — the *active* account, kept fresh by the running app;
+//!   - a claude-acc profile snapshot (`config-tokenCacheV2` / `config-tokenCache`
+//!     files, each the bare base64 value) — every *other* saved account.
+//!
+//! Decrypted, each is a JSON object keyed by `<clientId>:<org>:<aud>:<scopes>`;
+//! only the entry whose scopes include `user:inference` can call the usage API,
+//! so that is the one we lift.
+//!
+//! **Refresh safety.** Refreshing rotates the refresh token and invalidates the
+//! old one, so it must never run against a token the Desktop app is actively
+//! using. The active account is therefore constructed read-only *while the app
+//! runs* (`allow_refresh = false`), which blanks the refresh token so the
+//! generic fetch path never refreshes it — it just uses the app-maintained
+//! access token or falls back to cache. Non-active snapshots (and the active
+//! account when the app is stopped) refresh freely and write the rotation back
+//! to the same blob they came from, keeping the snapshot switch-ready.
+
+use std::path::PathBuf;
+
+use serde_json::Value;
+
+use crate::error::{AppError, Result};
+use crate::safe_storage;
+
+use super::creds::{CredentialsFile, OauthCreds};
+
+/// Only this scope can hit the usage endpoint; the app also stores a
+/// profile-only token we must skip.
+const INFERENCE_SCOPE: &str = "user:inference";
+
+/// Config.json keys / snapshot file names, newest format first.
+const CONFIG_KEYS: [&str; 2] = ["oauth:tokenCacheV2", "oauth:tokenCache"];
+const SNAPSHOT_FILES: [&str; 2] = ["config-tokenCacheV2", "config-tokenCache"];
+
+/// Where a Desktop token blob lives.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BlobSource {
+    /// The live `config.json`; the blob is a string value under one of
+    /// [`CONFIG_KEYS`], with the rest of the file preserved on write-back.
+    ConfigJson(PathBuf),
+    /// A claude-acc profile directory; each of [`SNAPSHOT_FILES`] is the bare
+    /// base64 value.
+    ProfileDir(PathBuf),
+}
+
+/// A resolved Desktop credential source. Cloneable plain data so it can ride
+/// inside [`super::creds::CredsTarget`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DesktopCreds {
+    pub source: BlobSource,
+    pub key: [u8; 16],
+    /// False for the active account while the app runs — blanks the refresh
+    /// token so nothing refreshes the app's live credential out from under it.
+    pub allow_refresh: bool,
+}
+
+/// Enough to put a refreshed token back exactly where it was read from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Writeback {
+    source: BlobSource,
+    key: [u8; 16],
+    /// Which config key / snapshot file the value was read from.
+    slot: String,
+    /// The `<clientId>:…:<scopes>` entry within the decrypted object.
+    entry_key: String,
+    allow_refresh: bool,
+}
+
+/// Build the credential source for a saved Desktop profile, applying the
+/// refresh-safety policy. The *active* account (the one `config.json` currently
+/// points at) is read from the live `config.json` — kept fresh by the app — and
+/// is refreshable only while the app is stopped. Every other account is read
+/// from its own snapshot and refreshes freely. Pure: the key and the app-running
+/// flag are injected, so it is testable without a Keychain or a running app.
+pub fn source_for(
+    config_json: &std::path::Path,
+    profile_dir: &std::path::Path,
+    is_active: bool,
+    app_running: bool,
+    key: [u8; 16],
+) -> DesktopCreds {
+    if is_active {
+        DesktopCreds {
+            source: BlobSource::ConfigJson(config_json.to_path_buf()),
+            key,
+            allow_refresh: !app_running,
+        }
+    } else {
+        DesktopCreds {
+            source: BlobSource::ProfileDir(profile_dir.to_path_buf()),
+            key,
+            allow_refresh: true,
+        }
+    }
+}
+
+impl DesktopCreds {
+    /// The file this source decrypts from, for diagnostics only.
+    pub fn blob_path(&self) -> &std::path::Path {
+        match &self.source {
+            BlobSource::ConfigJson(p) | BlobSource::ProfileDir(p) => p,
+        }
+    }
+
+    /// Lift the inference token into [`OauthCreds`], plus a [`Writeback`] handle
+    /// aimed at the same slot. `Err` if the blob is absent, undecryptable, or
+    /// has no inference entry — the caller drops the account from the report.
+    pub fn read(&self) -> Result<(CredentialsFile, Writeback)> {
+        let (slot, blob) = self.first_present_blob()?;
+        let plain = safe_storage::decrypt(&self.key, &blob)?;
+        let obj: Value = serde_json::from_slice(&plain)
+            .map_err(|e| AppError::Other(format!("Desktop token cache is not JSON: {e}")))?;
+        let map = obj
+            .as_object()
+            .ok_or_else(|| AppError::Other("Desktop token cache is not a JSON object".into()))?;
+
+        let (entry_key, entry) = map
+            .iter()
+            .find(|(k, _)| k.contains(INFERENCE_SCOPE))
+            .ok_or_else(|| {
+                AppError::Other("no inference-scoped token in the Desktop cache".into())
+            })?;
+
+        let oauth = entry_to_oauth(entry, self.allow_refresh)?;
+        let writeback = Writeback {
+            source: self.source.clone(),
+            key: self.key,
+            slot,
+            entry_key: entry_key.clone(),
+            allow_refresh: self.allow_refresh,
+        };
+        Ok((
+            CredentialsFile {
+                claude_ai_oauth: oauth,
+            },
+            writeback,
+        ))
+    }
+
+    /// The first present blob (base64 value) and the slot it came from.
+    fn first_present_blob(&self) -> Result<(String, String)> {
+        match &self.source {
+            BlobSource::ConfigJson(path) => {
+                let bytes = std::fs::read(path).map_err(|e| AppError::io_at(path, e))?;
+                let cfg: Value = serde_json::from_slice(&bytes)
+                    .map_err(|e| AppError::Other(format!("config.json is not JSON: {e}")))?;
+                for key in CONFIG_KEYS {
+                    if let Some(v) = cfg.get(key).and_then(Value::as_str) {
+                        return Ok((key.to_string(), v.to_string()));
+                    }
+                }
+                Err(AppError::Other(
+                    "config.json has no oauth token cache".into(),
+                ))
+            }
+            BlobSource::ProfileDir(dir) => {
+                for file in SNAPSHOT_FILES {
+                    let path = dir.join(file);
+                    if let Ok(v) = std::fs::read_to_string(&path) {
+                        return Ok((file.to_string(), v));
+                    }
+                }
+                Err(AppError::Other(format!(
+                    "no token cache snapshot in {}",
+                    dir.display()
+                )))
+            }
+        }
+    }
+}
+
+impl Writeback {
+    /// Persist a refreshed token back into the same blob it was read from.
+    /// A read-only source (active account, app running) is a no-op — but the
+    /// fetch path never refreshes such a source, so this is only defence.
+    pub fn write(&self, oauth: &OauthCreds) -> Result<()> {
+        if !self.allow_refresh {
+            return Ok(());
+        }
+        let blob = self.read_slot_blob()?;
+        let plain = safe_storage::decrypt(&self.key, &blob)?;
+        let mut obj: Value = serde_json::from_slice(&plain)
+            .map_err(|e| AppError::Other(format!("Desktop token cache is not JSON: {e}")))?;
+        let entry = obj
+            .as_object_mut()
+            .and_then(|m| m.get_mut(&self.entry_key))
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| AppError::Other("token entry vanished before write-back".into()))?;
+        entry.insert("token".into(), Value::String(oauth.access_token.clone()));
+        entry.insert(
+            "refreshToken".into(),
+            Value::String(oauth.refresh_token.clone()),
+        );
+        entry.insert("expiresAt".into(), Value::from(oauth.expires_at_ms));
+
+        let new_blob = safe_storage::encrypt(&self.key, &serde_json::to_vec(&obj)?);
+        self.write_slot_blob(&new_blob)
+    }
+
+    fn read_slot_blob(&self) -> Result<String> {
+        match &self.source {
+            BlobSource::ConfigJson(path) => {
+                let bytes = std::fs::read(path).map_err(|e| AppError::io_at(path, e))?;
+                let cfg: Value = serde_json::from_slice(&bytes)
+                    .map_err(|e| AppError::Other(format!("config.json is not JSON: {e}")))?;
+                cfg.get(&self.slot)
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .ok_or_else(|| AppError::Other("config token slot vanished".into()))
+            }
+            BlobSource::ProfileDir(dir) => {
+                let path = dir.join(&self.slot);
+                std::fs::read_to_string(&path).map_err(|e| AppError::io_at(&path, e))
+            }
+        }
+    }
+
+    fn write_slot_blob(&self, new_blob: &str) -> Result<()> {
+        match &self.source {
+            BlobSource::ConfigJson(path) => {
+                // Read-modify-write: only the one token value changes; every
+                // other config.json field (lastKnownAccountUuid, the other
+                // cache variant, app settings) is preserved.
+                let bytes = std::fs::read(path).map_err(|e| AppError::io_at(path, e))?;
+                let mut cfg: Value = serde_json::from_slice(&bytes)
+                    .map_err(|e| AppError::Other(format!("config.json is not JSON: {e}")))?;
+                cfg.as_object_mut()
+                    .ok_or_else(|| AppError::Other("config.json is not an object".into()))?
+                    .insert(self.slot.clone(), Value::String(new_blob.to_string()));
+                crate::cache::atomic_write(path, &serde_json::to_vec_pretty(&cfg)?)
+            }
+            BlobSource::ProfileDir(dir) => {
+                crate::cache::atomic_write(&dir.join(&self.slot), new_blob.as_bytes())
+            }
+        }
+    }
+}
+
+/// Map one decrypted `{token, refreshToken, expiresAt, …}` entry to [`OauthCreds`].
+fn entry_to_oauth(entry: &Value, allow_refresh: bool) -> Result<OauthCreds> {
+    let get_str = |k: &str| {
+        entry
+            .get(k)
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    };
+    let access_token = get_str("token");
+    if access_token.is_empty() {
+        return Err(AppError::Other("Desktop token entry has no `token`".into()));
+    }
+    Ok(OauthCreds {
+        access_token,
+        // Blanked when read-only: `creds::can_refresh` is then false, so the
+        // fetch path leaves the app's live credential untouched.
+        refresh_token: if allow_refresh {
+            get_str("refreshToken")
+        } else {
+            String::new()
+        },
+        expires_at_ms: entry.get("expiresAt").and_then(Value::as_i64).unwrap_or(0),
+        subscription_type: get_str("subscriptionType"),
+        rate_limit_tier: get_str("rateLimitTier"),
+        scopes: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key() -> [u8; 16] {
+        safe_storage::derive_key(b"test-secret")
+    }
+
+    // A decrypted token-cache object with the inference entry plus a
+    // profile-only decoy the picker must skip.
+    fn cache_json(access: &str, refresh: &str, expires: i64) -> Vec<u8> {
+        let obj = serde_json::json!({
+            "9d1c250a:org:https://api.anthropic.com:user:inference user:profile": {
+                "token": access,
+                "refreshToken": refresh,
+                "expiresAt": expires,
+                "subscriptionType": "max",
+                "rateLimitTier": "default_claude_max_20x",
+            },
+            "a473d7bb:org:https://api.anthropic.com:user:profile": {
+                "token": "sk-ant-oat01-PROFILE-ONLY",
+                "refreshToken": "sk-ant-ort01-PROFILE-ONLY",
+                "expiresAt": expires,
+                "subscriptionType": "max",
+                "rateLimitTier": "default_claude_max_20x",
+            }
+        });
+        serde_json::to_vec(&obj).unwrap()
+    }
+
+    fn profile_with(dir: &std::path::Path, plain: &[u8], k: &[u8; 16]) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("config-tokenCacheV2"),
+            safe_storage::encrypt(k, plain),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn lifts_the_inference_token_from_a_snapshot() {
+        let tmp = tempfile::tempdir().unwrap();
+        let k = key();
+        profile_with(
+            tmp.path(),
+            &cache_json("sk-ant-oat01-REAL", "sk-ant-ort01-REAL", 111),
+            &k,
+        );
+
+        let d = DesktopCreds {
+            source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
+            key: k,
+            allow_refresh: true,
+        };
+        let (creds, _wb) = d.read().unwrap();
+        let o = creds.claude_ai_oauth;
+        // The inference entry, not the profile-only decoy.
+        assert_eq!(o.access_token, "sk-ant-oat01-REAL");
+        assert_eq!(o.refresh_token, "sk-ant-ort01-REAL");
+        assert_eq!(o.expires_at_ms, 111);
+        assert_eq!(o.plan_label(), "Max 20x");
+    }
+
+    #[test]
+    fn read_only_blanks_the_refresh_token() {
+        // Active-account-while-running policy: no refresh token surfaces, so the
+        // generic fetch path can't rotate the app's live credential.
+        let tmp = tempfile::tempdir().unwrap();
+        let k = key();
+        profile_with(tmp.path(), &cache_json("at", "rt", 1), &k);
+        let d = DesktopCreds {
+            source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
+            key: k,
+            allow_refresh: false,
+        };
+        let (creds, wb) = d.read().unwrap();
+        assert_eq!(creds.claude_ai_oauth.refresh_token, "");
+        // And a write-back is a no-op even if called.
+        wb.write(&creds.claude_ai_oauth).unwrap();
+    }
+
+    #[test]
+    fn writeback_rotates_only_the_token_fields_in_place() {
+        let tmp = tempfile::tempdir().unwrap();
+        let k = key();
+        profile_with(tmp.path(), &cache_json("old-at", "old-rt", 1), &k);
+        let d = DesktopCreds {
+            source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
+            key: k,
+            allow_refresh: true,
+        };
+        let (mut creds, wb) = d.read().unwrap();
+        creds.claude_ai_oauth.access_token = "new-at".into();
+        creds.claude_ai_oauth.refresh_token = "new-rt".into();
+        creds.claude_ai_oauth.expires_at_ms = 999;
+        wb.write(&creds.claude_ai_oauth).unwrap();
+
+        // Re-read: rotation landed, and the profile-only decoy is untouched.
+        let (creds2, _) = d.read().unwrap();
+        assert_eq!(creds2.claude_ai_oauth.access_token, "new-at");
+        assert_eq!(creds2.claude_ai_oauth.expires_at_ms, 999);
+        let plain = safe_storage::decrypt(
+            &k,
+            &std::fs::read_to_string(tmp.path().join("config-tokenCacheV2")).unwrap(),
+        )
+        .unwrap();
+        let obj: Value = serde_json::from_slice(&plain).unwrap();
+        assert_eq!(
+            obj["a473d7bb:org:https://api.anthropic.com:user:profile"]["token"],
+            "sk-ant-oat01-PROFILE-ONLY"
+        );
+    }
+
+    #[test]
+    fn active_account_reads_from_config_json_and_preserves_other_fields() {
+        let tmp = tempfile::tempdir().unwrap();
+        let k = key();
+        let cfg = tmp.path().join("config.json");
+        let blob = safe_storage::encrypt(&k, &cache_json("cfg-at", "cfg-rt", 5));
+        std::fs::write(
+            &cfg,
+            serde_json::to_vec(&serde_json::json!({
+                "lastKnownAccountUuid": "keep-me",
+                "oauth:tokenCacheV2": blob,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let d = DesktopCreds {
+            source: BlobSource::ConfigJson(cfg.clone()),
+            key: k,
+            allow_refresh: true,
+        };
+        let (mut creds, wb) = d.read().unwrap();
+        assert_eq!(creds.claude_ai_oauth.access_token, "cfg-at");
+        creds.claude_ai_oauth.access_token = "rotated".into();
+        wb.write(&creds.claude_ai_oauth).unwrap();
+
+        let after: Value = serde_json::from_slice(&std::fs::read(&cfg).unwrap()).unwrap();
+        // Sibling field survived the write-back.
+        assert_eq!(after["lastKnownAccountUuid"], "keep-me");
+        let (creds2, _) = d.read().unwrap();
+        assert_eq!(creds2.claude_ai_oauth.access_token, "rotated");
+    }
+
+    #[test]
+    fn missing_blob_is_an_error_not_a_panic() {
+        let tmp = tempfile::tempdir().unwrap();
+        let d = DesktopCreds {
+            source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
+            key: key(),
+            allow_refresh: true,
+        };
+        assert!(d.read().is_err());
+    }
+}

--- a/src/anthropic/desktop_creds.rs
+++ b/src/anthropic/desktop_creds.rs
@@ -78,6 +78,46 @@ pub struct Writeback {
     allow_refresh: bool,
 }
 
+/// Resolve a saved Desktop account label to a fetchable target + its cache.
+/// Shared by the TUI and the widget so both surface the same accounts. macOS
+/// only — the Desktop token store and its Keychain key exist nowhere else, and
+/// such accounts are never enumerated off-Mac.
+#[cfg(target_os = "macos")]
+pub fn account_target(
+    config: &crate::config::Config,
+    label: &str,
+) -> Result<(super::creds::CredsTarget, crate::cache::Cache)> {
+    let paths = crate::claude_desktop::Paths::resolve(&config.anthropic)?;
+    let profile = crate::claude_desktop::load_profiles(&paths.profiles_dir)
+        .into_iter()
+        .find(|p| p.label == label)
+        .ok_or_else(|| AppError::Other(format!("no saved Desktop profile {label:?}")))?;
+    let is_active = crate::claude_desktop::active_account_uuid(&paths.config_json())
+        .is_some_and(|uuid| uuid == profile.account_uuid);
+    let key = crate::safe_storage::macos_key()?;
+    let source = source_for(
+        &paths.config_json(),
+        &paths.profile_dir(label),
+        is_active,
+        crate::claude_desktop::app::is_running(),
+        key,
+    );
+    // Plain `anthropic/<label>` cache — one usage source per label — so the
+    // widget, menu bar and `claude-acc list` all read the same file.
+    let cache = crate::cache::Cache::for_vendor_account("anthropic", label)?;
+    Ok((super::creds::CredsTarget::Desktop(source), cache))
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn account_target(
+    _config: &crate::config::Config,
+    label: &str,
+) -> Result<(super::creds::CredsTarget, crate::cache::Cache)> {
+    Err(AppError::Other(format!(
+        "Claude Desktop accounts are macOS-only (requested {label:?})"
+    )))
+}
+
 /// Build the credential source for a saved Desktop profile, applying the
 /// refresh-safety policy. The *active* account (the one `config.json` currently
 /// points at) is read from the live `config.json` — kept fresh by the app — and

--- a/src/anthropic/desktop_creds.rs
+++ b/src/anthropic/desktop_creds.rs
@@ -19,17 +19,16 @@
 //! so that is the one we lift.
 //!
 //! **Refresh safety.** Refreshing rotates the refresh token and invalidates the
-//! old one, so it must never run against a token the Desktop app is actively
-//! using. The active account is therefore constructed read-only *while the app
-//! runs* (`allow_refresh = false`), which blanks the refresh token so the
-//! generic fetch path never refreshes it — it just uses the app-maintained
-//! access token or falls back to cache. Non-active snapshots (and the active
-//! account when the app is stopped) refresh freely and write the rotation back
-//! to the same blob they came from, keeping the snapshot switch-ready.
+//! old one. The live `config.json` source is therefore always read-only: an app
+//! can start after any liveness check. Inactive snapshots refresh under the
+//! same lock as account switching, held from credential read through encrypted
+//! write-back, so a switch cannot install a stale token mid-rotation.
 
 use std::path::PathBuf;
 
 use serde_json::Value;
+#[cfg(any(target_os = "macos", test))]
+use sha1::{Digest, Sha1};
 
 use crate::error::{AppError, Result};
 use crate::safe_storage;
@@ -45,8 +44,9 @@ const CONFIG_KEYS: [&str; 2] = ["oauth:tokenCacheV2", "oauth:tokenCache"];
 const SNAPSHOT_FILES: [&str; 2] = ["config-tokenCacheV2", "config-tokenCache"];
 
 /// Where a Desktop token blob lives.
+#[cfg_attr(not(any(target_os = "macos", test)), allow(dead_code))]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum BlobSource {
+enum BlobSource {
     /// The live `config.json`; the blob is a string value under one of
     /// [`CONFIG_KEYS`], with the rest of the file preserved on write-back.
     ConfigJson(PathBuf),
@@ -59,11 +59,13 @@ pub enum BlobSource {
 /// inside [`super::creds::CredsTarget`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DesktopCreds {
-    pub source: BlobSource,
-    pub key: [u8; 16],
-    /// False for the active account while the app runs — blanks the refresh
-    /// token so nothing refreshes the app's live credential out from under it.
-    pub allow_refresh: bool,
+    source: BlobSource,
+    key: [u8; 16],
+    /// False for the active account — blanks the refresh token so nothing can
+    /// refresh the app's live credential out from under it.
+    allow_refresh: bool,
+    /// Shared account-switch lock. `None` only in pure unit fixtures.
+    coordination_lock: Option<PathBuf>,
 }
 
 /// Enough to put a refreshed token back exactly where it was read from.
@@ -99,12 +101,16 @@ pub fn account_target(
         &paths.config_json(),
         &paths.profile_dir(label),
         is_active,
-        crate::claude_desktop::app::is_running(),
         key,
-    );
-    // Plain `anthropic/<label>` cache — one usage source per label — so the
-    // widget, menu bar and `claude-acc list` all read the same file.
-    let cache = crate::cache::Cache::for_vendor_account("anthropic", label)?;
+    )
+    .with_coordination_lock(paths.account_switch_lock());
+    // Desktop is a distinct credential source, and the account UUID—not its
+    // reusable display label—owns the cache. This prevents a broken CLI entry
+    // or a newly captured profile from inheriting another identity's usage.
+    let cache = crate::cache::Cache::for_vendor_account(
+        "anthropic-desktop",
+        &desktop_cache_key(&profile.account_uuid),
+    )?;
     Ok((super::creds::CredsTarget::Desktop(source), cache))
 }
 
@@ -120,33 +126,51 @@ pub fn account_target(
 
 /// Build the credential source for a saved Desktop profile, applying the
 /// refresh-safety policy. The *active* account (the one `config.json` currently
-/// points at) is read from the live `config.json` — kept fresh by the app — and
-/// is refreshable only while the app is stopped. Every other account is read
-/// from its own snapshot and refreshes freely. Pure: the key and the app-running
-/// flag are injected, so it is testable without a Keychain or a running app.
-pub fn source_for(
+/// points at) is read from the live `config.json` and is always read-only.
+/// Every other account is read from its own refreshable snapshot. Pure: the
+/// key is injected, so it is testable without a Keychain.
+#[cfg(any(target_os = "macos", test))]
+pub(crate) fn source_for(
     config_json: &std::path::Path,
     profile_dir: &std::path::Path,
     is_active: bool,
-    app_running: bool,
     key: [u8; 16],
 ) -> DesktopCreds {
     if is_active {
         DesktopCreds {
             source: BlobSource::ConfigJson(config_json.to_path_buf()),
             key,
-            allow_refresh: !app_running,
+            allow_refresh: false,
+            coordination_lock: None,
         }
     } else {
         DesktopCreds {
             source: BlobSource::ProfileDir(profile_dir.to_path_buf()),
             key,
             allow_refresh: true,
+            coordination_lock: None,
         }
     }
 }
 
+/// Stable, path-safe cache identity. SHA-1 is already required by Chromium's
+/// PBKDF2 format here; this use is namespacing, not a security signature.
+#[cfg(any(target_os = "macos", test))]
+fn desktop_cache_key(account_uuid: &str) -> String {
+    format!("{:x}", Sha1::digest(account_uuid.as_bytes()))
+}
+
 impl DesktopCreds {
+    #[cfg(any(target_os = "macos", test))]
+    pub(crate) fn with_coordination_lock(mut self, path: PathBuf) -> Self {
+        self.coordination_lock = Some(path);
+        self
+    }
+
+    pub fn coordination_lock(&self) -> Option<&std::path::Path> {
+        self.coordination_lock.as_deref()
+    }
+
     /// The file this source decrypts from, for diagnostics only.
     pub fn blob_path(&self) -> &std::path::Path {
         match &self.source {
@@ -357,6 +381,27 @@ mod tests {
     }
 
     #[test]
+    fn the_live_config_source_is_never_refreshable() {
+        let tmp = tempfile::tempdir().unwrap();
+        let active = source_for(tmp.path(), tmp.path(), true, key());
+        let snapshot = source_for(tmp.path(), tmp.path(), false, key());
+
+        assert!(!active.allow_refresh);
+        assert!(snapshot.allow_refresh);
+    }
+
+    #[test]
+    fn desktop_cache_identity_is_account_scoped_and_path_safe() {
+        let a = desktop_cache_key("account-a");
+        let b = desktop_cache_key("account-b");
+
+        assert_eq!(a, desktop_cache_key("account-a"));
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 40);
+        assert!(a.bytes().all(|byte| byte.is_ascii_hexdigit()));
+    }
+
+    #[test]
     fn lifts_the_inference_token_from_a_snapshot() {
         let tmp = tempfile::tempdir().unwrap();
         let k = key();
@@ -370,6 +415,7 @@ mod tests {
             source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
             key: k,
             allow_refresh: true,
+            coordination_lock: None,
         };
         let (creds, _wb) = d.read().unwrap();
         let o = creds.claude_ai_oauth;
@@ -391,6 +437,7 @@ mod tests {
             source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
             key: k,
             allow_refresh: false,
+            coordination_lock: None,
         };
         let (creds, wb) = d.read().unwrap();
         assert_eq!(creds.claude_ai_oauth.refresh_token, "");
@@ -407,6 +454,7 @@ mod tests {
             source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
             key: k,
             allow_refresh: true,
+            coordination_lock: None,
         };
         let (mut creds, wb) = d.read().unwrap();
         creds.claude_ai_oauth.access_token = "new-at".into();
@@ -450,6 +498,7 @@ mod tests {
             source: BlobSource::ConfigJson(cfg.clone()),
             key: k,
             allow_refresh: true,
+            coordination_lock: None,
         };
         let (mut creds, wb) = d.read().unwrap();
         assert_eq!(creds.claude_ai_oauth.access_token, "cfg-at");
@@ -470,6 +519,7 @@ mod tests {
             source: BlobSource::ProfileDir(tmp.path().to_path_buf()),
             key: key(),
             allow_refresh: true,
+            coordination_lock: None,
         };
         assert!(d.read().is_err());
     }

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 
-use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
+use crate::cache::{Cache, LockGuard, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::AnthropicSnapshot;
 
@@ -65,6 +65,11 @@ pub async fn fetch_snapshot(
 ) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
     let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+    // Desktop snapshots and account switching can mutate the same rotating
+    // credential. Hold their shared lock from source resolution through any
+    // refresh write-back; the live config source is read-only but also uses the
+    // lock so it cannot be read halfway through our own switch transaction.
+    let credential_lock = acquire_credential_lock(creds_target, LOCK_TIMEOUT).await?;
 
     // Fast path: cache is fresh, no work needed. We still need creds for the
     // plan label though, so read them either way. `resolve` also reports where
@@ -148,6 +153,10 @@ pub async fn fetch_snapshot(
         }
     }
 
+    // Usage fetches do not mutate credentials and should not make an account
+    // switch wait on the network once refresh/write-back is complete.
+    drop(credential_lock);
+
     // Fetch usage.
     match tokio::time::timeout(
         HTTP_TIMEOUT,
@@ -181,6 +190,19 @@ pub async fn fetch_snapshot(
         }
         Err(_elapsed) => fallback_to_cache_silent(cache, plan_label),
     }
+}
+
+async fn acquire_credential_lock(
+    target: &creds::CredsTarget,
+    timeout: Duration,
+) -> Result<Option<LockGuard>> {
+    let creds::CredsTarget::Desktop(desktop) = target else {
+        return Ok(None);
+    };
+    let Some(path) = desktop.coordination_lock() else {
+        return Ok(None);
+    };
+    acquire_lock_async(path, timeout).await.map(Some)
 }
 
 fn reuse_cache(
@@ -332,6 +354,33 @@ mod tests {
         let cache = Cache::at(td.path().join("anthropic"));
         cache.ensure_dir().unwrap();
         (td, cache)
+    }
+
+    #[tokio::test]
+    async fn desktop_refresh_waits_for_the_account_switch_lock() {
+        let tmp = TempDir::new().unwrap();
+        let lock_path = tmp.path().join(".account-switch.lock");
+        let held = crate::cache::acquire_lock(&lock_path, Duration::from_secs(1)).unwrap();
+        let desktop = crate::anthropic::desktop_creds::source_for(
+            &tmp.path().join("config.json"),
+            &tmp.path().join("profile"),
+            false,
+            [0; 16],
+        )
+        .with_coordination_lock(lock_path);
+        let target = creds::CredsTarget::Desktop(desktop);
+
+        let waiter = tokio::spawn(async move {
+            acquire_credential_lock(&target, Duration::from_secs(2))
+                .await
+                .unwrap()
+                .is_some()
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!waiter.is_finished(), "refresh bypassed the switch lock");
+
+        drop(held);
+        assert!(waiter.await.unwrap());
     }
 
     #[tokio::test]

--- a/src/anthropic/mod.rs
+++ b/src/anthropic/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod cli_account;
 pub mod creds;
+pub mod desktop_creds;
 pub mod fetch;
 #[cfg(target_os = "macos")]
 pub mod keychain;

--- a/src/bin/ai-usagebar-tui.rs
+++ b/src/bin/ai-usagebar-tui.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, SystemTime};
 use ai_usagebar::config::Config;
 use ai_usagebar::tui::app::{
     ANTHROPIC_REFRESH_STAGGER, App, REFRESH_INTERVAL, TabId, TabState, refresh_one,
-    refresh_stagger, tabs_from_config,
+    refresh_stagger, tabs_with_desktop,
 };
 use ai_usagebar::tui::view::draw;
 use ai_usagebar::vendor::HTTP_CLIENT_TIMEOUT;
@@ -51,7 +51,7 @@ async fn run() -> io::Result<()> {
             ai_usagebar::config::config_path_hint()
         ))
     })?;
-    let tabs = tabs_from_config(&config);
+    let tabs = tabs_with_desktop(&config);
     if tabs.is_empty() {
         eprintln!(
             "No vendors are enabled in {}. Exiting.",
@@ -166,7 +166,7 @@ fn reload_config(
     app.context_enabled = config.context.enabled;
     app.overview_vendors = config.ui.overview_vendors.clone();
     app.vendor_box = config.ui.vendor_box();
-    app.set_tabs(tabs_from_config(config));
+    app.set_tabs(tabs_with_desktop(config));
     if reselect_primary {
         app.select_primary(config.ui.primary);
     }

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -66,7 +66,11 @@ fn set_private_mode(_path: &Path, _mode: u32) -> Result<()> {
 ///
 /// AppleScript answers correctly, and asking whether an application `is
 /// running` does not launch it.
-fn is_running() -> bool {
+///
+/// Also gates the *active* account's usage read: while the app runs it owns and
+/// refreshes `config.json`'s token, so ai-usagebar must read it but never
+/// refresh it (that would rotate the app's live credential out from under it).
+pub fn is_running() -> bool {
     Command::new("/usr/bin/osascript")
         .args(["-e", "application \"Claude\" is running"])
         .output()

--- a/src/claude_desktop/capture.rs
+++ b/src/claude_desktop/capture.rs
@@ -95,10 +95,8 @@ pub fn capture_profile(
     crate::config::validate_account_label(label)?;
     install_cancel_handler()?;
     CAPTURE_CANCELLED.store(false, Ordering::SeqCst);
-    let _lock = crate::cache::acquire_lock(
-        &paths.backups_dir.join(".account-switch.lock"),
-        Duration::from_secs(2),
-    )?;
+    let _lock =
+        crate::cache::acquire_lock(&paths.account_switch_lock(), super::ACCOUNT_LOCK_TIMEOUT)?;
     let profiles = super::load_profiles(&paths.profiles_dir);
     if profiles.iter().any(|profile| profile.label == label) {
         return Err(AppError::Credentials(format!(

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -57,6 +57,10 @@ const TOKEN_CACHE: &str = "config-tokenCache";
 const TOKEN_CACHE_V2: &str = "config-tokenCacheV2";
 const DESKTOP_STATE: &str = "desktop-state";
 const META_JSON: &str = "meta.json";
+/// One credential mutation can include a remote OAuth refresh. Account
+/// switching waits on the same lock rather than racing or failing after the
+/// old two-second window.
+pub const ACCOUNT_LOCK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
 /// Where the Claude Desktop app and the saved profiles live.
 ///
@@ -113,6 +117,12 @@ impl Paths {
 
     pub fn profile_dir(&self, label: &str) -> PathBuf {
         self.profiles_dir.join(label)
+    }
+
+    /// Shared by Desktop account switching and inactive-profile OAuth refresh.
+    /// Both operations can rotate or install the same saved credential.
+    pub fn account_switch_lock(&self) -> PathBuf {
+        self.backups_dir.join(".account-switch.lock")
     }
 
     /// Where [`capture`] parks the live login before clearing it, so a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod openrouter;
 pub mod pacing;
 pub mod pango;
 pub mod report;
+pub mod safe_storage;
 pub mod theme;
 pub mod tooltip;
 pub mod tui;

--- a/src/report.rs
+++ b/src/report.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 use serde_json::json;
 
 use crate::config::Config;
-use crate::tui::app::{TabId, TabState, refresh_one, tabs_from_config};
+use crate::tui::app::{TabId, TabState, refresh_one, tabs_with_desktop};
 use crate::tui::panels::{Section, sections_for};
 
 /// Matches the widget's `--pace-tolerance` default; only affects the pacing
@@ -85,7 +85,7 @@ pub async fn run(json: bool) -> i32 {
         }
     };
 
-    let tabs = tabs_from_config(&config);
+    let tabs = tabs_with_desktop(&config);
     if tabs.is_empty() {
         eprintln!(
             "ai-usagebar usage: no vendors enabled in {}",
@@ -173,6 +173,9 @@ fn tab_id(tab: &TabId) -> String {
 
 fn tab_name(tab: &TabId) -> String {
     match &tab.account {
+        // Mark a Desktop-sourced account so a mixed CLI+Desktop setup is legible;
+        // for a Desktop-only user every Claude row simply reads "· <label> (desktop)".
+        Some(account) if tab.desktop => format!("{} · {account} (desktop)", tab.vendor.slug()),
         Some(account) => format!("{} · {account}", tab.vendor.slug()),
         None => tab.vendor.slug().to_string(),
     }

--- a/src/safe_storage.rs
+++ b/src/safe_storage.rs
@@ -1,0 +1,139 @@
+//! Electron/Chromium **safeStorage** on macOS — the encryption Claude Desktop
+//! uses for the OAuth token blobs in its `config.json` (`oauth:tokenCacheV2`).
+//!
+//! The scheme is Chromium's `OSCrypt`: a random 128-bit secret lives in the
+//! login Keychain (generic-password service `Claude Safe Storage`), a 16-byte
+//! AES key is derived from it with PBKDF2-HMAC-SHA1 (salt `saltysalt`, 1003
+//! rounds), and each value is `"v10"` followed by AES-128-CBC ciphertext with a
+//! fixed all-spaces IV and PKCS7 padding. Both the salt/rounds/IV and the `v10`
+//! tag are Chromium constants, identical across every Electron app on macOS.
+//!
+//! Only [`macos_key`] touches the Keychain (macOS-gated); the derive/decrypt/
+//! encrypt transform is pure and platform-independent, so it is exercised by a
+//! round-trip test on Linux CI without any real secret (the hermeticity rule).
+
+use aes::cipher::{BlockDecryptMut, BlockEncryptMut, KeyIvInit, block_padding::Pkcs7};
+use base64::Engine;
+
+use crate::error::{AppError, Result};
+
+/// Chromium OSCrypt constants (macOS). Not secrets — the same values ship in
+/// every Chromium build.
+const SALT: &[u8] = b"saltysalt";
+const ROUNDS: u32 = 1003;
+const KEY_LEN: usize = 16;
+const IV: [u8; 16] = [b' '; 16];
+const PREFIX: &[u8] = b"v10";
+
+/// Login-Keychain generic-password service holding Claude Desktop's secret.
+#[cfg(target_os = "macos")]
+pub const SERVICE: &str = "Claude Safe Storage";
+
+type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
+type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
+
+/// Derive the 16-byte AES key from the Keychain secret (PBKDF2-HMAC-SHA1).
+pub fn derive_key(secret: &[u8]) -> [u8; KEY_LEN] {
+    let mut key = [0u8; KEY_LEN];
+    pbkdf2::pbkdf2_hmac::<sha1::Sha1>(secret, SALT, ROUNDS, &mut key);
+    key
+}
+
+/// Decrypt a base64 `v10…` safeStorage value into its plaintext bytes.
+pub fn decrypt(key: &[u8; KEY_LEN], value_b64: &str) -> Result<Vec<u8>> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(value_b64.trim())
+        .map_err(|e| AppError::Other(format!("safeStorage value is not base64: {e}")))?;
+    if raw.len() < PREFIX.len() || &raw[..PREFIX.len()] != PREFIX {
+        return Err(AppError::Other(
+            "safeStorage value is missing the v10 prefix".into(),
+        ));
+    }
+    let ct = &raw[PREFIX.len()..];
+    Aes128CbcDec::new(key.into(), &IV.into())
+        .decrypt_padded_vec_mut::<Pkcs7>(ct)
+        .map_err(|e| AppError::Other(format!("safeStorage decrypt failed: {e}")))
+}
+
+/// Encrypt plaintext back into a base64 `v10…` value, byte-compatible with what
+/// the app wrote (deterministic: fixed IV, no random salt). Used for the token
+/// write-back after a refresh.
+pub fn encrypt(key: &[u8; KEY_LEN], plaintext: &[u8]) -> String {
+    let ct = Aes128CbcEnc::new(key.into(), &IV.into()).encrypt_padded_vec_mut::<Pkcs7>(plaintext);
+    let mut out = Vec::with_capacity(PREFIX.len() + ct.len());
+    out.extend_from_slice(PREFIX);
+    out.extend_from_slice(&ct);
+    base64::engine::general_purpose::STANDARD.encode(out)
+}
+
+/// The derived AES key for Claude Desktop, read from the login Keychain.
+/// macOS-only; the caller handles the "no key / not macOS" case by skipping the
+/// Desktop usage source entirely.
+#[cfg(target_os = "macos")]
+pub fn macos_key() -> Result<[u8; KEY_LEN]> {
+    use std::process::Command;
+    let out = Command::new("/usr/bin/security")
+        .args(["find-generic-password", "-s", SERVICE, "-w"])
+        .output()
+        .map_err(|e| AppError::Other(format!("could not run `security`: {e}")))?;
+    if !out.status.success() {
+        return Err(AppError::Other(format!(
+            "no `{SERVICE}` item in the login Keychain (is Claude Desktop installed?)"
+        )));
+    }
+    let secret = String::from_utf8_lossy(&out.stdout);
+    Ok(derive_key(secret.trim().as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A fixed, fake secret — never a real Keychain read (hermeticity).
+    fn key() -> [u8; KEY_LEN] {
+        derive_key(b"not-a-real-secret")
+    }
+
+    #[test]
+    fn round_trips_plaintext() {
+        let k = key();
+        let msg = br#"{"token":"sk-ant-oat01-abc","refreshToken":"sk-ant-ort01-xyz"}"#;
+        let enc = encrypt(&k, msg);
+        assert!(
+            base64::engine::general_purpose::STANDARD
+                .decode(&enc)
+                .unwrap()
+                .starts_with(PREFIX)
+        );
+        assert_eq!(decrypt(&k, &enc).unwrap(), msg);
+    }
+
+    #[test]
+    fn encryption_is_deterministic() {
+        // Fixed IV + no random salt: the same plaintext must encrypt identically,
+        // which is what lets a write-back be verified and tested.
+        let k = key();
+        assert_eq!(encrypt(&k, b"same"), encrypt(&k, b"same"));
+    }
+
+    #[test]
+    fn rejects_a_value_without_the_v10_prefix() {
+        let k = key();
+        let no_prefix = base64::engine::general_purpose::STANDARD.encode(b"not-v10-data");
+        assert!(decrypt(&k, &no_prefix).is_err());
+    }
+
+    #[test]
+    fn rejects_non_base64() {
+        assert!(decrypt(&key(), "@@@not base64@@@").is_err());
+    }
+
+    #[test]
+    fn wrong_key_fails_rather_than_returning_garbage() {
+        // PKCS7 validation makes a wrong key overwhelmingly likely to error on
+        // the padding check instead of silently yielding wrong bytes.
+        let enc = encrypt(&key(), b"secret payload here, long enough to pad");
+        let other = derive_key(b"different-secret");
+        assert!(decrypt(&other, &enc).is_err());
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -445,7 +445,9 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             // `credentials_path` is an explicit strict read, and only the
             // platform default gets the macOS Keychain fallback.
             let (creds_target, cache) = match tab.account.as_deref() {
-                Some(label) if tab.desktop => desktop_target(config, label)?,
+                Some(label) if tab.desktop => {
+                    crate::anthropic::desktop_creds::account_target(config, label)?
+                }
                 Some(label) => config.anthropic.account_target(label)?,
                 None => {
                     let target = match config.anthropic.credentials_path.clone() {
@@ -673,48 +675,6 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             Ok(outcome.into())
         }
     }
-}
-
-/// Resolve a Claude Desktop account label to its credential source + cache.
-/// The active account (the one `config.json` points at) reads the live token
-/// and refreshes only while the app is stopped; every other account reads its
-/// own snapshot. The cache is the plain `anthropic/<label>` dir — one usage
-/// source per label — so the widget, menu bar and `claude-acc list` all find
-/// it. macOS-only: the Desktop token store and its Keychain key don't exist
-/// elsewhere, and such tabs are never enumerated off-Mac.
-#[cfg(target_os = "macos")]
-fn desktop_target(
-    config: &Config,
-    label: &str,
-) -> Result<(crate::anthropic::creds::CredsTarget, crate::cache::Cache)> {
-    use crate::error::AppError;
-    let paths = crate::claude_desktop::Paths::resolve(&config.anthropic)?;
-    let profile = crate::claude_desktop::load_profiles(&paths.profiles_dir)
-        .into_iter()
-        .find(|p| p.label == label)
-        .ok_or_else(|| AppError::Other(format!("no saved Desktop profile {label:?}")))?;
-    let is_active = crate::claude_desktop::active_account_uuid(&paths.config_json())
-        .is_some_and(|uuid| uuid == profile.account_uuid);
-    let key = crate::safe_storage::macos_key()?;
-    let source = crate::anthropic::desktop_creds::source_for(
-        &paths.config_json(),
-        &paths.profile_dir(label),
-        is_active,
-        crate::claude_desktop::app::is_running(),
-        key,
-    );
-    let cache = crate::cache::Cache::for_vendor_account("anthropic", label)?;
-    Ok((crate::anthropic::creds::CredsTarget::Desktop(source), cache))
-}
-
-#[cfg(not(target_os = "macos"))]
-fn desktop_target(
-    _config: &Config,
-    label: &str,
-) -> Result<(crate::anthropic::creds::CredsTarget, crate::cache::Cache)> {
-    Err(crate::error::AppError::Other(format!(
-        "Claude Desktop accounts are macOS-only (requested {label:?})"
-    )))
 }
 
 /// Convenience for the watch-driven binary: how long to wait between

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -39,10 +39,13 @@ pub struct ReadyTab {
 /// Identity of one TUI tab. Usually a whole vendor; for Anthropic it can also
 /// name a specific configured account (issues #14 / #17). `account: None` is a
 /// plain vendor tab — the default Claude account, or any non-Anthropic vendor.
+/// `desktop` marks an account whose usage comes from the Claude Desktop app's
+/// own token rather than a `claude` CLI credential.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TabId {
     pub vendor: VendorId,
     pub account: Option<String>,
+    pub desktop: bool,
 }
 
 impl TabId {
@@ -51,6 +54,7 @@ impl TabId {
         Self {
             vendor,
             account: None,
+            desktop: false,
         }
     }
 
@@ -59,6 +63,17 @@ impl TabId {
         Self {
             vendor: VendorId::Anthropic,
             account: Some(label.into()),
+            desktop: false,
+        }
+    }
+
+    /// An Anthropic account whose usage is read from the Claude Desktop app's
+    /// own token store (a saved `~/.claude-acc/profiles/<label>` account).
+    pub fn desktop_account(label: impl Into<String>) -> Self {
+        Self {
+            vendor: VendorId::Anthropic,
+            account: Some(label.into()),
+            desktop: true,
         }
     }
 }
@@ -68,25 +83,114 @@ impl TabId {
 /// config order; every other vendor is a single tab. With no extra accounts
 /// configured the result equals `config.enabled_vendors()` — identical tab set
 /// and order to before (issue #14/#17 back-compat).
+///
+/// Config-only and pure — no Desktop profiles. Production uses
+/// [`tabs_with_desktop`]; this stays for the hermetic unit tests and any caller
+/// that only wants configured accounts.
 pub fn tabs_from_config(config: &Config) -> Vec<TabId> {
+    build_tabs(config, &[], &[])
+}
+
+/// The production tab list: configured accounts plus every saved Claude Desktop
+/// profile that has usable credentials and is not already a working CLI account.
+/// Desktop discovery is best-effort and macOS-only; anywhere else this equals
+/// [`tabs_from_config`].
+pub fn tabs_with_desktop(config: &Config) -> Vec<TabId> {
+    let desktop = desktop_profile_labels(config);
+    // A configured CLI account normally wins its label, but only if it can
+    // actually authenticate. A half-finished `account add <label>` (config
+    // entry written, login never completed) would otherwise mask a perfectly
+    // good Desktop profile of the same name — the account shows an error
+    // instead of its usage. Where that happens, let the Desktop source take
+    // over. Checked only for labels that exist in both, so the credential probe
+    // is rare.
+    let broken = broken_cli_labels(config, &desktop);
+    build_tabs(config, &desktop, &broken)
+}
+
+/// Core expansion, parameterized so it stays pure and unit-testable.
+/// `desktop_labels` are Claude Desktop accounts; `broken_cli` names configured
+/// CLI accounts to drop (their credential is unusable and a Desktop profile
+/// covers them). Desktop accounts follow the CLI accounts, de-duplicated by
+/// label (a *working* configured CLI account wins), and count toward "Anthropic
+/// has accounts" for the default-tab suppression.
+fn build_tabs(config: &Config, desktop_labels: &[String], broken_cli: &[String]) -> Vec<TabId> {
     let mut tabs = Vec::new();
     for vendor in config.enabled_vendors() {
         if vendor == VendorId::Anthropic {
-            let accounts = config.anthropic.all_accounts();
+            let accounts: Vec<_> = config
+                .anthropic
+                .all_accounts()
+                .into_iter()
+                .filter(|a| !broken_cli.iter().any(|b| b == &a.label))
+                .collect();
+            let cli_labels: HashSet<&str> = accounts.iter().map(|a| a.label.as_str()).collect();
+            let desktop: Vec<&String> = desktop_labels
+                .iter()
+                .filter(|label| !cli_labels.contains(label.as_str()))
+                .collect();
             // The default (unnamed) Claude tab is suppressible once every
             // account is named — but never when it would leave Anthropic with
-            // no tab at all.
-            if config.anthropic.show_default_account || accounts.is_empty() {
+            // no tab at all. Desktop accounts count as named accounts here.
+            if config.anthropic.show_default_account || (accounts.is_empty() && desktop.is_empty())
+            {
                 tabs.push(TabId::vendor(vendor));
             }
             for acct in accounts {
                 tabs.push(TabId::account(acct.label));
+            }
+            for label in desktop {
+                tabs.push(TabId::desktop_account(label.clone()));
             }
         } else {
             tabs.push(TabId::vendor(vendor));
         }
     }
     tabs
+}
+
+/// Configured CLI accounts that both (a) share a label with a Desktop profile
+/// and (b) can't authenticate — so the Desktop source should win. Resolving the
+/// credential may read the macOS Keychain, so this only runs for the rare label
+/// present in both places.
+fn broken_cli_labels(config: &Config, desktop_labels: &[String]) -> Vec<String> {
+    use crate::anthropic::creds;
+    config
+        .anthropic
+        .all_accounts()
+        .into_iter()
+        .filter(|a| desktop_labels.iter().any(|d| d == &a.label))
+        .filter(|a| match config.anthropic.account_target(&a.label) {
+            Ok((target, _)) => creds::resolve(&target)
+                .map(|(c, _)| creds::is_unusable(&c.claude_ai_oauth))
+                .unwrap_or(true),
+            Err(_) => true,
+        })
+        .map(|a| a.label)
+        .collect()
+}
+
+/// Labels of saved Claude Desktop profiles with usable credentials. macOS-only
+/// (elsewhere there is no Desktop app); best-effort, so an unreadable profile
+/// store just yields none rather than failing the whole tab list.
+#[cfg(target_os = "macos")]
+fn desktop_profile_labels(config: &Config) -> Vec<String> {
+    let Ok(paths) = crate::claude_desktop::Paths::resolve(&config.anthropic) else {
+        return Vec::new();
+    };
+    if !paths.available() {
+        return Vec::new();
+    }
+    crate::claude_desktop::load_profiles(&paths.profiles_dir)
+        .into_iter()
+        .filter(|p| p.has_credentials)
+        .map(|p| p.label)
+        .collect()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn desktop_profile_labels(_config: &Config) -> Vec<String> {
+    Vec::new()
 }
 
 #[derive(Debug)]
@@ -341,6 +445,7 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             // `credentials_path` is an explicit strict read, and only the
             // platform default gets the macOS Keychain fallback.
             let (creds_target, cache) = match tab.account.as_deref() {
+                Some(label) if tab.desktop => desktop_target(config, label)?,
                 Some(label) => config.anthropic.account_target(label)?,
                 None => {
                     let target = match config.anthropic.credentials_path.clone() {
@@ -568,6 +673,48 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             Ok(outcome.into())
         }
     }
+}
+
+/// Resolve a Claude Desktop account label to its credential source + cache.
+/// The active account (the one `config.json` points at) reads the live token
+/// and refreshes only while the app is stopped; every other account reads its
+/// own snapshot. The cache is the plain `anthropic/<label>` dir — one usage
+/// source per label — so the widget, menu bar and `claude-acc list` all find
+/// it. macOS-only: the Desktop token store and its Keychain key don't exist
+/// elsewhere, and such tabs are never enumerated off-Mac.
+#[cfg(target_os = "macos")]
+fn desktop_target(
+    config: &Config,
+    label: &str,
+) -> Result<(crate::anthropic::creds::CredsTarget, crate::cache::Cache)> {
+    use crate::error::AppError;
+    let paths = crate::claude_desktop::Paths::resolve(&config.anthropic)?;
+    let profile = crate::claude_desktop::load_profiles(&paths.profiles_dir)
+        .into_iter()
+        .find(|p| p.label == label)
+        .ok_or_else(|| AppError::Other(format!("no saved Desktop profile {label:?}")))?;
+    let is_active = crate::claude_desktop::active_account_uuid(&paths.config_json())
+        .is_some_and(|uuid| uuid == profile.account_uuid);
+    let key = crate::safe_storage::macos_key()?;
+    let source = crate::anthropic::desktop_creds::source_for(
+        &paths.config_json(),
+        &paths.profile_dir(label),
+        is_active,
+        crate::claude_desktop::app::is_running(),
+        key,
+    );
+    let cache = crate::cache::Cache::for_vendor_account("anthropic", label)?;
+    Ok((crate::anthropic::creds::CredsTarget::Desktop(source), cache))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn desktop_target(
+    _config: &Config,
+    label: &str,
+) -> Result<(crate::anthropic::creds::CredsTarget, crate::cache::Cache)> {
+    Err(crate::error::AppError::Other(format!(
+        "Claude Desktop accounts are macOS-only (requested {label:?})"
+    )))
 }
 
 /// Convenience for the watch-driven binary: how long to wait between
@@ -805,6 +952,75 @@ mod tests {
                 TabId::account("personal"), // sorted by label
                 TabId::account("work"),
             ]
+        );
+    }
+
+    #[test]
+    fn desktop_labels_become_account_tabs_after_cli_accounts() {
+        // Pure core: desktop accounts follow CLI accounts, in the order given.
+        let config = config_with_accounts(&["work"]);
+        let tabs = build_tabs(&config, &["gmail".into(), "hotmail".into()], &[]);
+        assert_eq!(
+            tabs,
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::account("work"),
+                TabId::desktop_account("gmail"),
+                TabId::desktop_account("hotmail"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_cli_account_shadows_a_desktop_profile_of_the_same_label() {
+        // One tab per label; the explicitly configured CLI account wins.
+        let config = config_with_accounts(&["gmail"]);
+        let tabs = build_tabs(&config, &["gmail".into(), "hotmail".into()], &[]);
+        assert_eq!(
+            tabs,
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::account("gmail"),
+                TabId::desktop_account("hotmail"),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_broken_cli_account_yields_its_label_to_the_desktop_profile() {
+        // The exact failure a half-finished `account add gmail` caused: a CLI
+        // account is configured but unusable, and a Desktop profile of the same
+        // name exists. Passed in `broken_cli`, the CLI account is dropped and the
+        // Desktop source surfaces instead of an error tab.
+        let config = config_with_accounts(&["gmail"]);
+        let tabs = build_tabs(&config, &["gmail".into()], &["gmail".into()]);
+        assert_eq!(
+            tabs,
+            vec![
+                TabId::vendor(VendorId::Anthropic),
+                TabId::desktop_account("gmail"),
+            ]
+        );
+    }
+
+    #[test]
+    fn desktop_accounts_suppress_the_default_tab_like_named_ones() {
+        // show_default_account=false + only Desktop accounts => no default tab,
+        // exactly as if they were [[anthropic.accounts]] (the Desktop-only user).
+        let mut config = config_with_accounts(&[]);
+        config.cursor.enabled = false;
+        config.anthropic.show_default_account = false;
+
+        // No accounts of either kind: the default tab survives (never leave
+        // Anthropic tab-less).
+        assert_eq!(
+            build_tabs(&config, &[], &[]),
+            vec![TabId::vendor(VendorId::Anthropic)]
+        );
+        // A Desktop account is present: default suppressed, only the account.
+        assert_eq!(
+            build_tabs(&config, &["gmail".into()], &[]),
+            vec![TabId::desktop_account("gmail")]
         );
     }
 

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -123,6 +123,13 @@ pub struct Cli {
     #[arg(long, value_name = "LABEL", conflicts_with = "creds_path")]
     pub account: Option<String>,
 
+    /// Read `--account <LABEL>`'s usage from the Claude **Desktop app's** own
+    /// token instead of a `claude` CLI credential — a saved
+    /// `~/.claude-acc/profiles/<LABEL>` account, no CLI login required (macOS).
+    /// This is how the menu bar shows Desktop accounts in its overview.
+    #[arg(long, requires = "account")]
+    pub desktop: bool,
+
     /// Administrative command. Omit it to run the normal usage widget.
     #[command(subcommand)]
     pub command: Option<Command>,

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -647,6 +647,18 @@ fn vendor_cache(cli: &Cli, vendor: &str) -> Result<Cache> {
 /// account behaves byte-identically to before.
 fn anthropic_target(cli: &Cli, config: &Config) -> Result<(CredsTarget, Cache)> {
     match cli.account.as_deref() {
+        // `--account <label> --desktop`: read the Claude Desktop app's own token
+        // for that saved profile (the menu bar's overview path). `--cache-dir`
+        // still relocates the cache for scripted/multi-monitor setups.
+        Some(label) if cli.desktop => {
+            let (target, default_cache) =
+                crate::anthropic::desktop_creds::account_target(config, label)?;
+            let cache = match cli.cache_dir.as_deref() {
+                Some(p) => Cache::at(p.join("anthropic").join(label)),
+                None => default_cache,
+            };
+            Ok((target, cache))
+        }
         Some(label) => named_account_target(cli, config, label),
         None => Ok((
             anthropic_default_creds(cli, config)?,


### PR DESCRIPTION
## Claude Desktop accounts now report usage with **no `claude` CLI login**

A saved Desktop account (`account add <label> --desktop`) used to need a
*second*, separate `claude` login before its quota could appear — usage came
only from a CLI credential, and the Desktop app's token was assumed to be a
different, unusable OAuth client.

It isn't. The Desktop app stores its token under the **same public OAuth client
as Claude Code**, and the usage endpoint accepts it. So this reads that token
directly: every saved Desktop profile now shows up as a Claude account in
`ai-usagebar usage`, the TUI, the macOS menu-bar overview, and (via the shared
cache) `claude-acc list` — labelled `· <label> (desktop)` — with zero CLI
involvement.

### How

- **`src/safe_storage.rs`** — Chromium/Electron `safeStorage` on macOS
  (AES-128-CBC, PBKDF2-HMAC-SHA1 key from the login Keychain, `v10` values). The
  crypto transform is pure and platform-independent, so it is round-trip
  unit-tested on Linux CI; only the Keychain key-read is macOS-gated.
- **`src/anthropic/desktop_creds.rs`** — decrypts the blob, picks the
  `user:inference`-scoped entry, and maps it onto the existing `OauthCreds`, so
  refresh / cache / rendering are all unchanged. Also handles write-back of a
  refreshed token.
- **`CredsTarget::Desktop` / `CredsSource::Desktop`** — a new credential source
  the existing `fetch_snapshot` uses unchanged.
- **Tab enumeration** (`tabs_with_desktop`) lists saved Desktop profiles as
  Anthropic accounts, de-duplicated against configured CLI accounts (a CLI
  account of the same label wins) and folded into default-tab suppression. The
  widget and menu bar surface them too.

### Refresh safety

Refreshing rotates the refresh token and invalidates the old one, so it must
never run against a token the app is actively using. The **active** account is
read from the live `config.json` the running app keeps fresh, and is refreshed
by ai-usagebar **only while the app is stopped** — otherwise the refresh token
is blanked so the generic fetch path can't rotate the app's live credential out
from under it. Every **other** account is read from its own profile snapshot and
refreshes freely, writing the rotation back to that snapshot (which keeps the
snapshot switch-ready).

### Tests

New hermetic coverage for the crypto round-trip, the inference-token picker, the
active-vs-snapshot policy, the write-back, and tab enumeration/dedup/suppression.
Full suite: 830 Rust tests, `clippy`/`fmt` clean, Swift menu-bar builds and its
harness tests pass. Verified live end-to-end on a Desktop-only setup (no CLI
login present).

---

**Stacks on #67** (`fix/desktop-merge-and-liveness`). The two commits unique to
this PR are `feat(desktop): read usage from the Claude Desktop app's own token`
and `feat(desktop): surface Desktop accounts in the widget and menu bar`;
everything earlier belongs to #67. GitHub will narrow the diff to just those two
once #67 merges.
