### PR TITLE
Draw the shared window block and pace arrow in the Kimi, MiniMax and Z.AI tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Each release is also published at
 - First-party Nix flake packaging supports `nix run`, profile installation,
   direct NixOS and Home Manager consumption, an overlay, and a development
   shell on x86_64 and aarch64 Linux and macOS.
+- The macOS menu bar shows Z.AI's monthly MCP-tools pool as a fourth row, with
+  its own bar, reset and pace marker — the widget, TUI and native panels have
+  always listed it, only the menu bar had no field for it. It fills the same
+  fourth-window slot Antigravity's second pool uses. An account with no MCP
+  quota reports no reset for it and keeps three rows, and an older binary that
+  does not know `{zai_mcp_*}` degrades the same way.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Each release is also published at
 - Kimi's tooltip is drawn with the same window block every other vendor uses —
   icon + label, progress bar with the percentage, then the reset countdown —
   instead of the bare `26 / 100  (26%)` pairs it printed before. The counters
-  ride the reset line so nothing reported is lost, and its bar text follows the
+  and the vendor's own remaining figure ride the reset line
+  (`26 / 100 · 74 left`) so nothing reported is lost, and its bar text follows the
   `{pct}% · {reset}` shape the other percentage vendors already use
   (`{kimi_weekly_pct}% · {kimi_weekly_reset}`, was a bare `{kimi_weekly_pct}%`).
 - MiniMax's tooltip rows are drawn with the shared window block too, so each

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,27 @@ Each release is also published at
   direct NixOS and Home Manager consumption, an overlay, and a development
   shell on x86_64 and aarch64 Linux and macOS.
 
+### Changed
+
+- Kimi's tooltip is drawn with the same window block every other vendor uses —
+  icon + label, progress bar with the percentage, then the reset countdown —
+  instead of the bare `26 / 100  (26%)` pairs it printed before. The counters
+  ride the reset line so nothing reported is lost, and its bar text follows the
+  `{pct}% · {reset}` shape the other percentage vendors already use
+  (`{kimi_weekly_pct}% · {kimi_weekly_reset}`, was a bare `{kimi_weekly_pct}%`).
+- MiniMax's tooltip rows are drawn with the shared window block too, so each
+  pool shows a progress bar rather than a bare `Session 20%` pair.
+
 ### Fixed
 
+- Z.AI and MiniMax show the pace arrow (`↑` / `→` / `↓`) next to each
+  percentage in the widget and `--vendor` tooltips. The pace placeholders added
+  in 1.3.0 reached the macOS menu bar, but the default tooltip never consulted
+  them: `tooltip::push_window` had no way to render a glyph, and only the
+  Anthropic renderer had one hand-rolled. The shared helper now takes a
+  `WindowRow`, so the arrow travels with the row. As on the Anthropic tooltip,
+  the elapsed marker inside the bar stays behind `--tooltip-pace-pts`; Codex and
+  Antigravity rows are unchanged.
 - A `401`/`403` response body no longer reaches the widget tooltip or the TUI on
   the run that hit it. The body was redacted on its way to the `.last_error`
   file but the copy handed to the outcome was built separately from the raw

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -111,8 +111,10 @@ currencies are present; otherwise they use CNY.
 `{kimi_window_remaining}`, `{kimi_window_reset}`
 
 These cover the subscription quota and rolling five-hour window from
-`api.kimi.com/coding/v1/usages`. Generic aliases are `{plan}` for the plan,
-`{weekly_pct}` for weekly usage, and `{session_pct}` for the five-hour window.
+`api.kimi.com/coding/v1/usages`. The default format is
+`{kimi_weekly_pct}% · {kimi_weekly_reset}`. Generic aliases are `{plan}` for the
+plan, `{weekly_pct}` for weekly usage, and `{session_pct}` for the five-hour
+window.
 
 ## Kilo
 

--- a/macos/README.md
+++ b/macos/README.md
@@ -83,7 +83,7 @@ Settings persist in `UserDefaults` and apply **live, no rebuild**.
 | Bar width | 8 | cells per menu-bar bar (4–20) |
 | Colors (low/mid/high/critical/empty) | One Dark | bar color per severity (≥90 / ≥75 / ≥50 / else) |
 | Refresh interval | 30 s | 5–3600 |
