### PR TITLE
feat(zai, minimax): add pace and elapsed-time placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ Each release is also published at
   `{zai_weekly_pace}`, `{zai_mcp_elapsed}`, `{zai_mcp_pace}`,
   `{minimax_session_elapsed}`, `{minimax_session_pace}`,
   `{minimax_weekly_elapsed}`, `{minimax_weekly_pace}`,
-  `{minimax_video_elapsed}`, `{minimax_video_pace}`, and their
-  `_pace_indicator` variants), plus the cross-vendor `{session_elapsed}` /
-  `{weekly_elapsed}` aliases — the macOS menu bar's pace marker now renders
-  for both vendors the same way it already does for Claude and Codex.
+  `{minimax_video_elapsed}`, `{minimax_video_pace}`,
+  `{minimax_video_weekly_reset}`, `{minimax_video_weekly_elapsed}`,
+  `{minimax_video_weekly_pace}`, and their `_pace_indicator` variants), plus
+  the cross-vendor `{session_elapsed}` / `{weekly_elapsed}` aliases — the macOS
+  menu bar's pace marker now renders for both vendors the same way it already
+  does for Claude and Codex.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ Each release is also published at
 
 ### Added
 
-- Z.AI now exposes pace and elapsed-time placeholders
+- Z.AI and MiniMax now expose pace and elapsed-time placeholders
   (`{zai_session_elapsed}`, `{zai_session_pace}`, `{zai_weekly_elapsed}`,
-  `{zai_weekly_pace}`, `{zai_mcp_elapsed}`, `{zai_mcp_pace}`, and their
+  `{zai_weekly_pace}`, `{zai_mcp_elapsed}`, `{zai_mcp_pace}`,
+  `{minimax_session_elapsed}`, `{minimax_session_pace}`,
+  `{minimax_weekly_elapsed}`, `{minimax_weekly_pace}`,
+  `{minimax_video_elapsed}`, `{minimax_video_pace}`, and their
   `_pace_indicator` variants), plus the cross-vendor `{session_elapsed}` /
   `{weekly_elapsed}` aliases — the macOS menu bar's pace marker now renders
-  for Z.AI the same way it already does for Claude and Codex.
+  for both vendors the same way it already does for Claude and Codex.
 
 ## [1.2.0] — 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- Z.AI now exposes pace and elapsed-time placeholders
+  (`{zai_session_elapsed}`, `{zai_session_pace}`, `{zai_weekly_elapsed}`,
+  `{zai_weekly_pace}`, `{zai_mcp_elapsed}`, `{zai_mcp_pace}`, and their
+  `_pace_indicator` variants), plus the cross-vendor `{session_elapsed}` /
+  `{weekly_elapsed}` aliases — the macOS menu bar's pace marker now renders
+  for Z.AI the same way it already does for Claude and Codex.
+
 ## [1.2.0] — 2026-08-18
 
 ### Added

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -25,6 +25,7 @@ and Other Models to the weekly slot; both reset with the billing cycle. Kiro
 has one pool, so it maps `kiro_pct` to both percentage slots.
 
 Claude and Codex also provide `*_elapsed`, `*_pace`, and `*_bar` families.
+Z.AI and MiniMax provide elapsed aliases plus provider-specific pace families.
 Antigravity provides elapsed values for all four windows plus
 `{session_model}`, `{weekly_model}`, `{scoped_model}`, and `{extra_model}`.
 Provider-specific families such as `{oai_*}`, `{zai_*}`, and `{or_*}` are empty
@@ -61,8 +62,32 @@ default widget automatically uses weekly values for a weekly-only response.
 ## Z.AI
 
 `{zai_plan}`, `{zai_session_pct}`, `{zai_session_reset}`,
-`{zai_weekly_pct}`, `{zai_weekly_reset}`, `{zai_mcp_pct}`,
-`{zai_mcp_reset}`
+`{zai_session_elapsed}`, `{zai_session_pace}`,
+`{zai_session_pace_indicator}`, `{zai_weekly_pct}`, `{zai_weekly_reset}`,
+`{zai_weekly_elapsed}`, `{zai_weekly_pace}`,
+`{zai_weekly_pace_indicator}`, `{zai_mcp_pct}`, `{zai_mcp_reset}`,
+`{zai_mcp_elapsed}`, `{zai_mcp_pace}`, `{zai_mcp_pace_indicator}`
+
+`{session_elapsed}` and `{weekly_elapsed}` are cross-provider aliases. An
+absent window returns empty values. A present window whose API response omits
+its reset uses the shared neutral pacing values: elapsed `0` and arrow `→`.
+
+## MiniMax
+
+`{minimax_plan}`, `{minimax_session_pct}`, `{minimax_session_reset}`,
+`{minimax_session_elapsed}`, `{minimax_session_pace}`,
+`{minimax_session_pace_indicator}`, `{minimax_weekly_pct}`,
+`{minimax_weekly_reset}`, `{minimax_weekly_elapsed}`,
+`{minimax_weekly_pace}`, `{minimax_weekly_pace_indicator}`,
+`{minimax_video_pct}`, `{minimax_video_reset}`, `{minimax_video_elapsed}`,
+`{minimax_video_pace}`, `{minimax_video_pace_indicator}`,
+`{minimax_video_weekly_pct}`, `{minimax_video_weekly_reset}`,
+`{minimax_video_weekly_elapsed}`, `{minimax_video_weekly_pace}`,
+`{minimax_video_weekly_pace_indicator}`
+
+`{session_elapsed}` and `{weekly_elapsed}` alias the text pool. Optional video
+windows return `—` when absent. As with Z.AI, a present window without a reset
+uses elapsed `0` and the neutral `→` pace marker.
 
 ## OpenRouter
 

