### PR TITLE
Converge a renamed routine's title across accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,13 @@ Each release is also published at
 
 - **A routine renamed in one account now converges to one title everywhere.** A
   scheduled task has no `updatedAt`, so a rename leaves `createdAt` untouched and
-  the merge — which resolves ties by registry-file mtime — only ever carried the
-  freshest title into the account you switched *to*, never settling: an unrelated
-  edit could even drag a stale name back. A switch now pushes that same
-  freshest-wins title into *every* account's registry, so the name stops
-  flip-flopping. Name-only: no other field is touched, there is no prompt (it
-  reconciles like any other merged field), and it applies to the terminal and the
-  menu bar alike since both drive the one switch path. Mirrored in claude-acc.
+  previously only reached the account you switched *to*. A switch now carries
+  the title selected by the baseline-aware routine merge into *every* account's
+  registry, so the name stops disagreeing across accounts. The convergence pass
+  changes only `displayName` and preserves the rest of each registry, including
+  unknown top-level fields. There is no prompt, and it applies to the terminal
+  and menu bar alike since both drive the same switch path. Mirrored in
+  claude-acc.
 
 ## [0.21.0] — 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ Each release is also published at
   when both exist; an existing but unreadable or malformed IDE database still
   surfaces its own error instead of silently switching to another login.
 
+### Fixed
+
+- **A routine renamed in one account now converges to one title everywhere.** A
+  scheduled task has no `updatedAt`, so a rename leaves `createdAt` untouched and
+  the merge — which resolves ties by registry-file mtime — only ever carried the
+  freshest title into the account you switched *to*, never settling: an unrelated
+  edit could even drag a stale name back. A switch now pushes that same
+  freshest-wins title into *every* account's registry, so the name stops
+  flip-flopping. Name-only: no other field is touched, there is no prompt (it
+  reconciles like any other merged field), and it applies to the terminal and the
+  menu bar alike since both drive the one switch path. Mirrored in claude-acc.
+
 ## [0.21.0] — 2026-08-03
 
 ### Added

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -56,6 +56,23 @@ pub struct ScheduledMerge {
     pub canonical_routines: BTreeMap<String, Value>,
 }
 
+impl ScheduledMerge {
+    /// User-visible names from the definitions selected for this switch.
+    /// These bytes were rendered while planning, so later registry writes
+    /// cannot change which title the convergence pass propagates.
+    pub(super) fn display_names(&self) -> Result<BTreeMap<String, String>> {
+        let document: Value = serde_json::from_slice(&self.bytes)?;
+        let tasks = document
+            .get("scheduledTasks")
+            .and_then(Value::as_array)
+            .ok_or_else(|| AppError::Other("planned scheduledTasks is not a JSON array".into()))?;
+        Ok(tasks
+            .iter()
+            .filter_map(|task| Some((task_id(task)?, display_name(task)?)))
+            .collect())
+    }
+}
+
 /// Plan the session-index merge into `<sessions_root>/<account_uuid>/<org_uuid>`.
 ///
 /// Infallible: an unreadable or absent tree simply means there is nothing to
@@ -438,68 +455,53 @@ pub struct NameConvergence {
     pub converged: usize,
 }
 
-/// The name every account should agree on, per routine id: the `displayName`
-/// from the copy the merge itself would keep — freshest by `createdAt`, then by
-/// registry mtime. Only ids that actually carry a name appear.
-///
-/// A rename leaves `createdAt` untouched, so without this a routine's title only
-/// ever propagates into the account you switch *to* (and by coarse file mtime,
-/// so an unrelated edit can drag a stale name back), and the accounts never
-/// settle on one name.
-fn canonical_display_names(sessions_root: &Path) -> BTreeMap<String, String> {
-    // id -> (createdAt, mtime, name) of the freshest holder seen so far.
-    let mut best: BTreeMap<String, (i64, i64, String)> = BTreeMap::new();
-    for (_, path) in scheduled_registries(sessions_root) {
-        let mtime = modified_at(&path);
-        let (tasks, _) = load_scheduled(&path);
-        for task in tasks {
-            let (Some(id), Some(name)) = (task_id(&task), display_name(&task)) else {
-                continue;
-            };
-            let rank = (created_at(&task), mtime);
-            match best.get(&id) {
-                Some((c, m, _)) if (*c, *m) >= rank => {}
-                _ => {
-                    best.insert(id, (rank.0, rank.1, name));
-                }
-            }
-        }
-    }
-    best.into_iter()
-        .map(|(id, (.., name))| (id, name))
-        .collect()
-}
-
 /// Rewrite every registry so a routine present in more than one account shows
