### PR TITLE
fix(antigravity): rank a TLS listener's echo below every real failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Antigravity no longer reports a TLS listener's `400 Client sent an HTTP
+  request to an HTTPS server` as the reason a probe run failed. Each product
+  binds an RPC port and an HTTPS port, and the probe order reaches the HTTPS
+  one only after the RPC one has already answered, so that reply describes our
+  own probe rather than the product. Because it is an `Http` and not a
+  `Transport`, letting it stand as the last failure also cost the silent cache
+  fallback that a not-yet-serving product is supposed to get. It is now ranked
+  below every other failure, and still reported when nothing else answered.
+
 ## [1.5.2] — 2026-08-24
 
 ### Fixed

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -161,18 +161,25 @@ async fn open_session(client: &reqwest::Client) -> Result<Session> {
 /// the one message worth reading behind transport noise.
 ///
 /// Note that this also decides *visibility*: transport errors are transient and
-/// fall back silently to cache, while the `401` surfaces in the widget.
+/// fall back silently to cache, while the `401` surfaces in the widget. That is
+/// why a TLS listener's echo is ranked below everything else rather than merely
+/// tie-breaking — see [`is_tls_echo`]. Being an `Http`, it is not transient, so
+/// letting it stand as "the last failure" turns a product that simply is not
+/// serving RPC into a visible error about a protocol the user never chose.
 fn select_probe_error(errors: Vec<AppError>) -> AppError {
     let mut actionable = None;
     let mut last = None;
+    let mut echo = None;
     for e in errors {
         if actionable.is_none() && is_actionable(&e) {
             actionable = Some(e);
+        } else if is_tls_echo(&e) {
+            echo = Some(e);
         } else {
             last = Some(e);
         }
     }
-    actionable.or(last).unwrap_or_else(|| {
+    actionable.or(last).or(echo).unwrap_or_else(|| {
         AppError::Other("antigravity: no local server answered GetUserStatus".into())
     })
 }
@@ -182,6 +189,25 @@ fn select_probe_error(errors: Vec<AppError>) -> AppError {
 /// authentication statuses are the whole set.
 fn is_actionable(e: &AppError) -> bool {
     matches!(e, AppError::Http { status, .. } if *status == 401 || *status == 403)
+}
+
+/// A TLS listener answering the plaintext JSON-RPC probe.
+///
+/// Each Antigravity product binds two ports: JSON-RPC in the clear on one and
+/// HTTPS on another. `probe_order` deliberately tries the RPC listener first
+/// and leaves the TLS one behind it, so reaching the TLS port at all means the
+/// RPC port already had its say. Go's `net/http.Server` answers cleartext on a
+/// TLS listener with this fixed `400`, which describes our own probe rather
+/// than anything wrong with the product — as a diagnosis it is noise that
+/// always arrives last and therefore always wins.
+///
+/// Matched on the body, not the status alone: a real `400` from the language
+/// server is a genuine complaint about the request and must keep outranking it.
+fn is_tls_echo(e: &AppError) -> bool {
+    matches!(
+        e,
+        AppError::Http { status: 400, body } if body.contains("HTTP request to an HTTPS server")
+    )
 }
 
 async fn fetch_live(
@@ -1536,6 +1562,87 @@ mod tests {
             err.to_string().contains("no local server answered"),
             "{err}"
         );
+    }
+
+    /// Verbatim from Go's `net/http`: this is what every Antigravity product's
+    /// HTTPS listener replies to the cleartext probe, so it is the tail of a
+    /// normal discovery run rather than a symptom.
+    fn tls_echo() -> AppError {
+        AppError::Http {
+            status: 400,
+            body: "Client sent an HTTP request to an HTTPS server.\n".into(),
+        }
+    }
+
+    /// The RPC listener is probed first, so whatever it said is the diagnosis.
+    /// The TLS port is reached only afterwards and always "fails", so without
+    /// demoting it, it overwrites the one error that came from the server the
+    /// user actually cares about.
+    #[test]
+    fn a_tls_echo_does_not_mask_what_the_rpc_listener_said() {
+        let err = select_probe_error(vec![
+            AppError::Http {
+                status: 500,
+                body: "GetUserStatus: internal".into(),
+            },
+            tls_echo(),
+        ]);
+        assert!(
+            matches!(&err, AppError::Http { status: 500, body } if body.contains("internal")),
+            "{err}"
+        );
+    }
+
+    /// The regression that motivated this: an `Http` is not transient, so an
+    /// echo standing in as "the last failure" costs the silent cache fallback
+    /// that `without_an_auth_failure_the_last_error_stands` exists to protect.
+    /// A product that is merely not serving RPC must stay quiet.
+    #[test]
+    fn a_tls_echo_does_not_cost_the_silent_fallback() {
+        let err = select_probe_error(vec![
+            AppError::Transport("connection refused".into()),
+            tls_echo(),
+        ]);
+        assert!(
+            matches!(&err, AppError::Transport(m) if m == "connection refused"),
+            "{err}"
+        );
+        assert!(
+            err.is_transient(),
+            "the echo must not make the run non-transient: {err}"
+        );
+    }
+
+    /// Demoted, not discarded. When the TLS listener is genuinely all that
+    /// answered, its reply is still better than a generic "nothing answered".
+    #[test]
+    fn a_tls_echo_still_stands_when_it_is_the_only_thing_that_answered() {
+        let err = select_probe_error(vec![tls_echo()]);
+        assert!(matches!(err, AppError::Http { status: 400, .. }), "{err}");
+    }
+
+    /// The demotion keys on the body, so the language server's own `400` — a
+    /// real complaint about a real request — keeps its normal rank.
+    #[test]
+    fn a_genuine_bad_request_is_not_mistaken_for_a_tls_echo() {
+        let err = select_probe_error(vec![
+            AppError::Http {
+                status: 400,
+                body: "unknown method GetUserStatus".into(),
+            },
+            tls_echo(),
+        ]);
+        assert!(
+            matches!(&err, AppError::Http { status: 400, body } if body.contains("unknown method")),
+            "{err}"
+        );
+    }
+
+    /// Ranking the echo last must not disturb the top of the order.
+    #[test]
+    fn an_auth_failure_still_outranks_a_tls_echo() {
+        let err = select_probe_error(vec![tls_echo(), http(401)]);
+        assert!(matches!(err, AppError::Http { status: 401, .. }), "{err}");
     }
 
     #[test]


### PR DESCRIPTION
Each Antigravity product binds two loopback ports: JSON-RPC in the clear on one, HTTPS on another. `probe_order` deliberately tries the RPC listener first and leaves the TLS one behind it, so reaching the TLS port at all means the RPC port has already had its say. Go's `net/http.Server` answers a cleartext request on a TLS listener with a fixed `400 Client sent an HTTP request to an HTTPS server`. That reply describes our own probe, not the product — and because it always arrives last, `select_probe_error` always kept it.

## Why this is worth a patch

**It masks the diagnosis.** Whatever the RPC listener actually said — a 5xx carrying a server message, a malformed 2xx body — is overwritten by a message about TLS, pointing the user at a protocol they never chose. That is the failure shape endpoint drift takes, so it lands squarely on the "Live API smoke discipline" loop in CLAUDE.md.

**It also costs the silent fallback, which I think is the worse half.** `is_transient()` is true only for `Transport`. An echo standing in as "the last failure" makes the run non-transient, so a product that is merely not serving RPC yet takes the `mark_stale` + `write_last_error` path and shouts in the widget. That is the opposite of what `without_an_auth_failure_the_last_error_stands` documents: *"stays transient, so the widget falls back silently instead of shouting about a product that simply is not running."* The echo quietly defeated that test's stated intent without failing it, because the test has no echo in its input.

## The change

`select_probe_error` gains a third tier below `actionable` and `last`. The echo is demoted, not discarded — when the TLS listener is genuinely all that answered, its reply still beats a generic "nothing answered", so no information is lost in that case.

The predicate keys on the body rather than the status alone, so a real `400` from the language server — a genuine complaint about a genuine request — keeps its normal rank. There is a test for exactly that.

Your five existing `select_probe_error` tests are untouched and still pass. I deliberately avoided a general rerank of `Http` versus `Transport`, which would have been the tempting fix: it breaks `without_an_auth_failure_the_last_error_stands`, because `http(500)` would then outrank `Transport("last")`. Demoting only this one echo leaves that ordering exactly as you wrote it.

## One judgement call I would like your read on

I matched the echo on `body.contains("HTTP request to an HTTPS server")`. That string is a Go constant and has been stable for many releases, but it is still someone else's literal. The alternative is to key on the *port* instead — we already know which listener we ranked second for each PID, so we could suppress the echo structurally and never parse a body. I did not do that because it would push probe-order knowledge into error handling and couple two things that are currently independent. Happy to switch if you would rather not depend on the string.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets --locked` — 1084 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean, on **Windows**. Worth noting since I could not tick this box on #121: your `b960f07` is what made it possible, and it works.
- [x] `cargo machete`
- [x] `node gnome-extension/marker-logic.test.mjs`, `node kde-plasmoid/plasmoid-logic.test.mjs`, `node omarchy/model.test.mjs`
- [ ] `omarchy plugin validate .` — not available on this machine
- [ ] Not exercised against a live half-started Antigravity; the echo is reproduced from Go's constant, not captured from a running product.

Six new tests cover: the echo not masking the RPC listener's error, the echo not costing the silent fallback (asserting `is_transient()`), the echo still standing when it is alone, a genuine `400` not being mistaken for an echo, and an auth failure still outranking an echo.
