### PR TITLE
fix(antigravity): group probe candidates per product before ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,15 @@ Each release is also published at
   a port that has moved. The override is still tried first, but discovered local
   ports are now probed behind it, and a signed-out server's authentication error
   is reported instead of being masked by connection refusals from products that
-  are simply not running (#119). On Windows the RPC listener is probed before
-  the TLS one, which also silences the TLS handshake warnings `agy` used to log
-  on every poll.
+  are simply not running (#119). The RPC listener is probed ahead of the TLS one
+  on Linux, macOS and Windows alike, which also silences the TLS handshake
+  warnings `agy` used to log on every poll.
+- Google Antigravity keeps each running product's listeners in their own group
+  when ordering those probes, so with more than one product up every RPC
+  listener is tried before any TLS listener, instead of the two products' ports
+  interleaving by number and putting the handshake warnings back. An
+  `ANTIGRAVITY_LS_ADDRESS` that leaves no host to connect to is now dropped
+  rather than probed.
 
 ## [1.4.0] — 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Each release is also published at
 
 ### Fixed
 
+- Google Antigravity probes the RPC listener ahead of the TLS one on Linux and
+  macOS too, not just Windows, and keeps each running product's listeners in
+  their own group when ordering them. With more than one product up, every RPC
+  listener is now tried before any TLS listener instead of the two products'
+  ports interleaving by number and putting back the `agy` handshake warnings
+  v1.5.0 set out to silence (#121). An `ANTIGRAVITY_LS_ADDRESS` that leaves no
+  host to connect to is dropped rather than probed.
 - A negative balance is now spelled the same way everywhere. DeepSeek, Moonshot
   (whose `cash_balance` is explicitly a debt), Kimi, SuperGrok, and the TUI
   panel rows rendered it as `$-5.71` while OpenRouter, Grok, Kilo, and Novita
@@ -36,15 +43,9 @@ Each release is also published at
   a port that has moved. The override is still tried first, but discovered local
   ports are now probed behind it, and a signed-out server's authentication error
   is reported instead of being masked by connection refusals from products that
-  are simply not running (#119). The RPC listener is probed ahead of the TLS one
-  on Linux, macOS and Windows alike, which also silences the TLS handshake
-  warnings `agy` used to log on every poll.
-- Google Antigravity keeps each running product's listeners in their own group
-  when ordering those probes, so with more than one product up every RPC
-  listener is tried before any TLS listener, instead of the two products' ports
-  interleaving by number and putting the handshake warnings back. An
-  `ANTIGRAVITY_LS_ADDRESS` that leaves no host to connect to is now dropped
-  rather than probed.
+  are simply not running (#119). On Windows the RPC listener is probed before
+  the TLS one, which also silences the TLS handshake warnings `agy` used to log
+  on every poll.
 
 ## [1.4.0] — 2026-08-21
 

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -490,11 +490,15 @@ fn is_antigravity_process(comm: &str, exe: Option<&str>) -> bool {
 /// `agy` session both up, one product's TLS port can sort above the other's
 /// RPC port. Ports are therefore grouped per pid, sorted high-to-low inside
 /// each group, and taken rank by rank — every product's highest port, then
-/// every product's second-highest, and so on — which leaves all the RPC
-/// listeners ahead of all the TLS ones.
+/// every product's second-highest, and so on. Where each product shows both
+/// listeners that puts every RPC one ahead of every TLS one.
 ///
-/// This stays a preference, not a guarantee: every candidate is still probed,
-/// so an inverted allocation costs one extra round-trip and nothing else.
+/// This stays a preference, not a guarantee, and the two-listener shape is the
+/// assumption it rests on: a product caught mid-startup, with only its TLS port
+/// bound so far, sits alone at rank 0 and is probed first. Every candidate is
+/// probed regardless, so a mis-ranked one costs an extra round-trip and a line
+/// on `agy`'s stderr, nothing more.
+///
 /// Order among products is arbitrary — all of them report the same
 /// account-wide quota, so whichever answers first is authoritative — and pid
 /// order is used only to keep the result reproducible, since `/proc`, `lsof`
@@ -505,6 +509,11 @@ fn probe_order(per_pid: std::collections::BTreeMap<u32, Vec<u16>>) -> Vec<u16> {
         .into_values()
         .map(|mut group| {
             group.sort_unstable_by(|a, b| b.cmp(a));
+            // Within a product a port is one listener however many rows named
+            // it — a dual-stack bind reports the same port from both
+            // `/proc/net/tcp` and `tcp6`. Collapsing them here keeps a rank
+            // meaning "the Nth listener" rather than "the Nth row".
+            group.dedup();
             group
         })
         .collect();
@@ -1706,6 +1715,41 @@ mod tests {
             vec![6000, 7000, 5000, 4000]
         );
         assert!(probe_order(BTreeMap::new()).is_empty());
+    }
+
+    /// A dual-stack bind names the same port from both `/proc/net/tcp` and
+    /// `tcp6`. Those rows are one listener, so they must not consume two ranks
+    /// and push the product's real second listener down past another
+    /// product's.
+    #[test]
+    fn a_port_named_twice_by_one_product_still_occupies_one_rank() {
+        use std::collections::BTreeMap;
+
+        assert_eq!(
+            probe_order(BTreeMap::from([
+                (10, vec![40001, 40001, 40000, 40000]),
+                (20, vec![50001, 50000]),
+            ])),
+            vec![40001, 50001, 40000, 50000],
+            "duplicate rows must not reorder the ranks below them"
+        );
+    }
+
+    /// The ordering rests on each product showing both listeners. A product
+    /// caught mid-startup, with only its TLS port bound, sits alone at rank 0
+    /// and is probed first — documented as the known cost, and harmless
+    /// because every candidate is probed anyway.
+    #[test]
+    fn a_half_started_product_is_the_documented_exception() {
+        use std::collections::BTreeMap;
+
+        assert_eq!(
+            probe_order(BTreeMap::from([
+                (10, vec![40000]),
+                (20, vec![50001, 50000])
+            ])),
+            vec![40000, 50001, 50000]
+        );
     }
 
     /// `ANTIGRAVITY_LS_ADDRESS` is user input. An entry that leaves no

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -418,11 +418,8 @@ fn candidate_bases() -> Vec<String> {
 /// discovered ports instead of reading the environment and `/proc`.
 fn candidate_bases_with(override_addr: Option<&str>, discovered: Vec<u16>) -> Vec<String> {
     let mut bases = Vec::new();
-    if let Some(addr) = override_addr {
-        let addr = addr.trim();
-        if !addr.is_empty() {
-            bases.push(normalize_base(addr));
-        }
+    if let Some(base) = override_addr.and_then(normalize_base) {
+        bases.push(base);
     }
 
     // No hardcoded fallback port on purpose: the server always binds with
@@ -440,13 +437,22 @@ fn candidate_bases_with(override_addr: Option<&str>, discovered: Vec<u16>) -> Ve
     bases
 }
 
-fn normalize_base(addr: &str) -> String {
-    let trimmed = addr.trim().trim_end_matches('/');
-    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
-        trimmed.to_string()
-    } else {
-        format!("http://{trimmed}")
-    }
+/// Turn a configured address into a base URL: trim surrounding whitespace,
+/// supply the default scheme when it is missing, and drop trailing slashes so
+/// the RPC paths built on top do not come out with a double slash.
+///
+/// Returns `None` when nothing but a scheme survives. `ANTIGRAVITY_LS_ADDRESS`
+/// is user input, and a value like `"/"` carries no authority to connect to;
+/// admitting it as a candidate would spend a probe to learn what is already
+/// knowable here.
+fn normalize_base(addr: &str) -> Option<String> {
+    let trimmed = addr.trim();
+    let (scheme, authority) = match trimmed.split_once("://") {
+        Some((scheme @ ("http" | "https"), rest)) => (scheme, rest),
+        _ => ("http", trimmed),
+    };
+    let authority = authority.trim_end_matches('/');
+    (!authority.is_empty()).then(|| format!("{scheme}://{authority}"))
 }
 
 /// Does this process look like one of the three Antigravity products?
@@ -468,6 +474,52 @@ fn is_antigravity_process(comm: &str, exe: Option<&str>) -> bool {
     })
 }
 
+/// Flatten per-process listener ports into the order they should be probed.
+///
+/// Each Antigravity product binds an HTTPS/TLS listener and the unencrypted
+/// HTTP JSON-RPC listener that serves `GetUserStatus` and
+/// `RetrieveUserQuotaSummary`. Both are ephemeral, but they are bound in that
+/// order, so in practice the RPC listener draws the higher number and probing
+/// high-to-low reaches it first — which keeps Go's `net/http.Server` from
+/// logging a TLS handshake error for every unencrypted request that lands on
+/// its HTTPS listener.
+///
+/// Sorting every discovered port as one descending set only gets that right
+/// for a single process, because the high/low tendency holds *within* a
+/// product and says nothing across two of them: with Antigravity 2.0 and an
+/// `agy` session both up, one product's TLS port can sort above the other's
+/// RPC port. Ports are therefore grouped per pid, sorted high-to-low inside
+/// each group, and taken rank by rank — every product's highest port, then
+/// every product's second-highest, and so on — which leaves all the RPC
+/// listeners ahead of all the TLS ones.
+///
+/// This stays a preference, not a guarantee: every candidate is still probed,
+/// so an inverted allocation costs one extra round-trip and nothing else.
+/// Order among products is arbitrary — all of them report the same
+/// account-wide quota, so whichever answers first is authoritative — and pid
+/// order is used only to keep the result reproducible, since `/proc`, `lsof`
+/// and the Windows TCP table each enumerate in their own order.
+#[cfg(any(test, target_os = "linux", target_os = "macos", target_os = "windows"))]
+fn probe_order(per_pid: std::collections::BTreeMap<u32, Vec<u16>>) -> Vec<u16> {
+    let groups: Vec<Vec<u16>> = per_pid
+        .into_values()
+        .map(|mut group| {
+            group.sort_unstable_by(|a, b| b.cmp(a));
+            group
+        })
+        .collect();
+
+    let mut ports: Vec<u16> = Vec::new();
+    for rank in 0..groups.iter().map(Vec::len).max().unwrap_or(0) {
+        for port in groups.iter().filter_map(|group| group.get(rank)) {
+            if !ports.contains(port) {
+                ports.push(*port);
+            }
+        }
+    }
+    ports
+}
+
 /// Loopback ports listened on by any running Antigravity product.
 ///
 /// Reads `/proc` directly rather than shelling out to `ss`/`lsof`: find the
@@ -476,14 +528,23 @@ fn is_antigravity_process(comm: &str, exe: Option<&str>) -> bool {
 /// shared quota, so whichever answers first is authoritative.
 #[cfg(target_os = "linux")]
 fn discover_ls_ports() -> Vec<u16> {
-    use std::collections::HashSet;
+    use std::collections::{BTreeMap, HashMap};
 
-    let mut inodes: HashSet<u64> = HashSet::new();
+    // Socket inode -> owning pid, so the ports found in `/proc/net` can be
+    // grouped back per process for `probe_order`.
+    let mut owners: HashMap<u64, u32> = HashMap::new();
     let Ok(entries) = std::fs::read_dir("/proc") else {
         return Vec::new();
     };
     for entry in entries.flatten() {
         let pid_dir = entry.path();
+        let Some(pid) = pid_dir
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
         let Ok(comm) = std::fs::read_to_string(pid_dir.join("comm")) else {
             continue;
         };
@@ -504,30 +565,29 @@ fn discover_ls_ports() -> Vec<u16> {
                 .and_then(|s| s.strip_suffix(']'))
                 .and_then(|s| s.parse::<u64>().ok())
             {
-                inodes.insert(ino);
+                owners.insert(ino, pid);
             }
         }
     }
 
-    if inodes.is_empty() {
+    if owners.is_empty() {
         return Vec::new();
     }
 
-    let mut ports = Vec::new();
+    let mut per_pid: BTreeMap<u32, Vec<u16>> = BTreeMap::new();
     for table in ["/proc/net/tcp", "/proc/net/tcp6"] {
         let Ok(contents) = std::fs::read_to_string(table) else {
             continue;
         };
         for line in contents.lines().skip(1) {
             if let Some((port, ino)) = parse_proc_net_line(line)
-                && inodes.contains(&ino)
-                && !ports.contains(&port)
+                && let Some(&pid) = owners.get(&ino)
             {
-                ports.push(port);
+                per_pid.entry(pid).or_default().push(port);
             }
         }
     }
-    ports
+    probe_order(per_pid)
 }
 
 /// macOS has no `/proc`, so fall back to `lsof` (present on every macOS
@@ -551,27 +611,35 @@ fn discover_ls_ports() -> Vec<u16> {
 }
 
 /// Pure parser for `lsof -F pcn` output, kept separate from process spawning
-/// so the parsing logic is unit-testable without shelling out.
-#[cfg(target_os = "macos")]
+/// so the parsing logic is unit-testable without shelling out. Compiled under
+/// `test` on every platform, like [`matching_windows_ports`], so its tests are
+/// not macOS-only.
+#[cfg(any(test, target_os = "macos"))]
 fn parse_lsof_pcn(output: &str) -> Vec<u16> {
-    let mut ports = Vec::new();
-    let mut current_matches = false;
+    let mut per_pid: std::collections::BTreeMap<u32, Vec<u16>> = std::collections::BTreeMap::new();
+    // The pid arrives on the `p` line and the command name on the `c` line
+    // right after it, so hold the pid until the name confirms it is ours.
+    let mut pid = None;
+    let mut owner = None;
     for line in output.lines() {
         let Some(rest) = line.get(1..) else { continue };
         match line.as_bytes().first() {
-            Some(b'p') => current_matches = false,
-            Some(b'c') => current_matches = is_antigravity_process(rest, None),
-            Some(b'n') if current_matches => {
-                if let Some(port) = rest.rsplit(':').next().and_then(|p| p.parse::<u16>().ok())
-                    && !ports.contains(&port)
+            Some(b'p') => {
+                pid = rest.parse::<u32>().ok();
+                owner = None;
+            }
+            Some(b'c') => owner = pid.filter(|_| is_antigravity_process(rest, None)),
+            Some(b'n') => {
+                if let Some(pid) = owner
+                    && let Some(port) = rest.rsplit(':').next().and_then(|p| p.parse::<u16>().ok())
                 {
-                    ports.push(port);
+                    per_pid.entry(pid).or_default().push(port);
                 }
             }
             _ => {}
         }
     }
-    ports
+    probe_order(per_pid)
 }
 
 #[cfg(any(test, target_os = "windows"))]
@@ -597,32 +665,24 @@ fn matching_windows_process_ids(processes: &[(u32, String)]) -> std::collections
         .collect()
 }
 
-/// Returns matching loopback ports in **descending** order.
-///
-/// The `agy` process binds two loopback ports: an HTTPS/TLS listener and the
-/// unencrypted HTTP JSON-RPC listener (where `GetUserStatus` and
-/// `RetrieveUserQuotaSummary` live). Both are ephemeral, but they are bound in
-/// that order, so in practice the RPC listener draws the higher number.
-/// Probing high-to-low therefore usually hits it first and avoids the spurious
-/// TLS handshake errors Go's `net/http.Server` writes to stderr whenever an
-/// unencrypted request reaches its HTTPS listener. It is only a preference:
-/// every candidate is still probed, so an inverted allocation costs one extra
-/// round-trip and nothing else.
+/// Loopback ports owned by the matching processes, grouped per pid and handed
+/// to [`probe_order`], which explains why the grouping matters.
 #[cfg(any(test, target_os = "windows"))]
 fn matching_windows_ports(
     pids: &std::collections::HashSet<u32>,
     rows: &[WindowsTcpRow],
 ) -> Vec<u16> {
-    rows.iter()
-        .filter(|row| pids.contains(&row.pid) && row.local_addr == [127, 0, 0, 1])
-        .filter_map(|row| {
-            let port = u16::from_be((row.local_port & u32::from(u16::MAX)) as u16);
-            (port != 0).then_some(port)
-        })
-        .collect::<std::collections::BTreeSet<_>>()
-        .into_iter()
-        .rev()
-        .collect()
+    let mut per_pid: std::collections::BTreeMap<u32, Vec<u16>> = std::collections::BTreeMap::new();
+    for row in rows {
+        if !pids.contains(&row.pid) || row.local_addr != [127, 0, 0, 1] {
+            continue;
+        }
+        let port = u16::from_be((row.local_port & u32::from(u16::MAX)) as u16);
+        if port != 0 {
+            per_pid.entry(row.pid).or_default().push(port);
+        }
+    }
+    probe_order(per_pid)
 }
 
 #[cfg(any(test, target_os = "windows"))]
@@ -1590,6 +1650,80 @@ mod tests {
         assert_eq!(matching_windows_ports(&pids, &rows), vec![59870, 59868]);
     }
 
+    /// Antigravity 2.0 and an interactive `agy` session at once. Their port
+    /// pairs must not be flattened into one set: sorting all four descending
+    /// would put pid 20's TLS listener ahead of pid 10's RPC listener.
+    #[test]
+    fn windows_ports_from_two_products_keep_tls_listeners_last() {
+        let pids = std::collections::HashSet::from([10, 20]);
+        let row = |port: u16, pid: u32| WindowsTcpRow {
+            local_addr: [127, 0, 0, 1],
+            local_port: u32::from(port.to_be()),
+            pid,
+        };
+        let rows = [
+            row(40000, 10),
+            row(40001, 10),
+            row(50000, 20),
+            row(50001, 20),
+        ];
+        assert_eq!(
+            matching_windows_ports(&pids, &rows),
+            vec![40001, 50001, 40000, 50000]
+        );
+    }
+
+    /// The high-to-low preference only means something per product, so the
+    /// grouping is what keeps a second product's TLS listener from being
+    /// probed before the first product's RPC listener.
+    #[test]
+    fn probe_order_puts_every_rpc_listener_ahead_of_every_tls_listener() {
+        use std::collections::BTreeMap;
+
+        // One process, the ordinary case: RPC (higher) before TLS (lower).
+        assert_eq!(
+            probe_order(BTreeMap::from([(10, vec![59868, 59870])])),
+            vec![59870, 59868]
+        );
+        // Two products. A plain descending sort would yield 50001, 50000,
+        // 40001, 40000 and reach pid 20's TLS listener second; taking the
+        // ports rank by rank leaves both TLS listeners at the back, where they
+        // are touched only if no RPC listener answered.
+        assert_eq!(
+            probe_order(BTreeMap::from([
+                (10, vec![40000, 40001]),
+                (20, vec![50000, 50001]),
+            ])),
+            vec![40001, 50001, 40000, 50000]
+        );
+        // Uneven groups: the extra port of the deeper group trails everything
+        // it ranks below, and a port claimed by two pids is probed once.
+        assert_eq!(
+            probe_order(BTreeMap::from([
+                (10, vec![6000, 5000, 4000]),
+                (20, vec![6000, 7000]),
+            ])),
+            vec![6000, 7000, 5000, 4000]
+        );
+        assert!(probe_order(BTreeMap::new()).is_empty());
+    }
+
+    /// `ANTIGRAVITY_LS_ADDRESS` is user input. An entry that leaves no
+    /// authority to connect to is dropped instead of probed, so it can neither
+    /// spend a round-trip nor add a failure that competes with the real one in
+    /// [`select_probe_error`].
+    #[test]
+    fn an_override_with_no_authority_is_dropped_not_probed() {
+        for junk in ["/", "///", "http://", "https://", "  /  "] {
+            assert_eq!(
+                candidate_bases_with(Some(junk), vec![4242]),
+                vec!["http://127.0.0.1:4242".to_string()],
+                "{junk:?} should not survive as a candidate"
+            );
+        }
+        assert!(candidate_bases_with(Some("/"), vec![]).is_empty());
+    }
+
     #[test]
     fn windows_table_bounds_reject_truncation_and_overflow() {
         assert_eq!(checked_windows_row_count(52, 4, 24, 2), Some(2));
@@ -1655,23 +1789,36 @@ mod tests {
         assert!(parse_windows_tcp_rows(&buffer, used - 1).is_empty());
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn lsof_parser_keeps_only_ports_owned_by_antigravity_processes() {
         // `agy` (pid 74101) has three listening sockets; `sshd` (pid 200) has
         // one that must be excluded even though it sorts right after `c`.
         let output = "p74101\ncagy\nf10\nn127.0.0.1:8829\nf11\nn127.0.0.1:61289\nf12\nn127.0.0.1:61290\np200\ncsshd\nf5\nn*:22\n";
-        assert_eq!(parse_lsof_pcn(output), vec![8829, 61289, 61290]);
+        assert_eq!(parse_lsof_pcn(output), vec![61290, 61289, 8829]);
     }
 
-    #[cfg(target_os = "macos")]
+    /// The pid on each `p` line has to survive to the `n` lines, or the ports
+    /// of two running products collapse into one group and rank ordering can
+    /// no longer keep the TLS listeners last.
+    #[test]
+    fn lsof_parser_keeps_each_products_ports_in_its_own_group() {
+        let output = concat!(
+            "p100\ncagy\nf3\nn127.0.0.1:40000\nf4\nn127.0.0.1:40001\n",
+            "p200\nclanguage_server\nf5\nn127.0.0.1:50000\nf6\nn127.0.0.1:50001\n",
+        );
+        assert_eq!(
+            parse_lsof_pcn(output),
+            vec![40001, 50001, 40000, 50000],
+            "both HTTP listeners must precede both TLS listeners"
+        );
+    }
+
     #[test]
     fn lsof_parser_matches_the_capitalised_macos_app_name() {
         let output = "p900\ncAntigravity\nf7\nn127.0.0.1:54321\n";
         assert_eq!(parse_lsof_pcn(output), vec![54321]);
     }
 
-    #[cfg(target_os = "macos")]
     #[test]
     fn lsof_parser_deduplicates_and_handles_empty_output() {
         let output = "p1\ncagy\nf3\nn127.0.0.1:9000\nf4\nn127.0.0.1:9000\n";


### PR DESCRIPTION
Follow-up to #119, which landed the fallback to discovered ports and the high-to-low listener ordering. This closes three gaps left in that ordering.

## Motivation

The high/low pairing of a product's TLS listener and its unencrypted JSON-RPC listener is a per-process binding-order tendency, as `7fa3847` documented. Sorting every discovered port into one descending set only honours that for a single process: with Antigravity 2.0 and an interactive `agy` session both running, one product's TLS listener sorts above the other's RPC listener, gets probed first, and the `http: TLS handshake error: client sent an HTTP request to an HTTPS server` line that #119 set out to silence comes straight back.

The ordering was also Windows-only, while the problem is not. Linux discovery pushes ports in `/proc/net/tcp` hash-bucket order and macOS in `lsof` fd order, so neither reaches the RPC listener first and both keep logging the handshake error on every poll.

Separately, `ANTIGRAVITY_LS_ADDRESS` is user input that `normalize_base()` could turn into a candidate with no authority to connect to — `/` normalized to `http://`. That candidate spends a probe and then contributes a failure for `select_probe_error()` to weigh against the real one.

## Implementation

- `probe_order()` is a new shared helper: group the discovered ports per pid, sort each group high-to-low, then emit them rank by rank — every product's highest port, then every product's second-highest, and so on — deduplicating globally. Under the two-listener model that leaves every RPC listener ahead of every TLS listener, so a TLS port is reached only once no RPC port answered at all.
- It stays a preference rather than a guarantee, on the same terms `7fa3847` set out: every candidate is still probed, so an inverted ephemeral allocation costs one extra round-trip and nothing else. Order among products is arbitrary — all of them report the same account-wide quota — so pid order is used purely to make the result reproducible, since `/proc`, `lsof` and the Windows TCP table each enumerate in their own order.
- `matching_windows_ports()`, the Linux `/proc` scan and `parse_lsof_pcn()` all feed `probe_order()`. The Linux scan maps socket inodes back to their owning pid instead of collecting them into one flat set, and the `lsof` parser carries the pid from each `p` line down to the `n` lines beneath it.
- `parse_lsof_pcn()` is now compiled under `test` on every platform, the way `matching_windows_ports()` already was, so the `lsof` tests stop being macOS-only and the new per-pid grouping is covered on all four CI jobs.
- `normalize_base()` splits the scheme before trimming trailing slashes and returns `Option<String>`. `127.0.0.1:1234/` still normalizes to `http://127.0.0.1:1234`, while `/` and `http://` now yield `None` and are dropped instead of probed.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --all-targets --locked` — 1066 passed, 0 failed, 9 ignored (the live-endpoint tests)
- [x] `cargo machete` — clean
- [x] `node gnome-extension/marker-logic.test.mjs`, `node kde-plasmoid/plasmoid-logic.test.mjs`, `node omarchy/model.test.mjs` — pass. `make` is unavailable on this machine, so the three `make test` frontend targets were run directly.
- [ ] `cargo clippy --all-targets --locked -- -D warnings` — not verifiable locally. On Windows it fails on three pre-existing dead-code errors in `src/nous/credentials.rs` (`file_mode`, `set_private_permissions_path`, `insert_other`), whose only callers sit inside `#[cfg(unix)]` blocks. Nothing in this branch is flagged. CI runs clippy on `ubuntu-latest`, where those functions are live.

New coverage: `probe_order_puts_every_rpc_listener_ahead_of_every_tls_listener`, `windows_ports_from_two_products_keep_tls_listeners_last`, `lsof_parser_keeps_each_products_ports_in_its_own_group`, and `an_override_with_no_authority_is_dropped_not_probed`. The existing `lsof_parser_keeps_only_ports_owned_by_antigravity_processes` assertion flips to descending to match the new ordering. Verified on Windows 11; CI covers ubuntu, macOS, Windows and Rust 1.88.

## One thing I deliberately did not change

`select_probe_error()` keeps the last failure when nothing is actionable, which is what preserves the silent cache fallback for a product that simply is not running. The cost is that the TLS listener, probed after the RPC one, answers an unencrypted request with a generic `400` that ranks the same as a real failure from the port that does speak JSON-RPC — so a schema drift on a live server surfaces in the tooltip as `HTTP 400: Client sent an HTTP request to an HTTPS server` rather than the drift itself. Preferring a non-transport failure over a transport one would fix that, but it would also make a stray 5xx surface where the current design deliberately stays quiet, so I left the behaviour exactly as `7fa3847` set it. Happy to send that as a separate change if you want it.