-/// the same `displayName` everywhere — the [`canonical_display_names`] winner.
+/// the same `displayName` everywhere. `selected` comes from the routine merge
+/// planned before any files are written, so an unrelated write cannot change
+/// the winner by refreshing a registry's mtime.
+///
 /// No prompt: renames converge on the next switch the way the merge already
-/// converges every other field. Only registries that actually change are
-/// returned; other task fields are left exactly as they were.
-pub fn plan_name_convergence(sessions_root: &Path) -> Result<NameConvergence> {
-    let canonical = canonical_display_names(sessions_root);
+/// converges every other field. The complete registry document is retained and
+/// only task titles are mutated, including top-level fields newer Desktop
+/// versions may add.
+pub fn plan_name_convergence(
+    sessions_root: &Path,
+    selected: &BTreeMap<String, String>,
+) -> Result<NameConvergence> {
     let mut out = NameConvergence::default();
     let mut converged_ids: BTreeSet<String> = BTreeSet::new();
     for (_, path) in scheduled_registries(sessions_root) {
-        let (tasks, skips) = load_scheduled(&path);
+        let bytes = std::fs::read(&path).map_err(|error| AppError::io_at(&path, error))?;
+        let mut document: Value = serde_json::from_slice(&bytes)?;
+        let object = document.as_object_mut().ok_or_else(|| {
+            AppError::Other(format!(
+                "scheduled task registry {} is not a JSON object",
+                path.display()
+            ))
+        })?;
+        let Some(tasks) = object.get_mut("scheduledTasks") else {
+            continue;
+        };
+        let tasks = tasks.as_array_mut().ok_or_else(|| {
+            AppError::Other(format!(
+                "scheduledTasks in {} is not a JSON array",
+                path.display()
+            ))
+        })?;
         let mut changed = false;
-        let tasks: Vec<Value> = tasks
-            .into_iter()
-            .map(|mut task| {
-                if let Some(id) = task_id(&task)
-                    && let Some(name) = canonical.get(&id)
-                    && display_name(&task).as_deref() != Some(name.as_str())
-                    && let Some(obj) = task.as_object_mut()
-                {
-                    obj.insert("displayName".into(), Value::String(name.clone()));
-                    changed = true;
-                    converged_ids.insert(id);
-                }
-                task
-            })
-            .collect();
+        for task in tasks {
+            if let Some(id) = task_id(task)
+                && let Some(name) = selected.get(&id)
+                && display_name(task).as_deref() != Some(name.as_str())
+                && let Some(obj) = task.as_object_mut()
+            {
+                obj.insert("displayName".into(), Value::String(name.clone()));
+                changed = true;
+                converged_ids.insert(id);
+            }
+        }
         if changed {
-            let merged = serde_json::json!({ "scheduledTasks": tasks, "recordedSkips": skips });
-            out.rewrites.push((path, serde_json::to_vec(&merged)?));
+            out.rewrites.push((path, serde_json::to_vec(&document)?));
         }
     }
     out.converged = converged_ids.len();
@@ -935,20 +937,6 @@ fn created_at(task: &Value) -> i64 {
     task.get("createdAt").map_or(0, json_i64)
 }
 
-/// When a registry file was last written, in epoch milliseconds — the freshness
-/// signal name convergence uses to pick the winning title (a rename touches the
-/// file but not the task's `createdAt`). Absent or unreadable counts as the
-/// beginning of time, so a file we cannot stat never wins a tie.
-fn modified_at(path: &Path) -> i64 {
-    std::fs::metadata(path)
-        .and_then(|meta| meta.modified())
-        .ok()
-        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
-        .map_or(0, |since| {
-            i64::try_from(since.as_millis()).unwrap_or(i64::MAX)
-        })
-}
-
 fn last_activity(path: &Path) -> i64 {
     let Ok(bytes) = std::fs::read(path) else {
         return 0;
@@ -975,19 +963,6 @@ mod tests {
     fn write(path: &Path, contents: &str) {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(path, contents).unwrap();
-    }
-
-    /// Set a file's mtime deterministically, so name-convergence freshness never
-    /// depends on wall-clock write order.
-    fn touch(path: &Path, mtime_millis: u64) {
-        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(mtime_millis);
-        let times = std::fs::FileTimes::new().set_modified(time);
-        std::fs::OpenOptions::new()
-            .write(true)
-            .open(path)
-            .unwrap()
-            .set_times(times)
-            .unwrap();
     }
 
     fn session(activity: i64) -> String {
@@ -1120,13 +1095,13 @@ mod tests {
         let sessions = root.path();
         let target = sessions.join("A/O1/scheduled-tasks.json");
         let source = sessions.join("B/O2/scheduled-tasks.json");
-        let old = r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"0 5 * * *","enabled":true}]}"#;
+        let old = r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Morning","cronExpression":"0 5 * * *","enabled":true}]}"#;
         write(&target, old);
         write(&source, old);
         let synced = sync_baseline(sessions);
         write(
             &source,
-            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"cronExpression":"30 9 * * *","enabled":false}]}"#,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Renamed","cronExpression":"30 9 * * *","enabled":false}]}"#,
         );
 
         let merge = plan_scheduled_merge(sessions, "A", "O1", &synced).unwrap();
