### PR TITLE
feat(omarchy): show absolute reset clock time in popup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
       - name: Test desktop integration models
         run: make desktop-test
 
+      # The Omarchy model contract was only ever run by `make test` locally,
+      # so changes to omarchy/Model.js reached main unverified. Node-only,
+      # like desktop-test.
+      - name: Test Omarchy plugin model
+        run: make plugin-test
+
       - name: Unused dependencies
         uses: bnjbvr/cargo-machete@ac30a525c0a8d163a92d727b3ff079ee3f6ecb08 # v0.9.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- The Omarchy panel's reset row now shows the wall-clock time the limit window
+  reopens alongside the countdown — `Resets in 4h 5m · 13:54` — and dates it
+  whenever the reset lands on another day (#120).
+
 ### Fixed
 
 - Google Antigravity no longer gives up when `ANTIGRAVITY_LS_ADDRESS` points at

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -246,7 +246,14 @@ function formatReset(resetAt, nowMs) {
   var resetMs = new Date(String(resetAt)).getTime()
   if (!isFinite(resetMs)) return ""
   var remaining = resetMs - Number(nowMs)
-  return remaining > 0 ? "Resets in " + formatDuration(remaining) : "Reset due"
+  if (remaining <= 0) return "Reset due"
+  // Show the real local clock time the window reopens, so the absolute
+  // reset moment is visible next to the countdown.
+  var at = new Date(resetMs)
+  var clock = ("0" + at.getHours()).slice(-2) + ":" + ("0" + at.getMinutes()).slice(-2)
+  if (remaining >= 86400000)
+    clock = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][at.getMonth()] + " " + at.getDate() + " " + clock
+  return "Resets in " + formatDuration(remaining) + " · " + clock
 }
 
 function formatUpdated(fetchedAt, nowMs) {

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -241,6 +241,19 @@ function formatDuration(milliseconds) {
   return Math.max(1, minutes) + "m"
 }
 
+var MONTH_NAMES = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+function pad2(value) {
+  return ("0" + value).slice(-2)
+}
+
+function isSameLocalDay(a, b) {
+  return a.getFullYear() === b.getFullYear()
+    && a.getMonth() === b.getMonth()
+    && a.getDate() === b.getDate()
+}
+
 function formatReset(resetAt, nowMs) {
   if (!resetAt) return ""
   var resetMs = new Date(String(resetAt)).getTime()
@@ -248,11 +261,15 @@ function formatReset(resetAt, nowMs) {
   var remaining = resetMs - Number(nowMs)
   if (remaining <= 0) return "Reset due"
   // Show the real local clock time the window reopens, so the absolute
-  // reset moment is visible next to the countdown.
+  // reset moment is visible next to the countdown. Date it whenever it
+  // lands on another day: a bare "03:00" on an 18h countdown reads as a
+  // time that has already passed, which is the ambiguity this row exists
+  // to remove. Keyed on the calendar day rather than on "is it 24h away",
+  // because tonight's reset crosses midnight long before it crosses 24h.
   var at = new Date(resetMs)
-  var clock = ("0" + at.getHours()).slice(-2) + ":" + ("0" + at.getMinutes()).slice(-2)
-  if (remaining >= 86400000)
-    clock = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"][at.getMonth()] + " " + at.getDate() + " " + clock
+  var clock = pad2(at.getHours()) + ":" + pad2(at.getMinutes())
+  if (!isSameLocalDay(at, new Date(Number(nowMs))))
+    clock = MONTH_NAMES[at.getMonth()] + " " + at.getDate() + " " + clock
   return "Resets in " + formatDuration(remaining) + " · " + clock
 }
 

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -627,6 +627,10 @@ Panel {
       color: root.dim
       font.family: root.fontFamily
       font.pixelSize: Style.font.caption
+      // The row now carries a date and clock as well as the countdown, so it
+      // can outgrow a narrow panel. Wrap like the detail line above it rather
+      // than painting past the panel edge.
+      wrapMode: Text.WordWrap
     }
   }
 

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -162,7 +162,11 @@ assert.equal(model.headline(parsed.entries[0]).text, '29%');
 assert.equal(model.headline(parsed.entries[1]).severity, 'critical');
 assert.equal(model.isAlarming(parsed.entries[0]), true); // stale
 assert.equal(model.isAlarming(parsed.entries[1]), true); // critical
-assert.equal(model.formatReset('2026-08-14T14:00:00Z', Date.parse('2026-08-14T12:00:00Z')), 'Resets in 2h 0m');
+const resetClock = new Date('2026-08-14T14:00:00Z');
+const resetClockText = `0${resetClock.getHours()}`.slice(-2) + ':' + `0${resetClock.getMinutes()}`.slice(-2);
+assert.equal(model.formatReset('2026-08-14T14:00:00Z', Date.parse('2026-08-14T12:00:00Z')), 'Resets in 2h 0m · ' + resetClockText);
+assert.match(model.formatReset('2026-09-14T14:00:00Z', Date.parse('2026-08-14T12:00:00Z')), /^Resets in \d+d \d+h · [A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}$/);
+assert.equal(model.formatReset('2026-08-14T12:00:00Z', Date.parse('2026-08-14T12:00:00Z')), 'Reset due');
 assert.equal(model.formatUpdated('2026-08-14T12:00:00Z', Date.parse('2026-08-14T12:03:00Z')), 'Updated 3m ago');
 assert.equal(model.metricDetail(parsed.entries[0].sections[1]), '60% elapsed · 31pts under');
 

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -162,11 +162,33 @@ assert.equal(model.headline(parsed.entries[0]).text, '29%');
 assert.equal(model.headline(parsed.entries[1]).severity, 'critical');
 assert.equal(model.isAlarming(parsed.entries[0]), true); // stale
 assert.equal(model.isAlarming(parsed.entries[1]), true); // critical
-const resetClock = new Date('2026-08-14T14:00:00Z');
-const resetClockText = `0${resetClock.getHours()}`.slice(-2) + ':' + `0${resetClock.getMinutes()}`.slice(-2);
-assert.equal(model.formatReset('2026-08-14T14:00:00Z', Date.parse('2026-08-14T12:00:00Z')), 'Resets in 2h 0m · ' + resetClockText);
-assert.match(model.formatReset('2026-09-14T14:00:00Z', Date.parse('2026-08-14T12:00:00Z')), /^Resets in \d+d \d+h · [A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}$/);
+// Reset-row fixtures are built from *local* calendar components, not UTC
+// strings, so every expectation below is a literal that holds in any
+// timezone the panel might run in. Deriving the expected clock from the same
+// getHours()/getMinutes() expression the implementation uses would pass no
+// matter what that expression did.
+const localReset = (y, mo, d, h, mi) => new Date(y, mo - 1, d, h, mi).toISOString();
+const at = (y, mo, d, h, mi) => Date.parse(new Date(y, mo - 1, d, h, mi).toISOString());
+
+// Same local day: the clock alone is unambiguous.
+assert.equal(model.formatReset(localReset(2026, 8, 14, 22, 0), at(2026, 8, 14, 8, 0)),
+  'Resets in 14h 0m · 22:00');
+// Both fields zero-padded.
+assert.equal(model.formatReset(localReset(2026, 8, 14, 9, 5), at(2026, 8, 14, 8, 0)),
+  'Resets in 1h 5m · 09:05');
+// Under 24h but past midnight: the date is what stops "03:00" reading as a
+// time that already went by this morning.
+assert.equal(model.formatReset(localReset(2026, 8, 15, 3, 0), at(2026, 8, 14, 20, 0)),
+  'Resets in 7h 0m · Aug 15 03:00');
+// Long windows carry the date too.
+assert.equal(model.formatReset(localReset(2026, 9, 14, 14, 30), at(2026, 8, 14, 12, 0)),
+  'Resets in 31d 2h · Sep 14 14:30');
+// Day-of-month is not padded, matching the rest of the row's typography.
+assert.equal(model.formatReset(localReset(2026, 9, 5, 14, 0), at(2026, 8, 14, 12, 0)),
+  'Resets in 22d 2h · Sep 5 14:00');
 assert.equal(model.formatReset('2026-08-14T12:00:00Z', Date.parse('2026-08-14T12:00:00Z')), 'Reset due');
+assert.equal(model.formatReset('', Date.parse('2026-08-14T12:00:00Z')), '');
+assert.equal(model.formatReset('not-a-date', Date.parse('2026-08-14T12:00:00Z')), '');
 assert.equal(model.formatUpdated('2026-08-14T12:00:00Z', Date.parse('2026-08-14T12:03:00Z')), 'Updated 3m ago');
 assert.equal(model.metricDetail(parsed.entries[0].sections[1]), '60% elapsed · 31pts under');
 


### PR DESCRIPTION
## What

The Omarchy popup reset row currently shows only a countdown: `Resets in 4h 05m`. This appends the real local clock time the limit window reopens:

```
⏱  Resets in 4h 05m · 13:54          (window < 24h)
⏱  Resets in 28d 1h · Sep 20 12:57    (window ≥ 24h, includes date)
```

## Why

A countdown alone requires mental math to know the actual moment the 5h/weekly/monthly limit resets. Showing the wall-clock time (local timezone) makes it immediately obvious when usage will be available again.

## Changes

- `omarchy/Model.js` — `formatReset()` renders the reset timestamp next to the countdown; adds the calendar date for windows ≥ 24h. Returns `Reset due` unchanged when the window has already elapsed.
- `omarchy/model.test.mjs` — covers short-window clock suffix, long-window date+clock suffix, and elapsed windows.

## Testing

```bash
node omarchy/model.test.mjs   # Omarchy model tests passed
```

No Rust changes; Waybar/CLI output is untouched.