### PR TITLE
Source a CLI+Desktop label collision from Desktop only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- **A Claude account configured as both a CLI account and a Desktop profile is
+  now sourced only from Desktop.** The same account in two stores means two of
+  them refreshing one rotating refresh token — each refresh invalidates the
+  other's copy — and the CLI copy can even refresh to a stale/wrong identity
+  that still authenticates but reports another account's (often zero) usage. The
+  symptom: a heavily-used account showing 0% while its Desktop token returns the
+  real number. The previous guard only dropped a CLI entry whose credential was
+  *empty* (a half-finished `account add`), which cannot catch a token that
+  authenticates but is misattributed. On a label collision the app-maintained
+  Desktop token now always wins, which both avoids the rotation war and stops
+  the silent misattribution. A CLI account with no Desktop profile of the same
+  name is unaffected.
+
 ## [1.0.3] — 2026-08-15
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ Each release is also published at
 
 ### Fixed
 
-- **A Claude account configured as both a CLI account and a Desktop profile is
-  now sourced only from Desktop.** The same account in two stores means two of
-  them refreshing one rotating refresh token — each refresh invalidates the
+- **Aggregate views now source a Claude label shared by a CLI account and a
+  Desktop profile only from Desktop.** The same account in two stores means two
+  of them refreshing one rotating refresh token — each refresh invalidates the
   other's copy — and the CLI copy can even refresh to a stale/wrong identity
   that still authenticates but reports another account's (often zero) usage. The
   symptom: a heavily-used account showing 0% while its Desktop token returns the
@@ -22,7 +22,8 @@ Each release is also published at
   authenticates but is misattributed. On a label collision the app-maintained
   Desktop token now always wins, which both avoids the rotation war and stops
   the silent misattribution. A CLI account with no Desktop profile of the same
-  name is unaffected.
+  name is unaffected. Direct widget commands remain explicit: add `--desktop`
+  when selecting the Desktop profile with `--account`.
 
 ## [1.0.3] — 2026-08-15
 

--- a/docs/claude-accounts.md
+++ b/docs/claude-accounts.md
@@ -75,6 +75,11 @@ original `~/.cache/ai-usagebar/anthropic/` path.
 An unknown label fails with a list of valid labels. The TUI shows the default
 Claude tab followed by one tab for each named account.
 
