### PR TITLE
Sanitize subprocess stderr before it reaches a terminal

### DIFF
--- a/src/anthropic/keychain.rs
+++ b/src/anthropic/keychain.rs
@@ -26,6 +26,7 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
+use crate::display::sanitize_untrusted_line;
 use crate::error::{AppError, Result};
 
 /// Generic-password *service* name Claude Code uses for the credentials blob.
@@ -105,7 +106,10 @@ fn read_raw_service(service: &str) -> Result<Option<String>> {
         if out.status.code() == Some(ERR_SEC_ITEM_NOT_FOUND) {
             return Ok(None);
         }
-        let detail = String::from_utf8_lossy(&out.stderr);
+        // `security` is a subprocess whose stderr is not this program's text.
+        // It reaches a terminal verbatim, so an escape sequence in it repaints
+        // the line and an embedded newline forges one.
+        let detail = sanitize_untrusted_line(&String::from_utf8_lossy(&out.stderr));
         let detail = detail.trim();
         return Err(AppError::Credentials(format!(
             "could not read the Claude credentials from the macOS Keychain \
@@ -196,7 +200,7 @@ fn delete_raw_service(service: &str) -> Result<()> {
     if out.status.success() || out.status.code() == Some(ERR_SEC_ITEM_NOT_FOUND) {
         return Ok(());
     }
-    let detail = String::from_utf8_lossy(&out.stderr);
+    let detail = sanitize_untrusted_line(&String::from_utf8_lossy(&out.stderr));
     Err(AppError::Credentials(format!(
         "failed to remove the Claude credentials from the macOS Keychain \
          (security exited {}): {}",

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
+use crate::display::{sanitize_untrusted_line, sanitize_untrusted_path};
 use crate::error::{AppError, Result};
 
 /// Host-level effects of a switch.
@@ -214,10 +215,12 @@ impl AppControl for DesktopApp {
             set_private_mode(archive, 0o600)?;
             return Ok(());
         }
-        let detail = String::from_utf8_lossy(&output.stderr);
+        // `tar` names the member it failed on, and members are paths from the
+        // account tree rather than literals in this program.
+        let detail = sanitize_untrusted_line(&String::from_utf8_lossy(&output.stderr));
         Err(AppError::Other(format!(
             "could not write the rollback archive {} (tar exited {}): {}",
-            archive.display(),
+            sanitize_untrusted_path(archive),
             output.status.code().unwrap_or(-1),
             detail.trim()
         )))

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -252,7 +252,7 @@ impl AppControl for DesktopApp {
         } else {
             Err(AppError::Other(format!(
                 "could not restore {} (tar exited {})",
-                archive.display(),
+                sanitize_untrusted_path(archive),
                 output.status.code().unwrap_or(-1)
             )))
         }
@@ -356,5 +356,30 @@ mod tests {
         let archive_mode = std::fs::metadata(&archive).unwrap().permissions().mode() & 0o777;
         assert_eq!(dir_mode, 0o700);
         assert_eq!(archive_mode, 0o600);
+    }
+
+    /// The rollback archive's path reaches this message from the account tree,
+    /// not from a literal, so an escape sequence in it would repaint the line
+    /// the user is reading. `tar` fails here because the archive does not
+    /// exist, which reaches the failure branch without needing a subprocess
+    /// seam — the same route the archive test above already takes.
+    #[test]
+    fn a_failed_restore_does_not_carry_a_terminal_escape_out_of_the_archive_path() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path().join("Claude");
+        std::fs::create_dir_all(&root).unwrap();
+        let archive = temp.path().join("\x1b[2Kabsent.tar.gz");
+
+        let error = DesktopApp
+            .restore(&archive, &root, &["config.json"])
+            .expect_err("tar cannot restore an archive that does not exist")
+            .to_string();
+
+        assert!(!error.contains('\u{1b}'), "{error:?}");
+        assert!(
+            !error.contains('\n'),
+            "an embedded newline forges a line: {error:?}"
+        );
+        assert!(error.contains("could not restore"), "{error}");
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -30,6 +30,28 @@ pub fn sanitize_untrusted_field(value: &str) -> String {
         .collect()
 }
 
+/// One line of untrusted text on its way to a terminal or a log.
+///
+/// [`sanitize_untrusted_field`] keeps newlines, which is right for a multi-line
+/// diagnostic in a UI cell and wrong for anything sharing a line-oriented
+/// stream with output the user is reading: one embedded newline forges a line.
+/// A subprocess's stderr is exactly that case — it is one or more lines on
+/// their way into an error message.
+pub fn sanitize_untrusted_line(value: &str) -> String {
+    sanitize_untrusted_field(value).replace('\n', " ")
+}
+
+/// A filesystem path on its way to the same place.
+///
+/// [`std::path::Display`] escapes nothing, and a path is not always a literal
+/// this program chose — it can carry a component from an account name, a
+/// vendor response, or an archive member. This is what [`crate::error::AppError::Io`]
+/// renders its path through, so an attacker-chosen path cannot carry a terminal
+/// escape out of *any* error site rather than only the ones that remembered.
+pub fn sanitize_untrusted_path(path: &std::path::Path) -> String {
+    sanitize_untrusted_line(&path.to_string_lossy())
+}
+
 fn is_bidi_control(ch: char) -> bool {
     matches!(
         ch,
@@ -48,6 +70,24 @@ mod tests {
             sanitize_untrusted_field(input),
             "before]52;c;Y2xpcGJvYXJkafter\nnext column returnspoof"
         );
+    }
+
+    /// A subprocess's stderr shares a line-oriented stream with the message
+    /// carrying it, so a newline in it forges a line the program never wrote.
+    /// This is the shape `security` and `tar` diagnostics arrive in.
+    #[test]
+    fn collapses_newlines_so_untrusted_text_cannot_forge_a_line() {
+        let stderr = "tar: \x1b[2Kall good\nRESTORED: 0 files";
+        let out = sanitize_untrusted_line(stderr);
+        assert!(!out.contains('\n'), "{out:?}");
+        assert!(!out.contains('\u{1b}'), "{out:?}");
+        assert_eq!(out, "tar: [2Kall good RESTORED: 0 files");
+    }
+
+    #[test]
+    fn a_path_carrying_an_escape_renders_without_it() {
+        let path = std::path::Path::new("/tmp/\x1b[2Kspoofed");
+        assert_eq!(sanitize_untrusted_path(path), "/tmp/[2Kspoofed");
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,7 +13,17 @@ pub const AUTH_FAILURE_MESSAGE: &str =
 #[derive(Debug, thiserror::Error)]
 pub enum AppError {
     /// Local I/O failed (cache write, credentials read, theme file, etc.).
-    #[error("io error at {path}: {source}")]
+    ///
+    /// **The path is sanitized here rather than at each print site.** A path in
+    /// this variant is not always a literal this program chose — it can carry a
+    /// component from an account label, a vendor response, or an archive
+    /// member — and `Display for Path` escapes nothing. Doing it at the
+    /// `Display` covers every site that formats an `AppError`, including the
+    /// ones written after this comment.
+    #[error(
+        "io error at {}: {source}",
+        crate::display::sanitize_untrusted_path(path)
+    )]
     Io {
         path: PathBuf,
         #[source]
@@ -108,6 +118,26 @@ impl From<reqwest::Error> for AppError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Asserted at the `Display`, not at a print site, because that is the
+    /// whole point: a path in this variant can come from an account label, a
+    /// vendor response, or an archive member, and there are a dozen places
+    /// that format one.
+    #[test]
+    fn an_io_path_carrying_a_terminal_escape_renders_without_it() {
+        let rendered = AppError::Io {
+            path: PathBuf::from("/tmp/\x1b[2Kspoofed\nRESTORED: 0"),
+            source: io::Error::other("disk full"),
+        }
+        .to_string();
+
+        assert!(!rendered.contains('\u{1b}'), "{rendered:?}");
+        assert!(
+            !rendered.contains('\n'),
+            "an embedded newline forges a line: {rendered:?}"
+        );
+        assert!(rendered.contains("disk full"), "{rendered}");
+    }
 
     #[test]
     fn user_message_does_not_expose_authentication_response_bodies() {


### PR DESCRIPTION
Three places forward a subprocess's stderr straight into an error message. `security` and `tar` are separate programs and their stderr is not this project's text — an escape sequence in it repaints the line the user is reading, and an embedded newline forges a line under it.

- `src/anthropic/keychain.rs:108` and `:199` — two `security` failures
- `src/claude_desktop/app.rs:217` — the rollback archive's `tar` failure

`display.rs` already has `sanitize_untrusted_field` for exactly this class of text, but it keeps newlines — right for a multi-line diagnostic in a UI cell, wrong for text sharing a line-oriented stream with the message carrying it. This adds `sanitize_untrusted_line` beside it (four lines) and routes the three sites through it.

`tar` names the member it failed on, and members come from the account tree rather than from literals in this program, so the archive path goes through a new `sanitize_untrusted_path` for the same reason.

**The second commit is the root cause and can be dropped on its own.** `AppError::Io` renders `{path}` raw and a dozen sites format one. A path in that variant is not always a literal this program chose — it can carry a component from an account label, a vendor response, or an archive member — and `Display for Path` escapes nothing. Doing it at the `Display` covers every site that formats an `AppError`, including ones written later. Asserted at the `Display` for the same reason.

### What I did not do

**No per-site tests.** None of the three sites has a subprocess seam — `keychain.rs` has no test module and calls `/usr/bin/security` directly, `app.rs` calls `/usr/bin/tar` directly — so testing them means adding injection points, which would make this change considerably larger than the fix. The behaviour is tested on the helper and on the `Display`. Happy to add the seams if you would rather have them.

ESC is written `\x1b` in the tests, not `\033`. The latter is not a Rust escape — it reads as `\0` followed by `33` — so an assertion using it passes on text carrying no ESC at all. I made that mistake first and would rather flag it than let it recur here.

### Context

This is unrelated to the sync work in #113 and touches none of it. You flagged unsanitized `tar` stderr there; these three predate that branch, so the same fix belongs here regardless of what happens to the rest.

Based on v1.4.0. Four CI jobs green on this exact head.
