### PR TITLE
docs: link the Noctalia plugin under community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,15 @@ privileges, and does not overwrite user configuration.
 Cursor is not available in the GNOME extension yet. On GNOME, use
 `ai-usagebar --vendor cursor` or open the TUI.
 
+## Community integrations
+
+External projects built on `ai-usagebar usage --json`. They live in their own
+repositories and are maintained by their authors, not here.
+
+- [AI Usage for Noctalia](https://github.com/noctalia-dev/community-plugins/tree/main/ai-usagebar)
+  — bar widget and panel for the Noctalia v5 shell, installable from its
+  plugin browser as `felipeartur/ai-usagebar`.
+
 ## Waybar config
 
 ### Single module, scroll-to-cycle (recommended)


### PR DESCRIPTION
README only. Adds a `Community integrations` section with one entry, a Noctalia v5 plugin that's now published in the Noctalia community registry:

https://github.com/noctalia-dev/community-plugins/tree/main/ai-usagebar

The plugin stays over there. It declares `ai-usagebar` as an external command and reads `usage --json`, so it downloads nothing and never touches a credential. This follows #83, where you suggested that shape.

It overlaps with #95, which creates the same section for the COSMIC applet. I copied its wording verbatim so the two are interchangeable, and left my PR to my own bullet. Merge either one first. If #95 goes in ahead of this, I'll rebase this down to the single bullet.
