### PR TITLE
Support multiple OpenRouter accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Each release is also published at
 
 ### Added
 
+- OpenRouter supports multiple named keys through `[[openrouter.accounts]]`.
+  Named accounts work with `--account`, appear separately in aggregate views,
+  and keep isolated caches; existing singular `[openrouter]` configs and cache
+  paths remain unchanged.
 - Z.AI and MiniMax now expose pace and elapsed-time placeholders
   (`{zai_session_elapsed}`, `{zai_session_pace}`, `{zai_weekly_elapsed}`,
   `{zai_weekly_pace}`, `{zai_mcp_elapsed}`, `{zai_mcp_pace}`,

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ come from environment variables or `config.toml`.
 | Anthropic API | Organization Admin key | Opt in with `ANTHROPIC_ADMIN_KEY` or `[anthropic_api] api_key`. Inference and Claude Code keys do not work. |
 | Codex | OAuth, read from `~/.codex/auth.json` | Run `codex login` once. Token auto-refreshes. |
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
-| OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. |
+| OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. Named keys are supported. |
 | DeepSeek | API key (`DEEPSEEK_API_KEY` or config) | Set either and opt in. |
 | Kimi | API key (`KIMI_API_KEY` or config) | Set either and opt in. |
 | Kilo | API key (`KILO_API_KEY` env or `[kilo] api_key` in config) | Set either. Opt-in. For a team balance, also set `[kilo] organization_id`; omit it for the personal balance. |
@@ -466,6 +466,15 @@ Claude Desktop or CLI login. The dedicated
 - safe credential and cache isolation;
 - Waybar modules for personal and work subscriptions;
 - macOS Desktop and CLI switching, backups, and history conflicts.
+
+### Multiple OpenRouter accounts
+
+Add one `[[openrouter.accounts]]` entry per key, then select it with
+`--vendor openrouter --account <label>`. Named accounts appear separately in
+the TUI, native integrations, and `usage` reports. Each has its own cache, so
+one key's fresh data cannot be shown for another. See the
+[OpenRouter account guide](docs/openrouter-accounts.md) for the config and
+Waybar examples.
 
 ## Hyprland: float the TUI window
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -113,6 +113,14 @@ api_key_env = "ZAI_API_KEY"      # checked first; if set + non-empty, used
 enabled = true
 api_key_env = "OPENROUTER_API_KEY"
 # api_key = "sk-or-v1-..."
+# Named keys appear as separate TUI/report entries and use isolated caches.
+# The default key above stays visible unless this is false. It is always kept
+# when no named accounts exist.
+# show_default_account = false
+# [[openrouter.accounts]]
+# label = "work"
+# api_key_env = "OPENROUTER_WORK_API_KEY"
+# api_key = "sk-or-v1-..."  # optional fallback; chmod 600 when inline
 
 [deepseek]
 # Disabled by default — enable once you've set a key (env var or inline).

--- a/docs/claude-accounts.md
+++ b/docs/claude-accounts.md
@@ -71,9 +71,10 @@ Each named account gets its own cache under
 `~/.cache/ai-usagebar/anthropic/<label>/`. The default account keeps the
 original `~/.cache/ai-usagebar/anthropic/` path.
 
-`--account` works only with Claude and cannot be combined with `--creds-path`.
-An unknown label fails with a list of valid labels. The TUI shows the default
-Claude tab followed by one tab for each named account.
+For Claude, `--account` cannot be combined with `--creds-path`. (OpenRouter
+also supports `--account` through its own account array.) An unknown label
+fails with a list of valid labels. The TUI shows the default Claude tab
+followed by one tab for each named account.
 
 If a CLI account and a saved Desktop profile share a label, aggregate views
 such as the TUI and `usage --json` use the Desktop profile to avoid refreshing

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,12 @@ api_key_env = "ZAI_API_KEY"
 enabled = true
 api_key_env = "OPENROUTER_API_KEY"
 # api_key = "sk-or-v1-..."
+# show_default_account = false  # hide default when named accounts exist
+
+# [[openrouter.accounts]]
+# label = "work"
+# api_key_env = "OPENROUTER_WORK_API_KEY"
+# api_key = "sk-or-v1-..."      # optional fallback; chmod 600 if inline
 
 [deepseek]
 enabled = true             # disabled by default; enable once you add an API key
@@ -115,3 +121,7 @@ enabled = true             # disabled by default; enable once you've run `kiro-c
 # data.sqlite3 after you logged in there.
 # db_path = "/home/you/.local/share/kiro-cli/data.sqlite3"
 ```
+
+For more than one OpenRouter key, see the
+[OpenRouter account guide](openrouter-accounts.md). The existing singular
+`[openrouter]` key remains the default account and needs no migration.

--- a/docs/openrouter-accounts.md
+++ b/docs/openrouter-accounts.md
@@ -1,0 +1,67 @@
+# OpenRouter account guide
+
+ai-usagebar can report several OpenRouter keys without running separate config
+or cache roots. The existing `[openrouter]` key remains the default account.
+
+## Add named accounts
+
+Add one entry per extra key to `~/.config/ai-usagebar/config.toml`:
+
+```toml
+[openrouter]
+enabled = true
+api_key_env = "OPENROUTER_API_KEY"
+# api_key = "sk-or-v1-default"
+
+[[openrouter.accounts]]
+label = "work"
+api_key_env = "OPENROUTER_WORK_API_KEY"
+
+[[openrouter.accounts]]
+label = "personal"
+api_key = "sk-or-v1-personal"
+```
+
+An account can use `api_key_env`, an inline `api_key`, or both. The environment
+variable wins when both are set. If you store any key inline, ai-usagebar
+tightens the config file to mode `0600` on Unix.
+
+Labels cannot be empty, contain path separators, drive prefixes, or control
+characters, or use a reserved cache filename. Duplicate labels are rejected.
+
+## Select an account
+
+Named accounts appear automatically as separate TUI tabs and `usage` report
+entries. Select one directly in the widget:
+
+```bash
+ai-usagebar --vendor openrouter --account work
+```
+
+The default account keeps the original
+`~/.cache/ai-usagebar/openrouter/` cache. Named accounts use
+`~/.cache/ai-usagebar/openrouter/<label>/`.
+
+To omit the unnamed account from aggregate views when all keys are named:
+
+```toml
+[openrouter]
+show_default_account = false
+```
+
+This setting does not disable direct access to the default key. When no named
+accounts exist, the default entry remains visible.
+
+## Use a named account in Waybar
+
+```jsonc
+"custom/openrouter-work": {
+    "exec": "ai-usagebar --vendor openrouter --account work --format '{or_balance} · {or_used_today}'",
+    "return-type": "json",
+    "interval": 300,
+    "tooltip": true
+}
+```
+
+The Settings panel edits the default key. Add or change named account entries
+in `config.toml`; saving other settings preserves them.

--- a/macos/README.md
+++ b/macos/README.md
@@ -175,6 +175,14 @@ ai-usagebar account switch work --desktop   # quits and reopens Claude.app
 
 See the main README's *Switching the active Claude account* for the full story.
 
+## Multiple OpenRouter accounts
+
+Entries from `[[openrouter.accounts]]` appear as separate menu choices and use
+`--vendor openrouter --account <label>` behind the scenes. Each account keeps
+its own cache. Set `[openrouter] show_default_account = false` when you do not
+want the unnamed key listed. See the main
+[OpenRouter account guide](../docs/openrouter-accounts.md) for configuration.
+
 ## Live config reload
 
 The app watches `config.toml` and reloads on any change — enable a vendor, add

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -757,25 +757,26 @@ func apiKeyEnvironment(_ v: VendorAuth) -> String {
     configValueTOML(v.id, "api_key_env") ?? v.env
 }
 
-// ── Anthropic multi-account ────────────────────────────────────────────────
-// Mirrors the Rust side (`src/config.rs`): explicit `[[anthropic.accounts]]`
-// entries plus subdirectories of `[anthropic] accounts_dir`, explicit labels
-// winning on a clash. Each account is a
+// ── Multi-account identities ───────────────────────────────────────────────
+// Claude mirrors the Rust side (`src/config.rs`): explicit
+// `[[anthropic.accounts]]` entries plus subdirectories of `[anthropic]`
+// `accounts_dir`, with explicit labels winning on a clash. Each account is a
 // selectable entry with the pseudo-id `anthropic@<label>`, fetched by the
 // binary as `--vendor anthropic --account <label>` — the binary resolves the
 // account's credentials itself (file or its own Keychain item), so the app
 // never needs to know where they live.
 
-/// `[[anthropic.accounts]]` labels, in file order. Pure text scan, like the
-/// rest of this app's TOML reading: a `[[anthropic.accounts]]` header opens a
-/// block, the first `label = "…"` inside it counts.
-func anthropicAccountLabels(inTOML text: String) -> [String] {
+/// Account-array labels for one provider, in file order. Pure text scan, like
+/// the rest of this app's TOML reading: a `[[provider.accounts]]` header opens
+/// a block, and the first `label = "…"` inside it counts.
+func accountLabels(inTOML text: String, vendor: String) -> [String] {
     var labels: [String] = []
     var inBlock = false
+    let header = "[[\(vendor).accounts]]"
     for rawLine in text.components(separatedBy: .newlines) {
         let line = rawLine.trimmingCharacters(in: .whitespaces)
         if line.hasPrefix("[") {
-            inBlock = line == "[[anthropic.accounts]]"
+            inBlock = line == header
             continue
         }
         guard inBlock, line.hasPrefix("label") else { continue }
@@ -794,6 +795,10 @@ func anthropicAccountLabels(inTOML text: String) -> [String] {
         }
     }
     return labels
+}
+
+func anthropicAccountLabels(inTOML text: String) -> [String] {
+    accountLabels(inTOML: text, vendor: "anthropic")
 }
 
 /// Immediate subdirectories of `dir`, sorted — the same discovery rule as the
@@ -826,16 +831,25 @@ func claudeAccountLabels() -> [String] {
     return mergedAccountLabels(explicit: explicit, discovered: discovered)
 }
 
-/// Rust semantics (`show_default_account`): `false` hides the default
-/// (unnamed) Claude entry, but is ignored when there are no named accounts,
-/// so Anthropic never loses its only entry.
-func showDefaultClaudeAccount(configValue: String?, hasAccounts: Bool) -> Bool {
+/// Explicit `[[openrouter.accounts]]` labels from the active config.
+func openRouterAccountLabels() -> [String] {
+    guard let text = try? String(contentsOfFile: configPathTOML(), encoding: .utf8) else {
+        return []
+    }
+    return accountLabels(inTOML: text, vendor: "openrouter")
+}
+
+/// Rust semantics (`show_default_account`): `false` hides an unnamed entry,
+/// but is ignored when there are no named accounts, so a vendor never loses
+/// its only entry.
+func showDefaultAccount(configValue: String?, hasAccounts: Bool) -> Bool {
     guard hasAccounts else { return true }
     return configValue != "false"
 }
 
-/// Pseudo-id mapping: `anthropic@<label>` selects a named account.
-let ACCOUNT_ID_PREFIX = "anthropic@"
+/// Pseudo-id mapping: `<vendor>@<label>` selects a named account.
+let CLAUDE_ACCOUNT_ID_PREFIX = "anthropic@"
+let OPENROUTER_ACCOUNT_ID_PREFIX = "openrouter@"
 // A Claude account whose usage comes from the Desktop app's own token (a saved
 // ~/.claude-acc/profiles/<label>), fetched with the widget's `--desktop` flag.
 // Distinct prefix so `vendorArgs` knows to pass it; every other helper treats it
@@ -846,41 +860,51 @@ func accountLabel(of id: String) -> String? {
     if id.hasPrefix(DESKTOP_ACCOUNT_ID_PREFIX) {
         return String(id.dropFirst(DESKTOP_ACCOUNT_ID_PREFIX.count))
     }
-    return id.hasPrefix(ACCOUNT_ID_PREFIX) ? String(id.dropFirst(ACCOUNT_ID_PREFIX.count)) : nil
+    guard let separator = id.firstIndex(of: "@") else { return nil }
+    let label = String(id[id.index(after: separator)...])
+    return label.isEmpty ? nil : label
 }
 
 func isDesktopAccountId(_ id: String) -> Bool { id.hasPrefix(DESKTOP_ACCOUNT_ID_PREFIX) }
 
 func baseVendorId(_ id: String) -> String {
-    accountLabel(of: id) != nil ? "anthropic" : id
+    if isDesktopAccountId(id) { return "anthropic" }
+    guard let separator = id.firstIndex(of: "@") else { return id }
+    return String(id[..<separator])
 }
 
 /// The subprocess arguments that select `id` (base vendor or named account).
 func vendorArgs(for id: String) -> [String] {
     if let label = accountLabel(of: id) {
-        var args = ["--vendor", "anthropic", "--account", label]
+        var args = ["--vendor", baseVendorId(id), "--account", label]
         if isDesktopAccountId(id) { args.append("--desktop") }
         return args
     }
     return ["--vendor", id]
 }
 
-/// One selectable entry: a base vendor or one Claude account.
+/// One selectable entry: a base vendor or a named account.
 struct MenuEntry {
-    let id: String    // "cursor", "anthropic", or "anthropic@<label>"
-    let name: String  // display: "Cursor", "Claude · <label>"
+    let id: String    // "cursor", "anthropic@<label>", or "openrouter@<label>"
+    let name: String  // display: "Cursor" or "Vendor · <label>"
 }
 
 func claudeAccountMenuEntries(_ accounts: [UsageAccount]) -> [MenuEntry] {
     accounts.map { account in
-        let prefix = account.desktop ? DESKTOP_ACCOUNT_ID_PREFIX : ACCOUNT_ID_PREFIX
+        let prefix = account.desktop ? DESKTOP_ACCOUNT_ID_PREFIX : CLAUDE_ACCOUNT_ID_PREFIX
         return MenuEntry(id: prefix + account.label, name: "Claude · \(account.label)")
     }
 }
 
+func openRouterAccountMenuEntries(_ labels: [String]) -> [MenuEntry] {
+    labels.map {
+        MenuEntry(id: OPENROUTER_ACCOUNT_ID_PREFIX + $0, name: "OpenRouter · \($0)")
+    }
+}
+
 /// Apply `[ui] overview_vendors` with the same semantics as the TUI: preserve
-/// config order, omit unavailable vendors, and include every named Claude
-/// account when `anthropic` is requested.
+/// config order, omit unavailable vendors, and include every named account
+/// when its base vendor is requested.
 func filterOverviewEntries(_ entries: [MenuEntry], requested: [String]?) -> [MenuEntry] {
     guard let requested else { return entries }
     var result: [MenuEntry] = []
@@ -895,8 +919,8 @@ func filterOverviewEntries(_ entries: [MenuEntry], requested: [String]?) -> [Men
 }
 
 /// The selectable entries, in menu order: every enabled+configured vendor,
-/// with Anthropic expanded into its named accounts (the default entry kept
-/// only per `show_default_account`). `active` stays listed even when
+/// with Claude and OpenRouter expanded into named accounts (their default
+/// entries kept only per `show_default_account`). `active` stays listed even when
 /// unconfigured — same rule the per-vendor list always had.
 func vendorEntries(active: String, usageAccounts: [UsageAccount]? = nil) -> [MenuEntry] {
     var out: [MenuEntry] = []
@@ -908,13 +932,22 @@ func vendorEntries(active: String, usageAccounts: [UsageAccount]? = nil) -> [Men
             let accounts = usageAccounts ?? claudeAccountLabels().map {
                 UsageAccount(label: $0, desktop: false)
             }
-            let showDefault = showDefaultClaudeAccount(
+            let showDefault = showDefaultAccount(
                 configValue: configValueTOML("anthropic", "show_default_account"),
                 hasAccounts: !accounts.isEmpty)
             if showDefault && (v.id == active || vendorConfigured(v)) {
                 out.append(MenuEntry(id: v.id, name: v.name))
             }
             out.append(contentsOf: claudeAccountMenuEntries(accounts))
+        } else if v.id == "openrouter" {
+            let labels = openRouterAccountLabels()
+            let showDefault = showDefaultAccount(
+                configValue: configValueTOML("openrouter", "show_default_account"),
+                hasAccounts: !labels.isEmpty)
+            if showDefault && (v.id == active || vendorConfigured(v)) {
+                out.append(MenuEntry(id: v.id, name: v.name))
+            }
+            out.append(contentsOf: openRouterAccountMenuEntries(labels))
         } else if v.id == active || vendorConfigured(v) {
             out.append(MenuEntry(id: v.id, name: v.name))
         }
@@ -925,7 +958,11 @@ func vendorEntries(active: String, usageAccounts: [UsageAccount]? = nil) -> [Men
 /// Display name for any selectable id (base vendor, account, or overview).
 func entryDisplayName(_ id: String) -> String {
     if id == "overview" { return "Visão geral" }
-    if let label = accountLabel(of: id) { return "Claude · \(label)" }
+    if let label = accountLabel(of: id) {
+        let base = baseVendorId(id)
+        let vendor = VENDOR_AUTH.first { $0.id == base }?.name ?? base
+        return "\(vendor) · \(label)"
+    }
     return VENDOR_AUTH.first { $0.id == id }?.name ?? id
 }
 
@@ -1299,13 +1336,19 @@ struct SettingsView: View {
     // Only enabled vendors appear in the selector: Rust treats opt-in vendors
     // (deepseek/kimi/kilo/novita/moonshot/grok/anthropic_api) as disabled when
     // their `[vendor].enabled` is omitted, and so must this picker. Claude
-    // accounts appear as their `anthropic@<label>` pseudo-ids, same as the
+    // accounts appear as their `vendor@<label>` pseudo-ids, same as the
     // "Trocar vendor" submenu.
     private var vendors: [String] {
         var ids = VENDOR_AUTH.filter { vendorEnabled($0) }.map { $0.id }
         let labels = claudeAccountLabels()
         if let at = ids.firstIndex(of: "anthropic") {
-            ids.insert(contentsOf: labels.map { ACCOUNT_ID_PREFIX + $0 }, at: at + 1)
+            ids.insert(contentsOf: labels.map { CLAUDE_ACCOUNT_ID_PREFIX + $0 }, at: at + 1)
+        }
+        let openRouterLabels = openRouterAccountLabels()
+        if let at = ids.firstIndex(of: "openrouter") {
+            ids.insert(
+                contentsOf: openRouterLabels.map { OPENROUTER_ACCOUNT_ID_PREFIX + $0 },
+                at: at + 1)
         }
         return ids
     }

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -401,6 +401,10 @@ func testClaudeAccounts() {
 
     [cursor]
     enabled = true
+
+    [[openrouter.accounts]]
+    label = "work"
+    api_key_env = "OPENROUTER_WORK_API_KEY"
     """
     assertEqual(anthropicAccountLabels(inTOML: toml).joined(separator: ","),
                 "struct,gmail", "labels in file order")
@@ -416,11 +420,11 @@ func testClaudeAccounts() {
                 "b,a,c", "explicit first, clash dropped")
 
     // show_default_account semantics mirror Rust: ignored without accounts.
-    assertEqual(showDefaultClaudeAccount(configValue: "false", hasAccounts: false), true,
+    assertEqual(showDefaultAccount(configValue: "false", hasAccounts: false), true,
                 "no accounts → default always shown")
-    assertEqual(showDefaultClaudeAccount(configValue: "false", hasAccounts: true), false,
+    assertEqual(showDefaultAccount(configValue: "false", hasAccounts: true), false,
                 "false hides the default")
-    assertEqual(showDefaultClaudeAccount(configValue: nil, hasAccounts: true), true,
+    assertEqual(showDefaultAccount(configValue: nil, hasAccounts: true), true,
                 "omitted → shown")
 
     // accounts_dir discovery: every subdir is an account (Keychain-backed
@@ -446,6 +450,14 @@ func testClaudeAccounts() {
     assertEqual(baseVendorId("cursor"), "cursor", "base id unchanged")
     assertEqual(vendorArgs(for: "anthropic@gmail").joined(separator: " "),
                 "--vendor anthropic --account gmail", "account fetch args")
+    assertEqual(accountLabels(inTOML: toml, vendor: "openrouter"), ["work"],
+                "provider-specific account array is parsed")
+    assertEqual(baseVendorId("openrouter@work"), "openrouter",
+                "OpenRouter account → base vendor")
+    assertEqual(vendorArgs(for: "openrouter@work").joined(separator: " "),
+                "--vendor openrouter --account work", "OpenRouter account fetch args")
+    assertEqual(entryDisplayName("openrouter@work"), "OpenRouter · work",
+                "OpenRouter account display name")
     assertEqual(vendorArgs(for: "zai").joined(separator: " "), "--vendor zai", "vendor fetch args")
     assertEqual(entryDisplayName("anthropic@gmail"), "Claude · gmail", "account display name")
     assertEqual(entryDisplayName("overview"), "Visão geral", "overview display name")
@@ -641,12 +653,12 @@ func testDesktopAccounts() {
     assertEqual(accountLabel(of: id), "gmail", "desktop id yields its label")
     assertEqual(baseVendorId(id), "anthropic", "desktop id is an anthropic entry")
     assertEqual(isDesktopAccountId(id), true, "desktop id detected")
-    assertEqual(isDesktopAccountId(ACCOUNT_ID_PREFIX + "gmail"), false, "cli id is not desktop")
+    assertEqual(isDesktopAccountId(CLAUDE_ACCOUNT_ID_PREFIX + "gmail"), false, "cli id is not desktop")
 
     // vendorArgs adds --desktop only for a desktop account.
     assertEqual(vendorArgs(for: id), ["--vendor", "anthropic", "--account", "gmail", "--desktop"],
                 "desktop account passes --desktop")
-    assertEqual(vendorArgs(for: ACCOUNT_ID_PREFIX + "gmail"),
+    assertEqual(vendorArgs(for: CLAUDE_ACCOUNT_ID_PREFIX + "gmail"),
                 ["--vendor", "anthropic", "--account", "gmail"],
                 "cli account omits --desktop")
 
@@ -655,8 +667,14 @@ func testDesktopAccounts() {
         UsageAccount(label: "personal", desktop: false),
     ])
     assertEqual(shared.map { $0.id },
-                [DESKTOP_ACCOUNT_ID_PREFIX + "work", ACCOUNT_ID_PREFIX + "personal"],
+                [DESKTOP_ACCOUNT_ID_PREFIX + "work", CLAUDE_ACCOUNT_ID_PREFIX + "personal"],
                 "menu uses the source selected by Rust status")
+
+    let openRouter = openRouterAccountMenuEntries(["work", "personal"])
+    assertEqual(openRouter.map { $0.id },
+                [OPENROUTER_ACCOUNT_ID_PREFIX + "work",
+                 OPENROUTER_ACCOUNT_ID_PREFIX + "personal"],
+                "OpenRouter accounts use generic report ids")
 }
 
 @main

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -86,6 +86,17 @@ assert.equal(model.preferredEntryId(parsed.entries, parsed.primary), 'openai');
 assert.equal(model.preferredEntryId(parsed.entries, 'anthropic'), 'anthropic@work');
 assert.equal(model.preferredEntryId(parsed.entries, 'missing'), 'anthropic@work');
 
+const openRouterAccounts = model.parseReport(JSON.stringify({entries: [{
+  id: 'openrouter@work', name: 'openrouter · work', display_name: 'OpenRouter · work',
+  error: null, sections: []
+}, {
+  id: 'openrouter@personal', name: 'openrouter · personal', display_name: 'OpenRouter · personal',
+  error: null, sections: []
+}]})).entries;
+assert.deepEqual(Array.from(model.filteredEntries(openRouterAccounts, 'openrouter')).map(entry => entry.id),
+  ['openrouter@work', 'openrouter@personal']);
+assert.equal(model.providerName(openRouterAccounts[0]), 'OpenRouter · work');
+
 assert.equal(model.headline(parsed.entries[0]).text, '29%');
 assert.equal(model.headline(parsed.entries[1]).severity, 'critical');
 assert.equal(model.isAlarming(parsed.entries[0]), true); // stale

--- a/src/config.rs
+++ b/src/config.rs
@@ -327,17 +327,22 @@ impl AnthropicConfig {
 /// cache sidecar names would escape, spoof terminal output, or collide with the
 /// cache layout (`usage.json`, `.stale`, …).
 pub fn validate_account_label(label: &str) -> Result<()> {
+    validate_account_label_for("anthropic", label)
+}
+
+fn validate_account_label_for(vendor: &str, label: &str) -> Result<()> {
     const RESERVED: [&str; 4] = ["usage.json", ".stale", ".last_error", ".fetch.lock"];
     let bad = label.is_empty()
         || label == "."
         || label == ".."
         || label.contains(['/', '\\'])
+        || label.contains(':')
         || label.chars().any(char::is_control)
         || RESERVED.contains(&label);
     if bad {
         return Err(AppError::Credentials(format!(
-            "invalid anthropic account label {label:?}: must be a non-empty name \
-             without path separators, control characters, or reserved cache names"
+            "invalid {vendor} account label {label:?}: must be a non-empty name \
+             without path separators, drive prefixes, control characters, or reserved cache names"
         )));
     }
     Ok(())
@@ -520,6 +525,13 @@ impl Default for ZaiConfig {
 #[serde(default)]
 pub struct OpenRouterConfig {
     pub enabled: bool,
+    /// Extra OpenRouter accounts beyond the default key. Each account gets a
+    /// separate aggregate-view entry and cache directory.
+    pub accounts: Vec<OpenRouterAccount>,
+    /// Whether aggregate views include the default (unnamed) key when named
+    /// accounts exist. Ignored when `accounts` is empty so OpenRouter never
+    /// loses its only tab.
+    pub show_default_account: bool,
     pub api_key_env: String,
     pub api_key: Option<String>,
 }
@@ -528,8 +540,63 @@ impl Default for OpenRouterConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            accounts: Vec::new(),
+            show_default_account: true,
             api_key_env: "OPENROUTER_API_KEY".to_string(),
             api_key: None,
+        }
+    }
+}
+
+/// One named OpenRouter account. The default account continues to use the
+/// singular `api_key_env` / `api_key` fields under `[openrouter]`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct OpenRouterAccount {
+    /// Stable CLI/report label and account-scoped cache subdirectory.
+    pub label: String,
+    /// Optional environment variable containing this account's key.
+    #[serde(default)]
+    pub api_key_env: Option<String>,
+    /// Inline fallback when the account environment variable is unset.
+    #[serde(default)]
+    pub api_key: Option<String>,
+}
+
+impl OpenRouterConfig {
+    /// Find a named account or fail loudly instead of falling back to the
+    /// default key (which would show the wrong account's usage).
+    pub fn account(&self, label: &str) -> Result<&OpenRouterAccount> {
+        validate_account_label_for("openrouter", label)?;
+        self.accounts
+            .iter()
+            .find(|account| account.label == label)
+            .ok_or_else(|| {
+                let known: Vec<&str> = self
+                    .accounts
+                    .iter()
+                    .map(|account| account.label.as_str())
+                    .collect();
+                AppError::Credentials(format!(
+                    "openrouter account {label:?} not found in [[openrouter.accounts]]; \
+                     known labels: {known:?}"
+                ))
+            })
+    }
+
+    /// Resolve either the backward-compatible default key or one named
+    /// account. Configured values are never included in an error message.
+    pub fn resolve_api_key(&self, label: Option<&str>) -> Result<String> {
+        match label {
+            None => resolve_api_key("OpenRouter", &self.api_key_env, self.api_key.as_deref()),
+            Some(label) => {
+                let account = self.account(label)?;
+                resolve_api_key_in_section(
+                    &format!("OpenRouter account {label:?}"),
+                    "[[openrouter.accounts]]",
+                    account.api_key_env.as_deref().unwrap_or(""),
+                    account.api_key.as_deref(),
+                )
+            }
         }
     }
 }
@@ -810,6 +877,19 @@ pub fn resolve_api_key(
     env_var_name: &str,
     inline: Option<&str>,
 ) -> crate::error::Result<String> {
+    let section = match vendor_label {
+        "OpenCode Go" => "[opencode-go]".to_string(),
+        _ => format!("[{}]", vendor_label.to_lowercase()),
+    };
+    resolve_api_key_in_section(vendor_label, &section, env_var_name, inline)
+}
+
+fn resolve_api_key_in_section(
+    vendor_label: &str,
+    section: &str,
+    env_var_name: &str,
+    inline: Option<&str>,
+) -> crate::error::Result<String> {
     let valid_env_name = is_valid_env_var_name(env_var_name);
     if valid_env_name
         && let Ok(v) = std::env::var(env_var_name)
@@ -827,12 +907,8 @@ pub fn resolve_api_key(
     } else {
         "fix the invalid `api_key_env` with a valid environment variable name or set `api_key`"
     };
-    let section = match vendor_label {
-        "OpenCode Go" => "opencode-go".to_string(),
-        _ => vendor_label.to_lowercase(),
-    };
     Err(crate::error::AppError::Credentials(format!(
-        "{vendor_label}: no API key. Either {advice} under [{section}] in {}.",
+        "{vendor_label}: no API key. Either {advice} under {section} in {}.",
         config_path_hint()
     )))
 }
@@ -909,6 +985,12 @@ impl Config {
             self.opencode_go.api_key.as_deref(),
         ]
         .into_iter()
+        .chain(
+            self.openrouter
+                .accounts
+                .iter()
+                .map(|account| account.api_key.as_deref()),
+        )
         .any(|key| key.is_some_and(|key| !key.is_empty()))
     }
 
@@ -1015,6 +1097,30 @@ impl Config {
             if !labels.insert(&account.label) {
                 return Err(AppError::Credentials(format!(
                     "duplicate anthropic account label {:?}",
+                    account.label
+                )));
+            }
+        }
+        let mut openrouter_labels = HashSet::new();
+        for account in &self.openrouter.accounts {
+            validate_account_label_for("openrouter", &account.label)?;
+            if !openrouter_labels.insert(&account.label) {
+                return Err(AppError::Credentials(format!(
+                    "duplicate openrouter account label {:?}",
+                    account.label
+                )));
+            }
+            let has_env = account
+                .api_key_env
+                .as_deref()
+                .is_some_and(|name| !name.is_empty());
+            let has_inline = account
+                .api_key
+                .as_deref()
+                .is_some_and(|key| !key.is_empty());
+            if !has_env && !has_inline {
+                return Err(AppError::Credentials(format!(
+                    "openrouter account {:?} must set api_key_env or api_key",
                     account.label
                 )));
             }
@@ -1170,6 +1276,18 @@ mod tests {
         assert!(config.has_inline_api_keys());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn openrouter_named_inline_keys_receive_config_file_protection() {
+        let mut config = Config::default();
+        config.openrouter.accounts.push(OpenRouterAccount {
+            label: "work".into(),
+            api_key_env: None,
+            api_key: Some("<redacted>".into()),
+        });
+        assert!(config.has_inline_api_keys());
+    }
+
     #[test]
     fn missing_file_uses_defaults() {
         let path = std::path::Path::new("/tmp/does-not-exist-ai-usagebar-test");
@@ -1205,6 +1323,8 @@ mod tests {
         assert_eq!(c.openai.admin_key_env, "MY_ADMIN_KEY");
         assert_eq!(c.zai.api_key_env, "MY_ZAI");
         assert_eq!(c.zai.plan_tier.as_deref(), Some("pro"));
+        assert!(c.openrouter.accounts.is_empty());
+        assert!(c.openrouter.show_default_account);
     }
 
     #[test]
@@ -1554,6 +1674,106 @@ enabled = false
     }
 
     #[test]
+    fn openrouter_named_accounts_preserve_the_default_contract() {
+        let f = write_toml(
+            r#"
+            [openrouter]
+            enabled = true
+            api_key_env = "AI_USAGEBAR_TEST_OR_DEFAULT"
+            api_key = "default-inline"
+            show_default_account = false
+
+            [[openrouter.accounts]]
+            label = "work"
+            api_key_env = "OPENROUTER_WORK_API_KEY"
+
+            [[openrouter.accounts]]
+            label = "personal"
+            api_key = "personal-inline"
+            "#,
+        );
+        let _g = env_guard();
+        unsafe { std::env::remove_var("AI_USAGEBAR_TEST_OR_DEFAULT") };
+        let config = Config::load_from(f.path()).unwrap();
+        assert!(!config.openrouter.show_default_account);
+        assert_eq!(config.openrouter.accounts.len(), 2);
+        assert_eq!(
+            config.openrouter.resolve_api_key(None).unwrap(),
+            "default-inline"
+        );
+        assert_eq!(
+            config.openrouter.resolve_api_key(Some("personal")).unwrap(),
+            "personal-inline"
+        );
+    }
+
+    #[test]
+    fn openrouter_named_accounts_reject_ambiguous_or_unsafe_labels() {
+        for source in [
+            r#"
+            [[openrouter.accounts]]
+            label = "work"
+            api_key = "one"
+            [[openrouter.accounts]]
+            label = "work"
+            api_key = "two"
+            "#,
+            r#"
+            [[openrouter.accounts]]
+            label = "../work"
+            api_key = "one"
+            "#,
+            r#"
+            [[openrouter.accounts]]
+            label = "work"
+            "#,
+        ] {
+            let f = write_toml(source);
+            assert!(Config::load_from(f.path()).is_err(), "accepted {source}");
+        }
+    }
+
+    #[test]
+    fn openrouter_unknown_account_never_falls_back_to_default_key() {
+        let mut config = OpenRouterConfig {
+            api_key: Some("default-secret".into()),
+            ..OpenRouterConfig::default()
+        };
+        config.accounts.push(OpenRouterAccount {
+            label: "work".into(),
+            api_key_env: None,
+            api_key: Some("work-secret".into()),
+        });
+        let message = config
+            .resolve_api_key(Some("missing"))
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("missing") && message.contains("work"));
+        assert!(!message.contains("default-secret"));
+        assert!(!message.contains("work-secret"));
+    }
+
+    #[test]
+    fn openrouter_account_key_errors_do_not_echo_configured_values() {
+        let config = OpenRouterConfig {
+            accounts: vec![OpenRouterAccount {
+                label: "work".into(),
+                api_key_env: Some("sk_pasted_secret".into()),
+                api_key: None,
+            }],
+            ..OpenRouterConfig::default()
+        };
+        let _g = env_guard();
+        unsafe { std::env::remove_var("sk_pasted_secret") };
+        let message = config
+            .resolve_api_key(Some("work"))
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("[[openrouter.accounts]]"));
+        assert!(!message.contains("sk_pasted_secret"));
+    }
+
+    #[test]
     fn enabled_vendors_preserves_canonical_order() {
         // DeepSeek and Kimi are disabled by default (require explicit API key
         // config), so they are absent from the enabled list unless enabled.
@@ -1788,6 +2008,7 @@ enabled = false
             "..",
             "a/b",
             r"a\b",
+            "C:work",
             "line\nbreak",
             "tab\tname",
             "usage.json",

--- a/src/report.rs
+++ b/src/report.rs
@@ -181,8 +181,8 @@ fn report_exit_code(entries: &[Entry]) -> i32 {
     i32::from(entries.iter().all(|entry| entry.error.is_some()))
 }
 
-/// Stable machine id, matching the `anthropic@<label>` convention the macOS
-/// menu bar already uses for accounts.
+/// Stable machine id shared by aggregate views and the macOS menu bar:
+/// `<vendor>@<label>` for named accounts.
 fn tab_id(tab: &TabId) -> String {
     match &tab.account {
         Some(account) => format!("{}@{account}", tab.vendor.slug()),
@@ -376,6 +376,11 @@ mod tests {
         assert_eq!(tab_id(&plain), "cursor");
         assert_eq!(tab_name(&plain), "cursor");
         assert_eq!(tab_display_name(&plain), "Cursor");
+
+        let openrouter = TabId::account_for(VendorId::Openrouter, "work");
+        assert_eq!(tab_id(&openrouter), "openrouter@work");
+        assert_eq!(tab_name(&openrouter), "openrouter · work");
+        assert_eq!(tab_display_name(&openrouter), "OpenRouter · work");
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -36,9 +36,9 @@ pub struct ReadyTab {
     pub fetched_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-/// Identity of one TUI tab. Usually a whole vendor; for Anthropic it can also
-/// name a specific configured account (issues #14 / #17). `account: None` is a
-/// plain vendor tab — the default Claude account, or any non-Anthropic vendor.
+/// Identity of one TUI tab. Usually a whole vendor; Claude and OpenRouter can
+/// also name a configured account. `account: None` is a plain vendor tab or
+/// that vendor's default account.
 /// `desktop` marks an account whose usage comes from the Claude Desktop app's
 /// own token rather than a `claude` CLI credential.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -60,8 +60,13 @@ impl TabId {
 
     /// A named Anthropic account tab (`[[anthropic.accounts]]` label).
     pub fn account(label: impl Into<String>) -> Self {
+        Self::account_for(VendorId::Anthropic, label)
+    }
+
+    /// A named account for a vendor that supports account arrays.
+    pub fn account_for(vendor: VendorId, label: impl Into<String>) -> Self {
         Self {
-            vendor: VendorId::Anthropic,
+            vendor,
             account: Some(label.into()),
             desktop: false,
         }
@@ -78,11 +83,10 @@ impl TabId {
     }
 }
 
-/// Expand enabled vendors into the tab list. Anthropic yields its default
-/// account tab followed by one tab per `[[anthropic.accounts]]` entry, in
-/// config order; every other vendor is a single tab. With no extra accounts
-/// configured the result equals `config.enabled_vendors()` — identical tab set
-/// and order to before (issue #14/#17 back-compat).
+/// Expand enabled vendors into the tab list. Claude and OpenRouter yield their
+/// default account followed by configured named accounts; every other vendor
+/// is a single tab. With no extra accounts the result equals
+/// `config.enabled_vendors()`, preserving the historical tab set and order.
 ///
 /// Config-only and pure — no Desktop profiles. Production uses
 /// [`tabs_with_desktop`]; this stays for the hermetic unit tests and any caller
@@ -134,6 +138,13 @@ fn build_tabs(config: &Config, desktop_labels: &[String]) -> Vec<TabId> {
             }
             for label in desktop_labels {
                 tabs.push(TabId::desktop_account(label.clone()));
+            }
+        } else if vendor == VendorId::Openrouter {
+            if config.openrouter.show_default_account || config.openrouter.accounts.is_empty() {
+                tabs.push(TabId::vendor(vendor));
+            }
+            for account in &config.openrouter.accounts {
+                tabs.push(TabId::account_for(vendor, account.label.clone()));
             }
         } else {
             tabs.push(TabId::vendor(vendor));
@@ -467,12 +478,11 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             Ok(outcome.into())
         }
         VendorId::Openrouter => {
-            let api_key = crate::config::resolve_api_key(
-                "OpenRouter",
-                &config.openrouter.api_key_env,
-                config.openrouter.api_key.as_deref(),
-            )?;
-            let cache = crate::cache::Cache::for_vendor("openrouter")?;
+            let api_key = config.openrouter.resolve_api_key(tab.account.as_deref())?;
+            let cache = match tab.account.as_deref() {
+                Some(label) => crate::cache::Cache::for_vendor_account("openrouter", label)?,
+                None => crate::cache::Cache::for_vendor("openrouter")?,
+            };
             let endpoints = crate::openrouter::fetch::Endpoints::default();
             let outcome = crate::openrouter::fetch_snapshot(
                 client,
@@ -932,6 +942,60 @@ mod tests {
         let vendors: Vec<VendorId> = tabs.iter().map(|t| t.vendor).collect();
         assert_eq!(vendors, config.enabled_vendors());
         assert!(tabs.iter().all(|t| t.account.is_none()));
+    }
+
+    #[test]
+    fn tabs_expand_openrouter_accounts_without_changing_other_vendors() {
+        let mut config = Config::default();
+        config.anthropic.enabled = false;
+        config.openai.enabled = false;
+        config.zai.enabled = false;
+        config.openrouter.accounts = vec![
+            crate::config::OpenRouterAccount {
+                label: "work".into(),
+                api_key_env: Some("OPENROUTER_WORK_API_KEY".into()),
+                api_key: None,
+            },
+            crate::config::OpenRouterAccount {
+                label: "personal".into(),
+                api_key_env: None,
+                api_key: Some("personal-key".into()),
+            },
+        ];
+        assert_eq!(
+            tabs_from_config(&config),
+            vec![
+                TabId::vendor(VendorId::Openrouter),
+                TabId::account_for(VendorId::Openrouter, "work"),
+                TabId::account_for(VendorId::Openrouter, "personal"),
+            ]
+        );
+    }
+
+    #[test]
+    fn openrouter_can_hide_default_only_when_named_accounts_exist() {
+        let mut config = Config::default();
+        config.anthropic.enabled = false;
+        config.openai.enabled = false;
+        config.zai.enabled = false;
+        config.openrouter.show_default_account = false;
+        assert_eq!(
+            tabs_from_config(&config),
+            vec![TabId::vendor(VendorId::Openrouter)]
+        );
+
+        config
+            .openrouter
+            .accounts
+            .push(crate::config::OpenRouterAccount {
+                label: "work".into(),
+                api_key_env: Some("OPENROUTER_WORK_API_KEY".into()),
+                api_key: None,
+            });
+        assert_eq!(
+            tabs_from_config(&config),
+            vec![TabId::account_for(VendorId::Openrouter, "work")]
+        );
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -1210,6 +1210,10 @@ plan_tier = "pro"
 [openrouter]
 enabled = true
 api_key_env = "OPENROUTER_API_KEY"
+
+[[openrouter.accounts]]
+label = "work"
+api_key_env = "OPENROUTER_WORK_API_KEY"
 "##,
         ));
 
@@ -1221,6 +1225,8 @@ api_key_env = "OPENROUTER_API_KEY"
         assert!(raw.contains("# pre-existing comment"));
         assert!(raw.contains("# tier comment"));
         assert!(raw.contains("api_key_env = \"ZAI_API_KEY\""));
+        assert!(raw.contains("[[openrouter.accounts]]"));
+        assert!(raw.contains("api_key_env = \"OPENROUTER_WORK_API_KEY\""));
         assert!(raw.contains("plan_tier = \"pro\""));
         assert!(raw.contains("primary = \"openrouter\""));
         assert!(raw.contains("api_key = \"zk2\""));

--- a/src/tui/view.rs
+++ b/src/tui/view.rs
@@ -79,9 +79,8 @@ fn vendor_label(id: VendorId) -> &'static str {
     }
 }
 
-/// Tab label for the header/sidebar/detail title. A named Anthropic account
-/// (#14/#17) appends its label, e.g. `Claude · work`; a plain vendor tab is
-/// just the vendor name.
+/// Tab label for the header/sidebar/detail title. A named account appends its
+/// label, e.g. `Claude · work` or `OpenRouter · personal`.
 fn tab_label(tab: &TabId) -> String {
     let label = match &tab.account {
         Some(acct) => format!("{} · {}", vendor_label(tab.vendor), acct),

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -116,11 +116,10 @@ pub struct Cli {
     #[arg(long, value_name = "FILE")]
     pub creds_path: Option<std::path::PathBuf>,
 
-    /// Select a named Anthropic account from `[[anthropic.accounts]]` in
-    /// config (issue #14). Without it, `--vendor anthropic` uses the default
-    /// account — the singular `[anthropic] credentials_path` — with unchanged
-    /// output and cache path. Anthropic only; conflicts with the lower-level
-    /// `--creds-path` (they both name a credentials file).
+    /// Select a named Claude or OpenRouter account from the matching
+    /// `[[...accounts]]` config array. Without it, the vendor's default account
+    /// and original cache path are unchanged. For Claude it conflicts with the
+    /// lower-level `--creds-path` because both select a credential source.
     #[arg(long, value_name = "LABEL", conflicts_with = "creds_path")]
     pub account: Option<String>,
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -133,6 +133,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
     // typo'd section shows another account's usage with no diagnostic.
     let config = Config::load()?;
     let vendor = cli.resolved_vendor(&config);
+    validate_vendor_options(cli, vendor)?;
     if !dispatch_is_eligible(cli, &config, vendor) {
         return Err(AppError::Other(format!(
             "vendor {:?} is disabled in {}",
@@ -160,6 +161,20 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::NousResearch => nous_output(cli).await,
         Vendor::OpenCodeGo => opencode_go_output(cli, &config).await,
     }
+}
+
+fn validate_vendor_options(cli: &Cli, vendor: Vendor) -> Result<()> {
+    if cli.account.is_some() && !matches!(vendor, Vendor::Anthropic | Vendor::Openrouter) {
+        return Err(AppError::Other(
+            "--account is supported only for Claude and OpenRouter".into(),
+        ));
+    }
+    if cli.desktop && vendor != Vendor::Anthropic {
+        return Err(AppError::Other(
+            "--desktop is supported only for Claude accounts".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Config and persisted selections may only dispatch enabled vendors. An
@@ -633,13 +648,8 @@ async fn zai_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
 }
 
 async fn openrouter_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
-    let api_key = crate::config::resolve_api_key(
-        "OpenRouter",
-        &config.openrouter.api_key_env,
-        config.openrouter.api_key.as_deref(),
-    )?;
+    let (api_key, cache) = openrouter_target(cli, config)?;
     let client = http_client()?;
-    let cache = vendor_cache(cli, "openrouter")?;
     let endpoints = openrouter::fetch::Endpoints::default();
     let outcome = match openrouter::fetch_snapshot(
         &client,
@@ -667,6 +677,21 @@ async fn openrouter_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
         &opts,
         chrono::Utc::now(),
     ))
+}
+
+/// Resolve an OpenRouter key and its cache as one identity. The unnamed key
+/// keeps the historical vendor-root cache; each named key is isolated below
+/// `openrouter/<label>` so fresh data can never cross accounts.
+fn openrouter_target(cli: &Cli, config: &Config) -> Result<(String, Cache)> {
+    let label = cli.account.as_deref();
+    let api_key = config.openrouter.resolve_api_key(label)?;
+    let cache = match (cli.cache_dir.as_deref(), label) {
+        (Some(root), Some(label)) => Cache::at(root.join("openrouter").join(label)),
+        (Some(root), None) => Cache::at(root.join("openrouter")),
+        (None, Some(label)) => Cache::for_vendor_account("openrouter", label)?,
+        (None, None) => Cache::for_vendor("openrouter")?,
+    };
+    Ok((api_key, cache))
 }
 
 async fn deepseek_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
@@ -1097,5 +1122,68 @@ mod tests {
         use clap::Parser;
         let res = Cli::try_parse_from(["ai-usagebar", "--account", "work", "--creds-path", "/x"]);
         assert!(res.is_err(), "--account and --creds-path must conflict");
+    }
+
+    #[test]
+    fn openrouter_named_account_uses_its_key_and_cache_subdir() {
+        let mut config = Config::default();
+        config
+            .openrouter
+            .accounts
+            .push(crate::config::OpenRouterAccount {
+                label: "work".into(),
+                api_key_env: None,
+                api_key: Some("work-key".into()),
+            });
+        config
+            .openrouter
+            .accounts
+            .push(crate::config::OpenRouterAccount {
+                label: "personal".into(),
+                api_key_env: None,
+                api_key: Some("personal-key".into()),
+            });
+        let root = tempfile::tempdir().unwrap();
+        let root_str = root.path().to_str().unwrap();
+        let cli = cli_with(Some("work"), None, Some(root_str));
+        let (key, cache) = openrouter_target(&cli, &config).unwrap();
+        assert_eq!(key, "work-key");
+        assert_eq!(cache.dir(), root.path().join("openrouter/work"));
+        cache.write_payload(b"work-only").unwrap();
+
+        let personal_cli = cli_with(Some("personal"), None, Some(root_str));
+        let (personal_key, personal_cache) = openrouter_target(&personal_cli, &config).unwrap();
+        assert_eq!(personal_key, "personal-key");
+        assert!(
+            personal_cache.maybe_payload().unwrap().is_none(),
+            "a named account must not reuse another account's fresh cache"
+        );
+    }
+
+    #[test]
+    fn openrouter_default_target_keeps_the_original_cache_path() {
+        let mut config = Config::default();
+        config.openrouter.api_key_env.clear();
+        config.openrouter.api_key = Some("default-key".into());
+        let cli = cli_with(None, None, Some("/tmp/cache"));
+        let (key, cache) = openrouter_target(&cli, &config).unwrap();
+        assert_eq!(key, "default-key");
+        assert_eq!(cache.dir(), std::path::Path::new("/tmp/cache/openrouter"));
+    }
+
+    #[test]
+    fn account_flag_rejects_unrelated_vendors() {
+        let cli = cli_with(Some("work"), None, Some("/tmp/cache"));
+        assert!(validate_vendor_options(&cli, Vendor::Zai).is_err());
+        assert!(validate_vendor_options(&cli, Vendor::Anthropic).is_ok());
+        assert!(validate_vendor_options(&cli, Vendor::Openrouter).is_ok());
+    }
+
+    #[test]
+    fn desktop_flag_remains_claude_only() {
+        let mut cli = cli_with(Some("work"), None, Some("/tmp/cache"));
+        cli.desktop = true;
+        assert!(validate_vendor_options(&cli, Vendor::Openrouter).is_err());
+        assert!(validate_vendor_options(&cli, Vendor::Anthropic).is_ok());
     }
 }


### PR DESCRIPTION
Closes #93.

Adds named `[[openrouter.accounts]]` keys with account-scoped caches and `--account` selection across the widget, TUI, reports, Omarchy, and macOS. Existing singular `[openrouter]` configuration and cache paths remain unchanged.

Security/compatibility details:
- rejects duplicate, traversal-like, control-character, drive-prefixed, and reserved labels
- never falls back from an unknown named account to the default key
- redacts configured key/env values from failures
- protects named inline keys with the existing Unix mode-0600 policy
- preserves named entries when the settings UI saves the default key

Validated locally with `make test`, formatting, Clippy with warnings denied, cargo-machete, the Omarchy plugin validator, and the security-surface audit. Swift tests require the hosted macOS runner.