@@ -1136,6 +1111,7 @@ mod tests {
         let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
         assert_eq!(value["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
         assert_eq!(value["scheduledTasks"][0]["enabled"], false);
+        assert_eq!(merge.display_names().unwrap()["t1"], "Renamed");
     }
 
     // Reads a registry's first task's displayName back off disk.
@@ -1148,10 +1124,10 @@ mod tests {
     }
 
     #[test]
-    fn name_convergence_pushes_the_freshest_title_to_every_account() {
+    fn name_convergence_pushes_the_selected_title_to_every_account() {
         // Same routine id, two different titles — the classic "renamed in one
-        // account, never settles" case. The freshest (by mtime, since a rename
-        // leaves createdAt alone) must win *everywhere*, not just in the target.
+        // account, never settles" case. The title selected by the earlier
+        // routine merge must win everywhere, not just in the target.
         let root = tempfile::TempDir::new().unwrap();
         let sessions = root.path();
         let a = sessions.join("A/O1/scheduled-tasks.json");
@@ -1164,10 +1140,9 @@ mod tests {
             &b,
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"New name","cronExpression":"0 5 * * *"}]}"#,
         );
-        touch(&a, 1_000);
-        touch(&b, 2_000); // renamed more recently
 
-        let plan = plan_name_convergence(sessions).unwrap();
+        let selected = BTreeMap::from([("t1".to_string(), "New name".to_string())]);
+        let plan = plan_name_convergence(sessions, &selected).unwrap();
         assert_eq!(plan.converged, 1);
         // Only the stale registry (A) is rewritten; B already holds the winner.
         assert_eq!(plan.rewrites.len(), 1);
@@ -1193,10 +1168,8 @@ mod tests {
             &b,
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Fresh","cronExpression":"30 9 * * *","enabled":false}]}"#,
         );
-        touch(&a, 5_000); // A is fresher, so A's name wins and B is rewritten
-        touch(&b, 1_000);
-
-        let plan = plan_name_convergence(sessions).unwrap();
+        let selected = BTreeMap::from([("t1".to_string(), "Stale".to_string())]);
+        let plan = plan_name_convergence(sessions, &selected).unwrap();
         for (path, bytes) in &plan.rewrites {
             std::fs::write(path, bytes).unwrap();
         }
@@ -1206,6 +1179,92 @@ mod tests {
         let vb: Value = serde_json::from_slice(&std::fs::read(&b).unwrap()).unwrap();
         assert_eq!(vb["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
         assert_eq!(vb["scheduledTasks"][0]["enabled"], false);
+    }
+
+    #[test]
+    fn name_convergence_preserves_unknown_registry_fields() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let registry = sessions.join("A/O1/scheduled-tasks.json");
+        write(
+            &registry,
+            r#"{"scheduledTasks":[{"id":"t1","displayName":"Old"}],
+                "recordedSkips":{"t1":"kept"},
+                "futureMetadata":{"must":"survive"}}"#,
+        );
+        let selected = BTreeMap::from([("t1".to_string(), "New".to_string())]);
+
+        let plan = plan_name_convergence(sessions, &selected).unwrap();
+        assert_eq!(plan.rewrites.len(), 1);
+        let value: Value = serde_json::from_slice(&plan.rewrites[0].1).unwrap();
+
+        assert_eq!(value["scheduledTasks"][0]["displayName"], "New");
+        assert_eq!(value["recordedSkips"]["t1"], "kept");
+        assert_eq!(value["futureMetadata"]["must"], "survive");
+    }
+
+    #[test]
+    fn name_convergence_fails_closed_on_an_invalid_registry_shape() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":"not-an-array","futureMetadata":true}"#,
+        );
+        let selected = BTreeMap::from([("t1".to_string(), "New".to_string())]);
+
+        let error = plan_name_convergence(sessions, &selected).unwrap_err();
+
+        assert!(error.to_string().contains("scheduledTasks"));
+        assert!(error.to_string().contains("not a JSON array"));
+    }
+
+    #[test]
+    fn name_convergence_keeps_the_prewrite_merge_decision() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let a = sessions.join("A/O1/scheduled-tasks.json");
+        let b = sessions.join("B/O2/scheduled-tasks.json");
+        write(
+            &a,
+            r#"{"scheduledTasks":[
+                {"id":"t1","createdAt":100,"displayName":"Old"},
+                {"id":"doomed","createdAt":200,"displayName":"Delete me"}]}"#,
+        );
+        write(
+            &b,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Old"}]}"#,
+        );
+        let synced = sync_baseline(sessions);
+        write(
+            &b,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"New"}]}"#,
+        );
+
+        // Capture the three-way merge's decision before anything is written.
+        let scheduled = plan_scheduled_merge(sessions, "B", "O2", &synced).unwrap();
+        let selected = scheduled.display_names().unwrap();
+        assert_eq!(selected["t1"], "New");
+
+        // An unrelated deletion then rewrites A. That must not make A's stale
+        // title the winner merely because its registry was written later.
+        let doomed = BTreeSet::from([DeletionKey {
+            kind: ConflictKind::Routine,
+            id: "doomed".to_string(),
+            deleted_by: "B".to_string(),
+            still_in: vec!["A".to_string()],
+        }]);
+        let sweep = plan_deletion_sweep(sessions, &doomed).unwrap();
+        for (path, bytes) in sweep.rewrites {
+            std::fs::write(path, bytes).unwrap();
+        }
+
+        let convergence = plan_name_convergence(sessions, &selected).unwrap();
+        for (path, bytes) in convergence.rewrites {
+            std::fs::write(path, bytes).unwrap();
+        }
+        assert_eq!(first_display_name(&a), "New");
+        assert_eq!(first_display_name(&b), "New");
     }
 
     #[test]
