### PR TITLE
feat(omarchy): add icon-only bar option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- Omarchy can hide the selected provider's percentage or balance for an
+  icon-only top-bar entry while keeping full details in the panel and tooltip
+  (#104). The established right-click TUI shortcut is unchanged.
+
 ### Fixed
 
 - Z.AI usage parsing accepts both `CREDIT_LIMIT` and the legacy

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Once enabled, **left-click the AI Usage widget** to open the native Quattro
 usage panel. From that panel, click the **gear** or press `s` to open the native
 QML settings page. **Right-click intentionally opens `ai-usagebar-tui` in a
 terminal**; it is not the settings shortcut. Middle-click or use the mouse
-wheel to switch providers.
+wheel to switch providers. In QML settings, turn off **Show usage value in the
+top bar** for an icon-only widget; the panel and tooltip keep the full details.
 
 The source-built `ai-usagebar` AUR package can replace `ai-usagebar-bin` in
 the first command.
@@ -323,6 +324,8 @@ The widget reads the providers and accounts already enabled in
 
 - Left-click opens the native panel.
 - The gear or `s` opens QML settings.
+- QML settings can hide the bar's percentage or balance for an icon-only
+  widget; this applies immediately and preserves the full panel and tooltip.
 - Right-click launches the TUI.
 - Middle-click or the mouse wheel switches providers.
 - The selected provider or named account is remembered across shell reloads

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,8 @@
     "defaultSection": "right",
     "defaults": {
       "provider": "",
-      "refreshIntervalSec": 300
+      "refreshIntervalSec": 300,
+      "showValue": true
     },
     "schema": [
       {
@@ -44,6 +45,13 @@
         "max": 3600,
         "step": 30,
         "defaultValue": 300
+      },
+      {
+        "key": "showValue",
+        "type": "boolean",
+        "label": "Show usage value",
+        "description": "Show the selected provider's percentage or balance next to the icon in the top bar.",
+        "defaultValue": true
       }
     ]
   }

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -154,11 +154,12 @@ function preferredEntryId(entries, primaryProvider, rememberedEntryId) {
   return list[0].id
 }
 