-| Vendor | anthropic | selectors: only enabled vendors (see [Vendor scope](#vendor-scope)). Claude, Codex, and Z.AI expose session/weekly windows; balance-only vendors show a credit balance instead. |
+| Vendor | anthropic | selectors: only enabled vendors (see [Vendor scope](#vendor-scope)). Claude, Codex, and Z.AI expose session/weekly windows — Z.AI adds its monthly MCP-tools pool as a fourth row when the account has one; balance-only vendors show a credit balance instead. |
 | Binary path | auto | empty = `~/.cargo/bin`, Homebrew, then `PATH` |
 | Global vendor shortcut | on | **⌥⌘\\** cycles every configured vendor/account and Overview; turns itself back off if macOS cannot register it |
 | Global compact shortcut | on | **⌥⌘E** toggles Overview between mini bars and compact text; turns itself back off if unavailable |
@@ -103,9 +103,9 @@ The Preferences window needs **macOS 12+** (the menu bar itself works on
 10.15+). Tags/labels use the system label colors, so they adapt to a light or
 dark menu bar; only the bar fill/empty colors are configurable.
 
-Pace markers require both a real reset and elapsed-time output. Currently only
-Anthropic's elapsed placeholder family supplies that pair, so other vendors can
-render their generic windows without a pace marker. When available, the fixed
+Pace markers require both a real reset and elapsed-time output. Claude, Codex,
+Z.AI, MiniMax and Antigravity supply that pair; the remaining vendors render
+their generic windows without a pace marker. When available, the fixed
 blue `│` pace marker is placed at elapsed time. Fill past the marker follows the
 point-delta colors used by the Rust widget: at
 least 10 points ahead is critical/red, 1–9 ahead is high/orange, -10 through

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -80,7 +80,8 @@ let POINT_CRITICAL_MIN = 10
 // fields (17-22) carry the per-vendor credits — only the selected vendor's is
 // populated — and the `aapi_*` fields (23-26) carry the Anthropic API headline
 // plus its spend-vs-limit bar. `cursor_total_pct` (27) is followed by the
-// Antigravity-only fourth-window fields (28-30). A final literal sentinel
+// Antigravity-only fourth-window fields (28-30) and the Z.AI MCP-tools pool
+// (31-33), which fills that same fourth-window slot. A final literal sentinel
 // absorbs the widget's stale suffix, preserving these fields.
 let FORMAT = "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_reset};;" +
              "{sonnet_pct};;{sonnet_reset};;{extra_pct};;{extra_spent};;{extra_limit};;" +
@@ -88,7 +89,8 @@ let FORMAT = "{plan};;{session_pct};;{session_reset};;{weekly_pct};;{weekly_rese
              "{session_elapsed};;{weekly_elapsed};;{scoped_elapsed};;{vendor_short};;{or_balance};;" +
              "{ds_balance};;{kilo_balance};;{nv_balance};;{km_balance};;{grok_balance};;" +
              "{aapi_headline};;{aapi_pct};;{aapi_spent};;{aapi_limit};;{cursor_total_pct};;" +
-             "{extra_model};;{extra_reset};;{extra_elapsed}"
+             "{extra_model};;{extra_reset};;{extra_elapsed};;" +
+             "{zai_mcp_pct};;{zai_mcp_reset};;{zai_mcp_elapsed}"
 
 let FORMAT_WITH_SENTINEL = FORMAT + ";;__aiub_end__"
 
@@ -135,9 +137,16 @@ func ringTrackColor(_ appearance: NSAppearance) -> NSColor {
     return isDark ? NSColor.white.withAlphaComponent(0.25) : hexColor(COLOR_EMPTY)
 }
 
+/// True when a countdown field carries a real value. The widget prints `—` for
+/// a window the vendor did not report, and an older binary that does not know a
+/// placeholder leaves it empty.
+func isReported(_ countdown: String) -> Bool {
+    !countdown.isEmpty && countdown != "—"
+}
+
 // A missing reset keeps its row visible but never has a meaningful pace marker.
 func markerElapsed(reset: String, elapsed: Int?) -> Int? {
-    guard !reset.isEmpty, reset != "—" else { return nil }
+    guard isReported(reset) else { return nil }
     return elapsed
 }
 
@@ -483,6 +492,14 @@ func parse(_ text: String, vendor: String) -> Snapshot? {
     if isAntigravity, !t(28).isEmpty {
         secondaryWeekly = quotaWindow(7, 29, 30)
         secondaryWeeklyLabel = "\(t(28)) Weekly"
+    } else if vendor == "zai", isReported(t(32)), let mcp = quotaWindow(31, 32, 33) {
+        // Z.AI's monthly MCP-tools pool is a real quota window with its own
+        // reset, so it rides the same fourth-window slot Antigravity uses.
+        // `{zai_mcp_pct}` flattens an absent pool to "0", so the reset is the
+        // presence signal — an account with no MCP quota reports "—" there and
+        // must not grow a phantom 0% row.
+        secondaryWeekly = mcp
+        secondaryWeeklyLabel = "MCP tools (monthly)"
     } else {
         secondaryWeekly = nil
         secondaryWeeklyLabel = ""

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -224,7 +224,7 @@ func snapshot(_ format: String, vendor: String, fields: [String]) -> Snapshot? {
 
 func testParserBalances() {
     print("parser balances per vendor")
-    // Build a field array long enough to cover index 26 (aapi_limit).
+    // Build a field array long enough to cover the highest index a case needs.
     func fields(through max: Int, set: [Int: String]) -> [String] {
         (0...max).map { set[$0] ?? "" }
     }
@@ -324,6 +324,50 @@ func testParserBalances() {
     assertEqual(agy?.sonnetLabel, "Claude & GPT OSS 5h", "antigravity third-party 5h label")
     assertEqual(agy?.secondaryWeeklyLabel, "Claude & GPT OSS Weekly", "antigravity fourth label")
     assertNil(agy?.extra, "antigravity fourth window is not a spend bar")
+
+    // Z.AI's monthly MCP-tools pool fills the same fourth-window slot.
+    let zai = snapshot(FORMAT, vendor: "zai",
+                       fields: fields(through: 33, set: [
+                          0: "GLM Coding Pro", 1: "42", 2: "2h", 3: "15", 4: "3d",
+                          13: "40", 14: "35", 16: "zai",
+                          31: "7", 32: "24d 13h", 33: "60"
+                       ]))
+    assertEqual(zai?.session?.pct, 42, "zai session pct")
+    assertEqual(zai?.weekly?.pct, 15, "zai weekly pct")
+    assertEqual(zai?.secondaryWeekly?.pct, 7, "zai MCP pct")
+    assertEqual(zai?.secondaryWeekly?.reset, "24d 13h", "zai MCP reset")
+    assertEqual(zai?.secondaryWeekly?.elapsed, 60, "zai MCP elapsed drives the pace marker")
+    assertEqual(zai?.secondaryWeeklyLabel, "MCP tools (monthly)", "zai MCP label")
+    assertNil(zai?.extra, "zai MCP window is not a spend bar")
+
+    // `{zai_mcp_pct}` flattens an account with no MCP quota to "0", so the row
+    // must key off the reset — otherwise every Z.AI user grows a phantom 0% row.
+    let zaiNoMcp = snapshot(FORMAT, vendor: "zai",
+                            fields: fields(through: 33, set: [
+                               0: "GLM Coding Pro", 1: "42", 2: "2h", 3: "15", 4: "3d",
+                               16: "zai", 31: "0", 32: "—", 33: "0"
+                            ]))
+    assertNil(zaiNoMcp?.secondaryWeekly, "no MCP quota reported → no fourth row")
+    assertEqual(zaiNoMcp?.secondaryWeeklyLabel, "", "no MCP quota reported → no label")
+
+    // An older binary knows nothing of `{zai_mcp_*}` and leaves them literal.
+    let zaiOldBinary = snapshot(FORMAT, vendor: "zai",
+                                fields: fields(through: 16, set: [
+                                   0: "GLM Coding Pro", 1: "42", 2: "2h", 3: "15",
+                                   4: "3d", 16: "zai"
+                                ]))
+    assertEqual(zaiOldBinary?.session?.pct, 42, "old binary still parses the windows it knows")
+    assertNil(zaiOldBinary?.secondaryWeekly, "unknown placeholders → no fourth row")
+
+    // The MCP pool only rides this slot for Z.AI; another vendor's fields at the
+    // same indices must not conjure one.
+    let notZai = snapshot(FORMAT, vendor: "anthropic",
+                          fields: fields(through: 33, set: [
+                             0: "Max", 1: "10", 2: "2h", 3: "20", 4: "3d",
+                             31: "7", 32: "24d 13h", 33: "60"
+                          ]))
+    assertEqual(notZai?.session?.pct, 10, "the non-Z.AI snapshot still parsed")
+    assertNil(notZai?.secondaryWeekly, "the MCP slot is Z.AI-only")
 
     // A non-Cursor vendor keeps the default time-window labels.
     assertEqual(cld?.sessionLabel, "Session", "anthropic keeps the Session label")

--- a/src/antigravity/vendor.rs
+++ b/src/antigravity/vendor.rs
@@ -16,7 +16,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
 use crate::usage::{AntigravitySnapshot, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -192,11 +192,9 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     let all = windows(snap);
-    let pace = |w: &UsageWindow| WindowRow {
-        marker_pct: opts
-            .tooltip_pace_pts
-            .then(|| elapsed_pct(w, now, opts.pace_tolerance)),
-        ..WindowRow::default()
+    let pace = |w: &UsageWindow| {
+        opts.tooltip_pace_pts
+            .then(|| elapsed_pct(w, now, opts.pace_tolerance))
     };
 
     // Two groups, each holding the same pair of pools. A Sep between them marks
@@ -447,8 +445,8 @@ mod tests {
         assert_ne!(plain, paced, "pace marker should change the bars");
     }
 
-    /// Antigravity kept its opt-in marker and gained nothing else when the
-    /// shared row helper learned about glyphs.
+    /// Antigravity keeps its opt-in marker through the stable `push_window`
+    /// and gains nothing else from the row helper.
     #[test]
     fn tooltip_rows_carry_no_pace_glyph() {
         let tip = tooltip(&opts(), None);

--- a/src/antigravity/vendor.rs
+++ b/src/antigravity/vendor.rs
@@ -16,7 +16,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
 use crate::usage::{AntigravitySnapshot, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -192,9 +192,11 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     let all = windows(snap);
-    let pace = |w: &UsageWindow| {
-        opts.tooltip_pace_pts
-            .then(|| elapsed_pct(w, now, opts.pace_tolerance))
+    let pace = |w: &UsageWindow| WindowRow {
+        marker_pct: opts
+            .tooltip_pace_pts
+            .then(|| elapsed_pct(w, now, opts.pace_tolerance)),
+        ..WindowRow::default()
     };
 
     // Two groups, each holding the same pair of pools. A Sep between them marks
@@ -443,5 +445,15 @@ mod tests {
             None,
         );
         assert_ne!(plain, paced, "pace marker should change the bars");
+    }
+
+    /// Antigravity kept its opt-in marker and gained nothing else when the
+    /// shared row helper learned about glyphs.
+    #[test]
+    fn tooltip_rows_carry_no_pace_glyph() {
+        let tip = tooltip(&opts(), None);
+        for glyph in ['↑', '→', '↓'] {
+            assert!(!tip.contains(glyph), "{tip}");
+        }
     }
 }

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -9,7 +9,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::PaceSeverity;
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
 use crate::usage::{KimiSnapshot, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -186,7 +186,7 @@ fn render_tooltip(
         used = snap.weekly_used,
         limit = snap.weekly_limit
     );
-    push_window(
+    push_window_with_row(
         &mut lines,
         "  󰅄  Weekly quota",
         &window(weekly_pct, snap.weekly_reset_at, WEEKLY_WINDOW),
@@ -202,7 +202,7 @@ fn render_tooltip(
             used = snap.window_used,
             limit = snap.window_limit
         );
-        push_window(
+        push_window_with_row(
             &mut lines,
             "  󰅁  Rolling window (5h)",
             &window(snap.window_pct(), snap.window_reset_at, ROLLING_WINDOW),

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -181,10 +181,14 @@ fn render_tooltip(
     // right there — project each quota onto a window and it draws like every
     // other vendor, with the counts riding along on the reset line.
     lines.push(TooltipLine::Body("".into()));
+    // `remaining` is the vendor's own number, not `limit - used`: `extract_block`
+    // keeps both when the wire reports both. Dropping it would lose the figure a
+    // request-counting quota is actually read for.
     let weekly_detail = format!(
-        "{used} / {limit}",
+        "{used} / {limit} · {remaining} left",
         used = snap.weekly_used,
-        limit = snap.weekly_limit
+        limit = snap.weekly_limit,
+        remaining = snap.weekly_remaining
     );
     push_window_with_row(
         &mut lines,
@@ -198,9 +202,10 @@ fn render_tooltip(
     if snap.window_limit > 0 {
         lines.push(TooltipLine::Body("".into()));
         let window_detail = format!(
-            "{used} / {limit}",
+            "{used} / {limit} · {remaining} left",
             used = snap.window_used,
-            limit = snap.window_limit
+            limit = snap.window_limit,
+            remaining = snap.window_remaining
         );
         push_window_with_row(
             &mut lines,
@@ -524,6 +529,30 @@ mod tests {
         let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
         assert!(out.tooltip.contains("· 26 / 100"), "{}", out.tooltip);
         assert!(out.tooltip.contains("· 15 / 100"), "{}", out.tooltip);
+    }
+
+    /// `remaining` is what a request-counting quota is read for, and it is the
+    /// vendor's own figure rather than `limit - used` — `extract_block` keeps
+    /// both when the wire reports both, so it cannot be recovered by
+    /// subtraction. The fixture makes them disagree to prove which one is
+    /// rendered.
+    #[test]
+    fn tooltip_keeps_the_vendors_own_remaining_count() {
+        let mut snap = sample_snap();
+        snap.weekly_remaining = 70; // not 100 - 26
+        snap.window_remaining = 80; // not 100 - 15
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        assert!(
+            out.tooltip.contains("· 26 / 100 · 70 left"),
+            "{}",
+            out.tooltip
+        );
+        assert!(
+            out.tooltip.contains("· 15 / 100 · 80 left"),
+            "{}",
+            out.tooltip
+        );
     }
 
     /// Kimi opts out of pacing, like Codex; the rows must not sprout a glyph

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -9,8 +9,8 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::PaceSeverity;
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, render_bordered};
-use crate::usage::KimiSnapshot;
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
+use crate::usage::{KimiSnapshot, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
@@ -37,7 +37,23 @@ pub fn warning_kind(code: u16, message: &str) -> WarningKind {
     }
 }
 
-pub const DEFAULT_FORMAT: &str = "{kimi_weekly_pct}%";
+pub const DEFAULT_FORMAT: &str = "{kimi_weekly_pct}% · {kimi_weekly_reset}";
+
+/// Kimi reports the weekly quota's reset instant but never its length; the
+/// subscription bucket rolls every 7 days.
+const WEEKLY_WINDOW: chrono::Duration = chrono::Duration::days(7);
+/// The rolling bucket's length *is* advertised — 300 minutes — and only that
+/// spelling is accepted on the way in (`types::is_five_hour_window`).
+const ROLLING_WINDOW: chrono::Duration = chrono::Duration::hours(5);
+
+/// Project a quota pair onto the shared window shape the tooltip helper draws.
+fn window(pct: i32, resets_at: Option<DateTime<Utc>>, duration: chrono::Duration) -> UsageWindow {
+    UsageWindow {
+        utilization_pct: pct,
+        resets_at,
+        window_duration: duration,
+    }
+}
 
 pub fn build_placeholders(
     snap: &KimiSnapshot,
@@ -143,8 +159,6 @@ fn render_tooltip(
 
     let weekly_pct = snap.weekly_pct();
     let weekly_color = severity_color(severity_for(weekly_pct), theme);
-    let window_pct = snap.window_pct();
-    let window_color = severity_color(severity_for(window_pct), theme);
 
     let mut lines: Vec<TooltipLine> = Vec::new();
     lines.push(TooltipLine::Center(format!(
@@ -162,38 +176,40 @@ fn render_tooltip(
         escape(plan)
     )));
 
+    // Kimi counts requests rather than reporting a percentage, which is why
+    // this block used to print bare `26 / 100  (26%)` pairs. The percentage is
+    // right there — project each quota onto a window and it draws like every
+    // other vendor, with the counts riding along on the reset line.
     lines.push(TooltipLine::Body("".into()));
-    lines.push(TooltipLine::Body(format!(
-        " <span foreground='{fg}'>  󰅄  Weekly quota</span>"
-    )));
-    lines.push(TooltipLine::Body(format!(
-        "   <span font_weight='bold' foreground='{weekly_color}'>{used} / {limit}</span>  ({pct}%)",
+    let weekly_detail = format!(
+        "{used} / {limit}",
         used = snap.weekly_used,
-        limit = snap.weekly_limit,
-        pct = weekly_pct
-    )));
-    lines.push(TooltipLine::Body(format!(
-        " <span foreground='{dim}'>     {remaining} remaining · reset {reset}</span>",
-        remaining = snap.weekly_remaining,
-        reset = escape(&countdown::format(snap.weekly_reset_at, now))
-    )));
+        limit = snap.weekly_limit
+    );
+    push_window(
+        &mut lines,
+        "  󰅄  Weekly quota",
+        &window(weekly_pct, snap.weekly_reset_at, WEEKLY_WINDOW),
+        theme,
+        now,
+        WindowRow::default().with_detail(&weekly_detail),
+    );
 
     if snap.window_limit > 0 {
         lines.push(TooltipLine::Body("".into()));
-        lines.push(TooltipLine::Body(format!(
-            " <span foreground='{fg}'>  󰅁  Rolling window</span>"
-        )));
-        lines.push(TooltipLine::Body(format!(
-            "   <span font_weight='bold' foreground='{window_color}'>{used} / {limit}</span>  ({pct}%)",
+        let window_detail = format!(
+            "{used} / {limit}",
             used = snap.window_used,
-            limit = snap.window_limit,
-            pct = window_pct
-        )));
-        lines.push(TooltipLine::Body(format!(
-            " <span foreground='{dim}'>     {remaining} remaining · reset {reset}</span>",
-            remaining = snap.window_remaining,
-            reset = escape(&countdown::format(snap.window_reset_at, now))
-        )));
+            limit = snap.window_limit
+        );
+        push_window(
+            &mut lines,
+            "  󰅁  Rolling window (5h)",
+            &window(snap.window_pct(), snap.window_reset_at, ROLLING_WINDOW),
+            theme,
+            now,
+            WindowRow::default().with_detail(&window_detail),
+        );
     }
 
     if let Some((code, msg)) = outcome.last_error.as_ref() {
@@ -481,5 +497,54 @@ mod tests {
         ] {
             assert!(values.contains_key(key), "missing placeholder {key}");
         }
+    }
+
+    /// The whole point of the rework: Kimi's quotas are percentages behind a
+    /// pair of counters, so they draw like every other vendor's window.
+    #[test]
+    fn tooltip_draws_a_progress_bar_for_both_quotas() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        assert_eq!(
+            out.tooltip.matches('░').count() + out.tooltip.matches('█').count(),
+            2 * crate::pango::BAR_LEN as usize,
+            "expected one full-width bar per quota: {}",
+            out.tooltip
+        );
+        assert!(out.tooltip.contains("Resets in"), "{}", out.tooltip);
+    }
+
+    /// The counters the old hand-rolled rows carried ride the reset line now —
+    /// the bar replaces the `26 / 100  (26%)` pair, it does not drop it.
+    #[test]
+    fn tooltip_keeps_the_raw_counts_on_the_reset_line() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        assert!(out.tooltip.contains("· 26 / 100"), "{}", out.tooltip);
+        assert!(out.tooltip.contains("· 15 / 100"), "{}", out.tooltip);
+    }
+
+    /// Kimi opts out of pacing, like Codex; the rows must not sprout a glyph
+    /// on their own.
+    #[test]
+    fn tooltip_rows_carry_no_pace_glyph() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        for glyph in ['↑', '→', '↓'] {
+            assert!(!out.tooltip.contains(glyph), "{}", out.tooltip);
+        }
+    }
+
+    /// `{pct}% · {reset}` is what every other percentage vendor puts on the
+    /// bar; Kimi printed a bare `26%`.
+    #[test]
+    fn default_bar_text_pairs_the_percentage_with_its_reset() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        assert!(out.text.contains("26% · 4d 0h"), "{}", out.text);
     }
 }

--- a/src/minimax/vendor.rs
+++ b/src/minimax/vendor.rs
@@ -14,7 +14,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
 use crate::usage::{MinimaxSnapshot, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -200,7 +200,7 @@ pub fn render(
     let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
         substitute(fmt, &pango_values)
     } else {
-        render_tooltip(outcome, snap, theme, now)
+        render_tooltip(outcome, snap, theme, opts, now)
     };
 
     WaybarOutput {
@@ -214,6 +214,7 @@ fn render_tooltip(
     outcome: &VendorOutcome,
     snap: &MinimaxSnapshot,
     theme: &Theme,
+    opts: &RenderOpts,
     now: DateTime<Utc>,
 ) -> String {
     let blue = &theme.blue;
@@ -227,22 +228,30 @@ fn render_tooltip(
     )));
     lines.push(TooltipLine::Sep);
 
+    // Rows go through the shared window helper so a pool reads like every
+    // other vendor's block — bar, percentage, pace arrow — instead of the bare
+    // `Session 20%` pair MiniMax printed before. The pool keeps its heading,
+    // the way Antigravity groups its Gemini / third-party budgets.
     let mut pool = |label: &str, icon: &str, session: &UsageWindow, weekly: &UsageWindow| {
         lines.push(TooltipLine::Body("".into()));
         lines.push(TooltipLine::Body(format!(
-            " <span foreground='{fg}'>  {icon}  {label}</span>"
+            " <span font_weight='bold' foreground='{fg}'>  {icon}  {label}</span>"
         )));
-        for (what, w) in [("Session", session), ("Weekly", weekly)] {
-            let color = severity_color(severity_for(w.utilization_pct), theme);
-            lines.push(TooltipLine::Body(format!(
-                "   <span foreground='{dim}'>{what}</span>  \
-                 <span font_weight='bold' foreground='{color}'>{pct}%</span>",
-                pct = w.utilization_pct
-            )));
-            lines.push(TooltipLine::Body(format!(
-                " <span foreground='{dim}'>     reset {}</span>",
-                escape(&countdown::format(w.resets_at, now))
-            )));
+        for (slot, (what, w)) in [("  󰔟  Session", session), ("  󰃰  Weekly", weekly)]
+            .into_iter()
+            .enumerate()
+        {
+            if slot > 0 {
+                lines.push(TooltipLine::Body("".into()));
+            }
+            push_window(
+                &mut lines,
+                what,
+                w,
+                theme,
+                now,
+                WindowRow::paced(w, now, opts.pace_tolerance, opts.tooltip_pace_pts),
+            );
         }
     };
 
@@ -462,7 +471,7 @@ mod tests {
     #[test]
     fn tooltip_lists_both_pools_when_present() {
         let s = snap();
-        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), now());
+        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), &opts(), now());
         assert!(tip.contains(POOL_GENERAL));
         assert!(tip.contains(POOL_VIDEO));
     }
@@ -472,7 +481,7 @@ mod tests {
         let mut s = snap();
         s.video_session = None;
         s.video_weekly = None;
-        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), now());
+        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), &opts(), now());
         assert!(tip.contains(POOL_GENERAL));
         assert!(!tip.contains(POOL_VIDEO));
     }
@@ -511,5 +520,38 @@ mod tests {
         o.stale = true;
         let out = render(&o, &s, &Theme::default(), &opts(), now());
         assert!(out.text.contains('⏸'));
+    }
+
+    /// MiniMax printed a bare `Session 20%` pair per pool; both rows now draw
+    /// the shared bar and carry the pace arrow the placeholders already had.
+    #[test]
+    fn tooltip_draws_a_bar_and_pace_arrow_for_every_pool_row() {
+        let s = snap();
+        let tip = render_tooltip(&outcome(&s), &s, &Theme::default(), &opts(), now());
+        let cells = tip.matches('░').count() + tip.matches('█').count();
+        assert_eq!(
+            cells,
+            4 * crate::pango::BAR_LEN as usize,
+            "expected a bar for each of the four windows: {tip}"
+        );
+        let arrows = tip.matches('↑').count() + tip.matches('→').count() + tip.matches('↓').count();
+        assert_eq!(arrows, 4, "expected one arrow per window: {tip}");
+    }
+
+    #[test]
+    fn the_elapsed_marker_stays_behind_tooltip_pace_pts() {
+        let s = snap();
+        let plain = render_tooltip(&outcome(&s), &s, &Theme::default(), &opts(), now());
+        let paced = render_tooltip(
+            &outcome(&s),
+            &s,
+            &Theme::default(),
+            &RenderOpts {
+                tooltip_pace_pts: true,
+                ..opts()
+            },
+            now(),
+        );
+        assert_ne!(plain, paced, "the marker should redraw the bars");
     }
 }

--- a/src/minimax/vendor.rs
+++ b/src/minimax/vendor.rs
@@ -14,7 +14,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
 use crate::usage::{MinimaxSnapshot, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -244,7 +244,7 @@ fn render_tooltip(
             if slot > 0 {
                 lines.push(TooltipLine::Body("".into()));
             }
-            push_window(
+            push_window_with_row(
                 &mut lines,
                 what,
                 w,

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -10,7 +10,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
 use crate::usage::{OpenAiSnapshot, OpenAiSource, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -197,13 +197,27 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     if let Some(session) = snap.session.as_ref() {
-        push_window(&mut lines, "  󰔟  Codex 5h", session, theme, now, None);
+        push_window(
+            &mut lines,
+            "  󰔟  Codex 5h",
+            session,
+            theme,
+            now,
+            WindowRow::default(),
+        );
     }
     if let Some(weekly) = snap.weekly.as_ref() {
         if snap.session.is_some() {
             lines.push(TooltipLine::Body("".into()));
         }
-        push_window(&mut lines, "  󰃰  Codex weekly", weekly, theme, now, None);
+        push_window(
+            &mut lines,
+            "  󰃰  Codex weekly",
+            weekly,
+            theme,
+            now,
+            WindowRow::default(),
+        );
     }
     if snap.session.is_none() && snap.weekly.is_none() {
         lines.push(TooltipLine::Body(format!(
@@ -219,7 +233,7 @@ fn render_tooltip(
             cr,
             theme,
             now,
-            None,
+            WindowRow::default(),
         );
     }
 
@@ -455,5 +469,16 @@ mod tests {
         let mut s = sample();
         s.weekly.as_mut().unwrap().utilization_pct = 95;
         assert_eq!(severity(&s), PaceSeverity::Critical);
+    }
+
+    /// Codex was left out of the tooltip pace change on purpose; reworking the
+    /// shared helper must not have handed it an arrow.
+    #[test]
+    fn tooltip_rows_carry_no_pace_glyph() {
+        let s = sample();
+        let out = render(&oc(s.clone()), &s, &Theme::default(), &opts(), Utc::now());
+        for glyph in ['↑', '→', '↓'] {
+            assert!(!out.tooltip.contains(glyph), "{}", out.tooltip);
+        }
     }
 }

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -10,7 +10,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
 use crate::usage::{OpenAiSnapshot, OpenAiSource, UsageWindow};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -197,27 +197,13 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     if let Some(session) = snap.session.as_ref() {
-        push_window(
-            &mut lines,
-            "  󰔟  Codex 5h",
-            session,
-            theme,
-            now,
-            WindowRow::default(),
-        );
+        push_window(&mut lines, "  󰔟  Codex 5h", session, theme, now, None);
     }
     if let Some(weekly) = snap.weekly.as_ref() {
         if snap.session.is_some() {
             lines.push(TooltipLine::Body("".into()));
         }
-        push_window(
-            &mut lines,
-            "  󰃰  Codex weekly",
-            weekly,
-            theme,
-            now,
-            WindowRow::default(),
-        );
+        push_window(&mut lines, "  󰃰  Codex weekly", weekly, theme, now, None);
     }
     if snap.session.is_none() && snap.weekly.is_none() {
         lines.push(TooltipLine::Body(format!(
@@ -233,7 +219,7 @@ fn render_tooltip(
             cr,
             theme,
             now,
-            WindowRow::default(),
+            None,
         );
     }
 
@@ -471,8 +457,9 @@ mod tests {
         assert_eq!(severity(&s), PaceSeverity::Critical);
     }
 
-    /// Codex was left out of the tooltip pace change on purpose; reworking the
-    /// shared helper must not have handed it an arrow.
+    /// Codex was left out of the tooltip pace change on purpose. It calls the
+    /// stable `push_window`, so the glyph the row helper learned must not leak
+    /// through that path.
     #[test]
     fn tooltip_rows_carry_no_pace_glyph() {
         let s = sample();

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -11,6 +11,7 @@
 use chrono::{DateTime, Utc};
 
 use crate::countdown;
+use crate::pacing;
 use crate::pango::{self, escape, severity_color, severity_for, visible_width};
 use crate::theme::Theme;
 use crate::usage::UsageWindow;
@@ -25,31 +26,85 @@ pub enum Line {
     Sep,
 }
 
+/// Optional decorations for a [`push_window`] row. `Default` reproduces the
+/// plain row every vendor drew before pacing reached the tooltip: bar +
+/// percentage, then `⏱  Resets in …`.
+///
+/// `glyph` and `detail` are inserted into Pango markup as-is, so a caller
+/// passing anything vendor-reported must [`escape`] it first.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WindowRow<'a> {
+    /// Elapsed-time marker drawn inside the bar (`--tooltip-pace-pts`).
+    pub marker_pct: Option<i32>,
+    /// Pace glyph appended after the bold percentage (`↑` / `→` / `↓`).
+    pub glyph: Option<&'static str>,
+    /// Extra dim text appended to the reset line — Kimi's `2 / 100` counters,
+    /// which the bar's percentage summarises but does not spell out.
+    pub detail: Option<&'a str>,
+}
+
+impl<'a> WindowRow<'a> {
+    /// The Anthropic tooltip's pace convention in one place (mirrors
+    /// `widget::render::pick_pace_glyph`): the ratio glyph by default, and with
+    /// `point_mode` (`--tooltip-pace-pts`) the point-delta glyph plus the
+    /// elapsed marker inside the bar.
+    ///
+    /// A window with no reported reset degrades to `pacing::Pacing::neutral()`,
+    /// so it still gets a `→` rather than a blank where every sibling row has
+    /// a glyph.
+    pub fn paced(w: &UsageWindow, now: DateTime<Utc>, tolerance: u32, point_mode: bool) -> Self {
+        let p = pacing::calc(
+            w.utilization_pct,
+            w.resets_at,
+            now,
+            w.window_duration,
+            tolerance,
+        );
+        Self {
+            marker_pct: point_mode.then_some(p.elapsed_pct),
+            glyph: Some(if point_mode {
+                p.point_pace.glyph()
+            } else {
+                p.ratio_pace.glyph()
+            }),
+            detail: None,
+        }
+    }
+
+    /// Same row, carrying an extra dim fragment on the reset line.
+    pub fn with_detail(self, detail: &'a str) -> Self {
+        Self {
+            detail: Some(detail),
+            ..self
+        }
+    }
+}
+
 /// Append the standard three-line block every vendor uses for a usage window:
 /// icon + label, progress bar + bold percentage, then the dim reset countdown.
-///
-/// `elapsed` draws the pace marker inside the bar; pass `None` for a plain bar.
 pub fn push_window(
     lines: &mut Vec<Line>,
     label: &str,
     w: &UsageWindow,
     theme: &Theme,
     now: DateTime<Utc>,
-    elapsed: Option<i32>,
+    row: WindowRow<'_>,
 ) {
     let color = severity_color(severity_for(w.utilization_pct), theme);
-    let bar = pango::progress_bar(w.utilization_pct, color, theme, elapsed);
+    let bar = pango::progress_bar(w.utilization_pct, color, theme, row.marker_pct);
     let fg = &theme.fg;
     let dim = &theme.dim;
+    let glyph = row.glyph.map(|g| format!(" {g}")).unwrap_or_default();
+    let detail = row.detail.map(|d| format!(" · {d}")).unwrap_or_default();
     lines.push(Line::Body(format!(
         " <span foreground='{fg}'>{label}</span>"
     )));
     lines.push(Line::Body(format!(
-        "   {bar}  <span font_weight='bold' foreground='{color}'>{pct}%</span>",
+        "   {bar}  <span font_weight='bold' foreground='{color}'>{pct}%{glyph}</span>",
         pct = w.utilization_pct
     )));
     lines.push(Line::Body(format!(
-        " <span foreground='{dim}'>  ⏱  Resets in {cd}</span>",
+        " <span foreground='{dim}'>  ⏱  Resets in {cd}{detail}</span>",
         cd = escape(&countdown::format(w.resets_at, now))
     )));
 }
@@ -182,5 +237,88 @@ mod tests {
         // The separator should reach the inner width of the box (just check
         // that it contains the unicode dash glyph repeated).
         assert!(out.contains("─"));
+    }
+
+    fn at(h: u32) -> DateTime<Utc> {
+        use chrono::TimeZone;
+        Utc.with_ymd_and_hms(2026, 8, 25, h, 0, 0).unwrap()
+    }
+
+    /// One five-hour window `resets_in` hours from `at(12)`.
+    fn window(pct: i32, resets_in: i64) -> UsageWindow {
+        UsageWindow {
+            utilization_pct: pct,
+            resets_at: Some(at(12) + chrono::Duration::hours(resets_in)),
+            window_duration: chrono::Duration::hours(5),
+        }
+    }
+
+    fn row_markup(w: &UsageWindow, row: WindowRow<'_>) -> String {
+        let mut lines = Vec::new();
+        push_window(&mut lines, "  L", w, &theme(), at(12), row);
+        render_bordered(&lines, &theme())
+    }
+
+    /// Every vendor that has not opted into pacing still renders the original
+    /// row; `WindowRow::default()` is what keeps that output untouched.
+    #[test]
+    fn a_default_row_stays_the_plain_bar_percent_and_reset() {
+        let out = row_markup(&window(40, 2), WindowRow::default());
+        assert!(out.contains("40%"), "{out}");
+        assert!(out.contains("Resets in 2h 00m"), "{out}");
+        assert!(
+            !out.contains('↑') && !out.contains('→') && !out.contains('↓'),
+            "an unpaced row must not grow a glyph: {out}"
+        );
+        assert!(!out.contains(" · "), "an unpaced row has no detail: {out}");
+    }
+
+    /// Mirrors the Anthropic tooltip: the ratio glyph always, the elapsed
+    /// marker only behind `--tooltip-pace-pts`.
+    #[test]
+    fn paced_rows_keep_the_marker_behind_point_mode() {
+        // 3h left of a 5h window → 40% elapsed, matched by 40% used.
+        let w = window(40, 3);
+        let ratio = WindowRow::paced(&w, at(12), pacing::DEFAULT_TOLERANCE, false);
+        assert_eq!(ratio.glyph, Some("→"));
+        assert_eq!(ratio.marker_pct, None);
+
+        let points = WindowRow::paced(&w, at(12), pacing::DEFAULT_TOLERANCE, true);
+        assert_eq!(points.glyph, Some("→"));
+        assert_eq!(points.marker_pct, Some(40));
+    }
+
+    /// The two modes disagree inside the tolerance band — the split `pacing`
+    /// documents, and the reason the glyph is picked from the mode.
+    #[test]
+    fn the_pace_modes_can_disagree_on_the_glyph() {
+        let w = window(42, 3); // 40% elapsed, 42% used
+        assert_eq!(WindowRow::paced(&w, at(12), 5, false).glyph, Some("→"));
+        assert_eq!(WindowRow::paced(&w, at(12), 5, true).glyph, Some("↑"));
+    }
+
+    /// A window the vendor reports without a reset still gets a glyph, so a
+    /// row never sits blank beside siblings that have one.
+    #[test]
+    fn a_window_without_a_reset_still_gets_the_neutral_glyph() {
+        let w = UsageWindow {
+            utilization_pct: 0,
+            resets_at: None,
+            window_duration: chrono::Duration::hours(5),
+        };
+        let row = WindowRow::paced(&w, at(12), 5, false);
+        assert_eq!(row.glyph, Some("→"));
+        assert_eq!(row.marker_pct, None);
+    }
+
+    #[test]
+    fn the_glyph_and_detail_reach_the_rendered_row() {
+        let w = window(40, 3);
+        let out = row_markup(
+            &w,
+            WindowRow::paced(&w, at(12), 5, false).with_detail("2 / 100"),
+        );
+        assert!(out.contains("40% →"), "{out}");
+        assert!(out.contains("Resets in 3h 00m · 2 / 100"), "{out}");
     }
 }

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -82,7 +82,33 @@ impl<'a> WindowRow<'a> {
 
 /// Append the standard three-line block every vendor uses for a usage window:
 /// icon + label, progress bar + bold percentage, then the dim reset countdown.
+///
+/// `elapsed` draws the pace marker inside the bar; pass `None` for a plain bar.
+/// Keep this signature stable for library callers — a row that also wants the
+/// pace glyph or a detail fragment goes through [`push_window_with_row`].
 pub fn push_window(
+    lines: &mut Vec<Line>,
+    label: &str,
+    w: &UsageWindow,
+    theme: &Theme,
+    now: DateTime<Utc>,
+    elapsed: Option<i32>,
+) {
+    push_window_with_row(
+        lines,
+        label,
+        w,
+        theme,
+        now,
+        WindowRow {
+            marker_pct: elapsed,
+            ..WindowRow::default()
+        },
+    );
+}
+
+/// [`push_window`], plus the optional decorations a [`WindowRow`] carries.
+pub fn push_window_with_row(
     lines: &mut Vec<Line>,
     label: &str,
     w: &UsageWindow,
@@ -255,7 +281,7 @@ mod tests {
 
     fn row_markup(w: &UsageWindow, row: WindowRow<'_>) -> String {
         let mut lines = Vec::new();
-        push_window(&mut lines, "  L", w, &theme(), at(12), row);
+        push_window_with_row(&mut lines, "  L", w, &theme(), at(12), row);
         render_bordered(&lines, &theme())
     }
 

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -9,7 +9,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
 use crate::usage::{UsageWindow, ZaiSnapshot};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -161,7 +161,7 @@ pub fn render(
     let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
         substitute(fmt, &values)
     } else {
-        render_tooltip(outcome, snap, theme, now)
+        render_tooltip(outcome, snap, theme, opts, now)
     };
 
     WaybarOutput {
@@ -175,10 +175,15 @@ fn render_tooltip(
     outcome: &VendorOutcome,
     snap: &ZaiSnapshot,
     theme: &Theme,
+    opts: &RenderOpts,
     now: DateTime<Utc>,
 ) -> String {
     let blue = &theme.blue;
     let dim = &theme.dim;
+    // The `{zai_*_pace}` placeholders already carry this; the default tooltip
+    // never consulted them, so the arrow the macOS bar draws was missing here.
+    let row =
+        |w: &UsageWindow| WindowRow::paced(w, now, opts.pace_tolerance, opts.tooltip_pace_pts);
     let mut lines: Vec<TooltipLine> = Vec::new();
     lines.push(TooltipLine::Center(format!(
         "<span font_weight='bold' foreground='{blue}'>{plan}</span>",
@@ -188,18 +193,25 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     if let Some(w) = snap.session.as_ref() {
-        push_window(&mut lines, "  󰔟  Session (5h)", w, theme, now, None);
+        push_window(&mut lines, "  󰔟  Session (5h)", w, theme, now, row(w));
     }
     if let Some(w) = snap.weekly.as_ref() {
         if snap.session.is_some() {
             lines.push(TooltipLine::Body("".into()));
         }
-        push_window(&mut lines, "  󰃰  Weekly", w, theme, now, None);
+        push_window(&mut lines, "  󰃰  Weekly", w, theme, now, row(w));
     }
     if let Some(w) = snap.mcp.as_ref() {
         lines.push(TooltipLine::Body("".into()));
         lines.push(TooltipLine::Sep);
-        push_window(&mut lines, "  󰓹  MCP tools (monthly)", w, theme, now, None);
+        push_window(
+            &mut lines,
+            "  󰓹  MCP tools (monthly)",
+            w,
+            theme,
+            now,
+            row(w),
+        );
     }
     if snap.session.is_none() && snap.weekly.is_none() && snap.mcp.is_none() {
         lines.push(TooltipLine::Body(format!(
@@ -473,5 +485,76 @@ mod tests {
         o.tooltip_format = Some("S:{zai_session_pct} W:{zai_weekly_pct}".into());
         let out = render(&oc, &snap, &Theme::default(), &o, Utc::now());
         assert_eq!(out.tooltip, "S:42 W:15");
+    }
+
+    fn fixed_now() -> DateTime<Utc> {
+        use chrono::TimeZone;
+        Utc.with_ymd_and_hms(2026, 8, 25, 12, 0, 0).unwrap()
+    }
+
+    fn paced_snap() -> ZaiSnapshot {
+        let now = fixed_now();
+        ZaiSnapshot {
+            plan: "GLM Coding Pro".into(),
+            // 3h left of 5h → 40% elapsed against 80% used: clearly ahead.
+            session: Some(UsageWindow {
+                utilization_pct: 80,
+                resets_at: Some(now + chrono::Duration::hours(3)),
+                window_duration: chrono::Duration::hours(5),
+            }),
+            // Reported without a reset — the case the user's own account hits.
+            weekly: Some(UsageWindow {
+                utilization_pct: 3,
+                resets_at: None,
+                window_duration: chrono::Duration::days(7),
+            }),
+            mcp: None,
+        }
+    }
+
+    /// The `{zai_*_pace}` placeholders have carried this since the pace PR; the
+    /// default tooltip never read them, so the CLI showed no arrow where the
+    /// macOS bar did.
+    #[test]
+    fn tooltip_shows_the_pace_arrow_next_to_each_percentage() {
+        let snap = paced_snap();
+        let out = render(
+            &outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            fixed_now(),
+        );
+        assert!(out.tooltip.contains("80% ↑"), "{}", out.tooltip);
+        // No reset reported → neutral pacing rather than a blank column.
+        assert!(out.tooltip.contains("3% →"), "{}", out.tooltip);
+    }
+
+    /// The elapsed marker stays opt-in, exactly as on the Anthropic tooltip.
+    #[test]
+    fn the_elapsed_marker_stays_behind_tooltip_pace_pts() {
+        let snap = paced_snap();
+        let plain = render(
+            &outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            fixed_now(),
+        );
+        let paced = render(
+            &outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &RenderOpts {
+                tooltip_pace_pts: true,
+                ..opts()
+            },
+            fixed_now(),
+        );
+        assert_ne!(
+            plain.tooltip, paced.tooltip,
+            "the marker should redraw the bars"
+        );
+        assert!(paced.tooltip.contains("80% ↑"), "{}", paced.tooltip);
     }
 }

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -9,7 +9,7 @@ use crate::format::{placeholders, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
-use crate::tooltip::{Line as TooltipLine, WindowRow, push_window, render_bordered};
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
 use crate::usage::{UsageWindow, ZaiSnapshot};
 use crate::vendor::{RenderOpts, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
@@ -193,18 +193,18 @@ fn render_tooltip(
     lines.push(TooltipLine::Body("".into()));
 
     if let Some(w) = snap.session.as_ref() {
-        push_window(&mut lines, "  󰔟  Session (5h)", w, theme, now, row(w));
+        push_window_with_row(&mut lines, "  󰔟  Session (5h)", w, theme, now, row(w));
     }
     if let Some(w) = snap.weekly.as_ref() {
         if snap.session.is_some() {
             lines.push(TooltipLine::Body("".into()));
         }
-        push_window(&mut lines, "  󰃰  Weekly", w, theme, now, row(w));
+        push_window_with_row(&mut lines, "  󰃰  Weekly", w, theme, now, row(w));
     }
     if let Some(w) = snap.mcp.as_ref() {
         lines.push(TooltipLine::Body("".into()));
         lines.push(TooltipLine::Sep);
-        push_window(
+        push_window_with_row(
             &mut lines,
             "  󰓹  MCP tools (monthly)",
             w,

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -37,3 +37,38 @@ fn pace_placeholder_builders_keep_their_two_argument_api() {
         "25"
     );
 }
+
+/// The macOS menu bar reads Z.AI's MCP pool through these three placeholders in
+/// its `--format` string (`macos/ai-usagebar-menubar.swift`, fields 31-33).
+/// Renaming one here would silently drop that row, so pin the names — and pin
+/// the `—` an absent pool reports, which is the presence signal the Swift
+/// parser keys off to avoid painting a phantom 0% row.
+#[test]
+fn the_zai_mcp_placeholders_the_macos_menu_bar_reads_keep_their_names() {
+    let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+    let mcp = UsageWindow {
+        utilization_pct: 7,
+        resets_at: Some(now + chrono::Duration::days(24)),
+        window_duration: chrono::Duration::days(30),
+    };
+    let with_mcp = ZaiSnapshot {
+        plan: "GLM Coding Pro".into(),
+        session: None,
+        weekly: None,
+        mcp: Some(mcp),
+    };
+    let v = zai_vendor::build_placeholders(&with_mcp, now);
+    assert_eq!(v["zai_mcp_pct"], "7");
+    assert_eq!(v["zai_mcp_reset"], "24d 0h");
+    assert_eq!(v["zai_mcp_elapsed"], "20");
+
+    let without_mcp = ZaiSnapshot {
+        mcp: None,
+        ..with_mcp
+    };
+    let v = zai_vendor::build_placeholders(&without_mcp, now);
+    assert_eq!(
+        v["zai_mcp_reset"], "—",
+        "an absent pool must stay distinguishable from a real 0% one"
+    );
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,6 +1,8 @@
 //! Source-compatibility checks for renderer helpers used by library consumers.
 
 use ai_usagebar::minimax::vendor as minimax_vendor;
+use ai_usagebar::theme::Theme;
+use ai_usagebar::tooltip::{self, WindowRow};
 use ai_usagebar::usage::{MinimaxSnapshot, UsageWindow, ZaiSnapshot};
 use ai_usagebar::zai::vendor as zai_vendor;
 use chrono::{TimeZone, Utc};
@@ -71,4 +73,45 @@ fn the_zai_mcp_placeholders_the_macos_menu_bar_reads_keep_their_names() {
         v["zai_mcp_reset"], "—",
         "an absent pool must stay distinguishable from a real 0% one"
     );
+}
+
+/// `push_window` is the shared tooltip row helper. Its sixth argument stayed an
+/// `Option<i32>` marker when the row gained a pace glyph and a detail fragment:
+/// those live on `WindowRow` behind `push_window_with_row`, so a library caller
+/// written against the original six-argument form still compiles.
+#[test]
+fn push_window_keeps_its_option_marker_api() {
+    let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();
+    let window = UsageWindow {
+        utilization_pct: 40,
+        resets_at: Some(now + chrono::Duration::hours(3)),
+        window_duration: chrono::Duration::hours(5),
+    };
+    let theme = Theme::default();
+
+    let mut plain = Vec::new();
+    tooltip::push_window(&mut plain, "  L", &window, &theme, now, None);
+    let plain = tooltip::render_bordered(&plain, &theme);
+
+    // The delegate must be indistinguishable from the row form it forwards to.
+    let mut forwarded = Vec::new();
+    tooltip::push_window_with_row(
+        &mut forwarded,
+        "  L",
+        &window,
+        &theme,
+        now,
+        WindowRow::default(),
+    );
+    assert_eq!(plain, tooltip::render_bordered(&forwarded, &theme));
+
+    // And it must not have grown a glyph behind its callers' backs.
+    for glyph in ['\u{2191}', '\u{2192}', '\u{2193}'] {
+        assert!(!plain.contains(glyph), "{plain}");
+    }
+
+    // The marker argument still reaches the bar.
+    let mut marked = Vec::new();
+    tooltip::push_window(&mut marked, "  L", &window, &theme, now, Some(40));
+    assert_ne!(plain, tooltip::render_bordered(&marked, &theme));
 }


### PR DESCRIPTION
Three tooltip defects with one shared cause, plus the macOS field that was missing for Z.AI's third pool.

`tooltip::push_window` could not express anything beyond a bar and a percentage, so vendors that needed more hand-rolled their rows and drifted from the house layout.

## Kimi drew no bar

Kimi counts requests rather than reporting a percentage, so it printed bare `26 / 100  (26%)` pairs with no bar — while its own TUI panel and `usage --json` projection have always treated the same numbers as a gauge (`tui::panels::kimi_sections` → `push_metric`). Both quotas now go through the shared helper: the percentage is already there, the counters ride the reset line so nothing reported is lost, and the rolling window picks up the `(5h)` label the TUI uses.

```
   󰅄  Weekly quota                              󰅄  Weekly quota
   26 / 100  (26%)                  →           ░░░░░░░░░░░░░░░░░░░░  26%
      74 remaining · reset 4d 0h                ⏱  Resets in 4d 0h · 26 / 100
```

Its bar text follows the `{pct}% · {reset}` shape every other percentage vendor uses (`{kimi_weekly_pct}% · {kimi_weekly_reset}`, was a bare `{kimi_weekly_pct}%`). MiniMax called the helper for nothing either, printing a `Session 20%` pair per pool; its rows are `UsageWindow`s already, so they move over as-is under the existing pool headings.

## The pace arrow never reached the tooltip

`{zai_*_pace}` and `{minimax_*_pace}` have carried the glyph since 1.3.0 and the macOS menu bar renders it, but the default tooltip never consulted them — only the Anthropic renderer drew an arrow, hand-rolled in `widget::render`. `WindowRow::paced` puts that convention in one place: the ratio glyph by default, the point-delta glyph plus the elapsed marker behind `--tooltip-pace-pts`. A window reported without a reset degrades to neutral pacing, so it shows `→` rather than a blank beside its siblings.

Codex and Antigravity are deliberately unchanged.

## `push_window` keeps its signature

The glyph initially arrived by changing `push_window`'s sixth argument — the same break this repo already walked back once in 2f52a62, where `build_placeholders` was restored to its two-argument form with the tolerance-aware variant moved behind it and a guard test added.

Same shape applied here: `push_window` keeps `elapsed: Option<i32>` and forwards to the new `push_window_with_row`, which takes the `WindowRow` carrying the optional glyph and detail. The new public surface is purely additive. The Codex and Antigravity call sites are untouched as a result — their diff is only a regression test proving no glyph leaks through the stable path.

## macOS: Z.AI's MCP-tools pool

Z.AI reports a third quota that the widget, TUI and native panels have always listed. The menu bar never did: its `--format` contract had no field for it. The Swift model's fourth-window slot — built for Antigravity's second pool, rendered from a free-form label — takes it as-is, so the only new surface is three format fields (31-33). The pace marker follows for free: `{zai_mcp_elapsed}` is already populated and the pool's window is a real 30 days.

The presence check keys off the reset, not the percentage: `{zai_mcp_pct}` flattens an account with no MCP quota to `0`, so keying on it would paint a phantom 0% row for every Z.AI user without the pool. An older binary that does not know `{zai_mcp_*}` leaves the placeholders literal and degrades the same way.

## Tests

- `src/tooltip.rs` — the default row is byte-identical to the old output; the two pace modes and their disagreement inside the tolerance band; a window with no reset still gets a glyph.
- Per vendor — Kimi draws two bars and keeps its counts and carries no glyph; Z.AI and MiniMax show the arrow and keep the marker opt-in; Codex and Antigravity carry no glyph.
- `tests/public_api.rs` — pins `push_window`'s six-argument form and asserts the delegate renders identically to `WindowRow::default()`; pins the three `{zai_mcp_*}` placeholder names, since renaming one would drop the row from the menu bar with nothing failing.
- `macos/ai-usagebar-tests.swift` — pool present, account without MCP, older binary, and another vendor's fields at those indices not conjuring the row.

`make test` (1119 lib + 3 `public_api` + the GNOME, KDE and Omarchy contract suites), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean. The Swift change was reviewed by hand — no Swift toolchain was available in the authoring environment — so the macOS CI job is its first real compile.

No version bump, `.SRCINFO` or PKGBUILD change: this is not a release. `cargo machete` was not run (not installed); no dependency was added or removed.
