### PR TITLE
feat(commandcode): add Command Code as a vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,11 @@ Each release is also published at
   the 5-hour and weekly rolling spend windows — priced in dollars, as Command
   Code meters spend rather than tokens — plus the plan and the monthly credit
   remaining. Like Cursor and Kiro CLI it needs no key of its own: it reuses the
-  OAuth credential whichever local harness is already signed in
-  (`~/.commandcode/auth.json`, then omp's and pi's), with `COMMANDCODE_API_KEY`
-  as an override. The credential is only ever read — refreshing it belongs to
-  the CLI that owns the file — so an expired token is reported as expired
+  OAuth credential from either the official CLI or pi
+  (`~/.commandcode/auth.json`, then `~/.pi/agent/auth.json`), with
+  `COMMANDCODE_API_KEY` as an override. The credential is only ever read —
+  refreshing it belongs to the CLI that owns the file — so an expired token is
+  reported as expired
   rather than silently rewritten.
 
 ## [1.7.0] — 2026-08-25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Command Code** (`commandcode.ai`) is supported as a vendor, selectable with
+  `--vendor commandcode` and enabled with `[commandcode]` in config. It shows
+  the 5-hour and weekly rolling spend windows — priced in dollars, as Command
+  Code meters spend rather than tokens — plus the plan and the monthly credit
+  remaining. Like Cursor and Kiro CLI it needs no key of its own: it reuses the
+  OAuth credential from either the official CLI or pi
+  (`~/.commandcode/auth.json`, then `~/.pi/agent/auth.json`), with
+  `COMMANDCODE_API_KEY` as an override. The credential is only ever read —
+  refreshing it belongs to the CLI that owns the file — so an expired token is
+  reported as expired rather than silently rewritten.
+
 ### Fixed
 
 - Z.AI's rows in the native panels — Omarchy Quattro, GNOME, KDE and the TUI —
@@ -95,17 +108,6 @@ Each release is also published at
   value column shows the same `{pct}%` every other vendor shows instead of
   raw request counts; the counts move to the footnote next to the remaining
   figure and the reset countdown.
-- **Command Code** (`commandcode.ai`) is supported as a vendor, selectable with
-  `--vendor commandcode` and enabled with `[commandcode]` in config. It shows
-  the 5-hour and weekly rolling spend windows — priced in dollars, as Command
-  Code meters spend rather than tokens — plus the plan and the monthly credit
-  remaining. Like Cursor and Kiro CLI it needs no key of its own: it reuses the
-  OAuth credential from either the official CLI or pi
-  (`~/.commandcode/auth.json`, then `~/.pi/agent/auth.json`), with
-  `COMMANDCODE_API_KEY` as an override. The credential is only ever read —
-  refreshing it belongs to the CLI that owns the file — so an expired token is
-  reported as expired
-  rather than silently rewritten.
 
 ## [1.7.0] — 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Command Code** (`commandcode.ai`) is supported as a vendor, selectable with
+  `--vendor commandcode` and enabled with `[commandcode]` in config. It shows
+  the 5-hour and weekly rolling spend windows — priced in dollars, as Command
+  Code meters spend rather than tokens — plus the plan and the monthly credit
+  remaining. Like Cursor and Kiro CLI it needs no key of its own: it reuses the
+  OAuth credential whichever local harness is already signed in
+  (`~/.commandcode/auth.json`, then omp's and pi's), with `COMMANDCODE_API_KEY`
+  as an override. The credential is only ever read — refreshing it belongs to
+  the CLI that owns the file — so an expired token is reported as expired
+  rather than silently rewritten.
+
 ## [1.7.0] — 2026-08-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,19 +13,25 @@ When cutting a new version (patch, minor, or major):
    - Add a new `## [X.Y.Z] — YYYY-MM-DD` section above the previous one.
    - Categorize entries by **Added / Changed / Fixed / Security** (Keep-A-Changelog).
    - Update the `[Unreleased]` compare link and add a new release link at the bottom.
-   - **Prove no published section moved**, before tagging:
+   - **Prove no published section moved**, before tagging. Compare the newest
+     released section against its own tag, byte for byte:
      ```
-     git diff <previous-tag> HEAD -- CHANGELOG.md | grep '^-' | grep -v '^---' \
-       | grep -v '^-\[Unreleased\]:'
+     prev=$(git describe --tags --abbrev=0)
+     diff <(git show "$prev:CHANGELOG.md" | sed -n "/^## \[${prev#v}\]/,/^## \[/p") \
+          <(sed -n "/^## \[${prev#v}\]/,/^## \[/p" CHANGELOG.md)
      ```
