### PR TITLE
fix(antigravity): fall back to discovered ports and probe HTTP before TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Google Antigravity no longer gives up when `ANTIGRAVITY_LS_ADDRESS` points at
+  a port that has moved. The override is still tried first, but discovered local
+  ports are now probed behind it, and a signed-out server's authentication error
+  is reported instead of being masked by connection refusals from products that
+  are simply not running (#119). On Windows the RPC listener is probed before
+  the TLS one, which also silences the TLS handshake warnings `agy` used to log
+  on every poll.
+
 ## [1.4.0] — 2026-08-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,10 @@ vendor's response shape drifts:
   no credential and no remote endpoint: quota comes from whichever local
   Antigravity product is running (2.0, the IDE, or an interactive `agy`
   session), over a loopback RPC on a **dynamically assigned** port that is
-  discovered from `/proc` on Linux or `lsof` on macOS (elsewhere set
-  `ANTIGRAVITY_LS_ADDRESS`).
+  discovered from `/proc` on Linux, `lsof` on macOS, and the process/TCP-table
+  APIs on Windows. `ANTIGRAVITY_LS_ADDRESS` is a *first* candidate, not an
+  exclusive one — discovered ports are still probed behind it, so a stale
+  override degrades to a slower success instead of a hard failure.
   Tests must never probe `/proc` or the wall clock — use `candidate_bases_with`
   and `parse_cache_at`/`fetch_snapshot_at`, not their production wrappers.
 - `src/kiro/` — Kiro CLI. Reads kiro-cli's own `data.sqlite3` (read-only) for

--- a/config.example.toml
+++ b/config.example.toml
@@ -218,7 +218,9 @@ enabled = false
 # Google Antigravity. No credentials: usage is read from whichever local
 # Antigravity product is running (Antigravity 2.0, the `agy` CLI, or the IDE) —
 # all three share one account-wide quota. Set ANTIGRAVITY_LS_ADDRESS to
-# "host:port" only if auto-discovery of that local server ever fails.
+# "host:port" only if auto-discovery of that local server ever fails. It is
+# tried first, not exclusively: if that address is dead — a stale port after a
+# restart, say — discovery still runs and its ports are probed as fallbacks.
 [antigravity]
 enabled = false
 

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -134,6 +134,7 @@ async fn open_session(client: &reqwest::Client) -> Result<Session> {
         ));
     }
 
+    let mut first_actionable_err = None;
     let mut last_err = None;
     for base in bases {
         let csrf = fetch_csrf(client, &base).await;
@@ -146,10 +147,19 @@ async fn open_session(client: &reqwest::Client) -> Result<Session> {
                     account: account_key(&v),
                 });
             }
-            Err(e) => last_err = Some(e),
+            Err(e) => {
+                if first_actionable_err.is_none()
+                    && (matches!(e, AppError::Http { status, .. } if status == 401 || status == 403)
+                        || matches!(e, AppError::Credentials(_)))
+                {
+                    first_actionable_err = Some(e);
+                } else {
+                    last_err = Some(e);
+                }
+            }
         }
     }