@@ -1220,7 +1279,8 @@ mod tests {
             &sessions.join("B/O2/scheduled-tasks.json"),
             r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Same"}]}"#,
         );
-        let plan = plan_name_convergence(sessions).unwrap();
+        let selected = BTreeMap::from([("t1".to_string(), "Same".to_string())]);
+        let plan = plan_name_convergence(sessions, &selected).unwrap();
         assert_eq!(plan.converged, 0);
         assert!(plan.rewrites.is_empty());
     }

--- a/src/claude_desktop/merge.rs
+++ b/src/claude_desktop/merge.rs
@@ -429,6 +429,83 @@ pub fn plan_deletion_sweep(
     Ok(sweep)
 }
 
+/// Registry rewrites that make every account agree on each routine's
+/// `displayName`.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct NameConvergence {
+    pub rewrites: Vec<(PathBuf, Vec<u8>)>,
+    /// How many distinct routines had a name reconciled.
+    pub converged: usize,
+}
+
+/// The name every account should agree on, per routine id: the `displayName`
+/// from the copy the merge itself would keep — freshest by `createdAt`, then by
+/// registry mtime. Only ids that actually carry a name appear.
+///
+/// A rename leaves `createdAt` untouched, so without this a routine's title only
+/// ever propagates into the account you switch *to* (and by coarse file mtime,
+/// so an unrelated edit can drag a stale name back), and the accounts never
+/// settle on one name.
+fn canonical_display_names(sessions_root: &Path) -> BTreeMap<String, String> {
+    // id -> (createdAt, mtime, name) of the freshest holder seen so far.
+    let mut best: BTreeMap<String, (i64, i64, String)> = BTreeMap::new();
+    for (_, path) in scheduled_registries(sessions_root) {
+        let mtime = modified_at(&path);
+        let (tasks, _) = load_scheduled(&path);
+        for task in tasks {
+            let (Some(id), Some(name)) = (task_id(&task), display_name(&task)) else {
+                continue;
+            };
+            let rank = (created_at(&task), mtime);
+            match best.get(&id) {
+                Some((c, m, _)) if (*c, *m) >= rank => {}
+                _ => {
+                    best.insert(id, (rank.0, rank.1, name));
+                }
+            }
+        }
+    }
+    best.into_iter()
+        .map(|(id, (.., name))| (id, name))
+        .collect()
+}
+
+/// Rewrite every registry so a routine present in more than one account shows
+/// the same `displayName` everywhere — the [`canonical_display_names`] winner.
+/// No prompt: renames converge on the next switch the way the merge already
+/// converges every other field. Only registries that actually change are
+/// returned; other task fields are left exactly as they were.
+pub fn plan_name_convergence(sessions_root: &Path) -> Result<NameConvergence> {
+    let canonical = canonical_display_names(sessions_root);
+    let mut out = NameConvergence::default();
+    let mut converged_ids: BTreeSet<String> = BTreeSet::new();
+    for (_, path) in scheduled_registries(sessions_root) {
+        let (tasks, skips) = load_scheduled(&path);
+        let mut changed = false;
+        let tasks: Vec<Value> = tasks
+            .into_iter()
+            .map(|mut task| {
+                if let Some(id) = task_id(&task)
+                    && let Some(name) = canonical.get(&id)
+                    && display_name(&task).as_deref() != Some(name.as_str())
+                    && let Some(obj) = task.as_object_mut()
+                {
+                    obj.insert("displayName".into(), Value::String(name.clone()));
+                    changed = true;
+                    converged_ids.insert(id);
+                }
+                task
+            })
+            .collect();
+        if changed {
+            let merged = serde_json::json!({ "scheduledTasks": tasks, "recordedSkips": skips });
+            out.rewrites.push((path, serde_json::to_vec(&merged)?));
+        }
+    }
+    out.converged = converged_ids.len();
+    Ok(out)
+}
+
 /// `(account uuid, org dir)` for every account/org folder.
 fn account_dirs(sessions_root: &Path) -> Vec<(String, PathBuf)> {
     account_org_dirs(sessions_root)
@@ -845,8 +922,31 @@ fn task_id(task: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
+/// A routine's user-visible title. Empty is treated as absent so a blank name
+/// never becomes the value every account converges to.
+fn display_name(task: &Value) -> Option<String> {
+    task.get("displayName")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
 fn created_at(task: &Value) -> i64 {
     task.get("createdAt").map_or(0, json_i64)
+}
+
+/// When a registry file was last written, in epoch milliseconds — the freshness
+/// signal name convergence uses to pick the winning title (a rename touches the
+/// file but not the task's `createdAt`). Absent or unreadable counts as the
+/// beginning of time, so a file we cannot stat never wins a tie.
+fn modified_at(path: &Path) -> i64 {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(|time| time.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |since| {
+            i64::try_from(since.as_millis()).unwrap_or(i64::MAX)
+        })
 }
 
 fn last_activity(path: &Path) -> i64 {
@@ -875,6 +975,19 @@ mod tests {
     fn write(path: &Path, contents: &str) {
         std::fs::create_dir_all(path.parent().unwrap()).unwrap();
         std::fs::write(path, contents).unwrap();
+    }
+
+    /// Set a file's mtime deterministically, so name-convergence freshness never
+    /// depends on wall-clock write order.
+    fn touch(path: &Path, mtime_millis: u64) {
+        let time = std::time::UNIX_EPOCH + std::time::Duration::from_millis(mtime_millis);
+        let times = std::fs::FileTimes::new().set_modified(time);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(path)
+            .unwrap()
+            .set_times(times)
+            .unwrap();
     }
 
     fn session(activity: i64) -> String {
@@ -1023,6 +1136,93 @@ mod tests {
         let value: Value = serde_json::from_slice(&merge.bytes).unwrap();
         assert_eq!(value["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
         assert_eq!(value["scheduledTasks"][0]["enabled"], false);
+    }
+
+    // Reads a registry's first task's displayName back off disk.
+    fn first_display_name(path: &Path) -> String {
+        let value: Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        value["scheduledTasks"][0]["displayName"]
+            .as_str()
+            .unwrap_or_default()
+            .to_string()
+    }
+
+    #[test]
+    fn name_convergence_pushes_the_freshest_title_to_every_account() {
+        // Same routine id, two different titles — the classic "renamed in one
+        // account, never settles" case. The freshest (by mtime, since a rename
+        // leaves createdAt alone) must win *everywhere*, not just in the target.
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let a = sessions.join("A/O1/scheduled-tasks.json");
+        let b = sessions.join("B/O2/scheduled-tasks.json");
+        write(
+            &a,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Old name","cronExpression":"0 5 * * *"}]}"#,
+        );
+        write(
+            &b,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"New name","cronExpression":"0 5 * * *"}]}"#,
+        );
+        touch(&a, 1_000);
+        touch(&b, 2_000); // renamed more recently
+
+        let plan = plan_name_convergence(sessions).unwrap();
+        assert_eq!(plan.converged, 1);
+        // Only the stale registry (A) is rewritten; B already holds the winner.
+        assert_eq!(plan.rewrites.len(), 1);
+        for (path, bytes) in &plan.rewrites {
+            std::fs::write(path, bytes).unwrap();
+        }
+        assert_eq!(first_display_name(&a), "New name");
+        assert_eq!(first_display_name(&b), "New name");
+    }
+
+    #[test]
+    fn name_convergence_touches_only_the_title() {
+        // Converging the name must not disturb any other field.
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        let a = sessions.join("A/O1/scheduled-tasks.json");
+        let b = sessions.join("B/O2/scheduled-tasks.json");
+        write(
+            &a,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Stale","cronExpression":"0 5 * * *","enabled":true,"model":"opus"}]}"#,
+        );
+        write(
+            &b,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Fresh","cronExpression":"30 9 * * *","enabled":false}]}"#,
+        );
+        touch(&a, 5_000); // A is fresher, so A's name wins and B is rewritten
+        touch(&b, 1_000);
+
+        let plan = plan_name_convergence(sessions).unwrap();
+        for (path, bytes) in &plan.rewrites {
+            std::fs::write(path, bytes).unwrap();
+        }
+        // B took A's name…
+        assert_eq!(first_display_name(&b), "Stale");
+        // …but kept its own cron/enabled — convergence is name-only.
+        let vb: Value = serde_json::from_slice(&std::fs::read(&b).unwrap()).unwrap();
+        assert_eq!(vb["scheduledTasks"][0]["cronExpression"], "30 9 * * *");
+        assert_eq!(vb["scheduledTasks"][0]["enabled"], false);
+    }
+
+    #[test]
+    fn name_convergence_is_a_noop_when_titles_already_agree() {
+        let root = tempfile::TempDir::new().unwrap();
+        let sessions = root.path();
+        write(
+            &sessions.join("A/O1/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Same"}]}"#,
+        );
+        write(
+            &sessions.join("B/O2/scheduled-tasks.json"),
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":100,"displayName":"Same"}]}"#,
+        );
+        let plan = plan_name_convergence(sessions).unwrap();
+        assert_eq!(plan.converged, 0);
+        assert!(plan.rewrites.is_empty());
     }
 
     /// The mirror image: only the target changed against the shared baseline,

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -463,6 +463,14 @@ fn apply_switch_while_stopped(
     plan: &SwitchPlan,
     notes: &mut Vec<String>,
 ) -> Result<()> {
+    // Derive convergence input from the immutable plan before touching any
+    // registries. Later writes must not be able to change the selected title.
+    let display_names = plan
+        .scheduled
+        .as_ref()
+        .map(ScheduledMerge::display_names)
+        .transpose()?;
+
     // History merges abort too — a partial merge is recoverable, but doing it
     // after the credential swap would strand the user on an account whose
     // history never arrived.
@@ -498,30 +506,33 @@ fn apply_switch_while_stopped(
         }
         Err(error) => notes.push(format!("deletion sweep skipped: {error}")),
     }
-    // Make every account agree on each routine's name. A rename doesn't touch
-    // `createdAt`, so the merge alone never lets titles settle — it only carries
-    // the freshest into the account being switched to. This pushes that same
-    // winner to every registry, so the name converges instead of flip-flopping.
+    // Make every account agree on each routine's name. The merge selects the
+    // winning definitions while the switch is planned; carry those names into
+    // every registry so writes above cannot change the decision.
     // Runs after the merge and the deletion sweep so it neither renames a
     // just-deleted routine nor is undone by a re-added copy.
-    match merge::plan_name_convergence(&paths.sessions_root()) {
-        Ok(convergence) => {
-            for (path, bytes) in convergence.rewrites {
-                if let Err(error) = crate::cache::atomic_write(&path, &bytes) {
+    if let Some(display_names) = &display_names {
+        match merge::plan_name_convergence(&paths.sessions_root(), display_names) {
+            Ok(convergence) => {
+                let mut fully_applied = true;
+                for (path, bytes) in convergence.rewrites {
+                    if let Err(error) = crate::cache::atomic_write(&path, &bytes) {
+                        fully_applied = false;
+                        notes.push(format!(
+                            "could not converge routine names in {}: {error}",
+                            path.display()
+                        ));
+                    }
+                }
+                if fully_applied && convergence.converged > 0 {
                     notes.push(format!(
-                        "could not converge routine names in {}: {error}",
-                        path.display()
+                        "converged {} routine name(s) across accounts",
+                        convergence.converged
                     ));
                 }
             }
-            if convergence.converged > 0 {
-                notes.push(format!(
-                    "converged {} routine name(s) across accounts",
-                    convergence.converged
-                ));
-            }
+            Err(error) => notes.push(format!("name convergence skipped: {error}")),
         }
-        Err(error) => notes.push(format!("name convergence skipped: {error}")),
     }
     // Record what every account holds now, so the next switch can tell an
     // intentional deletion from a task that account simply never received.

--- a/src/claude_desktop/mod.rs
+++ b/src/claude_desktop/mod.rs
@@ -498,6 +498,31 @@ fn apply_switch_while_stopped(
         }
         Err(error) => notes.push(format!("deletion sweep skipped: {error}")),
     }
+    // Make every account agree on each routine's name. A rename doesn't touch
+    // `createdAt`, so the merge alone never lets titles settle — it only carries
+    // the freshest into the account being switched to. This pushes that same
+    // winner to every registry, so the name converges instead of flip-flopping.
+    // Runs after the merge and the deletion sweep so it neither renames a
+    // just-deleted routine nor is undone by a re-added copy.
+    match merge::plan_name_convergence(&paths.sessions_root()) {
+        Ok(convergence) => {
+            for (path, bytes) in convergence.rewrites {
+                if let Err(error) = crate::cache::atomic_write(&path, &bytes) {
+                    notes.push(format!(
+                        "could not converge routine names in {}: {error}",
+                        path.display()
+                    ));
+                }
+            }
+            if convergence.converged > 0 {
+                notes.push(format!(
+                    "converged {} routine name(s) across accounts",
+                    convergence.converged
+                ));
+            }
+        }
+        Err(error) => notes.push(format!("name convergence skipped: {error}")),
+    }
     // Record what every account holds now, so the next switch can tell an
     // intentional deletion from a task that account simply never received.
     let mut synced = merge::current_state(&paths.sessions_root());
@@ -1288,6 +1313,41 @@ mod tests {
         apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
 
         assert_eq!(std::fs::read(&bystander).unwrap(), before);
+    }
+
+    /// The wiring: a switch must actually converge routine names across every
+    /// account, not just build the plan. Testing `plan_name_convergence` alone
+    /// would pass even if `apply_switch` never called it.
+    #[test]
+    fn a_switch_converges_routine_names_across_accounts() {
+        let fixture = fixture();
+        let sessions = fixture.paths.sessions_root();
+        let here = sessions.join("uuid-here/org-1/scheduled-tasks.json");
+        let there = sessions.join("uuid-there/org-2/scheduled-tasks.json");
+        // Same routine id, two different titles — the non-converging case.
+        write(
+            &here,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1,"displayName":"Home name"}]}"#,
+        );
+        write(
+            &there,
+            r#"{"scheduledTasks":[{"id":"t1","createdAt":1,"displayName":"There name"}]}"#,
+        );
+
+        let plan = plan_switch(&fixture.paths, "there", SwitchOpts::default()).unwrap();
+        apply_switch(&fixture.paths, &plan, &Recorder::default()).unwrap();
+
+        let name = |path: &std::path::Path| -> String {
+            let v: serde_json::Value =
+                serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+            v["scheduledTasks"][0]["displayName"]
+                .as_str()
+                .unwrap_or_default()
+                .to_string()
+        };
+        // The point is that both accounts agree afterwards, not which name won.
+        assert_eq!(name(&here), name(&there), "names did not converge");
+        assert!(!name(&here).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
A routine renamed in one account never settled on a single title across accounts — it flip-flopped, and an unrelated edit could bring a stale name back. This is the follow-up fix to the schedule reconciliation that shipped in v0.21.0 (#67).

## Why it didn't converge

The "title" is a task's `displayName`; tasks merge by a stable `id`. A scheduled task has **no `updatedAt`**, so a rename leaves `createdAt` untouched:

- The two copies tie on `createdAt`, and the merge breaks the tie by **registry-file mtime**.
- The merge only writes the account you switch **to** — the sources keep their own name.
- Each switch rewrites the target's registry (making *it* the freshest), so the "winning" name is just whichever account you last switched to. It never settles, and an unrelated edit to a registry can drag a stale name back.

## The fix

A switch now runs a **name-convergence pass** after the merge and the deletion sweep. For each routine id it takes the `displayName` from the copy the merge itself would keep (freshest by `createdAt`, then mtime) and writes that one title into **every** account's registry.

- **Name-only** — no other field is touched.
- **No prompt** — it reconciles silently, like every other merged field (this was the chosen behaviour; a rename shouldn't interrupt a switch).
- **Terminal and menu bar both get it** — it lives in the shared `apply_switch` path, so neither surface needed UI changes. The TUI has no switch UI and is untouched.
- **Mirrored in [claude-acc](https://github.com/ohmaseclaro/claude-acc)**, which shares the same profile store and had the same behaviour in its Python original.

## Tests

Unit tests on the pure pass (`plan_name_convergence`): freshest title wins everywhere, only the title changes, and a no-op when titles already agree. Plus a **wiring test through `apply_switch`** — because testing the pure function alone would keep passing even if nothing called it (the lesson from the deletion sweep in #67).

`cargo test` (915), `cargo clippy --all-targets`, `cargo fmt --check` — clean. No new dependencies.