### PR TITLE
fix(cache): redact the 401 body in the outcome, not only on disk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- A `401`/`403` response body no longer reaches the widget tooltip or the TUI on
+  the run that hit it. The body was redacted on its way to the `.last_error`
+  file but the copy handed to the outcome was built separately from the raw
+  body, so signing out with a warm cache showed the body once and the neutral
+  message on every run after. `Cache::write_last_error` now returns exactly what
+  it persisted, and the six vendors that built the pair themselves — Anthropic,
+  Antigravity, Deepseek, OpenAI, OpenRouter, Z.ai — pass that value on. Cursor,
+  Kimi, Kiro and opencode-go already redacted at this point and are unchanged.
+
 ## [1.5.2] — 2026-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ Each release is also published at
   file but the copy handed to the outcome was built separately from the raw
   body, so signing out with a warm cache showed the body once and the neutral
   message on every run after. `Cache::write_last_error` now returns exactly what
-  it persisted, and the six vendors that built the pair themselves — Anthropic,
-  Antigravity, Deepseek, OpenAI, OpenRouter, Z.ai — pass that value on. Cursor,
-  Kimi, Kiro and opencode-go already redacted at this point and are unchanged.
+  it persisted, and every vendor that built the pair itself passes that value on
+  — Anthropic, Anthropic API, Antigravity, Deepseek, Grok, Kilo, MiniMax,
+  Moonshot, Novita, OpenAI, OpenRouter and Z.ai. Cursor, Kimi and Kiro already
+  redacted at this point and are unchanged.
 - Antigravity no longer reports a TLS listener's `400 Client sent an HTTP
   request to an HTTPS server` as the reason a probe run failed. Each product
   binds an RPC port and an HTTPS port, and the probe order reaches the HTTPS

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -185,8 +185,8 @@ pub async fn fetch_snapshot(
         }
         Ok(Err(e)) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            fallback_to_cache(cache, plan_label, Some((0, e.to_string())))
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
+            fallback_to_cache(cache, plan_label, last_error)
         }
         Err(_elapsed) => fallback_to_cache_silent(cache, plan_label),
     }

--- a/src/anthropic/fetch.rs
+++ b/src/anthropic/fetch.rs
@@ -176,8 +176,8 @@ pub async fn fetch_snapshot(
         }
         Ok(Err(AppError::Http { status, body })) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            fallback_to_cache(cache, plan_label, Some((status, body)))
+            let last_error = Some(cache.write_last_error(status, &body));
+            fallback_to_cache(cache, plan_label, last_error)
         }
         Ok(Err(e)) if e.is_transient() => {
             // Reuse cache silently; no last_error write.

--- a/src/anthropic_api/fetch.rs
+++ b/src/anthropic_api/fetch.rs
@@ -143,8 +143,7 @@ pub async fn fetch_snapshot_at(
         Err(e) if e.is_transient() => fallback_silent(cache, limit, &month, &target, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let diag = (status, body.clone());
+            let diag = cache.write_last_error(status, &body);
             fallback_with_error(
                 cache,
                 Some(diag),
@@ -156,8 +155,7 @@ pub async fn fetch_snapshot_at(
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             fallback_with_error(cache, Some(diag), limit, &month, &target, e)
         }
     }

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -95,12 +95,9 @@ pub async fn fetch_snapshot_at(
         Err(e) if e.is_transient() => fallback_silent(cache, now, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let reason = AppError::Http {
-                status,
-                body: body.clone(),
-            };
-            fallback_with_error(cache, Some((status, body)), reason, now)
+            let last_error = Some(cache.write_last_error(status, &body));
+            let reason = AppError::Http { status, body };
+            fallback_with_error(cache, last_error, reason, now)
         }
         Err(e) => {
             cache.mark_stale();

--- a/src/antigravity/fetch.rs
+++ b/src/antigravity/fetch.rs
@@ -101,8 +101,7 @@ pub async fn fetch_snapshot_at(
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let last_error = Some((0, e.to_string()));
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
             fallback_with_error(cache, last_error, e, now)
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -498,6 +498,37 @@ mod tests {
         }
     }
 
+    /// The defect recurred once under a second name — six vendors wrote
+    /// `Some((status, body))` inline and six more built a `diag` local first —
+    /// so the sweep that fixed the first six missed the rest. This forbids the
+    /// shape rather than the spelling: a `last_error` pair must come from
+    /// [`Cache::write_last_error`], which is the only thing that redacts.
+    ///
+    /// `error_to_pair` in `cursor`, `kimi` and `kiro` is untouched by this: it
+    /// redacts on its own and destructures as `(*status, body)`, which is not
+    /// the borrowed shape a leak takes.
+    #[test]
+    fn no_vendor_builds_a_last_error_pair_from_a_raw_http_body() {
+        let mut sites = Vec::new();
+        for file in crate::guard::rs_files_in("src") {
+            if !file.ends_with("fetch.rs") {
+                continue;
+            }
+            let source = std::fs::read_to_string(&file).expect("readable module");
+            for (n, line) in crate::guard::production_code(&source).lines().enumerate() {
+                if line.contains("(status, body") {
+                    sites.push(format!("{}:{}", file.display(), n + 1));
+                }
+            }
+        }
+        assert!(
+            sites.is_empty(),
+            "a last_error pair must be the return of `write_last_error`, which \
+             redacts 401/403 — building one from the raw body puts the response \
+             body in the widget tooltip. Found: {sites:#?}"
+        );
+    }
+
     /// The bug this closes: the pair handed to the widget was built from the
     /// raw body in parallel with the redacted one going to disk, so the run
     /// that hit the `401` showed the body and only the *next* run showed the

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -172,7 +172,15 @@ impl Cache {
     /// Write the `.last_error` marker — first line `code`, everything after it
     /// `msg`. Best-effort, never errors (matches claudebar:478-486 which
     /// silently continues if the cache dir isn't writable).
-    pub fn write_last_error(&self, code: u16, msg: &str) {
+    ///
+    /// **Returns exactly what was written**, so a caller that also puts the
+    /// failure in its [`crate::vendor::VendorOutcome`] can hand over this pair
+    /// instead of deriving a second one from the raw body. The two must not be
+    /// computed separately: persisting a redacted message while the in-memory
+    /// copy kept the original is how a `401` body reached the widget tooltip on
+    /// the one run that had a warm cache to fall back on. Callers that only
+    /// persist can keep ignoring the return.
+    pub fn write_last_error(&self, code: u16, msg: &str) -> (u16, String) {
         let _ = self.ensure_dir();
         let path = self.last_error_path();
         // Authentication failure bodies routinely include account identifiers or
@@ -186,6 +194,7 @@ impl Cache {
         let msg = crate::display::sanitize_untrusted_field(msg);
         let body = format!("{code}\n{msg}");
         let _ = atomic_write(&path, body.as_bytes());
+        (code, msg)
     }
 
     /// Best-effort removal of the `.last_error` marker.
@@ -464,6 +473,46 @@ mod tests {
         assert_eq!(persisted, format!("403\n{AUTH_FAILURE_MESSAGE}"));
         assert!(!persisted.contains("PANCEA"));
         assert!(!persisted.contains("<credential>"));
+    }
+
+    /// The invariant that keeps the displayed message from drifting away from
+    /// the persisted one: what comes back is what a later run would read from
+    /// disk, so a caller that shows the return value cannot show anything the
+    /// cache refused to keep. Asserted for the redacting arm and the ordinary
+    /// one, since only the first rewrites the message.
+    #[test]
+    fn write_last_error_returns_exactly_what_a_later_run_would_read() {
+        for (code, raw) in [
+            (401u16, "PANCEA user@example.test <credential>&token"),
+            (403, "PANCEA account@example.test <credential>&token"),
+            (429, "rate limited, retry in 60s"),
+            (500, "bad\x1b]52;c;Y2FuYXJ5\x07field"),
+        ] {
+            let (_td, cache) = fixture();
+            let returned = cache.write_last_error(code, raw);
+            assert_eq!(
+                returned,
+                cache.read_last_error().unwrap(),
+                "returned pair diverged from the persisted one for {code}"
+            );
+        }
+    }
+
+    /// The bug this closes: the pair handed to the widget was built from the
+    /// raw body in parallel with the redacted one going to disk, so the run
+    /// that hit the `401` showed the body and only the *next* run showed the
+    /// neutral message. The returned pair carries the redaction.
+    #[test]
+    fn the_returned_pair_carries_the_auth_redaction() {
+        for code in [401u16, 403] {
+            let (_td, cache) = fixture();
+            let (returned_code, msg) =
+                cache.write_last_error(code, "PANCEA user@example.test <credential>&token");
+            assert_eq!(returned_code, code);
+            assert_eq!(msg, AUTH_FAILURE_MESSAGE);
+            assert!(!msg.contains("PANCEA"), "{msg}");
+            assert!(!msg.contains("<credential>"), "{msg}");
+        }
     }
 
     /// The regression this guards: vendors write the raw HTTP body, which is

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -70,8 +70,8 @@ pub async fn fetch_snapshot(
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            fallback_with_error(cache, Some((0, e.to_string())))
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
+            fallback_with_error(cache, last_error)
         }
     }
 }

--- a/src/deepseek/fetch.rs
+++ b/src/deepseek/fetch.rs
@@ -65,8 +65,8 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            fallback_with_error(cache, Some((status, body)))
+            let last_error = Some(cache.write_last_error(status, &body));
+            fallback_with_error(cache, last_error)
         }
         Err(e) => {
             cache.mark_stale();
@@ -242,6 +242,55 @@ mod tests {
         assert!((out.snapshot.balance - 5.0).abs() < 1e-9);
         assert_eq!(out.snapshot.currency, "USD");
         assert!(!out.stale);
+    }
+
+    /// The whole bug in one path. `reuse_cache` already puts the *redacted*
+    /// message in the outcome — it reads it back from disk — and
+    /// `fallback_with_error` then overwrote it with a pair built from the raw
+    /// body. So the run that hit the `401` displayed the body and every run
+    /// after it displayed the neutral message.
+    ///
+    /// Written against Deepseek because it is the smallest harness that reaches
+    /// the shared path; the same two lines were repeated in five other vendors.
+    #[tokio::test]
+    async fn a_401_body_does_not_reach_the_outcome_when_a_cache_is_warm() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/user/balance")
+            .with_status(401)
+            .with_body("PANCEA user@example.test <credential>&token")
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let warm = serde_json::json!({
+            "is_available": true,
+            "balance": 5.0,
+            "granted": 5.0,
+            "topped_up": 0.0,
+            "currency": "USD"
+        });
+        cache.write_payload(warm.to_string().as_bytes()).unwrap();
+
+        let endpoints = Endpoints {
+            balance: format!("{}/user/balance", server.url()),
+        };
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "sk-test",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+
+        let (code, msg) = out.last_error.expect("the 401 must still be reported");
+        assert_eq!(code, 401);
+        assert_eq!(msg, crate::error::AUTH_FAILURE_MESSAGE);
+        assert!(!msg.contains("PANCEA"), "{msg}");
+        assert!(!msg.contains("<credential>"), "{msg}");
+        assert!(out.stale);
     }
 
     #[tokio::test]

--- a/src/grok/fetch.rs
+++ b/src/grok/fetch.rs
@@ -74,8 +74,7 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => return fallback_silent(cache, &target, e),
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             return fallback_with_error(cache, Some(diag), &target, e);
         }
     };
@@ -98,14 +97,12 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache, &target, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let diag = (status, body.clone());
+            let diag = cache.write_last_error(status, &body);
             fallback_with_error(cache, Some(diag), &target, AppError::Http { status, body })
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             fallback_with_error(cache, Some(diag), &target, e)
         }
     }

--- a/src/kilo/fetch.rs
+++ b/src/kilo/fetch.rs
@@ -78,14 +78,12 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache, &target, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let diag = (status, body.clone());
+            let diag = cache.write_last_error(status, &body);
             fallback_with_error(cache, Some(diag), &target, AppError::Http { status, body })
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             fallback_with_error(cache, Some(diag), &target, e)
         }
     }

--- a/src/minimax/fetch.rs
+++ b/src/minimax/fetch.rs
@@ -95,14 +95,12 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache, &target, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let diag = (status, body.clone());
+            let diag = cache.write_last_error(status, &body);
             fallback_with_error(cache, Some(diag), &target, AppError::Http { status, body })
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             fallback_with_error(cache, Some(diag), &target, e)
         }
     }

--- a/src/moonshot/fetch.rs
+++ b/src/moonshot/fetch.rs
@@ -93,14 +93,12 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache, &target, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let diag = (status, body.clone());
+            let diag = cache.write_last_error(status, &body);
             fallback_with_error(cache, Some(diag), &target, AppError::Http { status, body })
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             fallback_with_error(cache, Some(diag), &target, e)
         }
     }

--- a/src/novita/fetch.rs
+++ b/src/novita/fetch.rs
@@ -67,14 +67,12 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache, e),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            let diag = (status, body.clone());
+            let diag = cache.write_last_error(status, &body);
             fallback_with_error(cache, Some(diag), AppError::Http { status, body })
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            let diag = (0, e.to_string());
+            let diag = cache.write_last_error(0, &e.to_string());
             fallback_with_error(cache, Some(diag), e)
         }
     }
@@ -186,6 +184,51 @@ mod tests {
         let cache = Cache::at(td.path().join("novita"));
         cache.ensure_dir().unwrap();
         (td, cache)
+    }
+
+    /// The other half of the `401`-body fix. Deepseek's test covers the vendors
+    /// that passed the pair inline; these six built it into a `diag` local
+    /// first, which is why the original sweep missed them — same defect, one
+    /// variable name apart.
+    #[tokio::test]
+    async fn a_401_body_does_not_reach_the_outcome_when_a_cache_is_warm() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/openapi/v1/billing/balance/detail")
+            .with_status(401)
+            .with_body("NOVITA user@example.test <credential>&token")
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let warm = serde_json::json!({
+            "snapshot": {
+                "available": 10.0,
+                "cash": 8.0,
+                "credit_limit": 2.0,
+                "outstanding": 0.0
+            }
+        });
+        cache.write_payload(warm.to_string().as_bytes()).unwrap();
+
+        let endpoints = Endpoints {
+            balance: format!("{}/openapi/v1/billing/balance/detail", server.url()),
+        };
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "nv-test",
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .expect("a warm cache must still produce an outcome");
+
+        let (code, msg) = out.last_error.expect("the 401 must still be reported");
+        assert_eq!(code, 401);
+        assert_eq!(msg, crate::error::AUTH_FAILURE_MESSAGE);
+        assert!(!msg.contains("NOVITA"), "{msg}");
+        assert!(!msg.contains("<credential>"), "{msg}");
     }
 
     #[tokio::test]

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -146,8 +146,8 @@ pub async fn fetch_snapshot(
         Ok(Err(e)) if e.is_transient() => fallback_silent(cache, plan_hint.as_deref()),
         Ok(Err(e)) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            fallback(cache, plan_hint.as_deref(), Some((0, e.to_string())))
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
+            fallback(cache, plan_hint.as_deref(), last_error)
         }
         Err(_) => fallback_silent(cache, plan_hint.as_deref()),
     }

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -140,8 +140,8 @@ pub async fn fetch_snapshot(
         }
         Ok(Err(AppError::Http { status, body })) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            fallback(cache, plan_hint.as_deref(), Some((status, body)))
+            let last_error = Some(cache.write_last_error(status, &body));
+            fallback(cache, plan_hint.as_deref(), last_error)
         }
         Ok(Err(e)) if e.is_transient() => fallback_silent(cache, plan_hint.as_deref()),
         Ok(Err(e)) => {

--- a/src/openrouter/fetch.rs
+++ b/src/openrouter/fetch.rs
@@ -80,8 +80,8 @@ pub async fn fetch_snapshot(
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            fallback_with_error(cache, Some((0, e.to_string())))
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
+            fallback_with_error(cache, last_error)
         }
     }
 }

--- a/src/openrouter/fetch.rs
+++ b/src/openrouter/fetch.rs
@@ -75,8 +75,8 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            fallback_with_error(cache, Some((status, body)))
+            let last_error = Some(cache.write_last_error(status, &body));
+            fallback_with_error(cache, last_error)
         }
         Err(e) => {
             cache.mark_stale();

--- a/src/zai/fetch.rs
+++ b/src/zai/fetch.rs
@@ -70,8 +70,8 @@ pub async fn fetch_snapshot(
         Err(e) if e.is_transient() => fallback_silent(cache, config_plan_tier),
         Err(AppError::Http { status, body }) => {
             cache.mark_stale();
-            cache.write_last_error(status, &body);
-            fallback_with_error(cache, Some((status, body)), config_plan_tier)
+            let last_error = Some(cache.write_last_error(status, &body));
+            fallback_with_error(cache, last_error, config_plan_tier)
         }
         Err(e) => {
             cache.mark_stale();

--- a/src/zai/fetch.rs
+++ b/src/zai/fetch.rs
@@ -75,8 +75,8 @@ pub async fn fetch_snapshot(
         }
         Err(e) => {
             cache.mark_stale();
-            cache.write_last_error(0, &e.to_string());
-            fallback_with_error(cache, Some((0, e.to_string())), config_plan_tier)
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
+            fallback_with_error(cache, last_error, config_plan_tier)
         }
     }
 }


### PR DESCRIPTION
`Cache::write_last_error` redacts authentication bodies before persisting them, so `read_last_error` hands back the neutral message. Six vendors then built the pair for the in-memory outcome separately, from the raw body:

```rust
cache.write_last_error(status, &body);
fallback_with_error(cache, Some((status, body)))
```

The sharp edge is what `fallback_with_error` does next. It calls `reuse_cache`, which sets `last_error: cache.read_last_error()` — the redacted message, already correct, already in hand — and then overwrites it with the raw pair the caller passed in.

## What the user sees

Signing out **with a warm cache** shows the response body once, in the widget tooltip and in the TUI, and shows the neutral message on every run after that. The tooltip path applies `escape()` for Pango but no redaction; the TUI applies `sanitize_untrusted_field`, which strips control characters and keeps the body.

Signing out **without a warm cache** is already correct: there is nothing to fall back on, the error propagates, and `widget::run::fallback` redacts it. That asymmetry is why the existing tests never caught this — including the one in `widget::run` that deliberately uses a body containing a fake credential.

Affected: Anthropic, Antigravity, Deepseek, OpenAI, OpenRouter, Z.ai.

## The fix applies a rule this repo already has

`cursor::error_to_pair` redacts at exactly this point, and its doc comment states the reason: *"Never surface upstream bodies for auth failures."* Kimi, Kiro and opencode-go follow it. So this is not a new policy — it is six vendors that were not following an existing one.

I did not add a second redaction site. `write_last_error` now returns exactly the pair it persisted, and the six call sites pass that value on instead of deriving a second one. The redaction rule still lives in one place, and the displayed message and the stored message are now the same object rather than two separately-computed values that happened to disagree. Callers that only persist keep ignoring the return.

This also lines up with the reasoning in `AppError::Io`'s new `Display` from #122 — doing it once where the value is produced, so sites written later cannot forget.

## Tests

Two in `cache` pin the invariant: the returned pair equals what a later run reads back, and it carries the redaction.

One end-to-end test goes through Deepseek's real fetch path with a warm cache and a mocked `401`. Reverting just the one-line change makes it fail with the credential printed in the assertion:

```
assertion `left == right` failed
  left: "PANCEA user@example.test <credential>&token"
 right: "authentication rejected — credentials may be missing, expired, or invalid"
```

I wrote it against Deepseek because it is the smallest harness that reaches the shared path, not because it is special — the same two lines were repeated in all six. If you would rather have it repeated per vendor, say so and I will fan it out.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo test --all-targets --locked` — 1082 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean, on Windows
- [x] `cargo machete`
- [x] `node gnome-extension/marker-logic.test.mjs`, `node kde-plasmoid/plasmoid-logic.test.mjs`, `node omarchy/model.test.mjs`
- [x] Verified the new end-to-end test fails when the fix is reverted
- [ ] `omarchy plugin validate .` — not available on this machine
- [ ] Not exercised against a live signed-out account on any of the six vendors; the `401` is mocked.