-    Err(last_err.unwrap_or_else(|| {
+    Err(first_actionable_err.or(last_err).unwrap_or_else(|| {
         AppError::Other("antigravity: no local server answered GetUserStatus".into())
     }))
 }
@@ -387,28 +397,35 @@ fn candidate_bases() -> Vec<String> {
 /// Test seam for [`candidate_bases`] — takes the address override and the
 /// discovered ports instead of reading the environment and `/proc`.
 fn candidate_bases_with(override_addr: Option<&str>, discovered: Vec<u16>) -> Vec<String> {
+    let mut bases = Vec::new();
     if let Some(addr) = override_addr {
         let addr = addr.trim();
         if !addr.is_empty() {
-            return vec![normalize_base(addr)];
+            bases.push(normalize_base(addr));
         }
     }
 
     // No hardcoded fallback port on purpose: the server always binds with
     // `--https_server_port 0`, so its port is drawn from the ephemeral range
     // and cannot be guessed. Probing a fixed one would just poke whatever
-    // unrelated process happens to own it. Discovery or the explicit override.
-    discovered
-        .into_iter()
-        .map(|p| format!("http://127.0.0.1:{p}"))
-        .collect()
+    // unrelated process happens to own it. Discovered ports follow any
+    // explicit override as fallback, with duplicates omitted.
+    for p in discovered {
+        let candidate = format!("http://127.0.0.1:{p}");
+        if !bases.contains(&candidate) {
+            bases.push(candidate);
+        }
+    }
+
+    bases
 }
 
 fn normalize_base(addr: &str) -> String {
-    if addr.starts_with("http://") || addr.starts_with("https://") {
-        addr.to_string()
+    let trimmed = addr.trim().trim_end_matches('/');
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
     } else {
-        format!("http://{addr}")
+        format!("http://{trimmed}")
     }
 }
 
@@ -560,6 +577,13 @@ fn matching_windows_process_ids(processes: &[(u32, String)]) -> std::collections
         .collect()
 }
 
+/// Returns matching loopback ports in **descending** order.
+///
+/// The `agy` process binds two loopback ports: a lower-numbered HTTPS/TLS
+/// listener and a higher-numbered HTTP JSON-RPC listener (where `GetUserStatus`
+/// and `RetrieveUserQuotaSummary` live). Probing the higher HTTP port first
+/// avoids spurious TLS handshake errors that Go's `net/http.Server` writes to
+/// stderr whenever an unencrypted HTTP request hits its HTTPS listener.
 #[cfg(any(test, target_os = "windows"))]
 fn matching_windows_ports(
     pids: &std::collections::HashSet<u32>,
@@ -573,6 +597,7 @@ fn matching_windows_ports(
         })
         .collect::<std::collections::BTreeSet<_>>()
         .into_iter()
+        .rev()
         .collect()
 }
 
@@ -1320,10 +1345,31 @@ mod tests {
     }
 
     #[test]
-    fn explicit_address_wins_and_gets_a_scheme() {
+    fn explicit_address_comes_first_and_gets_a_scheme() {
         assert_eq!(
             candidate_bases_with(Some("127.0.0.1:1234"), vec![5678]),
-            vec!["http://127.0.0.1:1234".to_string()]
+            vec![
+                "http://127.0.0.1:1234".to_string(),
+                "http://127.0.0.1:5678".to_string(),
+            ]
+        );
+        // Trailing slashes are trimmed.
+        assert_eq!(
+            candidate_bases_with(Some("127.0.0.1:1234/"), vec![5678]),
+            vec![
+                "http://127.0.0.1:1234".to_string(),
+                "http://127.0.0.1:5678".to_string(),
+            ]
+        );
+        // Duplicate base URL is omitted.
+        assert_eq!(
+            candidate_bases_with(Some("127.0.0.1:5678"), vec![5678]),
+            vec!["http://127.0.0.1:5678".to_string()]
+        );
+        // Duplicate discovered ports are omitted.
+        assert_eq!(
+            candidate_bases_with(None, vec![5678, 5678]),
+            vec!["http://127.0.0.1:5678".to_string()]
         );
         // An address that already carries a scheme is left alone.
         assert_eq!(
@@ -1450,7 +1496,7 @@ mod tests {
                 pid: 10,
             },
         ];
-        assert_eq!(matching_windows_ports(&pids, &rows), vec![59868, 59870]);
+        assert_eq!(matching_windows_ports(&pids, &rows), vec![59870, 59868]);
     }
 
     #[test]

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -134,8 +134,7 @@ async fn open_session(client: &reqwest::Client) -> Result<Session> {
         ));
     }
 
-    let mut first_actionable_err = None;
-    let mut last_err = None;
+    let mut errors = Vec::new();
     for base in bases {
         let csrf = fetch_csrf(client, &base).await;
         match post_rpc(client, &base, csrf.as_deref(), STATUS_RPC).await {
@@ -147,21 +146,42 @@ async fn open_session(client: &reqwest::Client) -> Result<Session> {
                     account: account_key(&v),
                 });
             }
-            Err(e) => {
-                if first_actionable_err.is_none()
-                    && (matches!(e, AppError::Http { status, .. } if status == 401 || status == 403)
-                        || matches!(e, AppError::Credentials(_)))
-                {
-                    first_actionable_err = Some(e);
-                } else {
-                    last_err = Some(e);
-                }
-            }
+            Err(e) => errors.push(e),
         }
     }
