### PR TITLE
Report a missing Grok Build CLI on Linux, not a protocol failure

### DIFF
--- a/src/supergrok/acp.rs
+++ b/src/supergrok/acp.rs
@@ -66,6 +66,19 @@ async fn fetch_billing_inner(grok_binary: &Path) -> Result<BillingResponse> {
 
     let result = run_protocol(stdout, stdin).await;
 
+    // The same "not installed" that `spawn` reports on macOS arrives on Linux as
+    // a child that exited 127: `posix_spawn` cannot fail the parent's call, so
+    // the exec failure surfaces in the child's status instead. Without this the
+    // friendly message above never fires on Linux and the user is told the
+    // protocol failed, rather than that the binary is missing.
+    let missing = matches!(child.try_wait(), Ok(Some(status)) if status.code() == Some(127));
+    if missing {
+        let _ = child.start_kill();
+        return Err(AppError::Credentials(
+            "official Grok Build CLI not found; install it or set [supergrok] grok_binary".into(),
+        ));
+    }
+
     // `grok agent stdio` is long-lived. End it immediately after this one
     // extension response; kill_on_drop is the final backstop on every error.
     let _ = child.start_kill();


### PR DESCRIPTION
`spawn()` reports a missing binary as `ErrorKind::NotFound` on macOS, so the "install it or set [supergrok] grok_binary" message fires there. On Linux the child starts through `posix_spawn`, which cannot fail the parent's call: the exec failure surfaces as the child exiting 127, the friendly arm is never reached, and the user is told the ACP protocol failed instead.

`missing_binary_has_a_clear_non_secret_error` has been failing on every Linux job for this reason — verified against untouched `main` inside `rust:1.88` on linux/amd64. The test was right; the code was macOS-shaped.