### PR TITLE
test(macos): cover OpenAI weekly-only quota window

### DIFF
--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -287,6 +287,17 @@ func testParserBalances() {
     assertNil(cld?.creditBalance, "anthropic has no balance")
     assertEqual(cld?.session?.pct, 42, "anthropic session pct")
 
+    let oaiWeekly = snapshot(FORMAT, vendor: "openai",
+                             fields: fields(through: 16, set: [
+                                0: "ChatGPT Pro", 3: "66", 4: "5d 12h", 14: "23", 16: "gpt"
+                             ]))
+    assertEqual(oaiWeekly?.hasUsageWindows, true, "openai weekly-only shows windows")
+    assertNil(oaiWeekly?.creditBalance, "openai weekly-only has no balance")
+    assertNil(oaiWeekly?.session, "openai weekly-only suppresses absent 5h session")
+    assertEqual(oaiWeekly?.weekly?.pct, 66, "openai weekly-only reports 7d pct")
+    assertEqual(oaiWeekly?.weekly?.reset, "5d 12h", "openai weekly-only reports 7d reset")
+    assertEqual(oaiWeekly?.weekly?.elapsed, 23, "openai weekly-only reports 7d pace elapsed")
+
     // Cursor: two included-usage pools carried on the session/weekly aliases
     // (session = Cursor Models, weekly = Other Models), both real, no balance.
     // The bars are relabeled away from the "Session"/"Weekly" time-window names.


### PR DESCRIPTION
## What changes

Adds automated pure-logic regression test coverage for OpenAI weekly-only rate limit responses in the macOS menu-bar test suite (`macos/ai-usagebar-tests.swift`).

- **OpenAI weekly-only assertions in `testParserBalances()`.** Verifies that when OpenAI reports only a 7-day rate-limit window (`limit_window_seconds: 604800`) and omits the 5-hour session window:
  - `hasUsageWindows` remains `true`
  - `session` (5h) window evaluates to `nil` (suppressing absent 5h session row/segment)
  - `weekly` (7d) window is populated with the real usage percentage, reset countdown, and pacing elapsed position
  - `creditBalance` remains `nil`

## Why

During OpenAI's July 2026 Codex rollout ([openai/codex#32707](https://github.com/openai/codex/issues/32707)), accounts with weekly-only rate limits began receiving responses where the 5-hour window is omitted. While PR #36 introduced optional quota window parsing (`Window?`) across desktop surfaces, the Swift test harness (`macos/ai-usagebar-tests.swift`) lacked an explicit test case asserting that weekly-only snapshots parse without fabricating an empty session window or dropping the weekly window.

## Test plan

- [x] `./macos/run-tests.sh` (all assertions pass, including new OpenAI weekly-only assertions)
- [x] `swiftc -O -parse-as-library -o /tmp/ai-usagebar-menubar macos/ai-usagebar-menubar.swift`
- [x] Manual validation: OpenAI snapshot with only weekly quota hides the `Session` row and renders the `Weekly` bar and reset timer accurately.