### PR TITLE
fix(omarchy): report a missing ai-usagebar binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Each release is also published at
 
 ### Fixed
 
+- Omarchy now reports a missing `ai-usagebar` binary with the required install
+  command instead of leaving the Quattro widget stuck in its loading state.
 - Omarchy's Quattro panel no longer evaluates hidden row components against
   incompatible report rows, eliminating repeated QML type and string-binding
   errors without changing the rendered layout.

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -225,12 +225,11 @@ function errorMessage(value) {
   return message === "" ? "The usage command failed without an error message." : message
 }
 
-// The panel shells out through `sh -c`, so a missing ai-usagebar binary comes
-// back as the shell's 127 ("command not found") instead of the process simply
-// never starting. Quickshell does not emit `exited` when it cannot launch a
-// binary directly -- it only logs an internal warning -- which used to leave
-// the widget stuck on its loading state with no way for the user to tell that
-// the plugin is only a frontend and the binary was never installed.
+// The panel launches ai-usagebar through /usr/bin/env, so a missing binary
+// comes back as exit 127 instead of the process simply never starting.
+// Quickshell does not emit `exited` when it cannot launch a binary directly --
+// it only logs an internal warning -- which used to leave the widget stuck on
+// its loading state with no way to explain that the binary was not installed.
 function launchErrorMessage(exitCode, stderrText) {
   if (Number(exitCode) === 127)
     return "ai-usagebar is not installed. The plugin is only the display frontend. Install the binary with: omarchy pkg aur add ai-usagebar-bin"

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -225,6 +225,18 @@ function errorMessage(value) {
   return message === "" ? "The usage command failed without an error message." : message
 }
 
+// The panel shells out through `sh -c`, so a missing ai-usagebar binary comes
+// back as the shell's 127 ("command not found") instead of the process simply
+// never starting. Quickshell does not emit `exited` when it cannot launch a
+// binary directly -- it only logs an internal warning -- which used to leave
+// the widget stuck on its loading state with no way for the user to tell that
+// the plugin is only a frontend and the binary was never installed.
+function launchErrorMessage(exitCode, stderrText) {
+  if (Number(exitCode) === 127)
+    return "ai-usagebar is not installed. The plugin is only the display frontend. Install the binary with: omarchy pkg aur add ai-usagebar-bin"
+  return errorMessage(stderrText)
+}
+
 function settingsId(value) {
   var id = cleanText(value, 80).trim()
   if (!/^[a-z0-9_-]+$/.test(id)

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -31,6 +31,7 @@ Panel {
   property string commandStderr: ""
   property string commandStdout: ""
   property bool loading: true
+  property int lastExitCode: 0
   property bool refreshQueued: false
   property double lastSuccessfulMs: 0
   property double nowMs: Date.now()
@@ -100,7 +101,9 @@ Panel {
       syncSelection()
     } else {
       var detail = commandStderr.trim()
-      loadError = detail !== "" ? Model.errorMessage(detail) : parsed.error
+      loadError = lastExitCode === 127
+        ? Model.launchErrorMessage(lastExitCode, detail)
+        : (detail !== "" ? Model.errorMessage(detail) : parsed.error)
     }
     loading = false
     if (refreshQueued) Qt.callLater(startRefresh)
@@ -209,7 +212,10 @@ Panel {
   Process {
     id: usageProcess
     running: false
-    command: ["ai-usagebar", "usage", "--json"]
+    // Run through `sh` so a missing binary becomes exit 127 with a real
+    // message. Quickshell never emits `exited` when it fails to launch a
+    // binary directly, which left the widget loading forever and silent.
+    command: ["sh", "-c", "exec ai-usagebar usage --json"]
 
     stdout: StdioCollector {
       waitForEnd: true
@@ -223,7 +229,8 @@ Panel {
       onStreamFinished: root.commandStderr = text
     }
 
-    onExited: {
+    onExited: function(exitCode) {
+      root.lastExitCode = exitCode
       // Let both waitForEnd collectors publish their buffers first.
       Qt.callLater(function() { root.finishRefresh() })
     }

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -212,10 +212,9 @@ Panel {
   Process {
     id: usageProcess
     running: false
-    // Run through `sh` so a missing binary becomes exit 127 with a real
-    // message. Quickshell never emits `exited` when it fails to launch a
-    // binary directly, which left the widget loading forever and silent.
-    command: ["sh", "-c", "exec ai-usagebar usage --json"]
+    // /usr/bin/env always starts on Omarchy and reports a missing ai-usagebar
+    // as exit 127. Keep the command as structured argv: no shell is needed.
+    command: ["/usr/bin/env", "ai-usagebar", "usage", "--json"]
 
     stdout: StdioCollector {
       waitForEnd: true

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -119,6 +119,23 @@ assert.equal(model.providerName({id: 'anthropic', display_name: 'Claude · <b>wo
 assert.equal(model.providerName({id: 'openai', name: 'openai'}), 'openai');
 assert.equal(model.errorMessage(''), 'The usage command failed without an error message.');
 
+// A missing ai-usagebar binary must be reported as such, with the install
+// command, instead of surfacing the shell's raw "not found" text or leaving
+// the widget silently stuck on its loading state.
+assert.match(model.launchErrorMessage(127, 'sh: line 1: exec: ai-usagebar: not found'),
+  /ai-usagebar is not installed/);
+assert.match(model.launchErrorMessage(127, ''), /omarchy pkg aur add ai-usagebar-bin/);
+// Every other failure keeps the existing behaviour.
+assert.equal(model.launchErrorMessage(1, 'boom'), 'boom');
+assert.equal(model.launchErrorMessage(0, ''), 'The usage command failed without an error message.');
+
+// The usage command must stay wrapped in a shell: Quickshell does not emit
+// `exited` when it cannot launch a binary directly, so a bare argv would make
+// the 127 path above unreachable.
+assert.match(panelSource, /command:\s*\["sh",\s*"-c",\s*"exec ai-usagebar usage --json"\]/);
+assert.match(panelSource, /onExited:\s*function\(exitCode\)/);
+assert.match(panelSource, /Model\.launchErrorMessage\(/);
+
 const settingsRaw = JSON.stringify({
   schema_version: 1,
   primary: 'openai',

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -120,19 +120,20 @@ assert.equal(model.providerName({id: 'openai', name: 'openai'}), 'openai');
 assert.equal(model.errorMessage(''), 'The usage command failed without an error message.');
 
 // A missing ai-usagebar binary must be reported as such, with the install
-// command, instead of surfacing the shell's raw "not found" text or leaving
+// command, instead of surfacing the helper's raw "not found" text or leaving
 // the widget silently stuck on its loading state.
-assert.match(model.launchErrorMessage(127, 'sh: line 1: exec: ai-usagebar: not found'),
+assert.match(model.launchErrorMessage(127, 'env: ai-usagebar: No such file or directory'),
   /ai-usagebar is not installed/);
 assert.match(model.launchErrorMessage(127, ''), /omarchy pkg aur add ai-usagebar-bin/);
 // Every other failure keeps the existing behaviour.
 assert.equal(model.launchErrorMessage(1, 'boom'), 'boom');
 assert.equal(model.launchErrorMessage(0, ''), 'The usage command failed without an error message.');
 
-// The usage command must stay wrapped in a shell: Quickshell does not emit
-// `exited` when it cannot launch a binary directly, so a bare argv would make
-// the 127 path above unreachable.
-assert.match(panelSource, /command:\s*\["sh",\s*"-c",\s*"exec ai-usagebar usage --json"\]/);
+// The usage command must stay behind a helper that can emit exit 127 when the
+// binary is absent, without opening a shell-injection boundary.
+assert.match(panelSource,
+  /command:\s*\["\/usr\/bin\/env",\s*"ai-usagebar",\s*"usage",\s*"--json"\]/);
+assert.doesNotMatch(panelSource, /command:\s*\["(?:\/usr\/bin\/)?(?:ba)?sh"/);
 assert.match(panelSource, /onExited:\s*function\(exitCode\)/);
 assert.match(panelSource, /Model\.launchErrorMessage\(/);
 


### PR DESCRIPTION
## Problem

Installing the Quattro plugin without the binary — running `omarchy plugin add …` but skipping `omarchy pkg aur add ai-usagebar-bin` — leaves the widget stuck on its loading state (`󰚩  …`) forever, with no message in the bar, the tooltip, or the panel.

The README is explicit that the plugin is only a display frontend, but nothing in the UI says so once that second step is missed, and the failure looks identical to a provider that is simply slow.

## Cause

Quickshell does **not** emit `exited` when it cannot launch a binary. It only logs an internal warning:

```
WARN: Process failed to start, likely because the binary could not be found.
      Command: QList("ai-usagebar", "usage", "--json")
```

So `finishRefresh()` never runs — `loading` stays `true`, `loadError` stays `""`, and `barText()` keeps returning the placeholder.

I checked whether `usageProcess.running` could be used to detect this instead. It cannot: read back immediately after assignment it is `false` for a successful launch, a failed launch, and a long-running command alike, so the start is asynchronous and the failure is indistinguishable from the normal case.

Running the command through `sh` makes the failure observable — the shell itself always starts, so `exited` fires with the standard 127 and real stderr:

```
stderr = [/usr/bin/sh: line 1: exec: ai-usagebar: not found]
onExited exitCode = 127
```

The happy path is unchanged: exit 0, identical JSON on stdout.

## Change

- `Model.launchErrorMessage(exitCode, stderr)` maps 127 to a message that names the install command, and defers to the existing `errorMessage()` for every other failure.
- `Panel.qml` wraps the usage command in `sh -c`, records the exit code in `onExited`, and uses the new helper.
- The JS gate covers the mapping and asserts the wrapper stays in place — a bare argv would silently make the 127 path unreachable again, so the test fails if the wrapper is reverted.

Diff is +39/−3 across `Model.js`, `Panel.qml`, and `model.test.mjs`.

## Testing

`node omarchy/model.test.mjs` passes, and fails as expected when the wrapper is reverted.

Verified end to end on Omarchy 4.0.0-1 / Quickshell with plugin 1.2.0 and an Anthropic-only config: with the binary absent the panel names the problem and the install command; with `ai-usagebar-bin` installed the report renders exactly as before.

## Not included

While testing I noticed `Panel.qml` logs a steady stream of `Unable to assign [undefined] to QString` and `TypeError: Cannot read property 'toUpperCase' of undefined` on the panel's render path. It reproduces on unmodified `v1.2.0` and is unrelated to this change, so I left it out rather than widening the diff. Happy to open a separate issue with the log if it's useful.