-     The `[Unreleased]:` compare link is excluded because it legitimately
-     changes every release; a check that fires every time gets ignored, which
-     is worse than no check. Any *other* output means an already-released
-     section changed. A PR branched before the last tag carries its entries
-     under `[Unreleased]`, and git merges them *cleanly* into whatever now
-     sits at that position — which is the section you just published. It
-     happened to v1.6.0 (#127's entries landed in it after release) and was
-     caught only by this diff. A clean merge is not evidence here; the diff is.
+     Any output means the released section changed. **It must compare, not
+     grep for removals.** The first version of this check greped `^-` and
+     therefore only caught a *rewritten* entry; #129 branched before v1.8.0 and
+     its `[Unreleased]` bullet merged in as a pure *insertion*, adding a feature
+     to a shipped release with no removed line for the grep to find. It passed
+     clean while the section was wrong.
+
+     The cause is the same both times: a PR branched before the last tag
+     carries its entries under `[Unreleased]`, and git merges them *cleanly*
+     into whatever now sits at that position — which is the section you just
+     published. It happened to v1.6.0 (#127) and again to v1.8.0 (#129). A
+     clean merge is not evidence here; the comparison is.
 3. **Bump `packaging/aur/PKGBUILD`** — `pkgver=X.Y.Z`, `pkgrel=1`, reset `sha256sums` to `'SKIP'`.
 4. **Bump `packaging/aur/PKGBUILD-bin`** — same `pkgver`, `pkgrel=1`, reset both
    `sha256sums_x86_64` and `sha256sums_aarch64` to `'SKIP'`.

--- a/README.md
+++ b/README.md
@@ -261,10 +261,10 @@ the bar and the meters show are derived from those figures.
 Command Code appears in the provider selector but not in the key list, the same
 way Claude, Codex, Cursor and Kiro do — enable `[commandcode]` and it works.
 
-Credentials are reused, never issued. Whichever local harness is signed in
-supplies the OAuth token — `~/.commandcode/auth.json` from the official CLI
-first, then `~/.omp/agent/auth.json`, then `~/.pi/agent/auth.json` — and
-`COMMANDCODE_API_KEY` outranks all three. **The token is only ever read.**
+Credentials are reused, never issued. The OAuth token comes from
+`~/.commandcode/auth.json` from the official CLI first, then
+`~/.pi/agent/auth.json`; `COMMANDCODE_API_KEY` outranks both. **The token is
+only ever read.**
 Refreshing it belongs to the CLI that owns the file, and writing back from here
 would race the harnesses that share it; an expired token is reported as expired
 instead. Set `[commandcode] auth_paths` to search somewhere else entirely.

--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ priced in dollars: `$1.23 of $14.00` for the 5-hour window and `$5.24 of $35.00`
 for the weekly one, alongside the monthly credit that is left. The percentages
 the bar and the meters show are derived from those figures.
 
+**There is no key to enter, and no key field in the settings panel.**
+Command Code appears in the provider selector but not in the key list, the same
+way Claude, Codex, Cursor and Kiro do — enable `[commandcode]` and it works.
+
 Credentials are reused, never issued. Whichever local harness is signed in
 supplies the OAuth token — `~/.commandcode/auth.json` from the official CLI
 first, then `~/.omp/agent/auth.json`, then `~/.pi/agent/auth.json` — and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-usagebar
 
-Native Omarchy Quattro panel, Waybar widget, and tabbed TUI for AI plan usage across **Claude**, **Codex/ChatGPT**, **Z.AI (GLM)**, **OpenRouter**, **DeepSeek**, **Kimi**, **Nous Research**, **OpenCode Go**, and other supported AI coding services.
+Native Omarchy Quattro panel, Waybar widget, and tabbed TUI for AI plan usage across **Claude**, **Codex/ChatGPT**, **Z.AI (GLM)**, **OpenRouter**, **DeepSeek**, **Kimi**, **Nous Research**, **OpenCode Go**, **Command Code**, and other supported AI coding services.
 
 ai-usagebar began as a Rust port of
 [`claudebar`](https://github.com/mryll/claudebar) and remains drop-in
@@ -223,6 +223,7 @@ come from environment variables or `config.toml`.
 | Kiro CLI | Existing kiro-cli login | Opt in and run `kiro-cli login` once. ai-usagebar refreshes the session when needed. |
 | Nous Research | OAuth device flow | Enable `[nous]`, click **Log in with Nous Research** in the Omarchy settings panel, or run `ai-usagebar auth nous login`. Credentials are kept in ai-usagebar's separate platform config directory (`~/.config/ai-usagebar/credentials.json` on Linux). |
 | OpenCode Go | API key (`OPENCODE_GO_API_KEY` env or `[opencode-go] api_key` in config) | Enable `[opencode-go]`, then enter the key in the Omarchy settings panel or set the environment variable. |
+| Command Code | Existing `commandcode`, pi, or omp login | Enable `[commandcode]` and sign in to any one of them once. No key to paste; `COMMANDCODE_API_KEY` overrides if you prefer one. |
 
 ### Nous credits and OpenCode Go
 
@@ -245,6 +246,27 @@ be entered through the native Settings panel; stored values are sent to the Rust
 settings command over stdin and are never placed in QML command arguments. Cache
 entries are tied to the endpoint and a one-way key fingerprint, so changing
 accounts cannot reuse another account's fresh or stale usage.
+
+### Command Code
+
+Command Code meters spend rather than tokens, so its two rolling windows are
+priced in dollars: `$1.23 of $14.00` for the 5-hour window and `$5.24 of $35.00`
+for the weekly one, alongside the monthly credit that is left. The percentages
+the bar and the meters show are derived from those figures.
+
+Credentials are reused, never issued. Whichever local harness is signed in
+supplies the OAuth token — `~/.commandcode/auth.json` from the official CLI
+first, then `~/.omp/agent/auth.json`, then `~/.pi/agent/auth.json` — and
+`COMMANDCODE_API_KEY` outranks all three. **The token is only ever read.**
+Refreshing it belongs to the CLI that owns the file, and writing back from here
+would race the harnesses that share it; an expired token is reported as expired
+instead. Set `[commandcode] auth_paths` to search somewhere else entirely.
+
+The plan's monthly allowance is not reported by the API, so a small table maps
+the plan id to it (GOAT → $70, and so on). An unrecognised plan keeps its id
+and simply omits the "spent of allowance" line rather than inventing a
+denominator. Cache entries are tied to the endpoint and a one-way token
+fingerprint, so changing accounts cannot reuse another account's usage.
 
 #### Grok: team-scoped vs organization-scoped keys
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -292,6 +292,20 @@ enabled = false
 
 # OpenCode Go — usage from /zen/go/v1/usage. Opt in only after exporting the
 # API key under this variable; the key itself is never written to this example.
+[commandcode]
+# Command Code (commandcode.ai). Disabled by default — enable it once any
+# local agent harness is signed in. There is no key to paste: the OAuth
+# credential written by the official `commandcode` CLI is reused as-is, and
+# it is only ever read, never refreshed or rewritten.
+enabled = false
+# Override where the credential is looked for. Leave commented out to search,
+# in order:
+#   ~/.commandcode/auth.json   (official command-code CLI)
+#   ~/.omp/agent/auth.json
+#   ~/.pi/agent/auth.json
+# COMMANDCODE_API_KEY in the environment outranks all of them.
+# auth_paths = ["~/.commandcode/auth.json"]
+
 [opencode-go]
 enabled = false
 api_key_env = "OPENCODE_GO_API_KEY"

--- a/config.example.toml
+++ b/config.example.toml
@@ -301,9 +301,8 @@ enabled = false
 # Override where the credential is looked for. Leave commented out to search,
 # in order:
 #   ~/.commandcode/auth.json   (official command-code CLI)
-#   ~/.omp/agent/auth.json
 #   ~/.pi/agent/auth.json
-# COMMANDCODE_API_KEY in the environment outranks all of them.
+# COMMANDCODE_API_KEY in the environment outranks both.
 # auth_paths = ["~/.commandcode/auth.json"]
 
 [opencode-go]

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -24,6 +24,7 @@ defensive and includes opt-in live tests for catching response changes.
 | **Kiro CLI** | `codewhisperer.<region>.amazonaws.com` `GetUsageLimits` (undocumented; the same call kiro-cli's own `/usage` slash command makes) | Single credit pool this cycle — used/limit/%, plan, reset | No — widget/TUI only |
 | **Nous Research** | `portal.nousresearch.com/api/oauth/account` (OAuth-authenticated Portal account response) | Subscription usage %, subscription credits, top-up/purchased credits, total usable credits, renewal | Yes |
 | **OpenCode Go** | `opencode.ai/zen/go/v1/usage` | Rolling, weekly, and monthly `percent` windows with absolute reset timestamps | Yes |
+| **Command Code** | `api.commandcode.ai` `/alpha/billing/credits` + `/alpha/billing/subscriptions` (undocumented; the same calls the official `commandcode` CLI's `/usage` makes) | 5-hour and weekly rolling spend windows ($ used of $ cap), plan, and remaining monthly credits | No — widget/TUI only |
 
 
 ## Stability notes
@@ -37,6 +38,7 @@ defensive and includes opt-in live tests for catching response changes.
 | Cursor | Undocumented endpoint called by Cursor's dashboard. Its shape may change with Cursor pricing. |
 | MiniMax | The Token Plan route is official, but no formal response schema is published. |
 | Kiro CLI | `GetUsageLimits` is the same undocumented CodeWhisperer operation used by kiro-cli's `/usage` command. AWS SSO OIDC `CreateToken`, used for refresh, is documented. |
+| Command Code | Undocumented `/alpha/*` routes called by the official `commandcode` CLI. The `alpha` path segment is the vendor's own signal that these may move. Windows are read by name (`fiveHour`, `weekly`) rather than by position, and `windowLimits` is accepted both at the top level and beside the ledger, so the most likely reshuffles are already tolerated. |
 
 Codex's known five-hour and seven-day windows are matched by their reported
 duration, not by `primary_window` or `secondary_window` position. This handles
@@ -51,7 +53,8 @@ make smoke
 ```
 
 Claude, Codex, Z.AI, and OpenRouter tests require their normal credentials or
-API keys. Kimi is optional: its test prints a skip reason when `KIMI_API_KEY` is
+API keys. Command Code needs no key of its own — it reuses whichever local
+agent harness is signed in, and skips when none is. Kimi is optional: its test prints a skip reason when `KIMI_API_KEY` is
 unset.
 
 To test only Kimi:

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -70,6 +70,12 @@ rather than argv or the environment. Leave a field blank to keep its current
 value, or use its clear button to remove an inline key. Saving a new key also
 enables that provider, matching the terminal overlay.
 
+Not every provider has a key field, and a missing one is not an omission.
+Claude, Codex, Cursor, Kiro, Antigravity, and Command Code authenticate through
+a login that already exists on the machine, so they appear in the provider
+selector but never in the key list — enable them in `config.toml` and they work
+with nothing to paste.
+
 Existing installations need no migration: `config.toml`, environment-variable
 precedence, the TUI, Waybar, macOS, and Windows behavior are unchanged. If the
 plugin is updated before the `ai-usagebar` package, the form offers the terminal

--- a/src/active.rs
+++ b/src/active.rs
@@ -117,6 +117,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "kiro" => Some(VendorId::Kiro),
         "nous" => Some(VendorId::NousResearch),
         "opencode-go" => Some(VendorId::OpenCodeGo),
+        "commandcode" => Some(VendorId::CommandCode),
         _ => None,
     }
 }

--- a/src/commandcode/creds.rs
+++ b/src/commandcode/creds.rs
@@ -1,0 +1,293 @@
+//! Locate the Command Code OAuth credential a local harness already holds.
+//!
+//! Command Code is reachable through several agent harnesses, and each files
+//! the same OAuth credential under its own key in its own file. This module
+//! reads them; it never writes. Refreshing an expired token belongs to the
+//! CLI that owns the file, and racing it here would corrupt state shared by
+//! every harness on the machine.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+use crate::cache::home_dir;
+use crate::error::{AppError, Result};
+
+/// Files searched in order; the first holding a live credential wins.
+pub const AUTH_FILES: &[&str] = &[
+    ".commandcode/auth.json", // official command-code CLI
+    ".omp/agent/auth.json",
+    ".pi/agent/auth.json",
+];
+
+/// Keys a harness may file the credential under.
+const CREDENTIAL_KEYS: &[&str] = &["command-code", "commandcode"];
+
+pub const SIGNED_OUT: &str =
+    "Command Code is not signed in. Run `commandcode` and sign in, or set COMMANDCODE_API_KEY.";
+pub const EXPIRED: &str = "Command Code sign-in expired. Run `commandcode` to sign in again.";
+
+/// A credential and where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Credential {
+    pub token: String,
+    pub source: String,
+}
+
+/// One candidate found on disk, before expiry is considered.
+struct Candidate {
+    token: String,
+    expires_ms: Option<i64>,
+}
+
+/// Default search paths, resolved against the OS home convention.
+pub fn default_paths() -> Result<Vec<PathBuf>> {
+    let home = home_dir()?;
+    Ok(AUTH_FILES.iter().map(|rel| home.join(rel)).collect())
+}
+
+/// Read whichever credential shape a harness wrote into `path`.
+///
+/// A missing or malformed file yields `None` rather than an error: one broken
+/// harness must not mask a working one further down the list.
+pub fn read_from(path: &Path) -> Option<Credential> {
+    let text = std::fs::read_to_string(path).ok()?;
+    let value: Value = serde_json::from_str(&text).ok()?;
+    let object = value.as_object()?;
+
+    let candidates = CREDENTIAL_KEYS
+        .iter()
+        .filter_map(|key| object.get(*key))
+        .chain(object.get("apiKey"))
+        .filter_map(candidate);
+
+    for found in candidates {
+        if found.expires_ms.is_some_and(is_past) {
+            continue;
+        }
+        return Some(Credential {
+            token: found.token,
+            source: path.display().to_string(),
+        });
+    }
+    None
+}
+
+/// Production resolver: the env override, then configured paths, then the
+/// platform defaults. Tests use [`resolve_from`], which takes both as inputs.
+pub fn resolve(configured: Option<&[PathBuf]>) -> Result<Credential> {
+    let paths = match configured {
+        Some(paths) if !paths.is_empty() => paths.to_vec(),
+        _ => default_paths()?,
+    };
+    resolve_from(std::env::var("COMMANDCODE_API_KEY").ok().as_deref(), &paths)
+}
+
+/// Resolve one credential from the environment, then each path in turn.
+pub fn resolve_from(env_key: Option<&str>, paths: &[PathBuf]) -> Result<Credential> {
+    if let Some(key) = env_key.map(str::trim).filter(|key| !key.is_empty()) {
+        return Ok(Credential {
+            token: key.to_string(),
+            source: "COMMANDCODE_API_KEY".to_string(),
+        });
+    }
+    for path in paths {
+        if let Some(credential) = read_from(path) {
+            return Ok(credential);
+        }
+    }
+    Err(AppError::Credentials(message_for(paths)))
+}
+
+/// Distinguish "never signed in" from "signed in, but the token lapsed" so the
+/// tooltip can tell the user which one to fix.
+fn message_for(paths: &[PathBuf]) -> String {
+    let any_expired = paths.iter().any(|path| {
+        std::fs::read_to_string(path)
+            .ok()
+            .and_then(|text| serde_json::from_str::<Value>(&text).ok())
+            .and_then(|value| {
+                let object = value.as_object()?.clone();
+                let found = CREDENTIAL_KEYS
+                    .iter()
+                    .filter_map(|key| object.get(*key))
+                    .chain(object.get("apiKey"))
+                    .filter_map(candidate)
+                    .any(|found| found.expires_ms.is_some_and(is_past));
+                Some(found)
+            })
+            .unwrap_or(false)
+    });
+    if any_expired { EXPIRED } else { SIGNED_OUT }.to_string()
+}
+
+fn candidate(value: &Value) -> Option<Candidate> {
+    if let Some(token) = value.as_str() {
+        let token = token.trim();
+        return (!token.is_empty()).then(|| Candidate {
+            token: token.to_string(),
+            expires_ms: None,
+        });
+    }
+    let object = value.as_object()?;
+    let token = ["access", "apiKey", "key"]
+        .iter()
+        .filter_map(|field| object.get(*field))
+        .filter_map(Value::as_str)
+        .map(str::trim)
+        .find(|token| !token.is_empty())?;
+    Some(Candidate {
+        token: token.to_string(),
+        expires_ms: object.get("expires").and_then(Value::as_i64),
+    })
+}
+
+fn is_past(expires_ms: i64) -> bool {
+    expires_ms > 0 && expires_ms <= chrono::Utc::now().timestamp_millis()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, name: &str, value: Value) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, serde_json::to_vec(&value).unwrap()).unwrap();
+        path
+    }
+
+    fn future_ms() -> i64 {
+        chrono::Utc::now().timestamp_millis() + 86_400_000
+    }
+
+    fn past_ms() -> i64 {
+        chrono::Utc::now().timestamp_millis() - 86_400_000
+    }
+
+    #[test]
+    fn reads_the_official_cli_oauth_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "auth.json",
+            serde_json::json!({
+                "command-code": {"type": "oauth", "access": "tok", "expires": future_ms()}
+            }),
+        );
+
+        assert_eq!(read_from(&path).unwrap().token, "tok");
+    }
+
+    #[test]
+    fn reads_the_pi_and_omp_oauth_shape() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "auth.json",
+            serde_json::json!({
+                "openai-codex": {"type": "oauth", "access": "other"},
+                "commandcode": {"type": "oauth", "access": "tok", "expires": future_ms()}
+            }),
+        );
+
+        assert_eq!(read_from(&path).unwrap().token, "tok");
+    }
+
+    #[test]
+    fn reads_a_legacy_plain_string_credential() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "auth.json",
+            serde_json::json!({"commandcode": "plain-token"}),
+        );
+
+        assert_eq!(read_from(&path).unwrap().token, "plain-token");
+    }
+
+    #[test]
+    fn an_expired_token_is_not_offered() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "auth.json",
+            serde_json::json!({
+                "command-code": {"type": "oauth", "access": "tok", "expires": past_ms()}
+            }),
+        );
+
+        assert!(read_from(&path).is_none());
+    }
+
+    #[test]
+    fn malformed_and_missing_files_are_skipped_not_fatal() {
+        let dir = tempfile::tempdir().unwrap();
+        let broken = dir.path().join("broken.json");
+        std::fs::write(&broken, "{not json").unwrap();
+
+        assert!(read_from(&broken).is_none());
+        assert!(read_from(&dir.path().join("absent.json")).is_none());
+    }
+
+    #[test]
+    fn env_key_outranks_every_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write(
+            dir.path(),
+            "auth.json",
+            serde_json::json!({"commandcode": {"access": "from-file"}}),
+        );
+
+        let credential = resolve_from(Some("from-env"), &[path]).unwrap();
+
+        assert_eq!(credential.token, "from-env");
+        assert_eq!(credential.source, "COMMANDCODE_API_KEY");
+    }
+
+    #[test]
+    fn a_stale_harness_does_not_mask_a_live_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = write(
+            dir.path(),
+            "stale.json",
+            serde_json::json!({
+                "command-code": {"access": "stale", "expires": past_ms()}
+            }),
+        );
+        let live = write(
+            dir.path(),
+            "live.json",
+            serde_json::json!({
+                "commandcode": {"access": "live", "expires": future_ms()}
+            }),
+        );
+
+        assert_eq!(resolve_from(None, &[stale, live]).unwrap().token, "live");
+    }
+
+    #[test]
+    fn all_expired_reports_expiry_and_nothing_reports_signed_out() {
+        let dir = tempfile::tempdir().unwrap();
+        let stale = write(
+            dir.path(),
+            "stale.json",
+            serde_json::json!({
+                "command-code": {"access": "stale", "expires": past_ms()}
+            }),
+        );
+
+        let expired = resolve_from(None, std::slice::from_ref(&stale)).unwrap_err();
+        assert!(expired.to_string().contains("expired"), "{expired}");
+
+        let absent = resolve_from(None, &[dir.path().join("absent.json")]).unwrap_err();
+        assert!(absent.to_string().contains("not signed in"), "{absent}");
+    }
+
+    #[test]
+    fn default_paths_cover_every_known_harness() {
+        let paths = default_paths().unwrap();
+
+        assert_eq!(paths.len(), AUTH_FILES.len());
+        assert!(paths[0].ends_with(".commandcode/auth.json"));
+    }
+}

--- a/src/commandcode/creds.rs
+++ b/src/commandcode/creds.rs
@@ -15,10 +15,15 @@ use crate::error::{AppError, Result};
 
 /// Files searched in order; the first holding a live credential wins.
 pub const AUTH_FILES: &[&str] = &[
-    ".commandcode/auth.json", // official command-code CLI
+    OFFICIAL_AUTH_FILE, // official command-code CLI
     ".omp/agent/auth.json",
     ".pi/agent/auth.json",
 ];
+
+/// The Command Code CLI's own file — the only one whose whole contents belong
+/// to Command Code. The others are shared harness keystores, which is why the
+/// unkeyed `apiKey` fallback below is scoped to this one.
+const OFFICIAL_AUTH_FILE: &str = ".commandcode/auth.json";
 
 /// Keys a harness may file the credential under.
 const CREDENTIAL_KEYS: &[&str] = &["command-code", "commandcode"];
@@ -55,10 +60,20 @@ pub fn read_from(path: &Path) -> Option<Credential> {
     let value: Value = serde_json::from_str(&text).ok()?;
     let object = value.as_object()?;
 
+    // `apiKey` is unkeyed, so it is only consulted in Command Code's own file,
+    // where the whole document is Command Code's. A harness keystore holds
+    // every provider the user has signed into — pi's `auth.json` is typed
+    // `Record<providerId, Credential>` and carries their Anthropic, OpenAI and
+    // OpenRouter credentials — so a key that names no provider must not be
+    // read out of one, whatever shape a future version gives it.
+    let generic = path
+        .ends_with(OFFICIAL_AUTH_FILE)
+        .then(|| object.get("apiKey"))
+        .flatten();
     let candidates = CREDENTIAL_KEYS
         .iter()
         .filter_map(|key| object.get(*key))
-        .chain(object.get("apiKey"))
+        .chain(generic)
         .filter_map(candidate);
 
     for found in candidates {
@@ -176,6 +191,36 @@ mod tests {
         );
 
         assert_eq!(read_from(&path).unwrap().token, "tok");
+    }
+
+    /// A harness keystore holds every provider the user signed into — pi types
+    /// its `auth.json` as `Record<providerId, Credential>` and carries their
+    /// Anthropic, OpenAI and OpenRouter credentials there. A key that names no
+    /// provider therefore must not be read out of one: only the provider-keyed
+    /// lookup applies, and only Command Code's own file may fall back to the
+    /// unkeyed `apiKey`.
+    #[test]
+    fn the_unkeyed_apikey_is_only_read_from_command_codes_own_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let body = serde_json::json!({ "apiKey": "another-providers-secret" });
+
+        let shared = dir.path().join(".pi/agent");
+        std::fs::create_dir_all(&shared).unwrap();
+        let shared = write(&shared, "auth.json", body.clone());
+        assert_eq!(
+            read_from(&shared),
+            None,
+            "an unkeyed apiKey in a shared harness keystore is not ours to read"
+        );
+
+        let own = dir.path().join(".commandcode");
+        std::fs::create_dir_all(&own).unwrap();
+        let own = write(&own, "auth.json", body);
+        assert_eq!(
+            read_from(&own).map(|c| c.token),
+            Some("another-providers-secret".to_string()),
+            "Command Code's own file still accepts a pasted key"
+        );
     }
 
     #[test]

--- a/src/commandcode/creds.rs
+++ b/src/commandcode/creds.rs
@@ -14,11 +14,7 @@ use crate::cache::home_dir;
 use crate::error::{AppError, Result};
 
 /// Files searched in order; the first holding a live credential wins.
-pub const AUTH_FILES: &[&str] = &[
-    OFFICIAL_AUTH_FILE, // official command-code CLI
-    ".omp/agent/auth.json",
-    ".pi/agent/auth.json",
-];
+pub const AUTH_FILES: &[&str] = &[OFFICIAL_AUTH_FILE, ".pi/agent/auth.json"];
 
 /// The Command Code CLI's own file — the only one whose whole contents belong
 /// to Command Code. The others are shared harness keystores, which is why the
@@ -122,11 +118,15 @@ fn message_for(paths: &[PathBuf]) -> String {
             .ok()
             .and_then(|text| serde_json::from_str::<Value>(&text).ok())
             .and_then(|value| {
-                let object = value.as_object()?.clone();
+                let object = value.as_object()?;
+                let generic = path
+                    .ends_with(OFFICIAL_AUTH_FILE)
+                    .then(|| object.get("apiKey"))
+                    .flatten();
                 let found = CREDENTIAL_KEYS
                     .iter()
                     .filter_map(|key| object.get(*key))
-                    .chain(object.get("apiKey"))
+                    .chain(generic)
                     .filter_map(candidate)
                     .any(|found| found.expires_ms.is_some_and(is_past));
                 Some(found)
@@ -224,7 +224,7 @@ mod tests {
     }
 
     #[test]
-    fn reads_the_pi_and_omp_oauth_shape() {
+    fn reads_the_pi_oauth_shape() {
         let dir = tempfile::tempdir().unwrap();
         let path = write(
             dir.path(),
@@ -326,13 +326,33 @@ mod tests {
 
         let absent = resolve_from(None, &[dir.path().join("absent.json")]).unwrap_err();
         assert!(absent.to_string().contains("not signed in"), "{absent}");
+
+        let shared_dir = dir.path().join(".pi/agent");
+        std::fs::create_dir_all(&shared_dir).unwrap();
+        let unrelated = write(
+            &shared_dir,
+            "auth.json",
+            serde_json::json!({
+                "apiKey": {"access": "other", "expires": past_ms()}
+            }),
+        );
+        let signed_out = resolve_from(None, &[unrelated]).unwrap_err();
+        assert!(
+            signed_out.to_string().contains("not signed in"),
+            "an unrelated expired apiKey must not be treated as Command Code: {signed_out}"
+        );
     }
 
     #[test]
-    fn default_paths_cover_every_known_harness() {
+    fn default_paths_only_include_verified_credential_files() {
         let paths = default_paths().unwrap();
 
+        assert_eq!(
+            AUTH_FILES,
+            &[".commandcode/auth.json", ".pi/agent/auth.json"]
+        );
         assert_eq!(paths.len(), AUTH_FILES.len());
-        assert!(paths[0].ends_with(".commandcode/auth.json"));
+        assert!(paths[0].ends_with(AUTH_FILES[0]));
+        assert!(paths[1].ends_with(AUTH_FILES[1]));
     }
 }

--- a/src/commandcode/fetch.rs
+++ b/src/commandcode/fetch.rs
@@ -1,0 +1,609 @@
+//! Fetch Command Code usage, with the same cache/lock discipline as every
+//! other vendor.
+//!
+//! The official CLI's `/usage` view is assembled from three calls: `whoami`
+//! names the org that scopes the rest, the credit ledger carries the balance
+//! and the rolling spend windows, and the subscription names the plan. Only
+//! the ledger is load-bearing — a failure anywhere else costs its own detail
+//! and nothing more.
+
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
+use crate::error::{AppError, Result};
+use crate::vendor::{MAX_BODY_BYTES, read_body_capped};
+
+use super::types::{Snapshot, apply_subscription, parse_credits};
+
+pub const BASE_URL: &str = "https://api.commandcode.ai";
+
+pub const WHOAMI_PATH: &str = "/alpha/whoami";
+pub const CREDITS_PATH: &str = "/alpha/billing/credits";
+pub const SUBSCRIPTIONS_PATH: &str = "/alpha/billing/subscriptions";
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+const SCHEMA_ERROR: &str = "Command Code usage response schema mismatch";
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub base: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            base: BASE_URL.to_string(),
+        }
+    }
+}
+
+impl Endpoints {
+    fn url(&self, path: &str) -> String {
+        format!("{}{path}", self.base.trim_end_matches('/'))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FetchOutcome {
+    pub snapshot: Snapshot,
+    pub stale: bool,
+    pub last_error: Option<(u16, String)>,
+    pub cache_age: Option<Duration>,
+}
+
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    token: &str,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+    let target = target_key(endpoints, token);
+
+    if let Some(bytes) = cache.fresh_payload(ttl)?
+        && let Ok(snapshot) = parse_cache(&bytes, &target)
+    {
+        return Ok(FetchOutcome {
+            snapshot,
+            stale: false,
+            last_error: cache.read_last_error(),
+            cache_age: cache.payload_age(),
+        });
+    }
+
+    match fetch_live(client, token, endpoints).await {
+        Ok(snapshot) => {
+            let body = serde_json::to_vec(&serde_json::json!({
+                "target": target,
+                "response": snapshot_repr(&snapshot),
+            }))?;
+            cache.write_payload(&body)?;
+            Ok(FetchOutcome {
+                snapshot,
+                stale: false,
+                last_error: None,
+                cache_age: Some(Duration::ZERO),
+            })
+        }
+        Err(error @ AppError::Transport(_)) => fallback_or_error(cache, None, &target, error),
+        Err(AppError::Http { status, .. }) => {
+            let message = status_message(status).to_string();
+            cache.mark_stale();
+            cache.write_last_error(status, &message);
+            fallback_or_error(
+                cache,
+                Some((status, message.clone())),
+                &target,
+                AppError::Http {
+                    status,
+                    body: message,
+                },
+            )
+        }
+        Err(AppError::Schema(_)) => {
+            let message = SCHEMA_ERROR.to_string();
+            cache.mark_stale();
+            cache.write_last_error(0, &message);
+            fallback_or_error(
+                cache,
+                Some((0, message.clone())),
+                &target,
+                AppError::Schema(message),
+            )
+        }
+        Err(error) => fallback_or_error(cache, None, &target, error),
+    }
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    token: &str,
+    endpoints: &Endpoints,
+) -> Result<Snapshot> {
+    // whoami scopes the ledger to an org. A personal account has none, and a
+    // failure here only costs that scoping, so the error is not propagated.
+    let org_id = get_json(client, token, &endpoints.url(WHOAMI_PATH), &[])
+        .await
+        .ok()
+        .and_then(|value| value.get("org")?.get("id")?.as_str().map(str::to_string));
+    let scope: Vec<(&str, String)> = org_id.iter().map(|id| ("orgId", id.clone())).collect();
+
+    let credits = get_json(client, token, &endpoints.url(CREDITS_PATH), &scope).await?;
+    let mut snapshot =
+        parse_credits(&credits).map_err(|error| AppError::Schema(error.to_string()))?;
+
+    // The plan is presentation detail; without it the windows still render.
+    if let Ok(subscription) =
+        get_json(client, token, &endpoints.url(SUBSCRIPTIONS_PATH), &scope).await
+    {
+        apply_subscription(&mut snapshot, &subscription);
+    }
+
+    Ok(snapshot)
+}
+
+async fn get_json(
+    client: &reqwest::Client,
+    token: &str,
+    url: &str,
+    query: &[(&str, String)],
+) -> Result<Value> {
+    let response = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(url)
+            .bearer_auth(token)
+            .query(query)
+            .header(reqwest::header::ACCEPT, "application/json")
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport("Command Code request timed out".to_string()))??;
+
+    let status = response.status();
+    let body = read_body_capped(response, MAX_BODY_BYTES).await?;
+    if !status.is_success() {
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body: status_message(status.as_u16()).to_string(),
+        });
+    }
+    serde_json::from_slice(&body).map_err(|error| AppError::Schema(error.to_string()))
+}
+
+/// Stable, non-secret identity for the endpoint and the account the token
+/// resolves to. Cache reuse must fail closed when either input changes.
+fn target_key(endpoints: &Endpoints, token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    let mut fingerprint = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(fingerprint, "{byte:02x}");
+    }
+    format!("{}|key:{fingerprint}", endpoints.base)
+}
+
+fn status_message(status: u16) -> &'static str {
+    match status {
+        401 | 403 => crate::error::AUTH_FAILURE_MESSAGE,
+        429 => "Command Code rate limited the usage request",
+        500..=599 => "Command Code usage endpoint is unavailable",
+        _ => "Command Code usage request failed",
+    }
+}
+
+/// Cache the parsed snapshot rather than the raw bodies: the raw ledger is
+/// account data with no reason to sit on disk longer than it must.
+fn snapshot_repr(snapshot: &Snapshot) -> Value {
+    let window = |window: &Option<super::types::SpendWindow>| {
+        window.as_ref().map(|w| {
+            serde_json::json!({
+                "used": w.used,
+                "cap": w.cap,
+                "resetAt": w.resets_at.map(|at| at.timestamp_millis()),
+            })
+        })
+    };
+    serde_json::json!({
+        "plan": snapshot.plan,
+        "creditPool": snapshot.credit_pool,
+        "credits": snapshot.credits.as_ref().map(|c| serde_json::json!({
+            "monthlyCredits": c.monthly,
+            "purchasedCredits": c.purchased,
+            "freeCredits": c.free,
+        })),
+        "windowLimits": {
+            "fiveHour": window(&snapshot.five_hour),
+            "weekly": window(&snapshot.weekly),
+        },
+    })
+}
+
+fn parse_cache(bytes: &[u8], target: &str) -> Result<Snapshot> {
+    let value: Value = serde_json::from_slice(bytes)
+        .map_err(|_| AppError::Schema("Command Code cache is invalid".into()))?;
+    if value.get("target").and_then(Value::as_str) != Some(target) {
+        return Err(AppError::Schema(
+            "Command Code cache belongs to a different account".into(),
+        ));
+    }
+    let response = value
+        .get("response")
+        .ok_or_else(|| AppError::Schema("Command Code cache is missing its response".into()))?;
+    let mut snapshot =
+        parse_credits(response).map_err(|error| AppError::Schema(error.to_string()))?;
+    snapshot.plan = response
+        .get("plan")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    snapshot.credit_pool = response.get("creditPool").and_then(Value::as_f64);
+    Ok(snapshot)
+}
+
+fn fallback_or_error(
+    cache: &Cache,
+    last_error: Option<(u16, String)>,
+    target: &str,
+    error: AppError,
+) -> Result<FetchOutcome> {
+    if let Some(outcome) = cached_outcome(cache, last_error, target)? {
+        return Ok(outcome);
+    }
+    Err(error)
+}
+
+fn cached_outcome(
+    cache: &Cache,
+    last_error: Option<(u16, String)>,
+    target: &str,
+) -> Result<Option<FetchOutcome>> {
+    let Some(body) = cache.fallback_payload(MAX_STALE)? else {
+        return Ok(None);
+    };
+    let Ok(snapshot) = parse_cache(&body, target) else {
+        return Ok(None);
+    };
+    Ok(Some(FetchOutcome {
+        snapshot,
+        stale: true,
+        last_error: last_error.or_else(|| cache.read_last_error()),
+        cache_age: cache.payload_age(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::Cache;
+
+    const CREDITS_BODY: &str = include_str!("../../tests/fixtures/commandcode/credits.json");
+    const SUBSCRIPTION_BODY: &str =
+        include_str!("../../tests/fixtures/commandcode/subscriptions.json");
+
+    fn cache_in(dir: &std::path::Path) -> Cache {
+        Cache::at(dir.join("commandcode"))
+    }
+
+    fn endpoints(server: &mockito::Server) -> Endpoints {
+        Endpoints { base: server.url() }
+    }
+
+    #[tokio::test]
+    async fn walks_the_chain_and_scopes_calls_to_the_org() {
+        let mut server = mockito::Server::new_async().await;
+        let whoami = server
+            .mock("GET", WHOAMI_PATH)
+            .with_body(r#"{"org":{"id":"org-42"}}"#)
+            .create_async()
+            .await;
+        let credits = server
+            .mock("GET", CREDITS_PATH)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "orgId".into(),
+                "org-42".into(),
+            ))
+            .with_body(CREDITS_BODY)
+            .create_async()
+            .await;
+        let subscription = server
+            .mock("GET", SUBSCRIPTIONS_PATH)
+            .match_query(mockito::Matcher::UrlEncoded(
+                "orgId".into(),
+                "org-42".into(),
+            ))
+            .with_body(SUBSCRIPTION_BODY)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+
+        let outcome = fetch_snapshot(
+            &reqwest::Client::new(),
+            "tok",
+            &cache_in(dir.path()),
+            &endpoints(&server),
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("fetch must succeed");
+
+        whoami.assert_async().await;
+        credits.assert_async().await;
+        subscription.assert_async().await;
+        assert_eq!(outcome.snapshot.plan.as_deref(), Some("GOAT"));
+        assert_eq!(outcome.snapshot.five_hour.unwrap().pct(), 25);
+        assert!(!outcome.stale);
+    }
+
+    #[tokio::test]
+    async fn a_personal_account_without_an_org_still_gets_its_ledger() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", WHOAMI_PATH)
+            .with_body(r#"{"org":null}"#)
+            .create_async()
+            .await;
+        let credits = server
+            .mock("GET", CREDITS_PATH)
+            .match_query(mockito::Matcher::Missing)
+            .with_body(CREDITS_BODY)
+            .create_async()
+            .await;
+        server
+            .mock("GET", SUBSCRIPTIONS_PATH)
+            .with_body(SUBSCRIPTION_BODY)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+
+        let outcome = fetch_snapshot(
+            &reqwest::Client::new(),
+            "tok",
+            &cache_in(dir.path()),
+            &endpoints(&server),
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("fetch must succeed without an org");
+
+        credits.assert_async().await;
+        assert!(outcome.snapshot.weekly.is_some());
+    }
+
+    #[tokio::test]
+    async fn a_failing_subscription_costs_the_plan_not_the_windows() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", WHOAMI_PATH)
+            .with_body("{}")
+            .create_async()
+            .await;
+        server
+            .mock("GET", CREDITS_PATH)
+            .with_body(CREDITS_BODY)
+            .create_async()
+            .await;
+        server
+            .mock("GET", SUBSCRIPTIONS_PATH)
+            .with_status(500)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+
+        let outcome = fetch_snapshot(
+            &reqwest::Client::new(),
+            "tok",
+            &cache_in(dir.path()),
+            &endpoints(&server),
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("windows must survive a subscription failure");
+
+        assert!(outcome.snapshot.plan.is_none());
+        assert_eq!(outcome.snapshot.weekly.unwrap().pct(), 30);
+    }
+
+    #[tokio::test]
+    async fn a_failing_ledger_is_fatal_and_maps_401_to_the_auth_message() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", WHOAMI_PATH)
+            .with_body("{}")
+            .create_async()
+            .await;
+        server
+            .mock("GET", CREDITS_PATH)
+            .with_status(401)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+
+        let error = fetch_snapshot(
+            &reqwest::Client::new(),
+            "tok",
+            &cache_in(dir.path()),
+            &endpoints(&server),
+            Duration::from_secs(60),
+        )
+        .await
+        .expect_err("the ledger is load-bearing");
+
+        assert!(
+            error
+                .to_string()
+                .contains(crate::error::AUTH_FAILURE_MESSAGE),
+            "{error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_fresh_cache_is_served_without_touching_the_network() {
+        let mut server = mockito::Server::new_async().await;
+        let whoami = server
+            .mock("GET", WHOAMI_PATH)
+            .expect(1)
+            .with_body("{}")
+            .create_async()
+            .await;
+        server
+            .mock("GET", CREDITS_PATH)
+            .expect(1)
+            .with_body(CREDITS_BODY)
+            .create_async()
+            .await;
+        server
+            .mock("GET", SUBSCRIPTIONS_PATH)
+            .expect(1)
+            .with_body(SUBSCRIPTION_BODY)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache = cache_in(dir.path());
+        let endpoints = endpoints(&server);
+        let client = reqwest::Client::new();
+
+        let first = fetch_snapshot(&client, "tok", &cache, &endpoints, Duration::from_secs(600))
+            .await
+            .unwrap();
+        let second = fetch_snapshot(&client, "tok", &cache, &endpoints, Duration::from_secs(600))
+            .await
+            .unwrap();
+
+        // Each endpoint was called exactly once across both fetches.
+        whoami.assert_async().await;
+        assert_eq!(first.snapshot, second.snapshot);
+        assert_eq!(second.snapshot.plan.as_deref(), Some("GOAT"));
+    }
+
+    #[tokio::test]
+    async fn a_cache_written_for_another_token_is_not_reused() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", WHOAMI_PATH)
+            .with_body("{}")
+            .expect_at_least(2)
+            .create_async()
+            .await;
+        server
+            .mock("GET", CREDITS_PATH)
+            .with_body(CREDITS_BODY)
+            .expect_at_least(2)
+            .create_async()
+            .await;
+        server
+            .mock("GET", SUBSCRIPTIONS_PATH)
+            .with_body(SUBSCRIPTION_BODY)
+            .expect_at_least(2)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache = cache_in(dir.path());
+        let endpoints = endpoints(&server);
+        let client = reqwest::Client::new();
+
+        fetch_snapshot(
+            &client,
+            "token-a",
+            &cache,
+            &endpoints,
+            Duration::from_secs(600),
+        )
+        .await
+        .unwrap();
+        // A different account must re-fetch rather than read the first's cache.
+        fetch_snapshot(
+            &client,
+            "token-b",
+            &cache,
+            &endpoints,
+            Duration::from_secs(600),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_stale_cache_carries_the_widget_through_an_outage() {
+        let mut server = mockito::Server::new_async().await;
+        let whoami = server
+            .mock("GET", WHOAMI_PATH)
+            .with_body("{}")
+            .create_async()
+            .await;
+        let credits = server
+            .mock("GET", CREDITS_PATH)
+            .with_body(CREDITS_BODY)
+            .create_async()
+            .await;
+        let subscription = server
+            .mock("GET", SUBSCRIPTIONS_PATH)
+            .with_body(SUBSCRIPTION_BODY)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache = cache_in(dir.path());
+        let endpoints = endpoints(&server);
+        let client = reqwest::Client::new();
+
+        fetch_snapshot(&client, "tok", &cache, &endpoints, Duration::ZERO)
+            .await
+            .unwrap();
+
+        // The endpoint starts failing; the cached snapshot still renders.
+        whoami.remove_async().await;
+        credits.remove_async().await;
+        subscription.remove_async().await;
+        server
+            .mock("GET", CREDITS_PATH)
+            .with_status(503)
+            .create_async()
+            .await;
+        server
+            .mock("GET", WHOAMI_PATH)
+            .with_status(503)
+            .create_async()
+            .await;
+
+        let outcome = fetch_snapshot(&client, "tok", &cache, &endpoints, Duration::ZERO)
+            .await
+            .expect("a stale snapshot beats no snapshot");
+
+        assert!(outcome.stale);
+        assert_eq!(outcome.snapshot.plan.as_deref(), Some("GOAT"));
+        assert_eq!(outcome.last_error.unwrap().0, 503);
+    }
+
+    #[tokio::test]
+    async fn a_schema_mismatch_is_reported_as_drift_not_as_success() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", WHOAMI_PATH)
+            .with_body("{}")
+            .create_async()
+            .await;
+        server
+            .mock("GET", CREDITS_PATH)
+            .with_body(r#"{"unexpected":true}"#)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+
+        let error = fetch_snapshot(
+            &reqwest::Client::new(),
+            "tok",
+            &cache_in(dir.path()),
+            &endpoints(&server),
+            Duration::from_secs(60),
+        )
+        .await
+        .expect_err("an unrecognised ledger must not pass as usage");
+
+        assert!(error.to_string().contains("schema"), "{error}");
+    }
+}

--- a/src/commandcode/mod.rs
+++ b/src/commandcode/mod.rs
@@ -1,0 +1,11 @@
+//! Command Code (commandcode.ai) subscription usage integration.
+//!
+//! Command Code meters spend rather than tokens: two rolling windows priced in
+//! dollars, drawn against a monthly credit allowance. Credentials come from
+//! whichever agent harness on the machine is signed in — the official CLI, pi,
+//! or omp — and are only ever read.
+
+pub mod creds;
+pub mod fetch;
+pub mod types;
+pub mod vendor;

--- a/src/commandcode/types.rs
+++ b/src/commandcode/types.rs
@@ -1,0 +1,438 @@
+//! Command Code usage response types and schema validation.
+//!
+//! Two documents make up a Command Code snapshot. `/alpha/billing/credits`
+//! carries the credit ledger and the rolling spend windows; the subscription
+//! names the plan. Both are parsed defensively — Command Code publishes no
+//! schema for either, so an additive field must never break a running widget,
+//! and a missing section degrades that section alone.
+
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+
+/// One rolling spend window: dollars drawn against a dollar cap.
+///
+/// Unlike most vendors' percentage windows, Command Code meters spend, so the
+/// absolute figures are kept and the percentage is derived. That keeps
+/// "$5.24 of $35" available to the tooltip without a second round trip.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpendWindow {
+    pub used: f64,
+    pub cap: f64,
+    pub resets_at: Option<DateTime<Utc>>,
+}
+
+impl Eq for SpendWindow {}
+
+impl SpendWindow {
+    /// Percentage of the cap consumed, rounded and clamped to `0..=100`.
+    pub fn pct(&self) -> i32 {
+        // Guards a zero cap and a non-finite one alike: either way there is
+        // no denominator to divide by.
+        if !self.cap.is_finite() || self.cap <= 0.0 {
+            return 0;
+        }
+        ((self.used / self.cap) * 100.0).round().clamp(0.0, 100.0) as i32
+    }
+}
+
+/// The monthly credit ledger. Command Code reports three separate pools and
+/// expects a client to sum them, which is what the official CLI does.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Credits {
+    pub monthly: f64,
+    pub purchased: f64,
+    pub free: f64,
+}
+
+impl Eq for Credits {}
+
+impl Credits {
+    /// Total credit still spendable across every pool.
+    pub fn remaining(&self) -> f64 {
+        self.monthly + self.purchased + self.free
+    }
+}
+
+/// Everything the widget shows for Command Code.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Snapshot {
+    /// Plan label, e.g. "GOAT". `None` until the subscription is read.
+    pub plan: Option<String>,
+    pub five_hour: Option<SpendWindow>,
+    pub weekly: Option<SpendWindow>,
+    pub credits: Option<Credits>,
+    /// Monthly credit allowance for the plan, when the plan is recognised.
+    pub credit_pool: Option<f64>,
+}
+
+impl Eq for Snapshot {}
+
+impl Snapshot {
+    /// The window closest to its cap, which is what the bar text leads with.
+    pub fn worst_pct(&self) -> i32 {
+        self.five_hour
+            .iter()
+            .chain(self.weekly.iter())
+            .map(SpendWindow::pct)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Fraction of the monthly allowance already spent, when both are known.
+    pub fn credits_spent(&self) -> Option<f64> {
+        let pool = self.credit_pool?;
+        let remaining = self.credits.as_ref()?.remaining();
+        Some((pool - remaining).max(0.0))
+    }
+}
+
+/// Monthly credit allowance per plan, in USD.
+///
+/// The API reports remaining credit but never the plan's ceiling, so the
+/// "spent of allowance" line needs this table. An unknown plan simply omits
+/// that line rather than guessing a denominator.
+const PLAN_CREDITS: &[(&str, f64)] = &[
+    ("individual-go", 10.0),
+    ("individual-goat", 70.0),
+    ("individual-pro", 30.0),
+    ("individual-pro-v1", 80.0),
+    ("individual-provider", 15.0),
+    ("individual-max", 150.0),
+    ("individual-ultra", 300.0),
+    ("teams-pro", 40.0),
+];
+
+/// Display label per plan id, matching what Command Code's own `/usage` shows.
+const PLAN_LABELS: &[(&str, &str)] = &[
+    ("individual-go", "Go"),
+    ("individual-goat", "GOAT"),
+    ("individual-pro", "Pro"),
+    ("individual-pro-v1", "Pro"),
+    ("individual-provider", "Provider"),
+    ("individual-max", "Max"),
+    ("individual-ultra", "Ultra"),
+    ("teams-pro", "Teams Pro"),
+];
+
+pub fn plan_label(plan_id: &str) -> String {
+    PLAN_LABELS
+        .iter()
+        .find(|(id, _)| *id == plan_id)
+        .map(|(_, label)| (*label).to_string())
+        .unwrap_or_else(|| plan_id.to_string())
+}
+
+pub fn plan_credits(plan_id: &str) -> Option<f64> {
+    PLAN_CREDITS
+        .iter()
+        .find(|(id, _)| *id == plan_id)
+        .map(|(_, credits)| *credits)
+}
+
+/// Parse `/alpha/billing/credits`.
+pub fn parse_credits(value: &Value) -> Result<Snapshot, String> {
+    let root = value
+        .as_object()
+        .ok_or_else(|| "Command Code credits response must be a JSON object".to_string())?;
+    if root.contains_key("error") {
+        return Err("Command Code credits response is an error envelope".to_string());
+    }
+
+    // `windowLimits` has been observed both at the top level and beside the
+    // ledger; accept either rather than betting on one.
+    let ledger = root.get("credits").and_then(Value::as_object);
+    let windows = root
+        .get("windowLimits")
+        .and_then(Value::as_object)
+        .or_else(|| {
+            ledger
+                .and_then(|l| l.get("windowLimits"))
+                .and_then(Value::as_object)
+        });
+
+    let credits = ledger.map(|ledger| Credits {
+        monthly: finite(ledger.get("monthlyCredits")).unwrap_or(0.0),
+        purchased: finite(ledger.get("purchasedCredits")).unwrap_or(0.0),
+        free: finite(ledger.get("freeCredits")).unwrap_or(0.0),
+    });
+
+    let snapshot = Snapshot {
+        plan: None,
+        five_hour: windows
+            .and_then(|w| parse_window(w.get("fiveHour"), "fiveHour"))
+            .transpose()?,
+        weekly: windows
+            .and_then(|w| parse_window(w.get("weekly"), "weekly"))
+            .transpose()?,
+        credits,
+        credit_pool: None,
+    };
+
+    if snapshot.five_hour.is_none() && snapshot.weekly.is_none() && snapshot.credits.is_none() {
+        return Err("Command Code credits response has no windows or ledger".to_string());
+    }
+    Ok(snapshot)
+}
+
+/// Fold `/alpha/billing/subscriptions` into a snapshot: plan label and the
+/// allowance its tier includes.
+pub fn apply_subscription(snapshot: &mut Snapshot, value: &Value) {
+    let Some(plan_id) = value
+        .get("data")
+        .and_then(|data| data.get("planId"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return;
+    };
+    snapshot.plan = Some(plan_label(plan_id));
+    snapshot.credit_pool = plan_credits(plan_id);
+}
+
+fn parse_window(value: Option<&Value>, name: &str) -> Option<Result<SpendWindow, String>> {
+    let value = value?;
+    if value.is_null() {
+        return None;
+    }
+    let Some(object) = value.as_object() else {
+        return Some(Err(format!("windowLimits.{name} must be an object")));
+    };
+    let (Some(used), Some(cap)) = (finite(object.get("used")), finite(object.get("cap"))) else {
+        return Some(Err(format!(
+            "windowLimits.{name} must carry finite used and cap"
+        )));
+    };
+    if used < 0.0 || cap < 0.0 {
+        return Some(Err(format!("windowLimits.{name} must not be negative")));
+    }
+    Some(Ok(SpendWindow {
+        used,
+        cap,
+        resets_at: object.get("resetAt").and_then(parse_reset),
+    }))
+}
+
+/// Resets arrive as millisecond epochs, which is why this cannot lean on the
+/// RFC3339 parsing every other vendor uses. A string is accepted too, in case
+/// the field ever changes shape.
+fn parse_reset(value: &Value) -> Option<DateTime<Utc>> {
+    if let Some(millis) = value.as_i64() {
+        return DateTime::from_timestamp_millis(millis);
+    }
+    if let Some(text) = value.as_str() {
+        if let Ok(parsed) = text.parse::<DateTime<chrono::FixedOffset>>() {
+            return Some(parsed.with_timezone(&Utc));
+        }
+        if let Ok(millis) = text.parse::<i64>() {
+            return DateTime::from_timestamp_millis(millis);
+        }
+    }
+    None
+}
+
+fn finite(value: Option<&Value>) -> Option<f64> {
+    value.and_then(Value::as_f64).filter(|n| n.is_finite())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn credits_value() -> Value {
+        serde_json::from_str(include_str!(
+            "../../tests/fixtures/commandcode/credits.json"
+        ))
+        .expect("fixture JSON must be valid")
+    }
+
+    #[test]
+    fn parses_the_live_credits_fixture() {
+        let snapshot = parse_credits(&credits_value()).expect("fixture must parse");
+
+        let five_hour = snapshot.five_hour.expect("fiveHour window");
+        assert_eq!(five_hour.cap, 14.0);
+        assert_eq!(five_hour.pct(), 25);
+        assert_eq!(
+            five_hour.resets_at.expect("reset").to_rfc3339(),
+            "2026-08-27T20:00:00+00:00"
+        );
+
+        let weekly = snapshot.weekly.expect("weekly window");
+        assert_eq!(weekly.cap, 35.0);
+        assert_eq!(weekly.pct(), 30);
+
+        let credits = snapshot.credits.expect("ledger");
+        assert_eq!(credits.remaining(), 42.0);
+    }
+
+    #[test]
+    fn millisecond_epoch_resets_become_utc_timestamps() {
+        // The API reports resets as ms epochs, not the RFC3339 every other
+        // vendor sends; a naive parser silently drops the countdown.
+        let value = serde_json::json!({
+            "windowLimits": {"weekly": {"used": 1, "cap": 4, "resetAt": 1788374172830_i64}}
+        });
+
+        let weekly = parse_credits(&value).unwrap().weekly.expect("weekly");
+
+        assert_eq!(
+            weekly.resets_at.expect("reset").to_rfc3339(),
+            "2026-09-02T18:36:12.830+00:00"
+        );
+    }
+
+    #[test]
+    fn accepts_windows_nested_beside_the_ledger() {
+        let value = serde_json::json!({
+            "credits": {
+                "monthlyCredits": 5.0,
+                "windowLimits": {"weekly": {"used": 1, "cap": 4, "resetAt": null}}
+            }
+        });
+
+        let snapshot = parse_credits(&value).expect("nested windows must parse");
+
+        assert_eq!(snapshot.weekly.expect("weekly").pct(), 25);
+        assert_eq!(snapshot.credits.expect("ledger").remaining(), 5.0);
+    }
+
+    #[test]
+    fn sums_every_credit_pool() {
+        let value = serde_json::json!({
+            "credits": {"monthlyCredits": 10.5, "purchasedCredits": 4.0, "freeCredits": 0.5},
+            "windowLimits": {"weekly": {"used": 1, "cap": 4}}
+        });
+
+        let credits = parse_credits(&value).unwrap().credits.expect("ledger");
+
+        assert_eq!(credits.remaining(), 15.0);
+    }
+
+    #[test]
+    fn rejects_error_envelopes_and_empty_documents() {
+        for value in [
+            serde_json::json!({}),
+            serde_json::json!({"error": "unauthorized"}),
+            serde_json::json!({"windowLimits": {}}),
+        ] {
+            assert!(parse_credits(&value).is_err(), "accepted {value}");
+        }
+        assert!(parse_credits(&serde_json::json!("nope")).is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_or_negative_windows() {
+        for window in [
+            serde_json::json!("not-an-object"),
+            serde_json::json!({"used": -1, "cap": 4}),
+            serde_json::json!({"used": 1}),
+            serde_json::json!({"used": "1", "cap": 4}),
+        ] {
+            let value = serde_json::json!({"windowLimits": {"weekly": window}});
+            assert!(parse_credits(&value).is_err(), "accepted {window}");
+        }
+    }
+
+    #[test]
+    fn additive_fields_and_null_windows_are_tolerated() {
+        // `exceeded` and `limited` already ship alongside the windows, and a
+        // plan without a five-hour cap sends null rather than omitting it.
+        let value = serde_json::json!({
+            "credits": {"monthlyCredits": 1.0, "unexpected": true},
+            "windowLimits": {
+                "limited": true,
+                "exceeded": null,
+                "fiveHour": null,
+                "weekly": {"used": 1, "cap": 4, "exceeded": false, "future": 1}
+            }
+        });
+
+        let snapshot = parse_credits(&value).expect("must tolerate additive fields");
+
+        assert!(snapshot.five_hour.is_none());
+        assert_eq!(snapshot.weekly.expect("weekly").pct(), 25);
+    }
+
+    #[test]
+    fn percentage_is_clamped_and_safe_at_a_zero_cap() {
+        assert_eq!(
+            SpendWindow {
+                used: 9.0,
+                cap: 0.0,
+                resets_at: None
+            }
+            .pct(),
+            0
+        );
+        assert_eq!(
+            SpendWindow {
+                used: 9.0,
+                cap: 4.0,
+                resets_at: None
+            }
+            .pct(),
+            100
+        );
+    }
+
+    #[test]
+    fn subscription_supplies_the_plan_label_and_its_allowance() {
+        let subscription: Value = serde_json::from_str(include_str!(
+            "../../tests/fixtures/commandcode/subscriptions.json"
+        ))
+        .expect("fixture JSON must be valid");
+        let mut snapshot = parse_credits(&credits_value()).unwrap();
+
+        apply_subscription(&mut snapshot, &subscription);
+
+        assert_eq!(snapshot.plan.as_deref(), Some("GOAT"));
+        assert_eq!(snapshot.credit_pool, Some(70.0));
+        // The $70 allowance less the $42 still on the ledger.
+        assert_eq!(snapshot.credits_spent(), Some(28.0));
+    }
+
+    #[test]
+    fn unknown_plan_keeps_its_id_and_claims_no_allowance() {
+        let mut snapshot = parse_credits(&credits_value()).unwrap();
+
+        apply_subscription(
+            &mut snapshot,
+            &serde_json::json!({"data": {"planId": "individual-future"}}),
+        );
+
+        assert_eq!(snapshot.plan.as_deref(), Some("individual-future"));
+        assert_eq!(snapshot.credit_pool, None);
+        assert_eq!(snapshot.credits_spent(), None);
+    }
+
+    #[test]
+    fn missing_subscription_leaves_the_snapshot_untouched() {
+        let mut snapshot = parse_credits(&credits_value()).unwrap();
+
+        apply_subscription(&mut snapshot, &serde_json::json!({"success": false}));
+
+        assert!(snapshot.plan.is_none());
+        assert!(snapshot.weekly.is_some());
+    }
+
+    #[test]
+    fn worst_window_leads_the_bar_text() {
+        let snapshot = Snapshot {
+            five_hour: Some(SpendWindow {
+                used: 1.0,
+                cap: 10.0,
+                resets_at: None,
+            }),
+            weekly: Some(SpendWindow {
+                used: 8.0,
+                cap: 10.0,
+                resets_at: None,
+            }),
+            ..Snapshot::default()
+        };
+
+        assert_eq!(snapshot.worst_pct(), 80);
+        assert_eq!(Snapshot::default().worst_pct(), 0);
+    }
+}

--- a/src/commandcode/vendor.rs
+++ b/src/commandcode/vendor.rs
@@ -1,0 +1,437 @@
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::format::{placeholders, substitute, updated_at_hm, usd};
+use crate::pacing::PaceSeverity;
+use crate::pango::{color_span, escape, severity_color, severity_for};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+use super::types::{Snapshot, SpendWindow};
+
+pub const DEFAULT_FORMAT: &str = "{cc_session_pct}% · {cc_session_reset}";
+const DEFAULT_PLAN: &str = "Command Code";
+const UNAVAILABLE: &str = "—";
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(outcome: FetchOutcome) -> Self {
+        Self {
+            snapshot: crate::usage::VendorSnapshot::CommandCode(outcome.snapshot),
+            stale: outcome.stale,
+            last_error: outcome.last_error,
+            cache_age: outcome.cache_age,
+        }
+    }
+}
+
+pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'static str, String> {
+    let plan = sanitize(snap.plan.as_deref().unwrap_or(DEFAULT_PLAN));
+    let session = window_values(snap.five_hour.as_ref(), now);
+    let weekly = window_values(snap.weekly.as_ref(), now);
+    let remaining = snap
+        .credits
+        .as_ref()
+        .map(|credits| usd(credits.remaining()))
+        .unwrap_or_else(|| UNAVAILABLE.to_string());
+    let pool = snap
+        .credit_pool
+        .map(usd)
+        .unwrap_or_else(|| UNAVAILABLE.to_string());
+    let spent = snap
+        .credits_spent()
+        .map(usd)
+        .unwrap_or_else(|| UNAVAILABLE.to_string());
+
+    placeholders([
+        ("vendor_short", "cc".to_string()),
+        ("plan", plan.clone()),
+        ("cc_plan", plan),
+        // Generic names so a shared format string works across vendors.
+        ("session_pct", session.percent.clone()),
+        ("session_reset", session.reset.clone()),
+        ("weekly_pct", weekly.percent.clone()),
+        ("weekly_reset", weekly.reset.clone()),
+        ("cc_session_pct", session.percent),
+        ("cc_session_reset", session.reset),
+        ("cc_session_used", session.used),
+        ("cc_session_cap", session.cap),
+        ("cc_weekly_pct", weekly.percent),
+        ("cc_weekly_reset", weekly.reset),
+        ("cc_weekly_used", weekly.used),
+        ("cc_weekly_cap", weekly.cap),
+        ("cc_credits", remaining),
+        ("cc_credits_pool", pool),
+        ("cc_credits_spent", spent),
+    ])
+}
+
+#[derive(Debug)]
+struct WindowValues {
+    percent: String,
+    reset: String,
+    used: String,
+    cap: String,
+}
+
+fn window_values(window: Option<&SpendWindow>, now: DateTime<Utc>) -> WindowValues {
+    let Some(window) = window else {
+        return WindowValues {
+            percent: UNAVAILABLE.to_string(),
+            reset: UNAVAILABLE.to_string(),
+            used: UNAVAILABLE.to_string(),
+            cap: UNAVAILABLE.to_string(),
+        };
+    };
+    WindowValues {
+        percent: window.pct().to_string(),
+        reset: countdown::format(window.resets_at, now),
+        used: usd(window.used),
+        cap: usd(window.cap),
+    }
+}
+
+fn sanitize(value: &str) -> String {
+    crate::display::sanitize_untrusted_field(value)
+}
+
+pub fn severity(snap: &Snapshot) -> PaceSeverity {
+    severity_for(snap.worst_pct())
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &Snapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    render_with_meta(
+        snap,
+        outcome.stale,
+        outcome.last_error.as_ref(),
+        outcome.cache_age,
+        theme,
+        opts,
+        now,
+    )
+}
+
+fn render_with_meta(
+    snap: &Snapshot,
+    stale: bool,
+    last_error: Option<&(u16, String)>,
+    cache_age: Option<Duration>,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let sev = severity(snap);
+    let format = opts.format.as_deref().unwrap_or(DEFAULT_FORMAT);
+    let values = escaped_placeholders(snap, now);
+    let mut text = substitute(format, &values);
+    if stale {
+        text.push_str(" ⏸");
+    }
+    let icon_prefix = match opts.icon.as_deref() {
+        Some(icon) if !icon.is_empty() => format!("{} ", escape(icon)),
+        _ => String::new(),
+    };
+    let bar_text = color_span(severity_color(sev, theme), &format!("{icon_prefix}{text}"));
+    let tooltip = opts
+        .tooltip_format
+        .as_deref()
+        .map(|format| substitute(format, &values))
+        .unwrap_or_else(|| render_tooltip(snap, stale, last_error, cache_age, theme, now));
+
+    WaybarOutput {
+        text: bar_text,
+        tooltip,
+        class: Class::from(sev),
+    }
+}
+
+fn escaped_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'static str, String> {
+    let mut values = build_placeholders(snap, now);
+    for key in ["plan", "cc_plan"] {
+        if let Some(value) = values.get_mut(key) {
+            *value = escape(value);
+        }
+    }
+    values
+}
+
+fn render_tooltip(
+    snap: &Snapshot,
+    stale: bool,
+    last_error: Option<&(u16, String)>,
+    cache_age: Option<Duration>,
+    theme: &Theme,
+    now: DateTime<Utc>,
+) -> String {
+    let plan = snap.plan.as_deref().unwrap_or(DEFAULT_PLAN);
+    let mut lines = vec![TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{}'>{}</span>",
+        theme.blue,
+        escape(&sanitize(plan))
+    ))];
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(String::new()));
+
+    let mut present = false;
+    for (label, window) in [
+        ("Session (5h)", snap.five_hour.as_ref()),
+        ("Weekly", snap.weekly.as_ref()),
+    ] {
+        let Some(window) = window else {
+            continue;
+        };
+        present = true;
+        let values = window_values(Some(window), now);
+        lines.push(TooltipLine::Body(format!(
+            "  {}  {}% · {} of {} · {}",
+            label,
+            escape(&values.percent),
+            escape(&values.used),
+            escape(&values.cap),
+            escape(&values.reset)
+        )));
+    }
+    if !present {
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{}'>no usage windows reported</span>",
+            theme.dim
+        )));
+    }
+
+    if let Some(credits) = snap.credits.as_ref() {
+        lines.push(TooltipLine::Body(String::new()));
+        let detail = match (snap.credits_spent(), snap.credit_pool) {
+            (Some(spent), Some(pool)) => {
+                format!(" · {} of {} spent", usd(spent), usd(pool))
+            }
+            _ => String::new(),
+        };
+        lines.push(TooltipLine::Body(format!(
+            "  Credits  {}{}",
+            escape(&usd(credits.remaining())),
+            escape(&detail)
+        )));
+    }
+
+    if stale {
+        lines.push(TooltipLine::Body(String::new()));
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{}'>  ⏸  Showing cached data</span>",
+            theme.orange
+        )));
+    }
+    if let Some((code, message)) = last_error
+        && *code != 0
+    {
+        lines.push(TooltipLine::Body(String::new()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{}'>  HTTP {code}: {}</span>",
+            theme.orange,
+            escape(message)
+        )));
+    }
+
+    lines.push(TooltipLine::Body(String::new()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{}'>  Updated {}</span>",
+        theme.dim,
+        updated_at_hm(now, cache_age)
+    )));
+    render_bordered(&lines, theme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commandcode::types::{Credits, Snapshot, SpendWindow};
+
+    fn at(value: &str) -> DateTime<Utc> {
+        value.parse().expect("RFC3339 timestamp")
+    }
+
+    fn sample() -> Snapshot {
+        Snapshot {
+            plan: Some("GOAT".into()),
+            five_hour: Some(SpendWindow {
+                used: 1.23,
+                cap: 14.0,
+                resets_at: Some(at("2026-08-27T04:40:19Z")),
+            }),
+            weekly: Some(SpendWindow {
+                used: 5.24,
+                cap: 35.0,
+                resets_at: Some(at("2026-09-02T18:36:12Z")),
+            }),
+            credits: Some(Credits {
+                monthly: 49.28,
+                purchased: 0.0,
+                free: 0.0,
+            }),
+            credit_pool: Some(70.0),
+        }
+    }
+
+    #[test]
+    fn exposes_exact_and_generic_placeholders() {
+        let values = build_placeholders(&sample(), at("2026-08-27T02:30:00Z"));
+
+        assert_eq!(values["vendor_short"], "cc");
+        assert_eq!(values["plan"], "GOAT");
+        assert_eq!(values["cc_session_pct"], "9");
+        assert_eq!(values["cc_weekly_pct"], "15");
+        // Generic aliases keep a shared format string working across vendors.
+        assert_eq!(values["session_pct"], "9");
+        assert_eq!(values["weekly_pct"], "15");
+    }
+
+    #[test]
+    fn spend_figures_use_the_shared_money_formatter() {
+        let values = build_placeholders(&sample(), at("2026-08-27T02:30:00Z"));
+
+        assert_eq!(values["cc_session_used"], "$1.23");
+        assert_eq!(values["cc_session_cap"], "$14.00");
+        assert_eq!(values["cc_credits"], "$49.28");
+        assert_eq!(values["cc_credits_pool"], "$70.00");
+        assert_eq!(values["cc_credits_spent"], "$20.72");
+    }
+
+    #[test]
+    fn default_format_leads_with_the_session_window() {
+        assert_eq!(DEFAULT_FORMAT, "{cc_session_pct}% · {cc_session_reset}");
+    }
+
+    #[test]
+    fn absent_windows_and_ledger_are_unavailable_not_zero() {
+        let values = build_placeholders(&Snapshot::default(), at("2026-08-27T02:30:00Z"));
+
+        for key in [
+            "session_pct",
+            "weekly_pct",
+            "cc_session_pct",
+            "cc_session_reset",
+            "cc_weekly_pct",
+            "cc_session_used",
+            "cc_credits",
+            "cc_credits_pool",
+            "cc_credits_spent",
+        ] {
+            assert_eq!(values[key], UNAVAILABLE, "{key} should be unavailable");
+            assert_ne!(values[key], "0");
+        }
+        // With no plan, the vendor name stands in.
+        assert_eq!(values["plan"], DEFAULT_PLAN);
+    }
+
+    #[test]
+    fn severity_follows_the_window_closest_to_its_cap() {
+        let mut snapshot = sample();
+        assert_eq!(severity(&snapshot), severity_for(15));
+
+        snapshot.weekly = Some(SpendWindow {
+            used: 34.0,
+            cap: 35.0,
+            resets_at: None,
+        });
+        assert_eq!(severity(&snapshot), severity_for(97));
+    }
+
+    #[test]
+    fn plan_is_sanitized_before_it_reaches_the_bar() {
+        let snapshot = Snapshot {
+            plan: Some("GO\u{1b}[31mAT\u{7}".into()),
+            ..sample()
+        };
+
+        let values = build_placeholders(&snapshot, at("2026-08-27T02:30:00Z"));
+
+        assert!(!values["plan"].contains('\u{1b}'));
+        assert!(!values["plan"].contains('\u{7}'));
+        assert!(!values["cc_plan"].contains('\u{1b}'));
+    }
+
+    #[test]
+    fn tooltip_shows_both_windows_and_the_credit_ledger() {
+        let theme = Theme::default();
+        let tooltip = render_tooltip(
+            &sample(),
+            false,
+            None,
+            None,
+            &theme,
+            at("2026-08-27T02:30:00Z"),
+        );
+
+        assert!(tooltip.contains("GOAT"), "{tooltip}");
+        assert!(tooltip.contains("Session (5h)"), "{tooltip}");
+        assert!(tooltip.contains("$1.23 of $14.00"), "{tooltip}");
+        assert!(tooltip.contains("Weekly"), "{tooltip}");
+        assert!(tooltip.contains("$49.28"), "{tooltip}");
+        assert!(tooltip.contains("$20.72 of $70.00 spent"), "{tooltip}");
+    }
+
+    #[test]
+    fn tooltip_says_so_when_the_vendor_reports_no_windows() {
+        let theme = Theme::default();
+        let tooltip = render_tooltip(
+            &Snapshot::default(),
+            false,
+            None,
+            None,
+            &theme,
+            at("2026-08-27T02:30:00Z"),
+        );
+
+        assert!(tooltip.contains("no usage windows reported"), "{tooltip}");
+    }
+
+    #[test]
+    fn stale_and_http_errors_surface_in_the_tooltip() {
+        let theme = Theme::default();
+        let tooltip = render_tooltip(
+            &sample(),
+            true,
+            Some(&(503, "service unavailable".to_string())),
+            None,
+            &theme,
+            at("2026-08-27T02:30:00Z"),
+        );
+
+        assert!(tooltip.contains("Showing cached data"), "{tooltip}");
+        assert!(tooltip.contains("HTTP 503"), "{tooltip}");
+    }
+
+    #[test]
+    fn an_unknown_plan_still_renders_without_an_allowance_line() {
+        let snapshot = Snapshot {
+            plan: Some("individual-future".into()),
+            credit_pool: None,
+            ..sample()
+        };
+        let theme = Theme::default();
+
+        let tooltip = render_tooltip(
+            &snapshot,
+            false,
+            None,
+            None,
+            &theme,
+            at("2026-08-27T02:30:00Z"),
+        );
+
+        assert!(tooltip.contains("$49.28"), "{tooltip}");
+        assert!(!tooltip.contains("spent"), "{tooltip}");
+    }
+}

--- a/src/commandcode/vendor.rs
+++ b/src/commandcode/vendor.rs
@@ -9,7 +9,7 @@ use crate::pacing::PaceSeverity;
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -49,7 +49,10 @@ pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'stat
         .unwrap_or_else(|| UNAVAILABLE.to_string());
 
     placeholders([
-        ("vendor_short", "cc".to_string()),
+        (
+            "vendor_short",
+            VendorId::CommandCode.short_name().to_string(),
+        ),
         ("plan", plan.clone()),
         ("cc_plan", plan),
         // Generic names so a shared format string works across vendors.
@@ -288,7 +291,7 @@ mod tests {
     fn exposes_exact_and_generic_placeholders() {
         let values = build_placeholders(&sample(), at("2026-08-27T02:30:00Z"));
 
-        assert_eq!(values["vendor_short"], "cc");
+        assert_eq!(values["vendor_short"], "cmc");
         assert_eq!(values["plan"], "GOAT");
         assert_eq!(values["cc_session_pct"], "9");
         assert_eq!(values["cc_weekly_pct"], "15");

--- a/src/config.rs
+++ b/src/config.rs
@@ -488,9 +488,9 @@ pub struct OpenCodeGoConfig {
     pub api_key: Option<String>,
 }
 
-/// Command Code reads the OAuth credential whichever local agent harness
-/// already wrote — the official CLI, pi, or omp — so it has no API key of its
-/// own. `auth_paths` overrides that search list for a non-standard install.
+/// Command Code reads the OAuth credential from the official CLI or pi, so it
+/// has no API key of its own. `auth_paths` overrides that search list for a
+/// non-standard install.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CommandCodeConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,6 +57,7 @@ pub struct Config {
     pub nous: NousConfig,
     #[serde(rename = "opencode-go")]
     pub opencode_go: OpenCodeGoConfig,
+    pub commandcode: CommandCodeConfig,
 }
 
 /// UI / dispatch preferences. Currently just `primary` — which vendor the
@@ -485,6 +486,16 @@ pub struct OpenCodeGoConfig {
     pub enabled: bool,
     pub api_key_env: String,
     pub api_key: Option<String>,
+}
+
+/// Command Code reads the OAuth credential whichever local agent harness
+/// already wrote — the official CLI, pi, or omp — so it has no API key of its
+/// own. `auth_paths` overrides that search list for a non-standard install.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CommandCodeConfig {
+    pub enabled: bool,
+    pub auth_paths: Option<Vec<PathBuf>>,
 }
 
 impl Default for OpenCodeGoConfig {
@@ -1037,6 +1048,7 @@ impl Config {
             VendorId::Kiro => self.kiro.enabled,
             VendorId::NousResearch => self.nous.enabled,
             VendorId::OpenCodeGo => self.opencode_go.enabled,
+            VendorId::CommandCode => self.commandcode.enabled,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod anthropic_api;
 pub mod antigravity;
 pub mod cache;
 pub mod claude_desktop;
+pub mod commandcode;
 pub mod config;
 pub mod context;
 pub mod countdown;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -730,6 +730,21 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             .await?;
             Ok(outcome.into())
         }
+        VendorId::CommandCode => {
+            let credential =
+                crate::commandcode::creds::resolve(config.commandcode.auth_paths.as_deref())?;
+            let cache = crate::cache::Cache::for_vendor("commandcode")?;
+            let endpoints = crate::commandcode::fetch::Endpoints::default();
+            let outcome = crate::commandcode::fetch::fetch_snapshot(
+                client,
+                &credential.token,
+                &cache,
+                &endpoints,
+                DEFAULT_TTL,
+            )
+            .await?;
+            Ok(outcome.into())
+        }
     }
 }
 

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -190,6 +190,16 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
                 .unwrap_or_else(|| ("—".into(), PaceSeverity::Low));
             (s.plan.clone().unwrap_or_default(), vec![cell])
         }
+        VendorSnapshot::CommandCode(s) => {
+            let cells = [
+                ("session", s.five_hour.as_ref()),
+                ("weekly", s.weekly.as_ref()),
+            ]
+            .into_iter()
+            .filter_map(|(label, window)| window.map(|window| pct(label, window.pct())))
+            .collect();
+            (s.plan.clone().unwrap_or_default(), cells)
+        }
         VendorSnapshot::OpenCodeGo(s) => {
             let cells = [
                 ("rolling", s.rolling.as_ref()),
@@ -250,6 +260,10 @@ pub fn headline_pct(snapshot: &VendorSnapshot) -> Option<i32> {
         VendorSnapshot::NousResearch(s) => s
             .usage_percent()
             .map(|value| value.round().clamp(0.0, 100.0) as i32),
+        VendorSnapshot::CommandCode(s) => {
+            let worst = s.worst_pct();
+            (s.five_hour.is_some() || s.weekly.is_some()).then_some(worst)
+        }
         VendorSnapshot::OpenCodeGo(s) => [
             s.rolling
                 .as_ref()
@@ -331,6 +345,7 @@ pub(crate) fn sections_with_metadata_for(
                 VendorSnapshot::Kiro(s) => kiro_sections(s, now),
                 VendorSnapshot::NousResearch(s) => nous_sections(s, now),
                 VendorSnapshot::OpenCodeGo(s) => opencode_go_sections(s, now),
+                VendorSnapshot::CommandCode(s) => commandcode_sections(s, now),
             };
             // Inject the (already-absolute) fetched-at instant into the title
             // row, right-aligned. Pre-snapshotted in app::refresh_one so it
@@ -764,6 +779,58 @@ fn nous_sections(s: &crate::nous::types::AccountSnapshot, now: DateTime<Utc>) ->
         sections.push(Section::Text {
             label: "Renews".into(),
             value: countdown::format(Some(period_end), now),
+        });
+    }
+    sections
+}
+
+fn commandcode_sections(
+    s: &crate::commandcode::types::Snapshot,
+    now: DateTime<Utc>,
+) -> SectionBuilder {
+    let title = match s.plan.as_deref() {
+        Some(plan) if !plan.is_empty() => format!("Command Code {plan}"),
+        _ => "Command Code".to_string(),
+    };
+    let mut sections = SectionBuilder::new(vec![Section::Title {
+        left: title,
+        right: None,
+    }]);
+    for (label, window) in [
+        ("Session (5h)", s.five_hour.as_ref()),
+        ("Weekly", s.weekly.as_ref()),
+    ] {
+        if let Some(window) = window {
+            let pct = window.pct();
+            sections.push_metric(
+                Section::Metric {
+                    label: label.into(),
+                    pct: pct.clamp(0, 100) as u16,
+                    severity: severity_for(pct),
+                    value_label: format!("{pct}%"),
+                    footnote: format!("{} of {}", usd(window.used), usd(window.cap)),
+                },
+                window.resets_at,
+            );
+            sections.push(Section::Text {
+                label: "Resets".into(),
+                value: countdown::format(window.resets_at, now),
+            });
+        }
+    }
+    if let Some(credits) = s.credits.as_ref() {
+        sections.push(Section::Spacer);
+        let footnote = match (s.credits_spent(), s.credit_pool) {
+            (Some(spent), Some(pool)) => format!("{} of {} spent", usd(spent), usd(pool)),
+            _ => String::new(),
+        };
+        sections.push(Section::Text {
+            label: "Credits".into(),
+            value: if footnote.is_empty() {
+                usd(credits.remaining())
+            } else {
+                format!("{} · {footnote}", usd(credits.remaining()))
+            },
         });
     }
     sections

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -1,8 +1,9 @@
 //! Settings overlay — opened from the TUI by pressing `s`. Lets the user pick
 //! the primary vendor and paste an API key for any key-authenticated vendor
 //! (including Z.AI, Kimi, MiniMax, and the balance vendors) without hand-editing
-//! config.toml. Anthropic, OpenAI, Cursor, and Antigravity authenticate through
-//! local product state, so they have no key field here.
+//! config.toml. Anthropic, OpenAI, Cursor, Kiro, Antigravity, and Command Code
+//! authenticate through local product state, so they have no key field here —
+//! there is nothing to paste, and a field would only imply otherwise.
 //!
 //! Persistence uses `toml_edit` so the existing config keeps its comments,
 //! whitespace, and unrelated fields. Writing a key also flips that vendor's

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -356,6 +356,7 @@ pub enum VendorSnapshot {
     Kiro(KiroSnapshot),
     NousResearch(crate::nous::types::AccountSnapshot),
     OpenCodeGo(crate::opencode_go::types::Usage),
+    CommandCode(crate::commandcode::types::Snapshot),
 }
 
 /// Google Antigravity 2.0 / CLI snapshot. The API groups models into Gemini

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -36,6 +36,7 @@ pub(crate) const VENDOR_SECRET_ENV_VARS: &[&str] = &[
     "XAI_API_KEY",
     "GROK_API_KEY",
     "OPENCODE_GO_API_KEY",
+    "COMMANDCODE_API_KEY",
 ];
 
 pub(crate) fn vendor_secret_env_vars_to_remove(keep: &[&str]) -> Vec<&'static str> {
@@ -128,6 +129,8 @@ pub enum VendorId {
     NousResearch,
     #[serde(rename = "opencode-go")]
     OpenCodeGo,
+    #[serde(rename = "commandcode")]
+    CommandCode,
 }
 
 impl VendorId {
@@ -151,6 +154,7 @@ impl VendorId {
             VendorId::Kiro => "kiro",
             VendorId::NousResearch => "nous",
             VendorId::OpenCodeGo => "opencode-go",
+            VendorId::CommandCode => "commandcode",
         }
     }
 
@@ -177,6 +181,7 @@ impl VendorId {
             VendorId::Kiro => "Kiro",
             VendorId::NousResearch => "Nous Research",
             VendorId::OpenCodeGo => "OpenCode Go",
+            VendorId::CommandCode => "Command Code",
         }
     }
 
@@ -200,6 +205,7 @@ impl VendorId {
             VendorId::Kiro,
             VendorId::NousResearch,
             VendorId::OpenCodeGo,
+            VendorId::CommandCode,
         ]
     }
 }

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -209,6 +209,7 @@ impl VendorId {
             VendorId::Kiro => "kir",
             VendorId::NousResearch => "nrs",
             VendorId::OpenCodeGo => "ocg",
+            VendorId::CommandCode => "cmc",
         }
     }
 

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -298,6 +298,8 @@ pub enum Vendor {
     NousResearch,
     #[value(name = "opencode-go")]
     OpenCodeGo,
+    #[value(name = "commandcode")]
+    CommandCode,
 }
 
 impl Vendor {
@@ -321,6 +323,7 @@ impl Vendor {
             Vendor::Kiro => crate::vendor::VendorId::Kiro,
             Vendor::NousResearch => crate::vendor::VendorId::NousResearch,
             Vendor::OpenCodeGo => crate::vendor::VendorId::OpenCodeGo,
+            Vendor::CommandCode => crate::vendor::VendorId::CommandCode,
         }
     }
 }
@@ -411,6 +414,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::Kiro => Vendor::Kiro,
         crate::vendor::VendorId::NousResearch => Vendor::NousResearch,
         crate::vendor::VendorId::OpenCodeGo => Vendor::OpenCodeGo,
+        crate::vendor::VendorId::CommandCode => Vendor::CommandCode,
     }
 }
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -160,6 +160,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::Kiro => kiro_output(cli, &config).await,
         Vendor::NousResearch => nous_output(cli).await,
         Vendor::OpenCodeGo => opencode_go_output(cli, &config).await,
+        Vendor::CommandCode => commandcode_output(cli, &config).await,
     }
 }
 
@@ -236,6 +237,40 @@ async fn opencode_go_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> 
     let snapshot = outcome.snapshot.clone();
     let vendor_outcome: VendorOutcome = outcome.into();
     Ok(crate::opencode_go::vendor::render(
+        &vendor_outcome,
+        &snapshot,
+        &theme_from_cli(cli),
+        &RenderOpts::from_cli(cli),
+        Utc::now(),
+    ))
+}
+
+/// Command Code has no API key of its own: it reuses the OAuth credential a
+/// local agent harness already holds, so there is nothing to resolve from
+/// config beyond an optional override of where to look.
+async fn commandcode_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let credential = crate::commandcode::creds::resolve(config.commandcode.auth_paths.as_deref())?;
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "commandcode")?;
+    let endpoints = crate::commandcode::fetch::Endpoints::default();
+    let outcome = match crate::commandcode::fetch::fetch_snapshot(
+        &client,
+        &credential.token,
+        &cache,
+        &endpoints,
+        DEFAULT_TTL,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) if error.is_transient() => {
+            return Ok(WaybarOutput::loading(cli.icon.as_deref()));
+        }
+        Err(error) => return Err(error),
+    };
+    let snapshot = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    Ok(crate::commandcode::vendor::render(
         &vendor_outcome,
         &snapshot,
         &theme_from_cli(cli),

--- a/tests/fixtures/commandcode/credits.json
+++ b/tests/fixtures/commandcode/credits.json
@@ -1,0 +1,26 @@
+{
+  "credits": {
+    "belowThreshold": false,
+    "creditThreshold": 0,
+    "monthlyCredits": 42,
+    "purchasedCredits": 0,
+    "freeCredits": 0
+  },
+  "windowLimits": {
+    "limited": true,
+    "exceeded": null,
+    "fiveHour": {
+      "used": 3.5,
+      "cap": 14,
+      "exceeded": false,
+      "resetAt": 1787860800000
+    },
+    "weekly": {
+      "used": 10.5,
+      "cap": 35,
+      "exceeded": false,
+      "resetAt": 1788307200000
+    },
+    "future_field": "ignored-additive-field"
+  }
+}

--- a/tests/fixtures/commandcode/subscriptions.json
+++ b/tests/fixtures/commandcode/subscriptions.json
@@ -1,0 +1,25 @@
+{
+  "success": true,
+  "data": {
+    "id": "sub_example",
+    "status": "active",
+    "userId": "user_example",
+    "orgId": null,
+    "createdAt": "2026-08-19T16:39:05.000Z",
+    "priceId": "price_example",
+    "metadata": {
+      "commandCode": "true",
+      "commandCodeUserId": "user_example"
+    },
+    "quantity": 1,
+    "cancelAtPeriodEnd": false,
+    "currentPeriodStart": "2026-08-19T16:39:05.000Z",
+    "currentPeriodEnd": "2026-09-19T16:39:05.000Z",
+    "endedAt": null,
+    "cancelAt": null,
+    "canceledAt": null,
+    "planId": "individual-goat",
+    "pendingPhase": null,
+    "future_field": "ignored-additive-field"
+  }
+}

--- a/tests/fixtures/commandcode/whoami.json
+++ b/tests/fixtures/commandcode/whoami.json
@@ -1,0 +1,6 @@
+{
+  "org": null,
+  "user": {
+    "id": "user_example"
+  }
+}

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -551,3 +551,70 @@ async fn minimax_live() {
             .map(|w| w.utilization_pct),
     );
 }
+
+/// Command Code reuses whichever local agent harness is signed in, so this
+/// test needs no key of its own — it skips when nothing on the machine holds
+/// a credential.
+#[tokio::test]
+#[ignore]
+async fn commandcode_live() {
+    use ai_usagebar::commandcode;
+
+    let credential = match commandcode::creds::resolve(None) {
+        Ok(credential) => credential,
+        Err(error) => {
+            eprintln!("commandcode_live: {error} — skipping Command Code smoke test");
+            return;
+        }
+    };
+    let cache = xdg_cache_for("commandcode");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let endpoints = commandcode::fetch::Endpoints::default();
+    let out = commandcode::fetch::fetch_snapshot(
+        &client,
+        &credential.token,
+        &cache,
+        &endpoints,
+        Duration::from_secs(0),
+    )
+    .await
+    .expect("command code fetch should succeed against the real API");
+
+    // The ledger is load-bearing; the windows are what the bar leads with.
+    assert!(
+        out.snapshot.five_hour.is_some()
+            || out.snapshot.weekly.is_some()
+            || out.snapshot.credits.is_some(),
+        "commandcode returned neither a window nor a ledger"
+    );
+    for (label, window) in [
+        ("commandcode.five_hour", out.snapshot.five_hour.as_ref()),
+        ("commandcode.weekly", out.snapshot.weekly.as_ref()),
+    ] {
+        if let Some(window) = window {
+            assert_pct(label, window.pct());
+            assert!(window.cap > 0.0, "{label} reported a non-positive cap");
+            assert!(
+                window.resets_at.is_some(),
+                "{label} lost its reset timestamp — the API sends a ms epoch"
+            );
+        }
+    }
+    println!(
+        "✅ command code — plan={:?}, 5h={:?}, weekly={:?}, credits={:?} of pool {:?}",
+        out.snapshot.plan,
+        out.snapshot
+            .five_hour
+            .as_ref()
+            .map(|w| (w.used, w.cap, w.pct())),
+        out.snapshot
+            .weekly
+            .as_ref()
+            .map(|w| (w.used, w.cap, w.pct())),
+        out.snapshot.credits.as_ref().map(|c| c.remaining()),
+        out.snapshot.credit_pool,
+    );
+}


### PR DESCRIPTION
Adds [Command Code](https://commandcode.ai) as a nineteenth vendor, selectable with `--vendor commandcode` and enabled with `[commandcode]` in config.

## What it shows

Command Code meters spend rather than tokens, so its two rolling windows are priced in dollars. The bar leads with the 5-hour window. The tooltip and TUI carry the absolute amounts and the credit ledger:

```
9% · 2h 09m

╭──────────────────────────────────────────────╮
│                     GOAT                     │
│ ──────────────────────────────────────────── │
│  Session (5h)  9% · $1.23 of $14.00 · 2h 09m │
│  Weekly  15% · $5.24 of $35.00 · 6d 16h      │
│                                              │
│  Credits  $49.28 · $20.72 of $70.00 spent    │
│ ──────────────────────────────────────────── │
│   Updated 22:30                              │
╰──────────────────────────────────────────────╯
```

## Endpoints

The same undocumented `/alpha` routes that the official `commandcode` CLI's own `/usage` command calls:

| Route | Supplies |
|---|---|
| `/alpha/whoami` | `org.id`, which scopes the rest when present |
| `/alpha/billing/credits` | the ledger and both `windowLimits` |
| `/alpha/billing/subscriptions` | `planId` |

Only the ledger is required. A personal account with no org, or a subscription lookup that returns 500, still renders its windows.

## Credentials

There is no key to issue. Like Cursor and Kiro CLI, it reuses what a local harness already holds: `~/.commandcode/auth.json` from the official CLI, then omp's, then pi's. `COMMANDCODE_API_KEY` outranks all three, and `[commandcode] auth_paths` overrides the list.

The token is only ever read. Refreshing it belongs to the CLI that owns the file, and writing back from here would race the harnesses that share it. So an expired token is reported as expired instead of being silently rewritten, and one stale harness never masks a live one further down the list.

## Two shape details the parser pins

Both are easy to get silently wrong, so both have named tests.

Resets arrive as millisecond epochs, not the RFC3339 that every other vendor sends. A naive parser drops the countdown without failing.

`windowLimits` has been observed both at the top level and beside the ledger. Either is accepted, and windows are read by name (`fiveHour`, `weekly`) rather than by position.

The API never reports the plan's monthly allowance, so a small plan-to-credits table supplies it. An unrecognised plan keeps its id and omits the "spent of allowance" line instead of inventing a denominator.

## Notes on the invariants in CLAUDE.md

Tests are hermetic. `creds::resolve_from(env, paths)` and `fetch::Endpoints` are the seams, and `creds::resolve` is the production wrapper. Nothing under `#[test]` reads a real `$HOME`, `$XDG` path, or ambient env var.

Formatting goes through the shared helpers. Money uses `format::usd`, report rows use `SectionBuilder::push_metric` so the absolute reset travels with its row, and the label comes from `VendorId::display_name`. No new name or money table in any frontend.

Cache entries are tied to the endpoint plus a one-way SHA-256 token fingerprint, so changing accounts cannot reuse another account's fresh or stale usage. Stale payloads carry the widget through an outage.

The plan string is sanitized and escaped before it reaches the bar or the tooltip.

There are no new dependencies.

## Tests

`make test` goes from 1120 to 1159, all green, with clippy `-D warnings` and `cargo fmt --check` clean.

The 39 new tests cover the parser, the credential search, the endpoint chain (mockito, including no-org, partial failure, 401, cache reuse, cross-account isolation, stale fallback and schema drift), and the renderer. Fixtures are synthetic, matching the `opencode-go` convention.

`tests/live.rs` gains one `#[ignore]`d `commandcode_live`. It skips with a message when no harness on the machine is signed in, so `make smoke` stays green for everyone else. I verified it against the real API.

Docs: a support-matrix row and stability note in `docs/vendor-endpoints.md`, an auth-table row and a Command Code section in `README.md`, a `[commandcode]` section in `config.example.toml`, and a `[Unreleased]` entry in `CHANGELOG.md`. No published changelog section moved.

I left version numbers, PKGBUILDs and `.SRCINFO`s alone, since those belong to your release checklist rather than to a feature PR.