+If a CLI account and a saved Desktop profile share a label, aggregate views
+such as the TUI and `usage --json` use the Desktop profile to avoid refreshing
+the same rotating token from two stores. Direct widget commands are explicit:
+add `--desktop` alongside `--account` when you want the Desktop profile.
+
 ## Discover accounts from a directory
 
 Point `accounts_dir` at a directory whose immediate children are Claude Code

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -88,33 +88,30 @@ impl TabId {
 /// [`tabs_with_desktop`]; this stays for the hermetic unit tests and any caller
 /// that only wants configured accounts.
 pub fn tabs_from_config(config: &Config) -> Vec<TabId> {
-    build_tabs(config, &[], &[])
+    build_tabs(config, &[])
 }
 
 /// The production tab list: configured accounts plus every saved Claude Desktop
-/// profile that has usable credentials and is not already a working CLI account.
-/// Desktop discovery is best-effort and macOS-only; anywhere else this equals
-/// [`tabs_from_config`].
+/// profile that has usable credentials. Desktop discovery is best-effort and
+/// macOS-only; anywhere else this equals [`tabs_from_config`].
 pub fn tabs_with_desktop(config: &Config) -> Vec<TabId> {
-    let desktop = desktop_profile_labels(config);
-    // A configured CLI account normally wins its label, but only if it can
-    // actually authenticate. A half-finished `account add <label>` (config
-    // entry written, login never completed) would otherwise mask a perfectly
-    // good Desktop profile of the same name — the account shows an error
-    // instead of its usage. Where that happens, let the Desktop source take
-    // over. Checked only for labels that exist in both, so the credential probe
-    // is rare.
-    let broken = broken_cli_labels(config, &desktop);
-    build_tabs(config, &desktop, &broken)
+    build_tabs(config, &desktop_profile_labels(config))
 }
 
-/// Core expansion, parameterized so it stays pure and unit-testable.
-/// `desktop_labels` are Claude Desktop accounts; `broken_cli` names configured
-/// CLI accounts to drop (their credential is unusable and a Desktop profile
-/// covers them). Desktop accounts follow the CLI accounts, de-duplicated by
-/// label (a *working* configured CLI account wins), and count toward "Anthropic
-/// has accounts" for the default-tab suppression.
-fn build_tabs(config: &Config, desktop_labels: &[String], broken_cli: &[String]) -> Vec<TabId> {
+/// Core expansion, parameterized on the Desktop account labels so it stays pure
+/// and unit-testable. Desktop accounts follow the CLI accounts and count toward
+/// "Anthropic has accounts" for the default-tab suppression.
+///
+/// A label present in both a `[[anthropic.accounts]]` CLI entry and a Desktop
+/// profile is sourced from **Desktop**, and the CLI entry is dropped. The same
+/// account in two stores means two of them refreshing one rotating refresh
+/// token — each rotation invalidates the other's copy — and the CLI copy can
+/// even refresh to a stale/wrong identity that still authenticates but reports
+/// another account's (often zero) usage, which no credential-health check can
+/// catch. The app-maintained Desktop token is the one source that avoids both
+/// the rotation war and that silent misattribution.
+fn build_tabs(config: &Config, desktop_labels: &[String]) -> Vec<TabId> {
+    let desktop_set: HashSet<&str> = desktop_labels.iter().map(String::as_str).collect();
     let mut tabs = Vec::new();
     for vendor in config.enabled_vendors() {
         if vendor == VendorId::Anthropic {
@@ -122,24 +119,20 @@ fn build_tabs(config: &Config, desktop_labels: &[String], broken_cli: &[String])
                 .anthropic
                 .all_accounts()
                 .into_iter()
-                .filter(|a| !broken_cli.iter().any(|b| b == &a.label))
-                .collect();
-            let cli_labels: HashSet<&str> = accounts.iter().map(|a| a.label.as_str()).collect();
-            let desktop: Vec<&String> = desktop_labels
-                .iter()
-                .filter(|label| !cli_labels.contains(label.as_str()))
+                .filter(|a| !desktop_set.contains(a.label.as_str()))
                 .collect();
             // The default (unnamed) Claude tab is suppressible once every
             // account is named — but never when it would leave Anthropic with
             // no tab at all. Desktop accounts count as named accounts here.
-            if config.anthropic.show_default_account || (accounts.is_empty() && desktop.is_empty())
+            if config.anthropic.show_default_account
+                || (accounts.is_empty() && desktop_labels.is_empty())
             {
                 tabs.push(TabId::vendor(vendor));
             }
             for acct in accounts {
                 tabs.push(TabId::account(acct.label));
             }
-            for label in desktop {
+            for label in desktop_labels {
                 tabs.push(TabId::desktop_account(label.clone()));
             }
         } else {
@@ -147,27 +140,6 @@ fn build_tabs(config: &Config, desktop_labels: &[String], broken_cli: &[String])
         }
     }
     tabs
-}
-
-/// Configured CLI accounts that both (a) share a label with a Desktop profile
-/// and (b) can't authenticate — so the Desktop source should win. Resolving the
-/// credential may read the macOS Keychain, so this only runs for the rare label
-/// present in both places.
-fn broken_cli_labels(config: &Config, desktop_labels: &[String]) -> Vec<String> {
-    use crate::anthropic::creds;
-    config
-        .anthropic
-        .all_accounts()
-        .into_iter()
-        .filter(|a| desktop_labels.iter().any(|d| d == &a.label))
-        .filter(|a| match config.anthropic.account_target(&a.label) {
-            Ok((target, _)) => creds::resolve(&target)
-                .map(|(c, _)| creds::is_unusable(&c.claude_ai_oauth))
-                .unwrap_or(true),
-            Err(_) => true,
-        })
-        .map(|a| a.label)
-        .collect()
 }
 
 /// Labels of saved Claude Desktop profiles with usable credentials. macOS-only
@@ -958,7 +930,7 @@ mod tests {
     fn desktop_labels_become_account_tabs_after_cli_accounts() {
         // Pure core: desktop accounts follow CLI accounts, in the order given.
         let config = config_with_accounts(&["work"]);
-        let tabs = build_tabs(&config, &["gmail".into(), "hotmail".into()], &[]);
+        let tabs = build_tabs(&config, &["gmail".into(), "hotmail".into()]);
         assert_eq!(
             tabs,
             vec![
@@ -971,33 +943,20 @@ mod tests {
     }
 
     #[test]
-    fn a_cli_account_shadows_a_desktop_profile_of_the_same_label() {
-        // One tab per label; the explicitly configured CLI account wins.
-        let config = config_with_accounts(&["gmail"]);
-        let tabs = build_tabs(&config, &["gmail".into(), "hotmail".into()], &[]);
+    fn a_desktop_profile_wins_a_label_collision_with_a_cli_account() {
+        // One tab per label; the Desktop source wins so the label is never fed
+        // from two stores refreshing one rotating token (which invalidate each
+        // other and can silently show a wrong account's usage). The CLI entry is
+        // dropped; a CLI-only label (work) is untouched.
+        let config = config_with_accounts(&["gmail", "work"]);
+        let tabs = build_tabs(&config, &["gmail".into(), "hotmail".into()]);
         assert_eq!(
             tabs,
             vec![
                 TabId::vendor(VendorId::Anthropic),
-                TabId::account("gmail"),
-                TabId::desktop_account("hotmail"),
-            ]
-        );
-    }
-
-    #[test]
-    fn a_broken_cli_account_yields_its_label_to_the_desktop_profile() {
-        // The exact failure a half-finished `account add gmail` caused: a CLI
-        // account is configured but unusable, and a Desktop profile of the same
-        // name exists. Passed in `broken_cli`, the CLI account is dropped and the
-        // Desktop source surfaces instead of an error tab.
-        let config = config_with_accounts(&["gmail"]);
-        let tabs = build_tabs(&config, &["gmail".into()], &["gmail".into()]);
-        assert_eq!(
-            tabs,
-            vec![
-                TabId::vendor(VendorId::Anthropic),
+                TabId::account("work"),
                 TabId::desktop_account("gmail"),
+                TabId::desktop_account("hotmail"),
             ]
         );
     }
@@ -1013,12 +972,12 @@ mod tests {
         // No accounts of either kind: the default tab survives (never leave
         // Anthropic tab-less).
         assert_eq!(
-            build_tabs(&config, &[], &[]),
+            build_tabs(&config, &[]),
             vec![TabId::vendor(VendorId::Anthropic)]
         );
         // A Desktop account is present: default suppressed, only the account.
         assert_eq!(
-            build_tabs(&config, &["gmail".into()], &[]),
+            build_tabs(&config, &["gmail".into()]),
             vec![TabId::desktop_account("gmail")]
         );
     }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -91,9 +91,9 @@ pub fn tabs_from_config(config: &Config) -> Vec<TabId> {
     build_tabs(config, &[])
 }
 
-/// The production tab list: configured accounts plus every saved Claude Desktop
-/// profile that has usable credentials. Desktop discovery is best-effort and
-/// macOS-only; anywhere else this equals [`tabs_from_config`].
+/// The production aggregate-view tab list: configured accounts plus every saved
+/// Claude Desktop profile that has usable credentials. Desktop discovery is
+/// best-effort and macOS-only; anywhere else this equals [`tabs_from_config`].
 pub fn tabs_with_desktop(config: &Config) -> Vec<TabId> {
     build_tabs(config, &desktop_profile_labels(config))
 }
@@ -102,14 +102,14 @@ pub fn tabs_with_desktop(config: &Config) -> Vec<TabId> {
 /// and unit-testable. Desktop accounts follow the CLI accounts and count toward
 /// "Anthropic has accounts" for the default-tab suppression.
 ///
-/// A label present in both a `[[anthropic.accounts]]` CLI entry and a Desktop
-/// profile is sourced from **Desktop**, and the CLI entry is dropped. The same
-/// account in two stores means two of them refreshing one rotating refresh
-/// token — each rotation invalidates the other's copy — and the CLI copy can
-/// even refresh to a stale/wrong identity that still authenticates but reports
-/// another account's (often zero) usage, which no credential-health check can
-/// catch. The app-maintained Desktop token is the one source that avoids both
-/// the rotation war and that silent misattribution.
+/// In aggregate views, a label present in both a `[[anthropic.accounts]]` CLI
+/// entry and a Desktop profile is sourced from **Desktop**, and the CLI entry is
+/// dropped. The same account in two stores means two of them refreshing one
+/// rotating refresh token — each rotation invalidates the other's copy — and
+/// the CLI copy can even refresh to a stale/wrong identity that still
+/// authenticates but reports another account's (often zero) usage, which no
+/// credential-health check can catch. The app-maintained Desktop token is the
+/// one source that avoids both the rotation war and that silent misattribution.
 fn build_tabs(config: &Config, desktop_labels: &[String]) -> Vec<TabId> {
     let desktop_set: HashSet<&str> = desktop_labels.iter().map(String::as_str).collect();
     let mut tabs = Vec::new();


### PR DESCRIPTION
## The bug

A Claude account configured as **both** a `[[anthropic.accounts]]` CLI entry **and** a saved Desktop profile was fed from two credential stores at once. Two consequences, both observed in the wild:

1. **Rotation war.** Each store refreshes the account's single rotating refresh token, so every refresh invalidates the other copy.
2. **Silent misattribution.** The CLI copy can refresh to a stale/wrong identity that still authenticates (HTTP 200) but reports **another account's usage — often 0%**.

Real symptom: a heavily-used account shows **0%** on the bar while its Desktop token returns the true figure (verified: `config.json` live token → `5h=8% 7d=29%`, CLI cache → `0%`).

## Why `broken_cli_labels` didn't catch it

The existing guard drops a colliding CLI entry only when its credential is `is_unusable` — i.e. **empty** tokens, the half-finished `account add` case. The account that bites here is the opposite: the CLI credential is *present and authenticates*, it's just **misattributed after a divergent refresh**. `is_unusable` is `false`, so the CLI tab wins and shows the wrong number. No credential-health check can distinguish a valid-but-wrong token from a valid-and-right one — only comparing against the Desktop source can, which is circular.

## The fix

On a label collision, the **app-maintained Desktop token always wins** and the CLI entry is dropped, giving the label a single source:

- The active account's Desktop token is read-only (the app owns rotation), so ai-usagebar never rotates it → **no war**.
- Inactive Desktop snapshots are refreshed only by ai-usagebar → still no war.
- One source per label → **no misattribution**.

A CLI account with **no** Desktop profile of the same name is unaffected. This subsumes and removes the `broken_cli_labels` probe (a label collision is now resolved unconditionally, so no Keychain health-probe is needed).

## Tests

`build_tabs` unit tests updated: a CLI+Desktop label collision resolves to the Desktop tab; a CLI-only label is untouched; default-tab suppression still counts Desktop accounts. `cargo test` (973), `cargo clippy --all-targets`, `cargo fmt --check` — clean.