### PR TITLE
feat(cursor): fall back to cursor-agent's auth.json when the IDE db is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Cursor: `cursor-agent` fallback credential** (`[cursor] agent_auth_path`).
+  Text-only machines that never open the desktop IDE now get usage too: when
+  the IDE's `state.vscdb` is absent, the vendor falls back to the session
+  token the headless `cursor-agent` CLI wrote to its own
+  `~/.config/cursor/auth.json`. The IDE database stays the preferred source
+  when both exist.
+
 ## [0.21.0] — 2026-08-03
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,10 @@ vendor's response shape drifts:
   discovered from `/proc` (Linux only; elsewhere set `ANTIGRAVITY_LS_ADDRESS`).
   Tests must never probe `/proc` or the wall clock — use `candidate_bases_with`
   and `parse_cache_at`/`fetch_snapshot_at`, not their production wrappers.
+- `src/cursor/` — Cursor. Reads the IDE's own `state.vscdb` (read-only), with
+  a fallback to the headless `cursor-agent` CLI's `auth.json` when the IDE db
+  is absent — `db::resolve_access_token` tries both. Tests seed a temp db /
+  auth file and pass the paths in; never touch the real ones.
 - `src/anthropic/keychain.rs` — macOS-only `security(1)` fallback when
   `~/.claude/.credentials.json` is absent (Claude Code on macOS stores
   the OAuth blob in the login Keychain). Module-gated with

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Each vendor authenticates a little differently. Anthropic and OpenAI use OAuth c
 | Grok (xAI) | **Management** key (`XAI_MANAGEMENT_KEY` env or `[grok] api_key` in config) | Set either. Opt-in. This is **not** the inference key — create it under xAI Console → Management keys. See the team note below. |
 | MiniMax | **Token Plan** key (`MINIMAX_API_KEY` env or `[minimax] api_key` in config) | Set either. Opt-in. Must be the Token Plan **subscription** key — a pay-as-you-go key has no plan quota to report. Set `[minimax] region = "cn"` for `api.minimaxi.com`; the default `"global"` uses `api.minimax.io`. The two are separate instances and reject each other's keys. |
 | Google Antigravity | None — read from the local Antigravity server | Opt-in. Quota is served only while Antigravity 2.0, the Antigravity IDE, or an interactive `agy` session is running; all three share one account-wide quota. |
-| Cursor | None — read from Cursor's local `state.vscdb` | Opt-in. Sign in to the Cursor IDE at least once; ai-usagebar reads the session token it already wrote there. No key of your own to create. |
+| Cursor | None — read from Cursor's local `state.vscdb` (or the `cursor-agent` CLI's `auth.json`) | Opt-in. Sign in to the Cursor IDE at least once; ai-usagebar reads the session token it already wrote there. No key of your own to create. Headless machines with no desktop IDE work too: sign in to `cursor-agent` once and its own `auth.json` is used as a fallback when the IDE database is absent. |
 
 #### Grok: team-scoped vs organization-scoped keys
 
@@ -135,7 +135,7 @@ For each API-key vendor, ai-usagebar checks in this order:
 - If you put inline `api_key` values in config, `chmod 600 ~/.config/ai-usagebar/config.toml`. The default behavior reads only env vars, which is safer when your config might be world-readable.
 - Don't commit your config dir if you check it into dotfiles unless you've redacted `api_key` lines.
 - OAuth credential files (`~/.claude/.credentials.json`, `~/.codex/auth.json`) are managed by their respective CLIs and already chmod-protected.
-- Cursor's session token lives in its own `state.vscdb`, managed entirely by the Cursor IDE — ai-usagebar opens it read-only and never writes to it.
+- Cursor's session token lives in its own `state.vscdb`, managed entirely by the Cursor IDE — ai-usagebar opens it read-only and never writes to it. On machines without the IDE, the `cursor-agent` CLI's own `auth.json` is read as a fallback instead — same read-only treatment.
 
 #### macOS: Anthropic credentials in the Keychain
 