--- a/src/minimax/vendor.rs
+++ b/src/minimax/vendor.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 
 use crate::countdown;
 use crate::format::{placeholders, substitute, updated_at_hm};
-use crate::pacing::PaceSeverity;
+use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
@@ -30,6 +30,7 @@ pub const DEFAULT_FORMAT: &str = "{minimax_session_pct}% · {minimax_session_res
 
 pub fn build_placeholders(
     snap: &MinimaxSnapshot,
+    opts: &RenderOpts,
     now: DateTime<Utc>,
 ) -> HashMap<&'static str, String> {
     let session_pct = snap.session.utilization_pct;
@@ -45,6 +46,19 @@ pub fn build_placeholders(
             None => "—".to_string(),
         }
     };
+    // Session and weekly always carry a real duration (5h/7d default, or the
+    // API's own start/end span) and a reset timestamp, so pacing is
+    // computable — same contract as the OpenAI and Z.AI renderers.
+    let session = window_pacing(&snap.session, opts, now);
+    let weekly = window_pacing(&snap.weekly, opts, now);
+    let video_pacing = match snap.video_session.as_ref() {
+        Some(w) => window_pacing(w, opts, now),
+        None => WindowPacing {
+            elapsed: "—".to_string(),
+            ratio_pace: "—".to_string(),
+            point_pace: "—".to_string(),
+        },
+    };
 
     placeholders(vec![
         ("icon", "󰚩".to_string()),
@@ -55,16 +69,50 @@ pub fn build_placeholders(
         ("session_reset", session_reset.clone()),
         ("weekly_pct", weekly_pct.to_string()),
         ("weekly_reset", weekly_reset.clone()),
+        ("session_elapsed", session.elapsed.clone()),
+        ("weekly_elapsed", weekly.elapsed.clone()),
         // MiniMax-specific placeholders.
         ("minimax_plan", snap.plan.clone()),
         ("minimax_session_pct", session_pct.to_string()),
         ("minimax_session_reset", session_reset),
         ("minimax_weekly_pct", weekly_pct.to_string()),
         ("minimax_weekly_reset", weekly_reset),
+        ("minimax_session_elapsed", session.elapsed),
+        ("minimax_session_pace", session.ratio_pace),
+        ("minimax_session_pace_indicator", session.point_pace),
+        ("minimax_weekly_elapsed", weekly.elapsed),
+        ("minimax_weekly_pace", weekly.ratio_pace),
+        ("minimax_weekly_pace_indicator", weekly.point_pace),
         ("minimax_video_pct", video(&snap.video_session, true)),
         ("minimax_video_reset", video(&snap.video_session, false)),
+        ("minimax_video_elapsed", video_pacing.elapsed),
+        ("minimax_video_pace", video_pacing.ratio_pace),
+        ("minimax_video_pace_indicator", video_pacing.point_pace),
         ("minimax_video_weekly_pct", video(&snap.video_weekly, true)),
     ])
+}
+
+/// Elapsed fraction and pace glyphs for one window, as ready placeholder
+/// values.
+struct WindowPacing {
+    elapsed: String,
+    ratio_pace: String,
+    point_pace: String,
+}
+
+fn window_pacing(w: &UsageWindow, opts: &RenderOpts, now: DateTime<Utc>) -> WindowPacing {
+    let p = pacing::calc(
+        w.utilization_pct,
+        w.resets_at,
+        now,
+        w.window_duration,
+        opts.pace_tolerance,
+    );
+    WindowPacing {
+        elapsed: p.elapsed_pct.to_string(),
+        ratio_pace: p.ratio_pace.glyph().to_string(),
+        point_pace: p.point_pace.glyph().to_string(),
+    }
 }
 
 /// Worst of the two text-pool windows. The video pool deliberately does not
