### PR TITLE
fix(omarchy): only bind a section row to its matching component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Omarchy's Quattro panel no longer evaluates hidden row components against
+  incompatible report rows, eliminating repeated QML type and string-binding
+  errors without changing the rendered layout.
+
 ## [1.2.0] — 2026-08-18
 
 ### Added

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -439,22 +439,27 @@ Panel {
                 required property var modelData
                 width: usageSection.width
 
+                // `visible` alone is not enough: QML evaluates the bindings of
+                // hidden items too, so every row used to be handed to all three
+                // components and the two that did not match read fields the row
+                // does not carry. A "spacer" row has no label or value, which is
+                // what produced the TypeError below on every report.
                 MetricRow {
                   visible: modelData.type === "metric"
                   width: parent.width
-                  row: modelData
+                  row: modelData.type === "metric" ? modelData : null
                 }
 
                 DetailRow {
                   visible: modelData.type === "text"
                   width: parent.width
-                  row: modelData
+                  row: modelData.type === "text" ? modelData : null
                 }
 
                 BlockRow {
                   visible: modelData.type === "block"
                   width: parent.width
-                  row: modelData
+                  row: modelData.type === "block" ? modelData : null
                 }
 
                 Item {
@@ -594,7 +599,7 @@ Panel {
       id: headingLabel
       visible: detailRow.heading
       width: parent.width
-      text: detailRow.row ? Model.autoTextSafe(detailRow.row.label.toUpperCase()) : ""
+      text: detailRow.row ? Model.autoTextSafe(String(detailRow.row.label || "").toUpperCase()) : ""
       foreground: root.foreground
       fontFamily: root.fontFamily
     }


### PR DESCRIPTION
## Problem

Every usage report logs a TypeError and several failed string assignments, repeating on each shell start:

```
Panel.qml: TypeError: Cannot read property 'toUpperCase' of undefined
Panel.qml: Unable to assign [undefined] to QString
```

Reproduces on unmodified `v1.2.0`.

## Cause

The section `Repeater` hands `modelData` to `MetricRow`, `DetailRow` and `BlockRow` alike, and separates them with `visible`:

```qml
MetricRow { visible: modelData.type === "metric"; row: modelData }
DetailRow { visible: modelData.type === "text";   row: modelData }
BlockRow  { visible: modelData.type === "block";  row: modelData }
```

QML evaluates the bindings of hidden items too, so every row is also bound by the two components that do not match its type, and they read fields the row does not carry.

A `spacer` row carries neither `label` nor `value`:

```json
{"type": "spacer"}
```

The existing `row ? … : ""` guards only check that the row **object** exists, never the field — so `detailRow.row` is truthy and `row.label.toUpperCase()` throws. An Anthropic report carries three spacers per provider, which is where the repetition comes from.

## Change

Pass the row only to the component matching its type, so the others bind against `null` and their existing guards apply. Also make the heading tolerate a `text` row that arrives without a label.

+9/−4 in `Panel.qml`. No visual change — the same components render the same rows; only the bindings for non-matching types stop evaluating.

## Testing

Measured on Omarchy 4.0.0-1 / Quickshell with plugin 1.2.0, against an Anthropic report containing three spacer rows, counting matching journal lines from a timestamp taken immediately before each shell restart:

| Panel.qml | errors per shell start |
| --- | --- |
| `main` | 18 |
| with this change | 0 |

`node omarchy/model.test.mjs` still passes.

An alternative fix would be to instantiate the row components through a `Loader` chosen by type, which would also avoid building three objects per row. I kept the diff to the binding guards since that is the actual defect — happy to switch if you would rather have the structural change.

Independent of #101; the two do not overlap.