-    Err(first_actionable_err.or(last_err).unwrap_or_else(|| {
+    Err(select_probe_error(errors))
+}
+
+/// Which failure to report when no candidate answered.
+///
+/// A server that replies `401`/`403` is running and reachable but signed out —
+/// the user can act on that, so it outranks the connection refusals from the
+/// products that simply are not up. Without this, a stale
+/// `ANTIGRAVITY_LS_ADDRESS` (or a second product on another port) would mask
+/// the one message worth reading behind transport noise.
+///
+/// Note that this also decides *visibility*: transport errors are transient and
+/// fall back silently to cache, while the `401` surfaces in the widget.
+fn select_probe_error(errors: Vec<AppError>) -> AppError {
+    let mut actionable = None;
+    let mut last = None;
+    for e in errors {
+        if actionable.is_none() && is_actionable(&e) {
+            actionable = Some(e);
+        } else {
+            last = Some(e);
+        }
+    }
+    actionable.or(last).unwrap_or_else(|| {
         AppError::Other("antigravity: no local server answered GetUserStatus".into())
-    }))
+    })
+}
+
+/// An error the user can do something about, as opposed to "that product is not
+/// running". `post_rpc` only ever yields `Http`/`Transport`/`Other`, so the
+/// authentication statuses are the whole set.
+fn is_actionable(e: &AppError) -> bool {
+    matches!(e, AppError::Http { status, .. } if *status == 401 || *status == 403)
 }
 
 async fn fetch_live(
@@ -579,11 +599,15 @@ fn matching_windows_process_ids(processes: &[(u32, String)]) -> std::collections
 
 /// Returns matching loopback ports in **descending** order.
 ///
-/// The `agy` process binds two loopback ports: a lower-numbered HTTPS/TLS
-/// listener and a higher-numbered HTTP JSON-RPC listener (where `GetUserStatus`
-/// and `RetrieveUserQuotaSummary` live). Probing the higher HTTP port first
-/// avoids spurious TLS handshake errors that Go's `net/http.Server` writes to
-/// stderr whenever an unencrypted HTTP request hits its HTTPS listener.
+/// The `agy` process binds two loopback ports: an HTTPS/TLS listener and the
+/// unencrypted HTTP JSON-RPC listener (where `GetUserStatus` and
+/// `RetrieveUserQuotaSummary` live). Both are ephemeral, but they are bound in
+/// that order, so in practice the RPC listener draws the higher number.
+/// Probing high-to-low therefore usually hits it first and avoids the spurious
+/// TLS handshake errors Go's `net/http.Server` writes to stderr whenever an
+/// unencrypted request reaches its HTTPS listener. It is only a preference:
+/// every candidate is still probed, so an inverted allocation costs one extra
+/// round-trip and nothing else.
 #[cfg(any(test, target_os = "windows"))]
 fn matching_windows_ports(
     pids: &std::collections::HashSet<u32>,
@@ -1375,6 +1399,73 @@ mod tests {
         assert_eq!(
             candidate_bases_with(Some("https://host:9"), vec![]),
             vec!["https://host:9".to_string()]
+        );
+    }
+
+    fn http(status: u16) -> AppError {
+        AppError::Http {
+            status,
+            body: String::new(),
+        }
+    }
+
+    /// A signed-out server is worth reporting even when a later candidate only
+    /// refused the connection — that is the whole point of probing on past the
+    /// first failure.
+    #[test]
+    fn an_auth_failure_outranks_later_transport_noise() {
+        let err = select_probe_error(vec![
+            http(401),
+            AppError::Transport("connection refused".into()),
+        ]);
+        assert!(matches!(err, AppError::Http { status: 401, .. }), "{err}");
+
+        let err = select_probe_error(vec![
+            AppError::Transport("connection refused".into()),
+            http(403),
+        ]);
+        assert!(matches!(err, AppError::Http { status: 403, .. }), "{err}");
+    }
+
+    /// The *first* actionable failure wins, so the explicit override's message
+    /// survives a second signed-out product further down the list.
+    #[test]
+    fn the_first_auth_failure_wins() {
+        let err = select_probe_error(vec![http(401), http(403)]);
+        assert!(matches!(err, AppError::Http { status: 401, .. }), "{err}");
+    }
+
+    /// With nothing actionable, the last failure stands in for "nothing
+    /// answered" — and stays transient, so the widget falls back silently
+    /// instead of shouting about a product that simply is not running.
+    #[test]
+    fn without_an_auth_failure_the_last_error_stands() {
+        let err = select_probe_error(vec![
+            AppError::Transport("first".into()),
+            http(500),
+            AppError::Transport("last".into()),
+        ]);
+        assert!(
+            matches!(&err, AppError::Transport(m) if m == "last"),
+            "{err}"
+        );
+        assert!(err.is_transient());
+    }
+
+    /// A 5xx is a server that answered but broke; the user cannot act on it, so
+    /// it must not outrank a later real failure the way a 401 does.
+    #[test]
+    fn a_server_error_is_not_treated_as_actionable() {
+        let err = select_probe_error(vec![http(500), http(401)]);
+        assert!(matches!(err, AppError::Http { status: 401, .. }), "{err}");
+    }
+
+    #[test]
+    fn no_candidates_at_all_yields_a_generic_error() {
+        let err = select_probe_error(Vec::new());
+        assert!(
+            err.to_string().contains("no local server answered"),
+            "{err}"
         );
     }
 


### PR DESCRIPTION
## Summary

`ANTIGRAVITY_LS_ADDRESS` becomes a *first* candidate instead of an exclusive one: discovered local ports are probed behind it, so a stale override after the language server restarts on a new ephemeral port degrades to a slower success rather than a hard `connection refused`. Duplicate base URLs are omitted — the comparison is string equality on the normalized URL, so an override written as `localhost:5678` and a discovered `127.0.0.1:5678` are still two candidates and cost one extra probe. An override that normalizes down to nothing but a scheme is dropped instead of probed.

Probe ordering puts the unencrypted JSON-RPC listener ahead of the TLS one, so Go's `net/http.Server` inside the language server stops writing `http: TLS handshake error: client sent an HTTP request to an HTTPS server` to stderr on every poll cycle. The two listeners are both ephemeral and only *tend* to be allocated low-then-high, and that tendency holds within one process and says nothing across two, so ports are grouped per pid and taken rank by rank — every product's highest port, then every product's second-highest — which stops a second product's TLS listener from being reached before the first product's RPC listener. It stays a preference, not a guarantee: every candidate is still probed, so an inverted allocation costs one extra round-trip and nothing else. The ordering applies on Linux, macOS and Windows.

Probe-error selection is a pure `select_probe_error()`. An authentication failure outranks the connection refusals from products that are simply not running, the first such failure wins, a 5xx is not treated as actionable, and when nothing is actionable the last (transient) error stands so the widget keeps falling back silently instead of shouting about a product that is not up.

## Commits

- `75325bc` — the original change: fall back to discovered ports, and reorder the Windows listener probe.
- `7fa3847` — maintainer follow-up: lift error selection into a testable pure function, drop an `AppError::Credentials` arm that `post_rpc` never produces, soften the port-order comment to a tendency, and record the override's new meaning in `CLAUDE.md` and `config.example.toml`.
- `9ab63b1` — this pass: group candidates per product so the ordering still holds with more than one running, extend the same ordering to Linux and macOS, and reject authority-less overrides.

## Implementation

- `candidate_bases_with()` appends non-duplicate discovered port URLs after the normalized override.
- `normalize_base()` splits the scheme before trimming trailing slashes and returns `Option<String>`, so `127.0.0.1:1234/` normalizes cleanly while `/` and `http://` yield `None` rather than a malformed candidate that spends a probe and adds a failure for `select_probe_error()` to weigh.
- `probe_order()` is the shared ordering helper: sort each pid's ports high-to-low, then emit them rank by rank, deduplicating globally. Ordering among products is arbitrary — all of them report the same account-wide quota — so pid order is used only to keep the result reproducible across `/proc`, `lsof` and the Windows TCP table, which each enumerate in their own order.
- `matching_windows_ports()`, the Linux `/proc` scan and `parse_lsof_pcn()` all feed `probe_order()`. The Linux scan now maps socket inodes back to their owning pid instead of collecting them into one flat set, and the `lsof` parser carries the pid from each `p` line down to the `n` lines under it.
- `parse_lsof_pcn()` is compiled under `test` on every platform, the way `matching_windows_ports()` already was, so the `lsof` tests are no longer macOS-only.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --all-targets --locked` — 1061 passed, 0 failed, 9 ignored (the live-endpoint tests)
- [x] `cargo machete` — clean
- [x] `node gnome-extension/marker-logic.test.mjs`, `node kde-plasmoid/plasmoid-logic.test.mjs`, `node omarchy/model.test.mjs` — pass. `make` is unavailable on this machine, so the three `make test` frontend targets were run directly.
- [ ] `cargo clippy --all-targets --locked -- -D warnings` — not verifiable locally. Run on Windows it fails on three pre-existing dead-code errors in `src/nous/credentials.rs` (`file_mode`, `set_private_permissions_path`, `insert_other`), whose only callers sit inside `#[cfg(unix)]` blocks. Nothing in this branch is flagged. CI runs clippy on `ubuntu-latest`, where those functions are live.

Verified on Windows 11; CI covers ubuntu, macOS, Windows and Rust 1.88.

## One open question

`select_probe_error()` keeps the *last* failure when nothing is actionable, which is what preserves the silent cache fallback for a product that is not running. The cost is that the TLS listener, being probed after the RPC one, answers an unencrypted request with a generic `400` that ranks the same as a real failure from the port that does speak JSON-RPC — so a schema drift on the live server surfaces in the tooltip as `HTTP 400: Client sent an HTTP request to an HTTPS server` instead of the drift itself. Preferring a non-transport failure over a transport one would fix that but would also make a stray 5xx surface where the current design deliberately stays quiet, so I left the behaviour as `7fa3847` set it. Happy to follow up either way.
