### PR TITLE
feat(cli): add `--version` to the ai-usagebar binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- `--version` / `-V` on the `ai-usagebar` binary, reporting the crate version
+  (#81). Until now the only way to tell which build was installed was parsing
+  `cargo install --list`.
+
 ## [0.22.0] — 2026-08-06
 
 ### Added

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -390,7 +390,19 @@ fn is_stdout_tty() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clap::Parser;
+    use clap::{Parser, error::ErrorKind};
+
+    #[test]
+    fn version_flags_report_the_crate_version() {
+        let expected = format!("ai-usagebar {}\n", env!("CARGO_PKG_VERSION"));
+
+        for flag in ["--version", "-V"] {
+            let err = Cli::try_parse_from(["ai-usagebar", flag])
+                .expect_err("a version flag exits through clap's display path");
+            assert_eq!(err.kind(), ErrorKind::DisplayVersion, "flag: {flag}");
+            assert_eq!(err.to_string(), expected, "flag: {flag}");
+        }
+    }
 
     #[test]
     fn usage_subcommand_parses_machine_readable_mode() {

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -10,6 +10,7 @@ use clap::{Parser, ValueEnum};
 #[derive(Parser, Debug, Clone)]
 #[command(
     name = "ai-usagebar",
+    version,
     args_conflicts_with_subcommands = true,
     about = "Waybar widget and terminal dashboard for multi-provider AI plan usage",
     long_about = "\


### PR DESCRIPTION
Adds `version` to the `#[command(...)]` attribute in `src/widget/cli.rs`, so clap generates `--version` / `-V` from `CARGO_PKG_VERSION`:

```
$ ai-usagebar --version
ai-usagebar 0.22.0
```

Left `ai-usagebar-tui` out of this one — it doesn't parse arguments at all today, so adding the flag there would mean giving it a CLI first. Happy to follow up if you want that too.

Also added a short `[Unreleased]` entry to the changelog.

Gate is green here: `cargo test` (924 passing), `cargo clippy --all-targets -- -D warnings` clean.

Closes #81
