### PR TITLE
docs: link the COSMIC applet under community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,14 @@ privileges, and does not overwrite user configuration.
 Cursor is not available in the GNOME extension yet. On GNOME, use
 `ai-usagebar --vendor cursor` or open the TUI.
 
+## Community integrations
+
+External projects built on `ai-usagebar usage --json`. They live in their own
+repositories and are maintained by their authors, not here.
+
+- [cosmic-applet-ai-usage](https://github.com/jacksonsieben/cosmic-applet-ai-usage)
+  — panel applet for the COSMIC desktop.
+
 ## Waybar config
 
 ### Single module, scroll-to-cycle (recommended)


### PR DESCRIPTION
As offered in #92 — a small **Community integrations** section with a link to
[cosmic-applet-ai-usage](https://github.com/jacksonsieben/cosmic-applet-ai-usage),
worded as community-maintained and external.

It sits right after **Native desktop integrations**, so the in-tree integrations
and the external one read in order without the distinction blurring.

README-only; no code, no build, no maintenance surface here. The applet lives
in its own repository and treats `ai-usagebar usage --json` as its contract.

Closes #92