### PR TITLE
Add Nix flake packaging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,37 @@ jobs:
       - name: Check declared minimum Rust version
         run: cargo check --all-targets --locked
 
+  nix:
+    name: nix (${{ matrix.system }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - system: x86_64-linux
+            runner: ubuntu-24.04
+          - system: aarch64-linux
+            runner: ubuntu-24.04-arm
+          - system: x86_64-darwin
+            runner: macos-15-intel
+          - system: aarch64-darwin
+            runner: macos-15
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Build and test the flake
+        run: nix flake check --print-build-logs
+
+      - name: Smoke-test app outputs
+        env:
+          NIX_SYSTEM: ${{ matrix.system }}
+        run: |
+          nix run .#default -- --version
+          tui_program="$(nix eval --raw ".#apps.${NIX_SYSTEM}.tui.program")"
+          test -x "$tui_program"
+
   macos:
     name: test (macos-latest)
     runs-on: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- First-party Nix flake packaging supports `nix run`, profile installation,
+  direct NixOS and Home Manager consumption, an overlay, and a development
+  shell on x86_64 and aarch64 Linux and macOS.
+
 ## [1.5.2] — 2026-08-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ nixpkgs.lib.nixosSystem {
 For standalone Home Manager, use `extraSpecialArgs`:
 
 ```nix
+let
+  system = "x86_64-linux";
+in
 home-manager.lib.homeManagerConfiguration {
   pkgs = nixpkgs.legacyPackages.${system};
   extraSpecialArgs = { inherit inputs; };

--- a/README.md
+++ b/README.md
@@ -65,7 +65,28 @@ root `flake.nix`:
 inputs.ai-usagebar.url = "github:akitaonrails/ai-usagebar";
 ```
 
-Then consume it in a NixOS module that receives `inputs`:
+Pass `inputs` to your NixOS modules with `specialArgs`:
+
+```nix
+nixpkgs.lib.nixosSystem {
+  system = "x86_64-linux";
+  specialArgs = { inherit inputs; };
+  modules = [ ./configuration.nix ];
+}
+```
+
+For standalone Home Manager, use `extraSpecialArgs`:
+
+```nix
+home-manager.lib.homeManagerConfiguration {
+  pkgs = nixpkgs.legacyPackages.${system};
+  extraSpecialArgs = { inherit inputs; };
+  modules = [ ./home.nix ];
+}
+```
+
+If your configuration already passes `inputs` through these arguments, you do
+not need to add it again. Then consume the package in a NixOS module:
 
 ```nix
 { inputs, pkgs, ... }:

--- a/README.md
+++ b/README.md
@@ -43,6 +43,61 @@ codebase.
 
 ## Install
 
+### Nix
+
+Run either application directly from GitHub:
+
+```bash
+nix run github:akitaonrails/ai-usagebar
+nix run github:akitaonrails/ai-usagebar#tui
+```
+
+Install both `ai-usagebar` and `ai-usagebar-tui` into your user profile:
+
+```bash
+nix profile install github:akitaonrails/ai-usagebar
+```
+
+For a flake-based NixOS or Home Manager configuration, add the input in your
+root `flake.nix`:
+
+```nix
+inputs.ai-usagebar.url = "github:akitaonrails/ai-usagebar";
+```
+
+Then consume it in a NixOS module that receives `inputs`:
+
+```nix
+{ inputs, pkgs, ... }:
+{
+  environment.systemPackages = [
+    inputs.ai-usagebar.packages.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+}
+```
+
+The equivalent Home Manager module is:
+
+```nix
+{ inputs, pkgs, ... }:
+{
+  home.packages = [
+    inputs.ai-usagebar.packages.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+}
+```
+
+Alternatively, apply the overlay when you want the package available as
+`pkgs.ai-usagebar`:
+
+```nix
+{ inputs, pkgs, ... }:
+{
+  nixpkgs.overlays = [ inputs.ai-usagebar.overlays.default ];
+  environment.systemPackages = [ pkgs.ai-usagebar ];
+}
+```
+
 ### Omarchy Quattro
 
 The native plugin is a display frontend and does not bundle the

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777420751,
-        "narHash": "sha256-p7b509GeMzOr9WO0a5oPLK7FYP9Ex0c/RwOW6H90FlM=",
+        "lastModified": 1787323337,
+        "narHash": "sha256-PqomwlB2WugM9MC4tV1L2/yosMOfug3KBDjmqOqD1bU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c6f26568f8229cf3cb6bf9d1633e4502a9aa327",
+        "rev": "6062ba1a1b8b6281b12533c9075a2dbeb38f7e49",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777420751,
+        "narHash": "sha256-p7b509GeMzOr9WO0a5oPLK7FYP9Ex0c/RwOW6H90FlM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6c6f26568f8229cf3cb6bf9d1633e4502a9aa327",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,50 @@
         }
       );
 
+      apps = forAllSystems (
+        system:
+        let
+          package = packageFor system;
+        in
+        {
+          default = {
+            type = "app";
+            program = nixpkgs.lib.getExe package;
+          };
+          tui = {
+            type = "app";
+            program = nixpkgs.lib.getExe' package "ai-usagebar-tui";
+          };
+        }
+      );
+
+      overlays.default = final: _prev: {
+        ai-usagebar = final.callPackage ./nix/package.nix { };
+      };
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              actionlint
+              cargo
+              cargo-machete
+              clippy
+              gnumake
+              nasm
+              nixfmt-rfc-style
+              nodejs
+              rustc
+              rustfmt
+            ];
+          };
+        }
+      );
+
       checks = forAllSystems (system: {
         default = self.packages.${system}.default;
       });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "AI plan usage for Waybar, Omarchy, and the terminal";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: import nixpkgs { inherit system; };
+      packageFor = system: (pkgsFor system).callPackage ./nix/package.nix { };
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          package = packageFor system;
+        in
+        {
+          default = package;
+          ai-usagebar = package;
+        }
+      );
+
+      checks = forAllSystems (system: {
+        default = self.packages.${system}.default;
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,8 @@
 {
   description = "AI plan usage for Waybar, Omarchy, and the terminal";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  # Keep updates on the maintained final release branch for x86_64-darwin.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
 
   outputs =
     { self, nixpkgs }:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -34,6 +34,12 @@ rustPlatform.buildRustPackage {
 
   cargoLock.lockFile = ../Cargo.lock;
 
+  # `claude_desktop::app` shells out to `/usr/bin/tar`, which the build sandbox
+  # does not have. Skipped here rather than narrowing the module's `cfg`, so the
+  # two security assertions it carries — archive permissions, and that a path
+  # cannot carry a terminal escape out of a failure — keep running on Linux CI.
+  checkFlags = [ "--skip=claude_desktop::app::tests" ];
+
   nativeBuildInputs =
     lib.optionals stdenv.hostPlatform.isx86_64 [ nasm ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  makeWrapper,
+  nasm,
+  procps,
+  rustPlatform,
+  stdenv,
+  xdg-utils,
+}:
+
+let
+  cargoToml = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+  linuxRuntimePath = lib.makeBinPath [
+    procps
+    xdg-utils
+  ];
+in
+rustPlatform.buildRustPackage {
+  pname = "ai-usagebar";
+  version = cargoToml.package.version;
+
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../Cargo.toml
+      ../Cargo.lock
+      ../src
+      ../tests
+      ../config.example.toml
+      ../README.md
+      ../LICENSE
+    ];
+  };
+
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs =
+    lib.optionals stdenv.hostPlatform.isx86_64 [ nasm ]
+    ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];
+
+  postInstall =
+    ''
+      install -Dm644 config.example.toml \
+        "$out/share/ai-usagebar/config.example.toml"
+      install -Dm644 README.md \
+        "$out/share/doc/ai-usagebar/README.md"
+      install -Dm644 LICENSE \
+        "$out/share/licenses/ai-usagebar/LICENSE"
+    ''
+    + lib.optionalString stdenv.hostPlatform.isLinux ''
+      for program in ai-usagebar ai-usagebar-tui; do
+        wrapProgram "$out/bin/$program" \
+          --prefix PATH : "${linuxRuntimePath}"
+      done
+    '';
+
+  meta = {
+    description = "Omarchy/Waybar widgets + TUI for tracking multi-provider AI plan usage";
+    homepage = "https://github.com/akitaonrails/ai-usagebar";
+    license = lib.licenses.mit;
+    mainProgram = "ai-usagebar";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,21 +38,20 @@ rustPlatform.buildRustPackage {
     lib.optionals stdenv.hostPlatform.isx86_64 [ nasm ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ];
 
-  postInstall =
-    ''
-      install -Dm644 config.example.toml \
-        "$out/share/ai-usagebar/config.example.toml"
-      install -Dm644 README.md \
-        "$out/share/doc/ai-usagebar/README.md"
-      install -Dm644 LICENSE \
-        "$out/share/licenses/ai-usagebar/LICENSE"
-    ''
-    + lib.optionalString stdenv.hostPlatform.isLinux ''
-      for program in ai-usagebar ai-usagebar-tui; do
-        wrapProgram "$out/bin/$program" \
-          --prefix PATH : "${linuxRuntimePath}"
-      done
-    '';
+  postInstall = ''
+    install -Dm644 config.example.toml \
+      "$out/share/ai-usagebar/config.example.toml"
+    install -Dm644 README.md \
+      "$out/share/doc/ai-usagebar/README.md"
+    install -Dm644 LICENSE \
+      "$out/share/licenses/ai-usagebar/LICENSE"
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    for program in ai-usagebar ai-usagebar-tui; do
+      wrapProgram "$out/bin/$program" \
+        --prefix PATH : "${linuxRuntimePath}"
+    done
+  '';
 
   meta = {
     description = "Omarchy/Waybar widgets + TUI for tracking multi-provider AI plan usage";

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -334,7 +334,7 @@ mod liveness_tests {
     }
 }
 
-#[cfg(all(test, target_os = "macos"))]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;

--- a/src/claude_desktop/app.rs
+++ b/src/claude_desktop/app.rs
@@ -334,7 +334,7 @@ mod liveness_tests {
     }
 }
 
-#[cfg(all(test, unix))]
+#[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;


### PR DESCRIPTION
## Summary

This adds first-party Nix support for `ai-usagebar` across:

- `x86_64-linux`
- `aarch64-linux`
- `x86_64-darwin`
- `aarch64-darwin`

The flake provides:

- Packages containing both the CLI and TUI binaries
- Default CLI and tui apps for `nix run`
- A reusable nixpkgs overlay
- A development shell and direnv integration
- Package checks for every supported system
- Native four-platform CI coverage