-function settingsWithSelectedEntry(settings, moduleName, entryId) {
-  var selected = cleanText(entryId, 180).trim()
-  if (selected === "") return null
+function settingsWithOverrides(settings, moduleName, overrides) {
+  var moduleId = cleanText(moduleName, 180).trim()
+  if (moduleId === "" || !overrides || typeof overrides !== "object" || Array.isArray(overrides))
+    return null
 
-  var next = { id: cleanText(moduleName, 180).trim() }
+  var next = { id: moduleId }
   var current = settings && typeof settings === "object" && !Array.isArray(settings)
     ? settings : {}
   for (var key in current) {
@@ -166,8 +167,36 @@ function settingsWithSelectedEntry(settings, moduleName, entryId) {
       continue
     next[key] = current[key]
   }
-  next.lastSelectedEntryId = selected
+  for (var overrideKey in overrides) {
+    if (overrideKey === "id" || overrideKey === "__proto__" || overrideKey === "constructor"
+        || overrideKey === "prototype") continue
+    next[overrideKey] = overrides[overrideKey]
+  }
   return next
+}
+
+function settingsWithSelectedEntry(settings, moduleName, entryId) {
+  var selected = cleanText(entryId, 180).trim()
+  if (selected === "") return null
+  return settingsWithOverrides(settings, moduleName, { lastSelectedEntryId: selected })
+}
+
+function booleanSetting(value, fallback) {
+  if (value === true || value === false) return value
+  var normalized = String(value === undefined || value === null ? "" : value).trim().toLowerCase()
+  if (["true", "1", "yes", "on"].indexOf(normalized) >= 0) return true
+  if (["false", "0", "no", "off"].indexOf(normalized) >= 0) return false
+  return fallback === true
+}
+
+function barLabel(alarming, vertical, showValue, loading, hasEntry, summaryText) {
+  var icon = "󰚩"
+  if (vertical) return alarming ? "󰅙" : icon
+  if (loading && !hasEntry) return icon + "  …"
+  if (!hasEntry) return alarming ? "󰅙" : icon
+  if (!showValue) return icon
+  var summary = autoTextSafe(summaryText).trim()
+  return summary === "" ? icon : icon + "  " + summary
 }
 
 function headline(entry) {

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -42,6 +42,7 @@ Panel {
     Number(setting("refreshIntervalSec", 300)) || 300))
   readonly property string configuredProvider: String(setting("provider", "") || "").trim()
   readonly property string rememberedEntryId: String(setting("lastSelectedEntryId", "") || "").trim()
+  readonly property bool showValue: Model.booleanSetting(setting("showValue", true), true)
   readonly property var visibleEntries: Model.filteredEntries(entries, configuredProvider)
   readonly property int entryIndex: Model.selectedIndex(visibleEntries, selectedEntryId)
   readonly property var entry: entryIndex >= 0 ? visibleEntries[entryIndex] : null
@@ -77,21 +78,31 @@ Panel {
     selectedEntryId = Model.preferredEntryId(visibleEntries, primaryProvider, rememberedEntryId)
   }
 
-  function persistSelection(entryId) {
-    if (String(entryId || "").trim() === rememberedEntryId) return
-
+  function persistWidgetSettings(values) {
     // Quattro persists inline widget settings in shell.json and pushes them
     // live to every monitor. Keep every existing setting, including settings
-    // introduced by future versions, and add only the selected report id.
-    var entry = Model.settingsWithSelectedEntry(root.settings, root.moduleName, entryId)
-    if (!entry) return
+    // introduced by future versions, and apply only the requested overrides.
+    var entry = Model.settingsWithOverrides(root.settings, root.moduleName, values)
+    if (!entry) return false
 
-    // Apply locally first so selection remains responsive. Older compatible
-    // hosts without updateEntryInline still retain the choice for this session.
+    // Apply locally first so controls remain responsive. Older compatible hosts
+    // without updateEntryInline still retain the choice for this session.
     root.settings = entry
     if (hostWidget && "settings" in hostWidget) hostWidget.settings = entry
     if (bar && bar.shell && typeof bar.shell.updateEntryInline === "function")
       bar.shell.updateEntryInline(root.moduleName, entry)
+    return true
+  }
+
+  function persistSelection(entryId) {
+    if (String(entryId || "").trim() === rememberedEntryId) return
+    persistWidgetSettings({ lastSelectedEntryId: entryId })
+  }
+
+  function setShowValue(enabled) {
+    var next = enabled === true
+    if (next === showValue) return
+    persistWidgetSettings({ showValue: next })
   }
 
   function selectEntry(index) {
@@ -189,10 +200,8 @@ Panel {
   }
 
   function barText() {
-    if (vertical) return alarming ? "󰅙" : "󰚩"
-    if (loading && entries.length === 0) return "󰚩  …"
-    if (!entry) return alarming ? "󰅙" : "󰚩"
-    return "󰚩  " + Model.autoTextSafe(summary.text)
+    return Model.barLabel(alarming, vertical, showValue, loading,
+      entry !== null, summary.text)
   }
 
   function tooltipText() {
@@ -313,7 +322,7 @@ Panel {
             width: parent.width
             title: root.settingsOpen ? "Settings"
               : (root.entry ? Model.providerName(root.entry) : "AI usage")
-            meta: root.settingsOpen ? "Primary provider & API keys" : root.heroMeta()
+            meta: root.settingsOpen ? "Display, provider & API keys" : root.heroMeta()
             detail: root.settingsOpen
               ? "Existing configuration stays in place until you save."
               : (root.entry && root.summary.text !== "Ready" ? Model.autoTextSafe(root.summary.text) : "")
@@ -361,7 +370,9 @@ Panel {
             foreground: root.foreground
             urgent: root.urgent
             fontFamily: root.fontFamily
+            showValue: root.showValue
             onSaved: root.startRefresh()
+            onShowValueRequested: function(enabled) { root.setShowValue(enabled) }
             onFallbackRequested: root.openTerminalSettings()
             onNousLoginRequested: root.openNousLogin()
             onCloseRequested: root.closeSettings()

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -44,6 +44,9 @@ omarchy plugin remove akitaonrails.ai-usagebar
   in the widget's inline `shell.json` settings and restored after shell reloads
   and sleep/unlock cycles. Right-click is not the settings shortcut.
 - Panel: click the gear or press `s` to open the native QML settings page.
+  Its **Show usage value in the top bar** toggle switches between the normal
+  icon-and-value label and a compact icon-only label without hiding panel or
+  tooltip details.
   `h`/`l` or Left/Right switches provider, `j`/`k` or Up/Down scrolls, `r`,
   Enter, or Space refreshes, Tab moves to the neighboring bar panel, and Esc
   closes.
@@ -85,11 +88,15 @@ omarchy bar set akitaonrails.ai-usagebar provider ''
 
 # Numeric values need --json so shell.json stores a number.
 omarchy bar set akitaonrails.ai-usagebar refreshIntervalSec 300 --json
+
+# Booleans also need --json. The default is true for drop-in compatibility.
+omarchy bar set akitaonrails.ai-usagebar showValue false --json
 ```
 
 The refresh interval is clamped to 30–3600 seconds. The `provider` setting
 prefers an exact entry id; if there is no exact match, a base id such as
-`anthropic` selects all accounts for that provider.
+`anthropic` selects all accounts for that provider. `showValue` changes only
+the top-bar label; it never hides report details or changes provider fetching.
 
 ## Development checks
 
@@ -97,9 +104,11 @@ On an Omarchy 4 machine:
 
 ```bash
 omarchy plugin validate .
-qmllint -U -I /usr/share/omarchy/shell omarchy/BarWidget.qml omarchy/Panel.qml omarchy/SettingsView.qml
 node omarchy/model.test.mjs
 ```
+
+`qmllint` cannot resolve the `qs.*` modules that Omarchy injects at shell
+runtime, so it is not a reliable standalone check for plugin entry points.
 
 Saving files under an installed user plugin triggers Quattro's plugin hot
 reload. In a source checkout, rerun `omarchy plugin validate .` after changing

--- a/omarchy/SettingsView.qml
+++ b/omarchy/SettingsView.qml
@@ -14,6 +14,7 @@ Column {
   property color foreground: Color.foreground
   property color urgent: Color.urgent
   property string fontFamily: Style.font.family
+  property bool showValue: true
   readonly property color dim: Qt.darker(foreground, 1.45)
 
   property var snapshot: ({ primary_choices: [], keys: [] })
@@ -35,6 +36,7 @@ Column {
   signal saved()
   signal fallbackRequested()
   signal nousLoginRequested()
+  signal showValueRequested(bool enabled)
   signal closeRequested()
 
   spacing: Style.space(12)
@@ -197,6 +199,28 @@ Column {
       font.family: root.fontFamily
       font.pixelSize: Style.font.body
       horizontalAlignment: Text.AlignHCenter
+    }
+  }
+
+  Column {
+    visible: !root.loading
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "DISPLAY"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+    Toggle {
+      width: parent.width
+      label: "Show usage value in the top bar"
+      description: "Turn this off for an icon-only bar entry. The panel and tooltip still show full usage details. Applies immediately."
+      checked: root.showValue
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      enabled: !root.saving
+      onClicked: root.showValueRequested(!root.showValue)
     }
   }
 

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -13,6 +13,10 @@ vm.runInContext(source, model, {filename: 'Model.js'});
 const manifest = JSON.parse(fs.readFileSync(new URL('../manifest.json', import.meta.url), 'utf8'));
 assert.deepEqual(manifest.kinds, ['bar-widget']);
 assert.equal(manifest.entryPoints.barWidget, 'omarchy/BarWidget.qml');
+assert.equal(manifest.barWidget.defaults.showValue, true);
+const showValueSchema = manifest.barWidget.schema.find(row => row.key === 'showValue');
+assert.equal(showValueSchema.type, 'boolean');
+assert.equal(showValueSchema.defaultValue, true);
 
 const barWidgetSource = fs.readFileSync(new URL('./BarWidget.qml', import.meta.url), 'utf8');
 assert.match(barWidgetSource, /^BarWidget\s*\{/m);
@@ -21,6 +25,7 @@ for (const method of ['open', 'close', 'toggle', 'closeForPopoutSwitch'])
 assert.match(barWidgetSource, /source:\s*Qt\.resolvedUrl\("Panel\.qml"\)/);
 assert.match(barWidgetSource, /target\.anchorItem\s*=\s*button/);
 assert.match(barWidgetSource, /target\.hostWidget\s*=\s*root/);
+assert.match(barWidgetSource, /buttonCode\s*===\s*Qt\.RightButton\)\s*root\.launchDashboard\(\)/);
 assert.doesNotMatch(barWidgetSource, /\bIpcHandler\s*\{/);
 
 const panelSource = fs.readFileSync(new URL('./Panel.qml', import.meta.url), 'utf8');
@@ -30,10 +35,12 @@ assert.match(panelSource, /property\s+var\s+hostWidget:\s*null/);
 assert.match(panelSource, /SettingsView\s*\{/);
 assert.match(panelSource, /function\s+openSettings\s*\(/);
 assert.match(panelSource, /setting\("lastSelectedEntryId",\s*""\)/);
+assert.match(panelSource, /setting\("showValue",\s*true\)/);
 assert.match(panelSource, /function\s+persistSelection\s*\(/);
-assert.match(panelSource, /Model\.settingsWithSelectedEntry\(root\.settings,\s*root\.moduleName,\s*entryId\)/);
+assert.match(panelSource, /Model\.settingsWithOverrides\(root\.settings,\s*root\.moduleName,\s*values\)/);
 assert.match(panelSource, /bar\.shell\.updateEntryInline\(root\.moduleName,\s*entry\)/);
 assert.match(panelSource, /persistSelection\(selectedEntryId\)/);
+assert.match(panelSource, /Model\.barLabel\(/);
 
 const settingsViewSource = fs.readFileSync(new URL('./SettingsView.qml', import.meta.url), 'utf8');
 assert.match(settingsViewSource, /command:\s*\["ai-usagebar",\s*"settings",\s*"show"\]/);
@@ -41,6 +48,8 @@ assert.match(settingsViewSource, /command:\s*\["ai-usagebar",\s*"settings",\s*"a
 assert.match(settingsViewSource, /stdinEnabled:\s*true/);
 assert.match(settingsViewSource, /write\(root\.pendingPayload\s*\+\s*"\\n"\)/);
 assert.match(settingsViewSource, /signal\s+nousLoginRequested\(\)/);
+assert.match(settingsViewSource, /signal\s+showValueRequested\(bool\s+enabled\)/);
+assert.match(settingsViewSource, /label:\s*"Show usage value in the top bar"/);
 assert.match(settingsViewSource, /Log in with Nous Research/);
 assert.match(settingsViewSource, /Leave the terminal open until login completes/);
 assert.match(settingsViewSource, /model:\s*root\.snapshot\.keys/);
@@ -123,6 +132,31 @@ assert.deepEqual(JSON.parse(JSON.stringify(selectedWidgetSettings)), {
 });
 assert.equal(priorWidgetSettings.lastSelectedEntryId, undefined);
 assert.equal(model.settingsWithSelectedEntry({}, 'akitaonrails.ai-usagebar', ''), null);
+const hiddenValueSettings = model.settingsWithOverrides(
+  selectedWidgetSettings, 'akitaonrails.ai-usagebar', {showValue: false});
+assert.equal(hiddenValueSettings.showValue, false);
+assert.equal(hiddenValueSettings.lastSelectedEntryId, 'openrouter@personal');
+assert.equal(selectedWidgetSettings.showValue, undefined);
+const protectedSettings = model.settingsWithOverrides({}, 'akitaonrails.ai-usagebar', {
+  id: 'wrong-id', constructor: 'ignored', prototype: 'ignored', showValue: false
+});
+assert.equal(protectedSettings.id, 'akitaonrails.ai-usagebar');
+assert.notEqual(protectedSettings.constructor, 'ignored');
+assert.equal(protectedSettings.prototype, undefined);
+assert.equal(model.booleanSetting(undefined, true), true);
+assert.equal(model.booleanSetting(false, true), false);
+assert.equal(model.booleanSetting('false', true), false);
+assert.equal(model.booleanSetting('true', false), true);
+assert.equal(model.booleanSetting('invalid', true), true);
+
+assert.equal(model.barLabel(false, false, true, false, true, '29%'), '󰚩  29%');
+assert.equal(model.barLabel(false, false, false, false, true, '29%'), '󰚩');
+assert.equal(model.barLabel(true, false, true, false, true, '95%'), '󰚩  95%');
+assert.equal(model.barLabel(true, false, false, false, true, '95%'), '󰚩');
+assert.equal(model.barLabel(true, false, true, false, false, ''), '󰅙');
+assert.equal(model.barLabel(false, true, true, false, true, '29%'), '󰚩');
+assert.equal(model.barLabel(true, true, true, false, true, '95%'), '󰅙');
+assert.equal(model.barLabel(false, false, true, true, false, ''), '󰚩  …');
 
 assert.equal(model.headline(parsed.entries[0]).text, '29%');
 assert.equal(model.headline(parsed.entries[1]).severity, 'critical');


### PR DESCRIPTION
## Summary

- add a persistent native-QML toggle for an icon-only Omarchy top-bar label
- preserve full panel and tooltip details, provider fetching, and the established right-click TUI shortcut
- keep the current icon-and-value display as the default for drop-in compatibility
- preserve unknown and future inline widget settings when updating either display or provider selection

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --locked -- -D warnings`
- `make test` (1,066 unit tests plus integration, public API, GNOME, KDE, and Omarchy suites)
- `cargo machete`
- `cargo audit --file Cargo.lock`
- `omarchy plugin validate .`
- `cargo package --locked`

Closes #104.