@@ -232,8 +232,11 @@ api_key_env = "XAI_MANAGEMENT_KEY"
 [cursor]
 enabled = true             # disabled by default; enable once you've signed in to Cursor
 # No API key: reads the session token the Cursor IDE already wrote to its own
-# state.vscdb after you signed in there.
+# state.vscdb after you signed in there. No desktop IDE (headless machine)?
+# Sign in to the cursor-agent CLI once instead — its own auth.json is the
+# fallback when the IDE database is absent.
 # db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"
+# agent_auth_path = "/home/you/.config/cursor/auth.json"
 ```
 
 ## Quick start

--- a/config.example.toml
+++ b/config.example.toml
@@ -205,7 +205,9 @@ enabled = false
 [cursor]
 # Disabled by default — enable once you've signed in to the Cursor IDE at
 # least once (it needs no key from you, but it does need that one-time login
-# to exist).
+# to exist). Headless machines with no desktop IDE work too: sign in to the
+# `cursor-agent` CLI once instead — its own auth.json is used as a fallback
+# when the IDE database below is absent.
 enabled = false
 # Override Cursor's local state database path. Leave commented out to use the
 # platform default:
@@ -214,6 +216,12 @@ enabled = false
 #   Windows: %APPDATA%\Cursor\User\globalStorage\state.vscdb
 # Set this if you use a portable Cursor install or a renamed profile dir.
 # db_path = "/home/you/.config/Cursor/User/globalStorage/state.vscdb"
+# Override the cursor-agent CLI's own login file, tried only when db_path
+# does not exist. Leave commented out to use the platform default:
+#   Linux:   ~/.config/cursor/auth.json
+#   macOS:   ~/Library/Application Support/cursor/auth.json
+#   Windows: %APPDATA%\cursor\auth.json
+# agent_auth_path = "/home/you/.config/cursor/auth.json"
 
 [minimax]
 # Disabled by default — enable once you've set a key (env var or inline).

--- a/src/config.rs
+++ b/src/config.rs
@@ -678,6 +678,11 @@ pub struct CursorConfig {
     /// platform-standard `.../User/globalStorage/state.vscdb` — see
     /// `cursor::db::default_db_path`).
     pub db_path: Option<PathBuf>,
+    /// Override the headless `cursor-agent` CLI's own login file (defaults to
+    /// `.../cursor/auth.json` — see `cursor::db::default_agent_auth_path`).
+    /// Used as a fallback when `db_path` doesn't exist, so a text-only
+    /// machine that never runs the desktop IDE still gets usage.
+    pub agent_auth_path: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -778,6 +783,7 @@ impl Config {
         expand_tilde_opt(&mut self.anthropic.desktop_profiles_dir);
         expand_tilde_opt(&mut self.openai.codex_auth_path);
         expand_tilde_opt(&mut self.cursor.db_path);
+        expand_tilde_opt(&mut self.cursor.agent_auth_path);
         for account in &mut self.anthropic.accounts {
             account.credentials_path = expand_tilde(&account.credentials_path);
         }
@@ -1803,6 +1809,22 @@ enabled = false
         let c = Config::load_from(f.path()).unwrap();
         let home = crate::cache::home_dir().unwrap();
         assert_eq!(c.cursor.db_path, Some(home.join("cursor-state.vscdb")));
+    }
+
+    #[test]
+    fn cursor_agent_auth_path_is_tilde_expanded() {
+        let f = write_toml(
+            r#"
+            [cursor]
+            agent_auth_path = "~/cursor-agent-auth.json"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        let home = crate::cache::home_dir().unwrap();
+        assert_eq!(
+            c.cursor.agent_auth_path,
+            Some(home.join("cursor-agent-auth.json"))
+        );
     }
 
     #[test]

--- a/src/cursor/db.rs
+++ b/src/cursor/db.rs
@@ -82,6 +82,58 @@ pub fn read_access_token(path: &Path) -> Result<String> {
     Ok(token)
 }
 
+/// Default location of the `cursor-agent` CLI's own login state — a plain
+/// JSON file, not the IDE's `state.vscdb`. Written by the headless
+/// `cursor-agent` tool (and read by nothing else today), so it stays
+/// populated on machines that never run the desktop IDE at all.
+pub fn default_agent_auth_path() -> Result<PathBuf> {
+    let base = directories::BaseDirs::new().ok_or_else(|| {
+        AppError::Other("could not resolve the platform config directory (no HOME?)".into())
+    })?;
+    Ok(base.config_dir().join("cursor").join("auth.json"))
+}
+
+/// Read `cursor-agent`'s `accessToken` out of its `auth.json`. Same error
+/// shape as [`read_access_token`] (missing file / missing field / empty
+/// value are all a [`AppError::Credentials`]) so callers can treat both
+/// sources interchangeably.
+pub fn read_agent_access_token(path: &Path) -> Result<String> {
+    if !path.exists() {
+        return Err(AppError::Credentials(format!(
+            "cursor-agent auth file not found at {}. Run `cursor-agent` and sign in at least \
+             once, then try again.",
+            path.display()
+        )));
+    }
+    let bytes = std::fs::read(path).map_err(|e| AppError::io_at(path, e))?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Credentials(format!("could not parse {}: {e}", path.display())))?;
+    let token = value
+        .get("accessToken")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .ok_or_else(|| {
+            AppError::Credentials(format!(
+                "no accessToken in {}. Sign in with `cursor-agent` again.",
+                path.display()
+            ))
+        })?;
+    Ok(token.to_string())
+}
+
+/// Resolve a Cursor session token from either source. The IDE's `state.vscdb`
+/// is tried first (it is the live, continuously-refreshed source when the
+/// desktop app is actually running); a text-only / headless machine that has
+/// never opened the IDE falls back to whatever `cursor-agent` last wrote to
+/// its own `auth.json`. The IDE's error is the one surfaced when both are
+/// missing, since it names the more commonly expected path.
+pub fn resolve_access_token(db_path: &Path, agent_auth_path: &Path) -> Result<String> {
+    match read_access_token(db_path) {
+        Ok(token) => Ok(token),
+        Err(ide_err) => read_agent_access_token(agent_auth_path).or(Err(ide_err)),
+    }
+}
+
 /// The two values the `/api/usage` call needs, both derived from the same JWT:
 /// the bare user id (a query param) and the `WorkosCursorSessionToken` cookie
 /// value (`userId%3A%3Atoken` — literal, pre-encoded `::`, matching what the
@@ -263,5 +315,107 @@ mod tests {
         let token = fake_jwt(serde_json::json!({"sub": "no-pipe-here"}));
         let err = session_auth(&token).unwrap_err();
         assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn default_agent_auth_path_ends_with_cursor_auth_json() {
+        let p = default_agent_auth_path().unwrap();
+        assert!(p.ends_with(std::path::Path::new("cursor").join("auth.json")));
+    }
+
+    #[test]
+    fn agent_auth_missing_file_is_a_credentials_error_naming_the_path() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        let err = read_agent_access_token(&path).unwrap_err();
+        match err {
+            AppError::Credentials(m) => assert!(m.contains(&path.display().to_string())),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn agent_auth_reads_access_token_out_of_the_json_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(
+            &path,
+            serde_json::json!({"accessToken": "agent-token-value", "refreshToken": "r"})
+                .to_string(),
+        )
+        .unwrap();
+        assert_eq!(read_agent_access_token(&path).unwrap(), "agent-token-value");
+    }
+
+    #[test]
+    fn agent_auth_missing_field_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(&path, serde_json::json!({"refreshToken": "r"}).to_string()).unwrap();
+        let err = read_agent_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn agent_auth_empty_token_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(&path, serde_json::json!({"accessToken": ""}).to_string()).unwrap();
+        let err = read_agent_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn agent_auth_malformed_json_is_a_credentials_error() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(&path, "not json").unwrap();
+        let err = read_agent_access_token(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[test]
+    fn resolve_prefers_the_ide_db_when_both_are_present() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("state.vscdb");
+        seed_db(&db_path, Some("ide-token"));
+        let agent_path = dir.path().join("auth.json");
+        std::fs::write(
+            &agent_path,
+            serde_json::json!({"accessToken": "agent-token"}).to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_access_token(&db_path, &agent_path).unwrap(),
+            "ide-token"
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_the_agent_file_when_the_ide_db_is_missing() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("state.vscdb");
+        let agent_path = dir.path().join("auth.json");
+        std::fs::write(
+            &agent_path,
+            serde_json::json!({"accessToken": "agent-token"}).to_string(),
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_access_token(&db_path, &agent_path).unwrap(),
+            "agent-token"
+        );
+    }
+
+    #[test]
+    fn resolve_surfaces_the_ide_error_when_both_sources_are_missing() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("state.vscdb");
+        let agent_path = dir.path().join("auth.json");
+        let err = resolve_access_token(&db_path, &agent_path).unwrap_err();
+        match err {
+            AppError::Credentials(m) => assert!(m.contains(&db_path.display().to_string())),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
     }
 }

--- a/src/cursor/db.rs
+++ b/src/cursor/db.rs
@@ -84,7 +84,7 @@ pub fn read_access_token(path: &Path) -> Result<String> {
 
 /// Default location of the `cursor-agent` CLI's own login state — a plain
 /// JSON file, not the IDE's `state.vscdb`. Written by the headless
-/// `cursor-agent` tool (and read by nothing else today), so it stays
+/// `cursor-agent` tool, so it stays
 /// populated on machines that never run the desktop IDE at all.
 pub fn default_agent_auth_path() -> Result<PathBuf> {
     let base = directories::BaseDirs::new().ok_or_else(|| {
@@ -125,12 +125,15 @@ pub fn read_agent_access_token(path: &Path) -> Result<String> {
 /// is tried first (it is the live, continuously-refreshed source when the
 /// desktop app is actually running); a text-only / headless machine that has
 /// never opened the IDE falls back to whatever `cursor-agent` last wrote to
-/// its own `auth.json`. The IDE's error is the one surfaced when both are
-/// missing, since it names the more commonly expected path.
+/// its own `auth.json`. If the agent file exists but cannot be used, its error
+/// is surfaced so a headless user gets an actionable diagnostic. The IDE's
+/// error remains the one surfaced when both sources are absent, since it names
+/// the more commonly expected path.
 pub fn resolve_access_token(db_path: &Path, agent_auth_path: &Path) -> Result<String> {
     match read_access_token(db_path) {
         Ok(token) => Ok(token),
-        Err(ide_err) => read_agent_access_token(agent_auth_path).or(Err(ide_err)),
+        Err(_) if agent_auth_path.exists() => read_agent_access_token(agent_auth_path),
+        Err(ide_err) => Err(ide_err),
     }
 }
 
@@ -415,6 +418,23 @@ mod tests {
         let err = resolve_access_token(&db_path, &agent_path).unwrap_err();
         match err {
             AppError::Credentials(m) => assert!(m.contains(&db_path.display().to_string())),
+            other => panic!("expected Credentials error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_surfaces_the_agent_error_when_its_file_exists_but_is_malformed() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("state.vscdb");
+        let agent_path = dir.path().join("auth.json");
+        std::fs::write(&agent_path, "not json").unwrap();
+
+        let err = resolve_access_token(&db_path, &agent_path).unwrap_err();
+        match err {
+            AppError::Credentials(m) => {
+                assert!(m.contains(&agent_path.display().to_string()));
+                assert!(m.contains("could not parse"));
+            }
             other => panic!("expected Credentials error, got {other:?}"),
         }
     }

--- a/src/cursor/fetch.rs
+++ b/src/cursor/fetch.rs
@@ -46,15 +46,27 @@ pub struct FetchOutcome {
 
 /// Cache-aware fetch. `db_path` is Cursor's `state.vscdb` — the caller resolves
 /// `[cursor] db_path` (config override) vs [`db::default_db_path`], the same
-/// override pattern as `openai.codex_auth_path`.
+/// override pattern as `openai.codex_auth_path`. `agent_auth_path` is the
+/// headless `cursor-agent` CLI's own `auth.json`, tried when `db_path` is
+/// missing — see `db::resolve_access_token`.
 pub async fn fetch_snapshot(
     client: &reqwest::Client,
     db_path: &Path,
+    agent_auth_path: &Path,
     cache: &Cache,
     endpoints: &Endpoints,
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
-    fetch_snapshot_at(client, db_path, cache, endpoints, cache_ttl, Utc::now()).await
+    fetch_snapshot_at(
+        client,
+        db_path,
+        agent_auth_path,
+        cache,
+        endpoints,
+        cache_ttl,
+        Utc::now(),
+    )
+    .await
 }
 
 /// Clock seam for cache rollover tests. Cursor's payload describes one billing
@@ -62,6 +74,7 @@ pub async fn fetch_snapshot(
 async fn fetch_snapshot_at(
     client: &reqwest::Client,
     db_path: &Path,
+    agent_auth_path: &Path,
     cache: &Cache,
     endpoints: &Endpoints,
     cache_ttl: Duration,
@@ -73,7 +86,7 @@ async fn fetch_snapshot_at(
     // Resolve the local identity before accepting a cache hit. Cursor can switch
     // accounts in-place in this database; returning the cache first would show
     // the previous account's private usage until the TTL elapsed.
-    let token = db::read_access_token(db_path)?;
+    let token = db::resolve_access_token(db_path, agent_auth_path)?;
     let auth = db::session_auth(&token)?;
 
     if let Some(bytes) = cache.fresh_payload(cache_ttl)?
@@ -314,6 +327,12 @@ mod tests {
         db::session_auth(token).unwrap().account_key
     }
 
+    /// A path that never exists, for tests that only care about the IDE
+    /// `db_path` and want the agent fallback to stay out of the way.
+    fn no_agent_auth() -> std::path::PathBuf {
+        std::path::PathBuf::from("/nonexistent/cursor-agent-auth.json")
+    }
+
     fn cached_snapshot(account: &str, reset_at: &str) -> Vec<u8> {
         serde_json::to_vec(&serde_json::json!({
             "account": account,
@@ -367,6 +386,7 @@ mod tests {
         let out = fetch_snapshot(
             &client,
             &db_path,
+            &no_agent_auth(),
             &cache,
             &endpoints,
             Duration::from_secs(0),
@@ -387,10 +407,61 @@ mod tests {
         let endpoints = Endpoints::default();
         let db_path = std::path::Path::new("/nonexistent/state.vscdb");
 
-        let err = fetch_snapshot(&client, db_path, &cache, &endpoints, Duration::from_secs(0))
-            .await
-            .unwrap_err();
+        let err = fetch_snapshot(
+            &client,
+            db_path,
+            &no_agent_auth(),
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap_err();
         assert!(matches!(err, AppError::Credentials(_)));
+    }
+
+    #[tokio::test]
+    async fn agent_auth_file_is_used_when_the_ide_db_is_missing() {
+        let mut server = mockito::Server::new_async().await;
+        let token = fake_token("user_123");
+        let m = server
+            .mock("GET", "/api/usage-summary")
+            .match_header(
+                "cookie",
+                format!("WorkosCursorSessionToken=user_123%3A%3A{token}").as_str(),
+            )
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("state.vscdb"); // deliberately never seeded
+        let agent_path = dir.path().join("auth.json");
+        std::fs::write(
+            &agent_path,
+            serde_json::json!({"accessToken": token, "refreshToken": "r"}).to_string(),
+        )
+        .unwrap();
+        let (_cache_dir, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            summary: format!("{}/api/usage-summary", server.url()),
+        };
+
+        let out = fetch_snapshot(
+            &client,
+            &db_path,
+            &agent_path,
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        m.assert_async().await;
+        assert_eq!(out.snapshot.plan, "Ultra");
+        assert!(!out.stale);
     }
 
     #[tokio::test]
@@ -421,6 +492,7 @@ mod tests {
         let out = fetch_snapshot(
             &client,
             &db_path,
+            &no_agent_auth(),
             &cache,
             &endpoints,
             Duration::from_secs(0),
@@ -459,6 +531,7 @@ mod tests {
         let out = fetch_snapshot(
             &client,
             &db_path,
+            &no_agent_auth(),
             &cache,
             &endpoints,
             Duration::from_secs(3600),
@@ -503,6 +576,7 @@ mod tests {
         let out = fetch_snapshot(
             &reqwest::Client::new(),
             &db_path,
+            &no_agent_auth(),
             &cache,
             &endpoints,
             Duration::from_secs(3600),
@@ -542,6 +616,7 @@ mod tests {
         let err = fetch_snapshot_at(
             &reqwest::Client::new(),
             &db_path,
+            &no_agent_auth(),
             &cache,
             &endpoints,
             Duration::from_secs(0),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -668,10 +668,22 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
                 .clone()
                 .map(Ok)
                 .unwrap_or_else(crate::cursor::db::default_db_path)?;
+            let agent_auth_path = config
+                .cursor
+                .agent_auth_path
+                .clone()
+                .map(Ok)
+                .unwrap_or_else(crate::cursor::db::default_agent_auth_path)?;
             let endpoints = crate::cursor::fetch::Endpoints::default();
-            let outcome =
-                crate::cursor::fetch_snapshot(client, &db_path, &cache, &endpoints, DEFAULT_TTL)
-                    .await?;
+            let outcome = crate::cursor::fetch_snapshot(
+                client,
+                &db_path,
+                &agent_auth_path,
+                &cache,
+                &endpoints,
+                DEFAULT_TTL,
+            )
+            .await?;
             Ok(outcome.into())
         }
     }

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -198,13 +198,25 @@ async fn cursor_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
         Some(p) => p.to_path_buf(),
         None => cursor::db::default_db_path()?,
     };
+    let agent_auth_path = match config.cursor.agent_auth_path.as_deref() {
+        Some(p) => p.to_path_buf(),
+        None => cursor::db::default_agent_auth_path()?,
+    };
     let endpoints = cursor::fetch::Endpoints::default();
-    let outcome =
-        match cursor::fetch_snapshot(&client, &db_path, &cache, &endpoints, DEFAULT_TTL).await {
-            Ok(o) => o,
-            Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
-            Err(e) => return Err(e),
-        };
+    let outcome = match cursor::fetch_snapshot(
+        &client,
+        &db_path,
+        &agent_auth_path,
+        &cache,
+        &endpoints,
+        DEFAULT_TTL,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
+        Err(e) => return Err(e),
+    };
 
     let theme = theme_from_cli(cli);
     let snap = outcome.snapshot.clone();

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -1,9 +1,10 @@
 //! Live API smoke test suite — DETECTS UNDOCUMENTED-ENDPOINT DRIFT.
 //!
 //! Hits the real Anthropic, OpenAI Codex, Z.AI, OpenRouter, and Kimi endpoints
-//! using credentials from your shell. Asserts only the *fields we depend on*
-//! so when a vendor renames or removes one, the failure points at the exact
-//! field rather than dumping the whole response.
+//! using credentials from your shell (API keys, or the local IDE/CLI session
+//! files for Cursor). Asserts only the *fields we depend on* so when a vendor
+//! renames or removes one, the failure points at the exact field rather than
+//! dumping the whole response.
 //!
 //! These tests are `#[ignore]` so plain `cargo test` doesn't hit external
 //! APIs (and won't fail on machines without creds). Run explicitly:
@@ -42,7 +43,8 @@
 //! - **Cursor**: reads the session token from the local `state.vscdb`, then
 //!   asserts `premium_pct` is 0..=100 and a future `premium_reset_at` was
 //!   derived from `startOfMonth`. `cursor_live` skips when there is no Cursor
-//!   install (no state DB and no `CURSOR_DB_PATH`).
+//!   credential source (no state DB, no cursor-agent `auth.json`, and neither
+//!   `CURSOR_DB_PATH` nor `CURSOR_AGENT_AUTH_PATH` set).
 
 use std::time::Duration;
 
@@ -320,19 +322,28 @@ async fn kimi_live() {
 #[tokio::test]
 #[ignore = "live API; run with --ignored"]
 async fn cursor_live() {
-    // Cursor has no API key — the credential is the session token the Cursor
-    // IDE wrote to its local state DB. So this test needs a real Cursor install
-    // (or `CURSOR_DB_PATH` pointing at a copied `state.vscdb`) and skips
-    // otherwise, the same way `kimi_live` skips without a key. Nothing to fetch
-    // on a CI box with no Cursor.
+    // Cursor has no API key — the credential is a session token, either the
+    // one the Cursor IDE wrote to its local state DB, or (headless machines
+    // with no IDE) the one the `cursor-agent` CLI wrote to its own auth.json.
+    // So this test needs one of the two installed (or `CURSOR_DB_PATH` /
+    // `CURSOR_AGENT_AUTH_PATH` pointing at a copy) and skips otherwise, the
+    // same way `kimi_live` skips without a key. Nothing to fetch on a CI box
+    // with neither.
     let db_path = match std::env::var("CURSOR_DB_PATH") {
         Ok(p) if !p.trim().is_empty() => std::path::PathBuf::from(p),
         _ => cursor::db::default_db_path().expect("resolve platform config dir"),
     };
-    if !db_path.exists() {
+    let agent_auth_path = match std::env::var("CURSOR_AGENT_AUTH_PATH") {
+        Ok(p) if !p.trim().is_empty() => std::path::PathBuf::from(p),
+        _ => cursor::db::default_agent_auth_path().expect("resolve platform config dir"),
+    };
+    if !db_path.exists() && !agent_auth_path.exists() {
         eprintln!(
-            "cursor_live: no Cursor state DB at {} — skipping (sign in to the Cursor IDE, or set CURSOR_DB_PATH)",
-            db_path.display()
+            "cursor_live: no Cursor state DB at {} and no cursor-agent auth at {} — skipping \
+             (sign in to the Cursor IDE or run `cursor-agent`, or set CURSOR_DB_PATH / \
+             CURSOR_AGENT_AUTH_PATH)",
+            db_path.display(),
+            agent_auth_path.display()
         );
         return;
     }
@@ -346,6 +357,7 @@ async fn cursor_live() {
     let out = cursor::fetch_snapshot(
         &client,
         &db_path,
+        &agent_auth_path,
         &cache,
         &endpoints,
         Duration::from_secs(0),


### PR DESCRIPTION
## Summary

Machines that never run the desktop Cursor IDE (headless servers, text-only setups) had no way to show Cursor usage: the only credential source was the IDE's own `state.vscdb`. The headless [`cursor-agent` CLI](https://cursor.com/cli) writes its own login to `~/.config/cursor/auth.json` — a plain JSON file with an `accessToken` — which the same `/api/usage` endpoint accepts.

- `db::resolve_access_token` tries the IDE database first (it stays the live, continuously-refreshed source when the desktop app runs) and falls back to `cursor-agent`'s `auth.json` when the db is absent. The IDE's error is the one surfaced when both are missing, since it names the more commonly expected path.
- New `[cursor] agent_auth_path` config option overrides the fallback file's location (tilde-expanded like `db_path`).
- Widget, TUI and the live smoke test all resolve and pass both paths; `cursor_live` skips only when *neither* credential source exists (`CURSOR_DB_PATH` / `CURSOR_AGENT_AUTH_PATH` env overrides for both).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — hermetic tests seed a temp db / auth file; never touch real credentials. Covers: IDE-wins-when-both-exist, fallback-when-db-missing, error shape parity between the two readers
- [x] `cargo test -- --ignored cursor_live` against a real headless `cursor-agent` login

## Notes

- Fully backward compatible: when the IDE db exists (every current install), behavior is byte-for-byte identical — the fallback only engages in its absence.
- Docs updated: README vendor table/privacy/config sections, `config.example.toml`, CHANGELOG (Unreleased).
- Independent of (but complementary to) #69.

Made with [Cursor](https://cursor.com)