@@ -90,7 +138,7 @@ pub fn render(
         .format
         .clone()
         .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
-    let values = build_placeholders(snap, now);
+    let values = build_placeholders(snap, opts, now);
     // User formats are Pango markup after Waybar renders them. Escape API
     // strings there, while retaining raw values for the default tooltip (which
     // escapes exactly once at its markup insertion point).
@@ -267,7 +315,7 @@ mod tests {
     /// them MiniMax would render blank rows on the desktop.
     #[test]
     fn exposes_cross_vendor_aliases() {
-        let v = build_placeholders(&snap(), now());
+        let v = build_placeholders(&snap(), &opts(), now());
         assert_eq!(v.get("session_pct").map(String::as_str), Some("31"));
         assert_eq!(v.get("weekly_pct").map(String::as_str), Some("62"));
         assert_eq!(v.get("vendor_short").map(String::as_str), Some("mmx"));
@@ -290,12 +338,42 @@ mod tests {
         let mut s = snap();
         s.video_session = None;
         s.video_weekly = None;
-        let v = build_placeholders(&s, now());
+        let v = build_placeholders(&s, &opts(), now());
         assert_eq!(v.get("minimax_video_pct").map(String::as_str), Some("—"));
         assert_eq!(
             v.get("minimax_video_weekly_pct").map(String::as_str),
             Some("—")
         );
+        assert_eq!(v.get("minimax_video_pace").map(String::as_str), Some("—"));
+    }
+
+    #[test]
+    fn pace_placeholders_follow_usage_vs_elapsed() {
+        // Session: 80% used vs 2h/5h = 60% elapsed → ahead of pace. Weekly:
+        // 15% used vs 3d/7d = 57% elapsed → under pace.
+        let n = now();
+        let mut s = snap();
+        s.session = window(80, 120, chrono::Duration::hours(5));
+        s.weekly = window(15, 3 * 24 * 60, chrono::Duration::days(7));
+        let v = build_placeholders(&s, &opts(), n);
+        assert_eq!(v["minimax_session_elapsed"], "60");
+        assert_eq!(v["minimax_session_pace"], "↑");
+        assert_eq!(v["minimax_session_pace_indicator"], "↑");
+        assert_eq!(v["minimax_weekly_elapsed"], "57");
+        assert_eq!(v["minimax_weekly_pace"], "↓");
+        assert_eq!(v["minimax_weekly_pace_indicator"], "↓");
+    }
+
+    #[test]
+    fn video_pace_follows_usage_vs_elapsed() {
+        // 90% used vs 6h/24h = 75% elapsed → ahead of pace.
+        let n = now();
+        let mut s = snap();
+        s.video_session = Some(window(90, 6 * 60, chrono::Duration::hours(24)));
+        let v = build_placeholders(&s, &opts(), n);
+        assert_eq!(v["minimax_video_elapsed"], "75");
+        assert_eq!(v["minimax_video_pace"], "↑");
+        assert_eq!(v["minimax_video_pace_indicator"], "↑");
     }
 
     #[test]

--- a/src/minimax/vendor.rs
+++ b/src/minimax/vendor.rs
@@ -28,9 +28,20 @@ pub const POOL_VIDEO: &str = "Video";
 
 pub const DEFAULT_FORMAT: &str = "{minimax_session_pct}% · {minimax_session_reset}";
 
+/// Build placeholders with the historical default pacing tolerance.
+///
+/// Keep this signature stable for library callers. Rendering uses the private
+/// tolerance-aware helper so `--pace-tolerance` still applies.
 pub fn build_placeholders(
     snap: &MinimaxSnapshot,
-    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
+    build_placeholders_with_tolerance(snap, pacing::DEFAULT_TOLERANCE, now)
+}
+
+fn build_placeholders_with_tolerance(
+    snap: &MinimaxSnapshot,
+    pace_tolerance: u32,
     now: DateTime<Utc>,
 ) -> HashMap<&'static str, String> {
     let session_pct = snap.session.utilization_pct;
@@ -46,19 +57,14 @@ pub fn build_placeholders(
             None => "—".to_string(),
         }
     };
-    // Session and weekly always carry a real duration (5h/7d default, or the
-    // API's own start/end span) and a reset timestamp, so pacing is
-    // computable — same contract as the OpenAI and Z.AI renderers.
-    let session = window_pacing(&snap.session, opts, now);
-    let weekly = window_pacing(&snap.weekly, opts, now);
-    let video_pacing = match snap.video_session.as_ref() {
-        Some(w) => window_pacing(w, opts, now),
-        None => WindowPacing {
-            elapsed: "—".to_string(),
-            ratio_pace: "—".to_string(),
-            point_pace: "—".to_string(),
-        },
-    };
+    // Present windows normally carry resets, but degenerate upstream bounds
+    // are represented without one. `pacing::calc` deliberately returns
+    // neutral 0/arrow values then, matching the existing provider contract.
+    let session = window_pacing(&snap.session, pace_tolerance, now);
+    let weekly = window_pacing(&snap.weekly, pace_tolerance, now);
+    let video_pacing = optional_window_pacing(snap.video_session.as_ref(), pace_tolerance, now);
+    let video_weekly_pacing =
+        optional_window_pacing(snap.video_weekly.as_ref(), pace_tolerance, now);
 
     placeholders(vec![
         ("icon", "󰚩".to_string()),
@@ -89,6 +95,16 @@ pub fn build_placeholders(
         ("minimax_video_pace", video_pacing.ratio_pace),
         ("minimax_video_pace_indicator", video_pacing.point_pace),
         ("minimax_video_weekly_pct", video(&snap.video_weekly, true)),
+        (
+            "minimax_video_weekly_reset",
+            video(&snap.video_weekly, false),
+        ),
+        ("minimax_video_weekly_elapsed", video_weekly_pacing.elapsed),
+        ("minimax_video_weekly_pace", video_weekly_pacing.ratio_pace),
+        (
+            "minimax_video_weekly_pace_indicator",
+            video_weekly_pacing.point_pace,
+        ),
     ])
 }
 
@@ -100,13 +116,33 @@ struct WindowPacing {
     point_pace: String,
 }
 
-fn window_pacing(w: &UsageWindow, opts: &RenderOpts, now: DateTime<Utc>) -> WindowPacing {
+impl WindowPacing {
+    fn unavailable() -> Self {
+        Self {
+            elapsed: "—".to_string(),
+            ratio_pace: "—".to_string(),
+            point_pace: "—".to_string(),
+        }
+    }
+}
+
+fn optional_window_pacing(
+    window: Option<&UsageWindow>,
+    pace_tolerance: u32,
+    now: DateTime<Utc>,
+) -> WindowPacing {
+    window.map_or_else(WindowPacing::unavailable, |window| {
+        window_pacing(window, pace_tolerance, now)
+    })
+}
+
+fn window_pacing(w: &UsageWindow, pace_tolerance: u32, now: DateTime<Utc>) -> WindowPacing {
     let p = pacing::calc(
         w.utilization_pct,
         w.resets_at,
         now,
         w.window_duration,
-        opts.pace_tolerance,
+        pace_tolerance,
     );
     WindowPacing {
         elapsed: p.elapsed_pct.to_string(),
@@ -138,7 +174,7 @@ pub fn render(
         .format
         .clone()
         .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
-    let values = build_placeholders(snap, opts, now);
+    let values = build_placeholders_with_tolerance(snap, opts.pace_tolerance, now);
     // User formats are Pango markup after Waybar renders them. Escape API
     // strings there, while retaining raw values for the default tooltip (which
     // escapes exactly once at its markup insertion point).
@@ -295,6 +331,13 @@ mod tests {
         }
     }
 
+    fn placeholders_at(
+        snap: &MinimaxSnapshot,
+        now: DateTime<Utc>,
+    ) -> HashMap<&'static str, String> {
+        build_placeholders_with_tolerance(snap, opts().pace_tolerance, now)
+    }
+
     fn outcome(s: &MinimaxSnapshot) -> VendorOutcome {
         VendorOutcome {
             snapshot: crate::usage::VendorSnapshot::Minimax(s.clone()),
@@ -315,7 +358,7 @@ mod tests {
     /// them MiniMax would render blank rows on the desktop.
     #[test]
     fn exposes_cross_vendor_aliases() {
-        let v = build_placeholders(&snap(), &opts(), now());
+        let v = placeholders_at(&snap(), now());
         assert_eq!(v.get("session_pct").map(String::as_str), Some("31"));
         assert_eq!(v.get("weekly_pct").map(String::as_str), Some("62"));
         assert_eq!(v.get("vendor_short").map(String::as_str), Some("mmx"));
@@ -338,13 +381,41 @@ mod tests {
         let mut s = snap();
         s.video_session = None;
         s.video_weekly = None;
-        let v = build_placeholders(&s, &opts(), now());
+        let v = placeholders_at(&s, now());
         assert_eq!(v.get("minimax_video_pct").map(String::as_str), Some("—"));
         assert_eq!(
             v.get("minimax_video_weekly_pct").map(String::as_str),
             Some("—")
         );
         assert_eq!(v.get("minimax_video_pace").map(String::as_str), Some("—"));
+        assert_eq!(
+            v.get("minimax_video_weekly_reset").map(String::as_str),
+            Some("—")
+        );
+        assert_eq!(
+            v.get("minimax_video_weekly_pace").map(String::as_str),
+            Some("—")
+        );
+    }
+
+    #[test]
+    fn public_builder_keeps_the_default_tolerance_api() {
+        let snap = snap();
+        assert_eq!(
+            build_placeholders(&snap, now()),
+            build_placeholders_with_tolerance(&snap, pacing::DEFAULT_TOLERANCE, now())
+        );
+    }
+
+    #[test]
+    fn present_window_without_reset_uses_documented_neutral_pacing() {
+        let mut snap = snap();
+        snap.session.resets_at = None;
+        let values = placeholders_at(&snap, now());
+        assert_eq!(values["minimax_session_reset"], "—");
+        assert_eq!(values["minimax_session_elapsed"], "0");
+        assert_eq!(values["minimax_session_pace"], "→");
+        assert_eq!(values["minimax_session_pace_indicator"], "→");
     }
 
     #[test]
@@ -355,7 +426,7 @@ mod tests {
         let mut s = snap();
         s.session = window(80, 120, chrono::Duration::hours(5));
         s.weekly = window(15, 3 * 24 * 60, chrono::Duration::days(7));
-        let v = build_placeholders(&s, &opts(), n);
+        let v = placeholders_at(&s, n);
         assert_eq!(v["minimax_session_elapsed"], "60");
         assert_eq!(v["minimax_session_pace"], "↑");
         assert_eq!(v["minimax_session_pace_indicator"], "↑");
@@ -370,10 +441,22 @@ mod tests {
         let n = now();
         let mut s = snap();
         s.video_session = Some(window(90, 6 * 60, chrono::Duration::hours(24)));
-        let v = build_placeholders(&s, &opts(), n);
+        let v = placeholders_at(&s, n);
         assert_eq!(v["minimax_video_elapsed"], "75");
         assert_eq!(v["minimax_video_pace"], "↑");
         assert_eq!(v["minimax_video_pace_indicator"], "↑");
+    }
+
+    #[test]
+    fn video_weekly_exposes_the_complete_pacing_family() {
+        let n = now();
+        let mut s = snap();
+        s.video_weekly = Some(window(90, 3 * 24 * 60, chrono::Duration::days(7)));
+        let v = placeholders_at(&s, n);
+        assert_ne!(v["minimax_video_weekly_reset"], "—");
+        assert_eq!(v["minimax_video_weekly_elapsed"], "57");
+        assert_eq!(v["minimax_video_weekly_pace"], "↑");
+        assert_eq!(v["minimax_video_weekly_pace_indicator"], "↑");
     }
 
     #[test]

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -18,9 +18,17 @@ use super::fetch::FetchOutcome;
 
 pub const DEFAULT_FORMAT: &str = "{zai_session_pct}% · {zai_session_reset}";
 
-pub fn build_placeholders(
+/// Build placeholders with the historical default pacing tolerance.
+///
+/// Keep this signature stable for library callers. Rendering uses the private
+/// tolerance-aware helper so `--pace-tolerance` still applies.
+pub fn build_placeholders(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'static str, String> {
+    build_placeholders_with_tolerance(snap, pacing::DEFAULT_TOLERANCE, now)
+}
+
+fn build_placeholders_with_tolerance(
     snap: &ZaiSnapshot,
-    opts: &RenderOpts,
+    pace_tolerance: u32,
     now: DateTime<Utc>,
 ) -> HashMap<&'static str, String> {
     let session_pct = snap
@@ -30,11 +38,12 @@ pub fn build_placeholders(
         .unwrap_or(0);
     let weekly_pct = snap.weekly.as_ref().map(|w| w.utilization_pct).unwrap_or(0);
     let mcp_pct = snap.mcp.as_ref().map(|w| w.utilization_pct).unwrap_or(0);
-    // Both windows carry a real duration (5h/7d) and a reset timestamp, so
-    // pacing is computable — same contract as the OpenAI renderer.
-    let session = window_pacing(snap.session.as_ref(), opts, now);
-    let weekly = window_pacing(snap.weekly.as_ref(), opts, now);
-    let mcp = window_pacing(snap.mcp.as_ref(), opts, now);
+    // A present window normally carries a reset, but the upstream response may
+    // omit it. `pacing::calc` deliberately returns neutral 0/arrow values in
+    // that case, matching the established OpenAI placeholder contract.
+    let session = window_pacing(snap.session.as_ref(), pace_tolerance, now);
+    let weekly = window_pacing(snap.weekly.as_ref(), pace_tolerance, now);
+    let mcp = window_pacing(snap.mcp.as_ref(), pace_tolerance, now);
     placeholders(vec![
         ("icon", "󰚩".to_string()),
         ("vendor_short", "zai".to_string()),
@@ -95,7 +104,7 @@ struct WindowPacing {
     point_pace: String,
 }
 
-fn window_pacing(w: Option<&UsageWindow>, opts: &RenderOpts, now: DateTime<Utc>) -> WindowPacing {
+fn window_pacing(w: Option<&UsageWindow>, pace_tolerance: u32, now: DateTime<Utc>) -> WindowPacing {
     let Some(w) = w else {
         return WindowPacing::default();
     };
@@ -104,7 +113,7 @@ fn window_pacing(w: Option<&UsageWindow>, opts: &RenderOpts, now: DateTime<Utc>)
         w.resets_at,
         now,
         w.window_duration,
-        opts.pace_tolerance,
+        pace_tolerance,
     );
     WindowPacing {
         elapsed: p.elapsed_pct.to_string(),
@@ -136,7 +145,7 @@ pub fn render(
         .format
         .clone()
         .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
-    let values = build_placeholders(snap, opts, now);
+    let values = build_placeholders_with_tolerance(snap, opts.pace_tolerance, now);
 
     let mut text = substitute(&format, &values);
     if outcome.stale {
@@ -281,6 +290,10 @@ mod tests {
         }
     }
 
+    fn placeholders_at(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'static str, String> {
+        build_placeholders_with_tolerance(snap, opts().pace_tolerance, now)
+    }
+
     #[test]
     fn default_format_renders_session_pct() {
         let snap = sample_snap();
@@ -308,7 +321,7 @@ mod tests {
             }),
             mcp: None,
         };
-        let values = build_placeholders(&snap, &opts(), now);
+        let values = placeholders_at(&snap, now);
         assert_eq!(values["session_elapsed"], "60");
         assert_eq!(values["weekly_elapsed"], "57");
     }
@@ -332,13 +345,58 @@ mod tests {
             }),
             mcp: None,
         };
-        let values = build_placeholders(&snap, &opts(), now);
+        let values = placeholders_at(&snap, now);
         assert_eq!(values["zai_session_pace"], "↑");
         assert_eq!(values["zai_session_pace_indicator"], "↑");
         assert_eq!(values["zai_weekly_pace"], "↓");
         assert_eq!(values["zai_weekly_pace_indicator"], "↓");
         assert_eq!(values["zai_session_elapsed"], "60");
         assert_eq!(values["zai_weekly_elapsed"], "57");
+    }
+
+    #[test]
+    fn public_builder_keeps_the_default_tolerance_api() {
+        let now = Utc::now();
+        let snap = sample_snap();
+        assert_eq!(
+            build_placeholders(&snap, now),
+            build_placeholders_with_tolerance(&snap, pacing::DEFAULT_TOLERANCE, now)
+        );
+    }
+
+    #[test]
+    fn custom_tolerance_changes_the_ratio_pace() {
+        let now = Utc::now();
+        let snap = ZaiSnapshot {
+            plan: "GLM Coding Pro".into(),
+            session: Some(UsageWindow {
+                utilization_pct: 53,
+                resets_at: Some(now + chrono::Duration::minutes(150)),
+                window_duration: chrono::Duration::hours(5),
+            }),
+            weekly: None,
+            mcp: None,
+        };
+        assert_eq!(
+            build_placeholders_with_tolerance(&snap, 5, now)["zai_session_pace"],
+            "↑"
+        );
+        assert_eq!(
+            build_placeholders_with_tolerance(&snap, 10, now)["zai_session_pace"],
+            "→"
+        );
+    }
+
+    #[test]
+    fn present_window_without_reset_uses_documented_neutral_pacing() {
+        let now = Utc::now();
+        let mut snap = sample_snap();
+        snap.session.as_mut().unwrap().resets_at = None;
+        let values = placeholders_at(&snap, now);
+        assert_eq!(values["zai_session_reset"], "—");
+        assert_eq!(values["zai_session_elapsed"], "0");
+        assert_eq!(values["zai_session_pace"], "→");
+        assert_eq!(values["zai_session_pace_indicator"], "→");
     }
 
     #[test]
@@ -355,7 +413,7 @@ mod tests {
                 window_duration: chrono::Duration::days(30),
             }),
         };
-        let values = build_placeholders(&snap, &opts(), now);
+        let values = placeholders_at(&snap, now);
         assert_eq!(values["zai_mcp_elapsed"], "50");
         assert_eq!(values["zai_mcp_pace"], "↑");
         assert_eq!(values["zai_mcp_pace_indicator"], "↑");
@@ -369,7 +427,7 @@ mod tests {
             weekly: None,
             mcp: None,
         };
-        let values = build_placeholders(&snap, &opts(), Utc::now());
+        let values = placeholders_at(&snap, Utc::now());
         assert_eq!(values["session_elapsed"], "");
         assert_eq!(values["weekly_elapsed"], "");
         assert_eq!(values["zai_session_pace"], "");

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 
 use crate::countdown;
 use crate::format::{placeholders, substitute, updated_at_hm};
-use crate::pacing::PaceSeverity;
+use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
@@ -18,7 +18,11 @@ use super::fetch::FetchOutcome;
 
 pub const DEFAULT_FORMAT: &str = "{zai_session_pct}% · {zai_session_reset}";
 
-pub fn build_placeholders(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'static str, String> {
+pub fn build_placeholders(
+    snap: &ZaiSnapshot,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
     let session_pct = snap
         .session
         .as_ref()
@@ -26,6 +30,10 @@ pub fn build_placeholders(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'s
         .unwrap_or(0);
     let weekly_pct = snap.weekly.as_ref().map(|w| w.utilization_pct).unwrap_or(0);
     let mcp_pct = snap.mcp.as_ref().map(|w| w.utilization_pct).unwrap_or(0);
+    // Both windows carry a real duration (5h/7d) and a reset timestamp, so
+    // pacing is computable — same contract as the OpenAI renderer.
+    let session = window_pacing(snap.session.as_ref(), opts, now);
+    let weekly = window_pacing(snap.weekly.as_ref(), opts, now);
     placeholders(vec![
         ("icon", "󰚩".to_string()),
         ("vendor_short", "zai".to_string()),
@@ -40,6 +48,8 @@ pub fn build_placeholders(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'s
             "weekly_reset",
             countdown::format(window_reset(&snap.weekly), now),
         ),
+        ("session_elapsed", session.elapsed.clone()),
+        ("weekly_elapsed", weekly.elapsed.clone()),
         ("plan", snap.plan.clone()),
         ("zai_plan", snap.plan.clone()),
         ("zai_session_pct", session_pct.to_string()),
@@ -52,6 +62,12 @@ pub fn build_placeholders(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'s
             "zai_weekly_reset",
             countdown::format(window_reset(&snap.weekly), now),
         ),
+        ("zai_session_elapsed", session.elapsed),
+        ("zai_session_pace", session.ratio_pace),
+        ("zai_session_pace_indicator", session.point_pace),
+        ("zai_weekly_elapsed", weekly.elapsed),
+        ("zai_weekly_pace", weekly.ratio_pace),
+        ("zai_weekly_pace_indicator", weekly.point_pace),
         ("zai_mcp_pct", mcp_pct.to_string()),
         (
             "zai_mcp_reset",
@@ -62,6 +78,35 @@ pub fn build_placeholders(snap: &ZaiSnapshot, now: DateTime<Utc>) -> HashMap<&'s
 
 fn window_reset(w: &Option<UsageWindow>) -> Option<DateTime<Utc>> {
     w.as_ref().and_then(|w| w.resets_at)
+}
+
+/// Elapsed fraction and pace glyphs for one window, as ready placeholder
+/// values. Empty strings when the window is absent, mirroring the OpenAI
+/// renderer's convention; `pacing::calc` degrades to neutral 0/glyphs when
+/// the reset is unreported.
+#[derive(Default)]
+struct WindowPacing {
+    elapsed: String,
+    ratio_pace: String,
+    point_pace: String,
+}
+
+fn window_pacing(w: Option<&UsageWindow>, opts: &RenderOpts, now: DateTime<Utc>) -> WindowPacing {
+    let Some(w) = w else {
+        return WindowPacing::default();
+    };
+    let p = pacing::calc(
+        w.utilization_pct,
+        w.resets_at,
+        now,
+        w.window_duration,
+        opts.pace_tolerance,
+    );
+    WindowPacing {
+        elapsed: p.elapsed_pct.to_string(),
+        ratio_pace: p.ratio_pace.glyph().to_string(),
+        point_pace: p.point_pace.glyph().to_string(),
+    }
 }
 
 pub fn severity(snap: &ZaiSnapshot) -> PaceSeverity {
@@ -87,7 +132,7 @@ pub fn render(
         .format
         .clone()
         .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
-    let values = build_placeholders(snap, now);
+    let values = build_placeholders(snap, opts, now);
 
     let mut text = substitute(&format, &values);
     if outcome.stale {
@@ -238,6 +283,72 @@ mod tests {
         let oc = outcome(snap.clone());
         let out = render(&oc, &snap, &Theme::default(), &opts(), Utc::now());
         assert!(out.text.contains("42%"));
+    }
+
+    #[test]
+    fn elapsed_placeholders_follow_window_progress() {
+        // Fixed `now` on both sides so the fraction is exact: 2h left of a 5h
+        // window → 60% elapsed; 3d left of a 7d window → 57%.
+        let now = Utc::now();
+        let snap = ZaiSnapshot {
+            plan: "GLM Coding Pro".into(),
+            session: Some(UsageWindow {
+                utilization_pct: 42,
+                resets_at: Some(now + chrono::Duration::hours(2)),
+                window_duration: chrono::Duration::hours(5),
+            }),
+            weekly: Some(UsageWindow {
+                utilization_pct: 15,
+                resets_at: Some(now + chrono::Duration::days(3)),
+                window_duration: chrono::Duration::days(7),
+            }),
+            mcp: None,
+        };
+        let values = build_placeholders(&snap, &opts(), now);
+        assert_eq!(values["session_elapsed"], "60");
+        assert_eq!(values["weekly_elapsed"], "57");
+    }
+
+    #[test]
+    fn pace_placeholders_follow_usage_vs_elapsed() {
+        // Session: 80% used vs 60% elapsed → ahead of pace. Weekly: 15% used
+        // vs 57% elapsed → under pace.
+        let now = Utc::now();
+        let snap = ZaiSnapshot {
+            plan: "GLM Coding Pro".into(),
+            session: Some(UsageWindow {
+                utilization_pct: 80,
+                resets_at: Some(now + chrono::Duration::hours(2)),
+                window_duration: chrono::Duration::hours(5),
+            }),
+            weekly: Some(UsageWindow {
+                utilization_pct: 15,
+                resets_at: Some(now + chrono::Duration::days(3)),
+                window_duration: chrono::Duration::days(7),
+            }),
+            mcp: None,
+        };
+        let values = build_placeholders(&snap, &opts(), now);
+        assert_eq!(values["zai_session_pace"], "↑");
+        assert_eq!(values["zai_session_pace_indicator"], "↑");
+        assert_eq!(values["zai_weekly_pace"], "↓");
+        assert_eq!(values["zai_weekly_pace_indicator"], "↓");
+        assert_eq!(values["zai_session_elapsed"], "60");
+        assert_eq!(values["zai_weekly_elapsed"], "57");
+    }
+
+    #[test]
+    fn elapsed_placeholders_empty_without_window() {
+        let snap = ZaiSnapshot {
+            plan: "GLM Coding Unknown".into(),
+            session: None,
+            weekly: None,
+            mcp: None,
+        };
+        let values = build_placeholders(&snap, &opts(), Utc::now());
+        assert_eq!(values["session_elapsed"], "");
+        assert_eq!(values["weekly_elapsed"], "");
+        assert_eq!(values["zai_session_pace"], "");
     }
 
     #[test]

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -34,6 +34,7 @@ pub fn build_placeholders(
     // pacing is computable — same contract as the OpenAI renderer.
     let session = window_pacing(snap.session.as_ref(), opts, now);
     let weekly = window_pacing(snap.weekly.as_ref(), opts, now);
+    let mcp = window_pacing(snap.mcp.as_ref(), opts, now);
     placeholders(vec![
         ("icon", "󰚩".to_string()),
         ("vendor_short", "zai".to_string()),
@@ -73,6 +74,9 @@ pub fn build_placeholders(
             "zai_mcp_reset",
             countdown::format(window_reset(&snap.mcp), now),
         ),
+        ("zai_mcp_elapsed", mcp.elapsed),
+        ("zai_mcp_pace", mcp.ratio_pace),
+        ("zai_mcp_pace_indicator", mcp.point_pace),
     ])
 }
 
@@ -338,6 +342,26 @@ mod tests {
     }
 
     #[test]
+    fn mcp_pace_placeholders_follow_usage_vs_elapsed() {
+        // 70% used vs 15d/30d = 50% elapsed → ahead of pace.
+        let now = Utc::now();
+        let snap = ZaiSnapshot {
+            plan: "GLM Coding Pro".into(),
+            session: None,
+            weekly: None,
+            mcp: Some(UsageWindow {
+                utilization_pct: 70,
+                resets_at: Some(now + chrono::Duration::days(15)),
+                window_duration: chrono::Duration::days(30),
+            }),
+        };
+        let values = build_placeholders(&snap, &opts(), now);
+        assert_eq!(values["zai_mcp_elapsed"], "50");
+        assert_eq!(values["zai_mcp_pace"], "↑");
+        assert_eq!(values["zai_mcp_pace_indicator"], "↑");
+    }
+
+    #[test]
     fn elapsed_placeholders_empty_without_window() {
         let snap = ZaiSnapshot {
             plan: "GLM Coding Unknown".into(),
@@ -349,6 +373,8 @@ mod tests {
         assert_eq!(values["session_elapsed"], "");
         assert_eq!(values["weekly_elapsed"], "");
         assert_eq!(values["zai_session_pace"], "");
+        assert_eq!(values["zai_mcp_elapsed"], "");
+        assert_eq!(values["zai_mcp_pace"], "");
     }
 
     #[test]

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,0 +1,39 @@
+//! Source-compatibility checks for renderer helpers used by library consumers.
+
+use ai_usagebar::minimax::vendor as minimax_vendor;
+use ai_usagebar::usage::{MinimaxSnapshot, UsageWindow, ZaiSnapshot};
+use ai_usagebar::zai::vendor as zai_vendor;
+use chrono::{TimeZone, Utc};
+
+#[test]
+fn pace_placeholder_builders_keep_their_two_argument_api() {
+    let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+    let window = UsageWindow {
+        utilization_pct: 25,
+        resets_at: Some(now + chrono::Duration::hours(1)),
+        window_duration: chrono::Duration::hours(5),
+    };
+
+    let zai = ZaiSnapshot {
+        plan: "GLM Coding Pro".into(),
+        session: Some(window.clone()),
+        weekly: None,
+        mcp: None,
+    };
+    assert_eq!(
+        zai_vendor::build_placeholders(&zai, now)["session_pct"],
+        "25"
+    );
+
+    let minimax = MinimaxSnapshot {
+        plan: "MiniMax Token Plan".into(),
+        session: window.clone(),
+        weekly: window,
+        video_session: None,
+        video_weekly: None,
+    };
+    assert_eq!(
+        minimax_vendor::build_placeholders(&minimax, now)["session_pct"],
+        "25"
+    );
+}


### PR DESCRIPTION
## What changes

Z.AI's session/weekly/MCP windows and MiniMax's session/weekly/video windows already carry a real duration (5h/7d/30d, or the API's own start/end span) and reset timestamp — the same shape `pacing::calc` already consumes for Claude and Codex — but neither renderer surfaced the elapsed fraction or pace glyphs. This PR wires up both:

- **Cross-vendor `{session_elapsed}` / `{weekly_elapsed}`.** The macOS menu bar's pace marker (the blue tick + overshoot color on the ring/bar) reads these by fixed field position for every vendor; Z.AI and MiniMax substituted an empty placeholder before, so the marker never rendered — the ring looked "plain" even though the app had everything else it needed.
- **`{zai_session_pace}` / `{zai_weekly_pace}` / `{zai_mcp_pace}`** and **`{minimax_session_pace}` / `{minimax_weekly_pace}` / `{minimax_video_pace}`** (ratio-based, honors `--pace-tolerance`), plus their `{*_pace_indicator}` point-based counterparts, matching the placeholder contract `openai/vendor.rs` already established.
- **`{zai_session_elapsed}` / `{zai_weekly_elapsed}` / `{zai_mcp_elapsed}`** and **`{minimax_session_elapsed}` / `{minimax_weekly_elapsed}` / `{minimax_video_elapsed}`** — same elapsed-percent values, exposed with the vendor-prefixed names too.

Both vendors' MCP/video buckets get the same treatment as their main session/weekly windows since they are genuine `UsageWindow`s (real duration + reset) under the hood — there was no reason to leave them out. `minimax_video_weekly` is left untouched: it has no `_reset` placeholder at all today, a pre-existing gap unrelated to pacing.

For contrast, Claude's own monthly-ish bucket (`extra_usage`, the pay-as-you-go spend cap) carries no reset timestamp at all, so it has no pace analog — this isn't chasing parity with something Claude does; Z.AI and MiniMax's windows just happen to already have the right shape.

A full audit of all 17 vendors confirmed these were the only two with this specific gap (real duration data present, placeholder wiring missing). Everyone else either already had pace (Anthropic, Antigravity, OpenAI) or genuinely lacks the data to compute it (Kimi, Kiro, Cursor, OpenCode Go only report a bare `resets_at` with no window length; the remaining vendors are balance-only with no time-window concept at all).

## Why

Selecting Z.AI or MiniMax in the macOS menu bar showed plain rings with no pace marker, while Claude's rings show the blue elapsed-time tick. The root cause was missing plumbing, not missing data: both snapshots already had `window_duration` and `resets_at` populated from the real API response, but neither vendor's `build_placeholders` ever ran them through `pacing::calc` or exposed the result.

## Test plan

- [x] `cargo test` — 1044 passed, 0 failed (7 new tests across both vendors: exact elapsed-fraction math, pace glyphs in both directions for every window, and empty/absent-window placeholders)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual validation of Z.AI against the live API via the exact subprocess invocation the macOS menu bar uses (`--vendor zai --format <FORMAT>`): confirmed `session_elapsed`/`weekly_elapsed`/`mcp_elapsed` match the wall-clock fraction of each window, and the macOS ring now renders the pace marker for Z.AI exactly as it does for Claude
- [x] MiniMax has no live credentials available in this environment; verified via the same exact-fraction unit tests used for Z.AI (e.g. 2h left of a 5h window → 60% elapsed, confirmed against `pacing::calc`'s integer math by hand)

## CHANGELOG

Updated in `CHANGELOG.md` under `[Unreleased]`.

## Notes for reviewers

Scope is intentionally limited to the placeholder layer (`src/zai/vendor.rs`, `src/minimax/vendor.rs`). Two follow-ups are out of scope here, noted for a future PR:
- The Waybar tooltip's inline pace marker (`--tooltip-pace-pts`) is currently Anthropic-only — no other vendor's tooltip passes an elapsed marker into `pango::progress_bar`, so adding it just for Z.AI/MiniMax would be inconsistent with the rest of the codebase rather than fixing a gap.
- Both vendors' native TUI panels (`zai_sections` / `minimax_sections` in `src/tui/panels.rs`) pass `show_pacing` inconsistently today (Z.AI's is `false` for all three windows; MiniMax's is already `true`). Left untouched to keep this PR focused on the widget/menu-bar surface.