### PR TITLE
feat(kimi): accept a Kimi For Coding subscription login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- Kimi accepts a **Kimi For Coding subscription** as a credential: when no
+  `KIMI_API_KEY` (or inline `api_key`) is set, the vendor uses the OAuth
+  session the Kimi Code CLI already stored at
+  `~/.kimi-code/credentials/kimi-code.json` — so a subscriber who works through
+  the CLI has nothing to create, paste, or rotate by hand. Same
+  `/coding/v1/usages` endpoint, same weekly + 5h windows; an API key still takes
+  precedence when one is set. New optional `[kimi] credentials_path` (for
+  a relocated `KIMI_CODE_HOME`) and `[kimi] region` — `auto` follows
+  kimi-code's own `~/.kimi-code/region` marker, `cn` pins `api.kimi.com`,
+  `global` pins `api.kimi.ai`.
+
+  The CLI's access token lives 15 minutes, so ai-usagebar refreshes it against
+  `auth.kimi.com/api/oauth/token` and writes the rotated pair **back into
+  kimi-code's own credential file** (atomically, mode 0600) rather than into a
+  private sidecar the way the Kiro vendor does. Kimi rotates the refresh token
+  on every grant: a private copy would leave the CLI holding a superseded token
+  after each widget tick and log the user out of their own CLI. The refresh
+  runs under kimi-code's own `proper-lockfile` protocol so the two clients
+  never rotate at once, and the file is re-read inside the lock so a refresh
+  that landed while waiting is used instead of being redone.
+
+- Kimi's plan label now reads the subscription's own tier name ("Andante",
+  "Moderato", "Allegretto", "Allegro") from `/coding/v1/me`, fetched
+  concurrently with `/usages` so a widget tick still costs one round-trip.
+  `/usages` only carries the `LEVEL_*` wire enum, which was what the bar used
+  to show. When `/me` is unreachable or the account has no coding profile, the
+  enum is humanized instead (`LEVEL_INTERMEDIATE` → `Intermediate`) — never
+  mapped to an invented tier name. A still-fresh cache entry holding a raw
+  `LEVEL_*` plan is refreshed once rather than waiting out its TTL. The
+  profile response's personal fields (email, phone, nickname) are never
+  deserialized, so they cannot reach a snapshot, the cache, or an error
+  message.
+
+### Changed
+
+- Kimi's default widget format now shows both independent quotas —
+  `5h X% · 7d Y%` — instead of a single percentage that silently discarded
+  one of them. A custom `format` in config.toml is untouched. The TUI panel's
+  value column shows the same `{pct}%` every other vendor shows instead of
+  raw request counts; the counts move to the footnote next to the remaining
+  figure and the reset countdown.
+
 ## [1.7.0] — 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ come from environment variables or `config.toml`.
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
 | OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. Named keys are supported. |
 | DeepSeek | API key (`DEEPSEEK_API_KEY` or config) | Set either and opt in. |
-| Kimi | API key (`KIMI_API_KEY` or config) | Set either and opt in. |
+| Kimi | Existing Kimi Code CLI login **or** API key (`KIMI_API_KEY` or config) | Opt in, then either log in with `kimi` (nothing to paste) or set an API key, which wins when present. A Kimi For Coding subscription can issue one at kimi.com/code/console. |
 | Kilo | API key (`KILO_API_KEY` env or `[kilo] api_key` in config) | Set either. Opt-in. For a team balance, also set `[kilo] organization_id`; omit it for the personal balance. |
 | Novita | API key (`NOVITA_API_KEY` env or `[novita] api_key` in config) | Set either. Opt-in. |
 | Moonshot | API key (`MOONSHOT_API_KEY` or config) | Opt in. Set region `cn` for CNY; `global` uses USD. |
@@ -276,6 +276,11 @@ installs are unaffected until you opt in. Use either method:
 
 The primary-vendor selector only offers vendors that are currently enabled, so a
 vendor you haven't opted into cannot be set as primary.
+
+Vendors that authenticate through a local login rather than a key — Cursor,
+Kiro CLI, SuperGrok, Antigravity, and Kimi when you have a Kimi For Coding
+subscription — have no key to save, so enable them with `enabled = true` in
+`config.toml`.
 
 ### Credential resolution order (for API-key vendors)
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -131,7 +131,12 @@ api_key_env = "DEEPSEEK_API_KEY"  # checked first; if set + non-empty, used
 # api_key = "sk-..."              # fallback; chmod 600 the file if you use it
 
 [kimi]
-# Disabled by default — enable once you've set a key (env var or inline).
+# Disabled by default. Two ways to authenticate:
+#   1. An existing Kimi Code CLI login: log in with `kimi` and just set
+#      `enabled = true` — nothing to create or paste. ai-usagebar reads the
+#      CLI's own OAuth session and refreshes it in place.
+#   2. An API key (env var or inline), which takes precedence when set. A Kimi
+#      For Coding subscription can issue one at kimi.com/code/console.
 # Saving a key in the Settings overlay writes the inline fallback AND flips
 # `enabled` to true; clearing the field removes the inline key again.
 # Shows Kimi Code subscription quota (weekly + 5h rolling window) from the
@@ -139,6 +144,9 @@ api_key_env = "DEEPSEEK_API_KEY"  # checked first; if set + non-empty, used
 enabled = false
 api_key_env = "KIMI_API_KEY"      # checked first; if set + non-empty, used
 # api_key = "sk-..."              # fallback; chmod 600 the file if you use it
+# credentials_path = "~/.kimi-code/credentials/kimi-code.json"  # CLI login file
+# region = "auto"                 # auto follows ~/.kimi-code/region;
+#                                 # cn -> api.kimi.com | global -> api.kimi.ai
 
 # --- Account-balance vendors -------------------------------------------------
 # These report your REMAINING credit as money, rather than plan usage as a %.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,9 +59,16 @@ api_key_env = "DEEPSEEK_API_KEY"
 # api_key = "sk-..."       # used if DEEPSEEK_API_KEY is unset; chmod 600 the file!
 
 [kimi]
-enabled = true             # disabled by default; enable once you add an API key
+enabled = true             # disabled by default; a Kimi Code CLI login is enough
+# Log in with `kimi` and ai-usagebar reads the OAuth session the CLI already
+# stored, refreshing it in place when it expires — no key to create or paste.
+# An API key still wins when one is set; a Kimi For Coding subscription can
+# issue one at kimi.com/code/console, and a platform key works too.
 api_key_env = "KIMI_API_KEY"
 # api_key = "sk-..."       # used if KIMI_API_KEY is unset; chmod 600 the file!
+# credentials_path = "~/.kimi-code/credentials/kimi-code.json"  # CLI login file
+# region = "auto"          # auto follows ~/.kimi-code/region
+#                          # cn -> api.kimi.com | global -> api.kimi.ai
 
 [minimax]
 enabled = true             # disabled by default; enable once you add an API key

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -12,7 +12,7 @@ defensive and includes opt-in live tests for catching response changes.
 | **Z.AI** | `api.z.ai/api/monitor/usage/quota/limit` (undocumented) | Session 5h, Weekly 7d, MCP tools monthly | Yes |
 | **OpenRouter** | `openrouter.ai/api/v1/{credits,key}` (documented) | Balance, today/week/month spend, free vs paid tier | Yes |
 | **DeepSeek** | `api.deepseek.com/user/balance` (documented) | Balance, granted, topped-up credits | Yes |
-| **Kimi** | `api.kimi.com/coding/v1/usages` (undocumented; community-confirmed) | Weekly subscription quota + 5h rolling rate-limit window | No — widget/TUI only; desktop protocol and marker parity are future work |
+| **Kimi** | `api.kimi.com\|.ai/coding/v1/usages` (undocumented; community-confirmed), plus `auth.kimi.com\|.ai/api/oauth/token` to refresh a Kimi Code CLI login | Weekly subscription quota + 5h rolling rate-limit window | No — widget/TUI only; desktop protocol and marker parity are future work |
 | **MiniMax** | `api.minimax.io/v1/token_plan/remains` (official Token Plan quota route) | Token Plan rolling interval window + weekly, per model bucket (text, video) | No — widget/TUI only |
 | **Kilo** | `api.kilo.ai/api/profile/balance` (undocumented; extension-internal) | Remaining credit balance ($) | No — widget/TUI only |
 | **Novita** | `api.novita.ai/openapi/v1/billing/balance/detail` (documented) | Remaining credit balance ($) | No — widget/TUI only |
@@ -33,7 +33,7 @@ defensive and includes opt-in live tests for catching response changes.
 | Claude | Undocumented usage endpoint, but used by the official `claude` CLI. Less fragile than a scraped web page. |
 | Codex | Undocumented ChatGPT usage endpoint used by the official `codex` CLI. Windows are identified by duration instead of response position. |
 | Z.AI | Reverse-engineered from a third-party plugin. Treat this as the most fragile integration. |
-| Kimi | Community-confirmed `/coding/v1/usages` route used by third-party quota tools. Drift is possible. |
+| Kimi | Community-confirmed `/coding/v1/usages` route used by third-party quota tools. Drift is possible. The refresh grant is the Kimi Code CLI's own documented-by-behaviour device-flow token endpoint, using the CLI's public client id. |
 | Cursor | Undocumented endpoint called by Cursor's dashboard. Its shape may change with Cursor pricing. |
 | MiniMax | The Token Plan route is official, but no formal response schema is published. |
 | Kiro CLI | `GetUsageLimits` is the same undocumented CodeWhisperer operation used by kiro-cli's `/usage` command. AWS SSO OIDC `CreateToken`, used for refresh, is documented. |
@@ -52,7 +52,8 @@ make smoke
 
 Claude, Codex, Z.AI, and OpenRouter tests require their normal credentials or
 API keys. Kimi is optional: its test prints a skip reason when `KIMI_API_KEY` is
-unset.
+unset (the smoke test covers the API-key path; a subscription login is exercised
+by `ai-usagebar --vendor kimi`).
 
 To test only Kimi:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -624,7 +624,18 @@ impl Default for DeepseekConfig {
 pub struct KimiConfig {
     pub enabled: bool,
     pub api_key_env: String,
+    /// Optional: with no key set, the vendor falls back to the Kimi Code CLI's
+    /// own OAuth login, which is what a subscriber already has locally.
     pub api_key: Option<String>,
+    /// Override for kimi-code's credential file (default
+    /// `~/.kimi-code/credentials/kimi-code.json`), mirroring `[cursor] db_path`
+    /// and `[kiro] db_path`. Useful with a relocated `KIMI_CODE_HOME`.
+    pub credentials_path: Option<PathBuf>,
+    /// `"auto"` follows kimi-code's own install marker (`~/.kimi-code/region`);
+    /// `"cn"` pins `api.kimi.com` / `auth.kimi.com`, `"global"` pins
+    /// `api.kimi.ai` / `auth.kimi.ai`. A token minted by one deployment means
+    /// nothing to the other, so this picks the instance, not a currency.
+    pub region: String,
 }
 
 impl Default for KimiConfig {
@@ -633,6 +644,8 @@ impl Default for KimiConfig {
             enabled: false,
             api_key_env: "KIMI_API_KEY".to_string(),
             api_key: None,
+            credentials_path: None,
+            region: "auto".to_string(),
         }
     }
 }
@@ -884,24 +897,29 @@ pub fn resolve_api_key(
     resolve_api_key_in_section(vendor_label, &section, env_var_name, inline)
 }
 
+/// The env-then-inline lookup without the "or fail" ending, for vendors where
+/// an absent API key is a legitimate state rather than an error — Kimi accepts
+/// a Kimi Code CLI subscription login instead.
+pub fn optional_api_key(env_var_name: &str, inline: Option<&str>) -> Option<String> {
+    if is_valid_env_var_name(env_var_name)
+        && let Ok(v) = std::env::var(env_var_name)
+        && !v.is_empty()
+    {
+        return Some(v);
+    }
+    inline.filter(|v| !v.is_empty()).map(str::to_string)
+}
+
 fn resolve_api_key_in_section(
     vendor_label: &str,
     section: &str,
     env_var_name: &str,
     inline: Option<&str>,
 ) -> crate::error::Result<String> {
+    if let Some(key) = optional_api_key(env_var_name, inline) {
+        return Ok(key);
+    }
     let valid_env_name = is_valid_env_var_name(env_var_name);
-    if valid_env_name
-        && let Ok(v) = std::env::var(env_var_name)
-        && !v.is_empty()
-    {
-        return Ok(v);
-    }
-    if let Some(v) = inline
-        && !v.is_empty()
-    {
-        return Ok(v.to_string());
-    }
     let advice = if valid_env_name {
         "set an API key in a valid environment variable or set `api_key`"
     } else {
@@ -959,6 +977,7 @@ impl Config {
         expand_tilde_opt(&mut self.cursor.db_path);
         expand_tilde_opt(&mut self.cursor.agent_auth_path);
         expand_tilde_opt(&mut self.kiro.db_path);
+        expand_tilde_opt(&mut self.kimi.credentials_path);
         self.supergrok.grok_binary = expand_tilde(&self.supergrok.grok_binary);
         expand_tilde_opt(&mut self.supergrok.auth_path);
         expand_tilde_opt(&mut self.supergrok.config_path);
@@ -1077,6 +1096,14 @@ impl Config {
                  remove it to show spend without a limit"
                     .into(),
             ));
+        }
+        if crate::kimi::oauth::Region::parse(&self.kimi.region).is_none()
+            && !self.kimi.region.eq_ignore_ascii_case("auto")
+        {
+            return Err(AppError::Other(format!(
+                "[kimi] region must be \"auto\", \"cn\", or \"global\", got {:?}",
+                self.kimi.region
+            )));
         }
         if !self.minimax.region.eq_ignore_ascii_case("global")
             && !self.minimax.region.eq_ignore_ascii_case("cn")
@@ -1425,6 +1452,59 @@ enabled = false
             let error = Config::load_from(file.path()).unwrap_err().to_string();
             assert!(error.contains("[minimax] region"), "{error}");
         }
+    }
+
+    #[test]
+    fn kimi_region_accepts_auto_and_both_deployments() {
+        for region in ["auto", "AUTO", "cn", "mainland-cn", "global"] {
+            let file = write_toml(&format!("[kimi]\nregion = {region:?}\n"));
+            assert_eq!(Config::load_from(file.path()).unwrap().kimi.region, region);
+        }
+
+        for region in ["", "us", "oversea"] {
+            let file = write_toml(&format!("[kimi]\nregion = {region:?}\n"));
+            let error = Config::load_from(file.path()).unwrap_err().to_string();
+            assert!(error.contains("[kimi] region"), "{error}");
+        }
+    }
+
+    #[test]
+    fn kimi_defaults_to_auto_region_and_no_credential_override() {
+        let defaults = KimiConfig::default();
+        assert_eq!(defaults.region, "auto");
+        assert_eq!(defaults.credentials_path, None);
+        assert!(!defaults.enabled);
+    }
+
+    #[test]
+    fn kimi_credentials_path_expands_a_tilde() {
+        let file = write_toml("[kimi]\ncredentials_path = \"~/kimi/creds.json\"\n");
+        let path = Config::load_from(file.path())
+            .unwrap()
+            .kimi
+            .credentials_path
+            .unwrap();
+        assert!(!path.starts_with("~"), "{}", path.display());
+        assert!(path.ends_with("kimi/creds.json"), "{}", path.display());
+    }
+
+    #[test]
+    fn optional_api_key_reports_absence_instead_of_failing() {
+        assert_eq!(
+            optional_api_key("KIMI_API_KEY_DEFINITELY_UNSET", Some("inline")),
+            Some("inline".to_string())
+        );
+        assert_eq!(
+            optional_api_key("KIMI_API_KEY_DEFINITELY_UNSET", None),
+            None
+        );
+        assert_eq!(optional_api_key("KIMI_API_KEY_UNSET", Some("")), None);
+        // An unusable `api_key_env` still lets an inline key through, exactly
+        // as `resolve_api_key` does.
+        assert_eq!(
+            optional_api_key("9INVALID", Some("inline")),
+            Some("inline".to_string())
+        );
     }
 
     #[test]

--- a/src/kimi/fetch.rs
+++ b/src/kimi/fetch.rs
@@ -1,5 +1,10 @@
 //! Fetch Kimi usage from `/coding/v1/usages`.
+//!
+//! One endpoint, two credentials: an **API key**, or the **Kimi Code CLI's
+//! OAuth session** — the credential a subscriber already has locally, with no
+//! key to create or paste. See [`Auth`] and `oauth.rs`.
 
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -8,10 +13,12 @@ use crate::cache::{Cache, MAX_STALE, acquire_lock_async};
 use crate::error::{AppError, Result};
 use crate::usage::KimiSnapshot;
 
-use super::types::UsagesResponse;
+use super::oauth::{self, Region};
+use super::types::{UsagesResponse, UserInfoResponse, humanize_membership_level};
 
 pub const BASE_URL: &str = "https://api.kimi.com";
 const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const REFRESH_TIMEOUT: Duration = Duration::from_secs(15);
 const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
 /// Stable marker stored alongside code 0 for a successful HTTP response whose
 /// payload no longer matches Kimi's undocumented usage schema.
@@ -20,12 +27,62 @@ pub const SCHEMA_DRIFT_MESSAGE: &str = "Kimi API schema drift";
 #[derive(Debug, Clone)]
 pub struct Endpoints {
     pub usages: String,
+    /// Profile endpoint, read solely for the subscription's own tier name.
+    pub me: String,
+    /// OAuth token endpoint for the same deployment. Unused by the API-key
+    /// path, which never refreshes anything.
+    pub token: String,
 }
 
 impl Default for Endpoints {
     fn default() -> Self {
+        Self::for_region(Region::MainlandCn)
+    }
+}
+
+impl Endpoints {
+    pub fn for_region(region: Region) -> Self {
         Self {
-            usages: format!("{BASE_URL}/coding/v1/usages"),
+            usages: format!("{}/usages", region.api_base()),
+            me: format!("{}/me", region.api_base()),
+            token: oauth::token_endpoint(region.oauth_host()),
+        }
+    }
+}
+
+/// Where the bearer for `/coding/v1/usages` comes from.
+#[derive(Debug, Clone)]
+pub enum Auth {
+    /// A platform API key (`KIMI_API_KEY` or `[kimi] api_key`).
+    ApiKey(String),
+    /// The Kimi Code CLI's own OAuth session — a subscription login.
+    KimiCode(KimiCodeAuth),
+}
+
+/// The two paths inside a kimi-code home this vendor touches: the credential
+/// file it reads and rewrites, and the lock target that serializes a refresh
+/// against the CLI's own (see `lock.rs`).
+#[derive(Debug, Clone)]
+pub struct KimiCodeAuth {
+    pub credentials_path: PathBuf,
+    pub lock_target: PathBuf,
+}
+
+impl KimiCodeAuth {
+    pub fn in_home(home: &Path) -> Self {
+        Self {
+            credentials_path: oauth::credentials_path_in(home),
+            lock_target: oauth::lock_target_in(home),
+        }
+    }
+
+    /// A credential file relocated by config (`[kimi] credentials_path`) still
+    /// belongs to a kimi-code home; the lock target is derived from that home
+    /// so both clients agree on which file the lock protects.
+    pub fn with_credentials_path(home: &Path, credentials_path: PathBuf) -> Self {
+        Self {
+            credentials_path,
+            lock_target: oauth::lock_target_in(home),
         }
     }
 }
@@ -38,6 +95,8 @@ pub struct FetchOutcome {
     pub cache_age: Option<Duration>,
 }
 
+/// API-key fetch. Kept as-is for existing callers; the OAuth path goes
+/// through [`fetch_snapshot_with_auth`].
 pub async fn fetch_snapshot(
     client: &reqwest::Client,
     api_key: &str,
@@ -45,18 +104,55 @@ pub async fn fetch_snapshot(
     endpoints: &Endpoints,
     cache_ttl: Duration,
 ) -> Result<FetchOutcome> {
+    fetch_snapshot_with_auth(
+        client,
+        &Auth::ApiKey(api_key.to_string()),
+        cache,
+        endpoints,
+        cache_ttl,
+    )
+    .await
+}
+
+pub async fn fetch_snapshot_with_auth(
+    client: &reqwest::Client,
+    auth: &Auth,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+) -> Result<FetchOutcome> {
+    fetch_snapshot_at(client, auth, cache, endpoints, cache_ttl, Utc::now()).await
+}
+
+/// Clock seam for the OAuth expiry decision, mirroring
+/// `kiro::fetch::fetch_snapshot_at`.
+async fn fetch_snapshot_at(
+    client: &reqwest::Client,
+    auth: &Auth,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+    now: DateTime<Utc>,
+) -> Result<FetchOutcome> {
     cache.ensure_dir()?;
     let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
 
-    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
-        && let Ok(outcome) = reuse_cache(bytes, cache, false)
-    {
-        return Ok(outcome);
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)? {
+        // Releases before the profile lookup cached `/usages`' internal enum
+        // verbatim. Do not let a still-fresh legacy entry postpone `/me` until
+        // the normal TTL expires: refresh it once and replace it with Kimi's
+        // own tier name. If the network is down, the fallback path below still
+        // serves the quota after humanizing the enum.
+        if !cache_has_legacy_plan(&bytes)
+            && let Ok(outcome) = reuse_cache(bytes, cache, false)
+        {
+            return Ok(outcome);
+        }
     }
     // Corrupt fresh cache: fall through to live fetch rather than return a
     // fabricated zero snapshot.
 
-    match fetch_live(client, &endpoints.usages, api_key).await {
+    match fetch_live(client, endpoints, auth, now).await {
         Ok(snap) => {
             let bytes = serde_json::to_vec(&snap_to_json(&snap))?;
             cache.write_payload(&bytes)?;
@@ -123,7 +219,13 @@ fn reuse_cache(bytes: Vec<u8>, cache: &Cache, stale: bool) -> Result<FetchOutcom
 fn parse_cache(bytes: &[u8]) -> Result<KimiSnapshot> {
     let v: serde_json::Value = serde_json::from_slice(bytes)?;
     Ok(KimiSnapshot {
-        plan: v["plan"].as_str().map(|s| s.to_string()),
+        plan: v["plan"].as_str().map(|plan| {
+            if plan.starts_with("LEVEL_") {
+                humanize_membership_level(plan)
+            } else {
+                plan.to_string()
+            }
+        }),
         weekly_limit: parse_cache_u64(&v["weekly_limit"], "weekly_limit")?,
         weekly_used: parse_cache_u64(&v["weekly_used"], "weekly_used")?,
         weekly_remaining: parse_cache_u64(&v["weekly_remaining"], "weekly_remaining")?,
@@ -133,6 +235,13 @@ fn parse_cache(bytes: &[u8]) -> Result<KimiSnapshot> {
         window_remaining: parse_cache_u64(&v["window_remaining"], "window_remaining")?,
         window_reset_at: parse_cache_datetime(&v["window_reset_at"])?,
     })
+}
+
+fn cache_has_legacy_plan(bytes: &[u8]) -> bool {
+    serde_json::from_slice::<serde_json::Value>(bytes)
+        .ok()
+        .and_then(|value| value["plan"].as_str().map(str::to_owned))
+        .is_some_and(|plan| plan.starts_with("LEVEL_"))
 }
 
 fn parse_cache_u64(v: &serde_json::Value, name: &str) -> Result<u64> {
@@ -166,17 +275,118 @@ fn snap_to_json(snap: &KimiSnapshot) -> serde_json::Value {
     })
 }
 
-async fn fetch_live(client: &reqwest::Client, url: &str, api_key: &str) -> Result<KimiSnapshot> {
+/// Resolve the bearer for this fetch. The API key is already one; a Kimi Code
+/// login may first need a refresh, which rotates the CLI's stored token pair
+/// and is therefore serialized against the CLI itself.
+async fn bearer_token(
+    client: &reqwest::Client,
+    endpoints: &Endpoints,
+    auth: &Auth,
+    now: DateTime<Utc>,
+) -> Result<String> {
+    let kimi_code = match auth {
+        Auth::ApiKey(key) => return Ok(key.clone()),
+        Auth::KimiCode(kimi_code) => kimi_code,
+    };
+
+    let creds = oauth::read_from(&kimi_code.credentials_path)?;
+    if !oauth::needs_refresh(creds.expires_at, now.timestamp()) {
+        return Ok(creds.access_token);
+    }
+
+    let _lock = super::lock::acquire(&kimi_code.lock_target).await?;
+    // Re-read under the lock: the CLI (or another ai-usagebar process) may
+    // have refreshed while we waited, and reusing our pre-lock copy would burn
+    // an already-rotated refresh token.
+    let creds = oauth::read_from(&kimi_code.credentials_path)?;
+    if !oauth::needs_refresh(creds.expires_at, now.timestamp()) {
+        return Ok(creds.access_token);
+    }
+
+    let refreshed = tokio::time::timeout(
+        REFRESH_TIMEOUT,
+        oauth::refresh(
+            client,
+            &endpoints.token,
+            oauth::CLIENT_ID,
+            &creds.refresh_token,
+        ),
+    )
+    .await
+    .map_err(|_| AppError::Transport(format!("kimi token refresh timeout: {}", endpoints.token)))?
+    .map_err(|e| match e {
+        AppError::Transport(msg) => AppError::Transport(msg),
+        e => AppError::Credentials(format!(
+            "Kimi Code CLI token refresh failed ({e}). Run `kimi` and log in again."
+        )),
+    })?;
+
+    let next = oauth::apply_refresh(&creds, refreshed, now.timestamp());
+    oauth::write_to(&kimi_code.credentials_path, &next).map_err(|e| {
+        // The rotation already happened upstream, so a failed write-back means
+        // the CLI is now holding a dead refresh token: say so plainly instead
+        // of leaving the user to discover it at their next `kimi` run.
+        AppError::Credentials(format!(
+            "the refreshed Kimi Code CLI credentials could not be saved ({e}); run `kimi` and log in again"
+        ))
+    })?;
+    Ok(next.access_token)
+}
+
+/// Ask `/coding/v1/me` for the subscription's own tier name ("Allegretto"),
+/// which is the only place the vendor spells its plans the way its pricing
+/// page does — `/usages` only carries the `LEVEL_*` wire enum.
+///
+/// Best-effort by construction: every failure returns `None` and leaves the
+/// humanized enum in place. A missing plan label must never cost the user
+/// their quota numbers, and this endpoint is documented (by kimi-code's own
+/// error text) to 404 for accounts without a coding profile.
+async fn plan_label(client: &reqwest::Client, url: &str, token: &str) -> Option<String> {
     let resp = tokio::time::timeout(
         HTTP_TIMEOUT,
         client
             .get(url)
-            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Authorization", format!("Bearer {token}"))
             .header("Accept", "application/json")
             .send(),
     )
     .await
-    .map_err(|_| AppError::Transport(format!("kimi timeout: {url}")))??;
+    .ok()?
+    .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES)
+        .await
+        .ok()?;
+    serde_json::from_slice::<UserInfoResponse>(&bytes)
+        .ok()?
+        .plan_label()
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    endpoints: &Endpoints,
+    auth: &Auth,
+    now: DateTime<Utc>,
+) -> Result<KimiSnapshot> {
+    let url = &endpoints.usages;
+    let token = bearer_token(client, endpoints, auth, now).await?;
+    // Concurrent, not sequential: the plan label is a second request against
+    // the same deployment, and a widget tick should cost one round-trip's
+    // latency, not two.
+    let (usages, label) = tokio::join!(
+        tokio::time::timeout(
+            HTTP_TIMEOUT,
+            client
+                .get(url)
+                .header("Authorization", format!("Bearer {token}"))
+                .header("Accept", "application/json")
+                .send(),
+        ),
+        plan_label(client, &endpoints.me, &token),
+    );
+    let resp = usages.map_err(|_| AppError::Transport(format!("kimi timeout: {url}")))??;
 
     let status = resp.status();
 
@@ -197,7 +407,11 @@ async fn fetch_live(client: &reqwest::Client, url: &str, api_key: &str) -> Resul
     let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
     let r: UsagesResponse = serde_json::from_slice(&bytes)
         .map_err(|e| AppError::Schema(format!("kimi usages response: {e}")))?;
-    r.into_snapshot()
+    let mut snap = r.into_snapshot()?;
+    if let Some(label) = label {
+        snap.plan = Some(label);
+    }
+    Ok(snap)
 }
 
 #[cfg(test)]
@@ -210,6 +424,16 @@ mod tests {
         let cache = Cache::at(td.path().join("kimi"));
         cache.ensure_dir().unwrap();
         (td, cache)
+    }
+
+    /// Both endpoints point at the same mock server, so an OAuth test can
+    /// serve `/api/oauth/token` and `/coding/v1/usages` from one mockito.
+    fn test_endpoints(base: &str) -> Endpoints {
+        Endpoints {
+            usages: format!("{base}/coding/v1/usages"),
+            me: format!("{base}/coding/v1/me"),
+            token: format!("{base}/api/oauth/token"),
+        }
     }
 
     fn sample_json() -> &'static str {
@@ -253,9 +477,7 @@ mod tests {
 
         let (_td, cache) = cache_fixture();
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let out = fetch_snapshot(
             &client,
             "sk-test",
@@ -266,7 +488,8 @@ mod tests {
         .await
         .unwrap();
         m.assert_async().await;
-        assert_eq!(out.snapshot.plan, Some("LEVEL_INTERMEDIATE".into()));
+        // No /me mock on this server, so the humanized wire enum stands.
+        assert_eq!(out.snapshot.plan, Some("Intermediate".into()));
         assert_eq!(out.snapshot.weekly_limit, 100);
         assert_eq!(out.snapshot.weekly_used, 26);
         assert_eq!(out.snapshot.weekly_remaining, 74);
@@ -291,9 +514,7 @@ mod tests {
             .unwrap();
 
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let out = fetch_snapshot(
             &client,
             "bad-key",
@@ -324,9 +545,7 @@ mod tests {
             .unwrap();
 
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let out = fetch_snapshot(
             &client,
             "sk-test",
@@ -352,9 +571,7 @@ mod tests {
 
         let (_td, cache) = cache_fixture();
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let err = fetch_snapshot(
             &client,
             "bad-key",
@@ -382,9 +599,7 @@ mod tests {
 
         let (_td, cache) = cache_fixture();
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let err = fetch_snapshot(
             &client,
             "sk-test",
@@ -415,9 +630,7 @@ mod tests {
         cache.write_payload(seeded.as_bytes()).unwrap();
 
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let out = fetch_snapshot(
             &client,
             "sk-test",
@@ -450,9 +663,7 @@ mod tests {
 
         let (_td, cache) = cache_fixture();
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let err = fetch_snapshot(
             &client,
             "sk-test",
@@ -479,9 +690,7 @@ mod tests {
         cache.write_payload(b"not valid json".as_slice()).unwrap();
 
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let out = fetch_snapshot(
             &client,
             "sk-test",
@@ -493,6 +702,52 @@ mod tests {
         .unwrap();
         assert_eq!(out.snapshot.weekly_used, 26);
         assert!(!out.stale);
+    }
+
+    #[tokio::test]
+    async fn a_fresh_legacy_plan_cache_is_upgraded_through_the_profile_endpoint() {
+        let mut server = mockito::Server::new_async().await;
+        let usages = server
+            .mock("GET", "/coding/v1/usages")
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+        let me = server
+            .mock("GET", "/coding/v1/me")
+            .with_status(200)
+            .with_body(r#"{"user_level_name":"Allegretto"}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        cache
+            .write_payload(sample_seed().to_string().as_bytes())
+            .unwrap();
+
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "sk-test",
+            &cache,
+            &test_endpoints(&server.url()),
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+
+        usages.assert_async().await;
+        me.assert_async().await;
+        assert_eq!(out.snapshot.plan, Some("Allegretto".into()));
+        let cached: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(cache.payload_path()).unwrap()).unwrap();
+        assert_eq!(cached["plan"], "Allegretto");
+    }
+
+    #[test]
+    fn a_legacy_plan_is_humanized_when_only_fallback_cache_is_available() {
+        let bytes = sample_seed().to_string();
+        let snap = parse_cache(bytes.as_bytes()).unwrap();
+        assert_eq!(snap.plan, Some("Intermediate".into()));
     }
 
     #[tokio::test]
@@ -509,9 +764,7 @@ mod tests {
         cache.write_payload(b"not valid json".as_slice()).unwrap();
 
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: format!("{}/coding/v1/usages", server.url()),
-        };
+        let endpoints = test_endpoints(&server.url());
         let err = fetch_snapshot(
             &client,
             "bad-key",
@@ -536,9 +789,7 @@ mod tests {
             .unwrap();
 
         let client = reqwest::Client::new();
-        let endpoints = Endpoints {
-            usages: "http://localhost:1/coding/v1/usages".into(),
-        };
+        let endpoints = test_endpoints("http://localhost:1");
         let out = fetch_snapshot(
             &client,
             "sk-test",
@@ -568,9 +819,7 @@ mod tests {
             &reqwest::Client::new(),
             "sk-test",
             &cache,
-            &Endpoints {
-                usages: format!("{}/coding/v1/usages", server.url()),
-            },
+            &test_endpoints(&server.url()),
             Duration::ZERO,
         )
         .await
@@ -595,9 +844,7 @@ mod tests {
             &reqwest::Client::new(),
             "sk-test",
             &cache,
-            &Endpoints {
-                usages: format!("{}/coding/v1/usages", server.url()),
-            },
+            &test_endpoints(&server.url()),
             Duration::ZERO,
         )
         .await
@@ -624,9 +871,7 @@ mod tests {
             &reqwest::Client::new(),
             "sk-test",
             &cache,
-            &Endpoints {
-                usages: format!("{}/coding/v1/usages", server.url()),
-            },
+            &test_endpoints(&server.url()),
             Duration::ZERO,
         )
         .await
@@ -634,5 +879,348 @@ mod tests {
         assert!(
             matches!(err, AppError::Http { status: 500, ref body } if body == "Kimi API returned HTTP 500")
         );
+    }
+
+    // ---- Kimi Code CLI (subscription) credential path ----
+
+    /// A kimi-code home with a stored login. `expires_at` is relative to
+    /// `NOW_SECS`, the instant every OAuth test below passes in.
+    const NOW_SECS: i64 = 1_800_000_000;
+
+    fn kimi_code_home(td: &TempDir, expires_in: i64) -> (PathBuf, KimiCodeAuth) {
+        let home = td.path().join(".kimi-code");
+        let auth = KimiCodeAuth::in_home(&home);
+        std::fs::create_dir_all(auth.credentials_path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &auth.credentials_path,
+            serde_json::json!({
+                "access_token": "cli-at",
+                "refresh_token": "cli-rt",
+                "expires_at": NOW_SECS + expires_in,
+                "expires_in": 900,
+                "scope": "kimi-code",
+                "token_type": "Bearer",
+            })
+            .to_string(),
+        )
+        .unwrap();
+        (home, auth)
+    }
+
+    fn now() -> DateTime<Utc> {
+        DateTime::from_timestamp(NOW_SECS, 0).unwrap()
+    }
+
+    #[tokio::test]
+    async fn a_valid_cli_token_is_used_as_is_and_never_refreshed() {
+        let mut server = mockito::Server::new_async().await;
+        let usages = server
+            .mock("GET", "/coding/v1/usages")
+            .match_header("authorization", "Bearer cli-at")
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+        let refresh = server
+            .mock("POST", "/api/oauth/token")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let (td, cache) = cache_fixture();
+        let (_home, auth) = kimi_code_home(&td, 600);
+        let out = fetch_snapshot_at(
+            &reqwest::Client::new(),
+            &Auth::KimiCode(auth.clone()),
+            &cache,
+            &test_endpoints(&server.url()),
+            Duration::ZERO,
+            now(),
+        )
+        .await
+        .unwrap();
+
+        usages.assert_async().await;
+        refresh.assert_async().await;
+        assert_eq!(out.snapshot.weekly_used, 26);
+        let stored = std::fs::read_to_string(&auth.credentials_path).unwrap();
+        assert!(stored.contains("cli-rt"), "an unused token must not rotate");
+    }
+
+    #[tokio::test]
+    async fn an_expiring_cli_token_is_refreshed_and_the_rotation_is_written_back() {
+        let mut server = mockito::Server::new_async().await;
+        let refresh = server
+            .mock("POST", "/api/oauth/token")
+            .match_body(mockito::Matcher::UrlEncoded(
+                "refresh_token".into(),
+                "cli-rt".into(),
+            ))
+            .with_status(200)
+            .with_body(
+                r#"{"access_token":"fresh-at","refresh_token":"fresh-rt","expires_in":900,
+                    "scope":"kimi-code","token_type":"Bearer"}"#,
+            )
+            .create_async()
+            .await;
+        let usages = server
+            .mock("GET", "/coding/v1/usages")
+            .match_header("authorization", "Bearer fresh-at")
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+
+        let (td, cache) = cache_fixture();
+        // Inside the refresh buffer: still valid, but not for long enough.
+        let (home, auth) = kimi_code_home(&td, 30);
+        let out = fetch_snapshot_at(
+            &reqwest::Client::new(),
+            &Auth::KimiCode(auth.clone()),
+            &cache,
+            &test_endpoints(&server.url()),
+            Duration::ZERO,
+            now(),
+        )
+        .await
+        .unwrap();
+
+        refresh.assert_async().await;
+        usages.assert_async().await;
+        assert_eq!(out.snapshot.weekly_used, 26);
+
+        let stored: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&auth.credentials_path).unwrap()).unwrap();
+        assert_eq!(stored["access_token"], "fresh-at");
+        assert_eq!(
+            stored["refresh_token"], "fresh-rt",
+            "the CLI's own store must carry the rotated token, or its next run is dead"
+        );
+        assert_eq!(stored["expires_at"], NOW_SECS + 900);
+        // The lock is the CLI's own target, and it must not be left behind.
+        assert!(!super::super::lock::lock_dir_for(&auth.lock_target).exists());
+        assert!(home.join("oauth").is_dir());
+    }
+
+    #[tokio::test]
+    async fn a_rejected_refresh_reports_a_credential_error_naming_the_cli() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/api/oauth/token")
+            .with_status(401)
+            .with_body(r#"{"error":"invalid_grant"}"#)
+            .create_async()
+            .await;
+
+        let (td, cache) = cache_fixture();
+        let (_home, auth) = kimi_code_home(&td, -60);
+        let err = fetch_snapshot_at(
+            &reqwest::Client::new(),
+            &Auth::KimiCode(auth),
+            &cache,
+            &test_endpoints(&server.url()),
+            Duration::ZERO,
+            now(),
+        )
+        .await
+        .unwrap_err();
+        let message = err.to_string();
+        assert!(matches!(err, AppError::Credentials(_)), "{err:?}");
+        assert!(message.contains("log in again"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn a_logged_out_cli_falls_back_to_cache_with_a_credential_warning() {
+        let (td, cache) = cache_fixture();
+        let (_home, auth) = kimi_code_home(&td, 600);
+        std::fs::write(
+            &auth.credentials_path,
+            r#"{"access_token":"","refresh_token":"","expires_at":0}"#,
+        )
+        .unwrap();
+        cache
+            .write_payload(sample_seed().to_string().as_bytes())
+            .unwrap();
+
+        let out = fetch_snapshot_at(
+            &reqwest::Client::new(),
+            &Auth::KimiCode(auth),
+            &cache,
+            &test_endpoints("http://localhost:1"),
+            Duration::ZERO,
+            now(),
+        )
+        .await
+        .unwrap();
+        assert!(out.stale);
+        assert_eq!(out.snapshot.weekly_used, 30);
+        let (code, message) = out.last_error.unwrap();
+        assert_eq!(code, 0);
+        assert!(message.contains("logged out"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn a_peer_refresh_during_the_wait_is_picked_up_instead_of_rotating_again() {
+        let mut server = mockito::Server::new_async().await;
+        let refresh = server
+            .mock("POST", "/api/oauth/token")
+            .expect(0)
+            .create_async()
+            .await;
+        let usages = server
+            .mock("GET", "/coding/v1/usages")
+            .match_header("authorization", "Bearer peer-at")
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+
+        let (td, cache) = cache_fixture();
+        let (_home, auth) = kimi_code_home(&td, -60);
+        // Stand in for the CLI finishing its own refresh while we queued: the
+        // re-read under the lock must win over the copy read before it.
+        let peer = serde_json::json!({
+            "access_token": "peer-at",
+            "refresh_token": "peer-rt",
+            "expires_at": NOW_SECS + 900,
+            "expires_in": 900,
+            "scope": "kimi-code",
+            "token_type": "Bearer",
+        });
+        std::fs::write(&auth.credentials_path, peer.to_string()).unwrap();
+
+        let out = fetch_snapshot_at(
+            &reqwest::Client::new(),
+            &Auth::KimiCode(auth),
+            &cache,
+            &test_endpoints(&server.url()),
+            Duration::ZERO,
+            now(),
+        )
+        .await
+        .unwrap();
+        refresh.assert_async().await;
+        usages.assert_async().await;
+        assert_eq!(out.snapshot.weekly_used, 26);
+    }
+
+    #[test]
+    fn endpoints_follow_the_region() {
+        let cn = Endpoints::for_region(Region::MainlandCn);
+        assert_eq!(cn.usages, "https://api.kimi.com/coding/v1/usages");
+        assert_eq!(cn.token, "https://auth.kimi.com/api/oauth/token");
+        let global = Endpoints::for_region(Region::Global);
+        assert_eq!(global.usages, "https://api.kimi.ai/coding/v1/usages");
+        assert_eq!(global.token, "https://auth.kimi.ai/api/oauth/token");
+        // The default stays the endpoint the API-key path has always used.
+        assert_eq!(Endpoints::default().usages, cn.usages);
+    }
+
+    #[tokio::test]
+    async fn the_vendors_own_tier_name_replaces_the_wire_enum() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/coding/v1/usages")
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+        let me = server
+            .mock("GET", "/coding/v1/me")
+            .match_header("authorization", "Bearer sk-test")
+            .with_status(200)
+            .with_body(r#"{"user_id":"u-1","user_level":25,"user_level_name":"Allegretto"}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "sk-test",
+            &cache,
+            &test_endpoints(&server.url()),
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+        me.assert_async().await;
+        assert_eq!(out.snapshot.plan, Some("Allegretto".into()));
+        // …and it survives the cache round-trip, not just the live fetch.
+        let cached: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(cache.payload_path()).unwrap()).unwrap();
+        assert_eq!(cached["plan"], "Allegretto");
+    }
+
+    #[tokio::test]
+    async fn a_profile_endpoint_that_fails_costs_the_label_and_nothing_else() {
+        // 404 is documented by kimi-code's own error text for accounts with no
+        // coding profile; the quota numbers must still come through.
+        for status in [404, 401, 500] {
+            let mut server = mockito::Server::new_async().await;
+            server
+                .mock("GET", "/coding/v1/usages")
+                .with_status(200)
+                .with_body(sample_json())
+                .create_async()
+                .await;
+            server
+                .mock("GET", "/coding/v1/me")
+                .with_status(status)
+                .with_body(r#"{"error":"nope"}"#)
+                .create_async()
+                .await;
+
+            let (_td, cache) = cache_fixture();
+            let out = fetch_snapshot(
+                &reqwest::Client::new(),
+                "sk-test",
+                &cache,
+                &test_endpoints(&server.url()),
+                Duration::ZERO,
+            )
+            .await
+            .unwrap();
+            assert_eq!(out.snapshot.plan, Some("Intermediate".into()), "{status}");
+            assert_eq!(out.snapshot.weekly_used, 26, "{status}");
+            assert!(out.last_error.is_none(), "{status}: must not warn");
+        }
+    }
+
+    #[tokio::test]
+    async fn an_unreachable_profile_endpoint_does_not_fail_the_fetch() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/coding/v1/usages")
+            .with_status(200)
+            .with_body(sample_json())
+            .create_async()
+            .await;
+        let mut endpoints = test_endpoints(&server.url());
+        endpoints.me = "http://localhost:1/coding/v1/me".into();
+
+        let (_td, cache) = cache_fixture();
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            "sk-test",
+            &cache,
+            &endpoints,
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+        assert_eq!(out.snapshot.plan, Some("Intermediate".into()));
+        assert!(!out.stale);
+    }
+
+    #[test]
+    fn a_relocated_credential_file_keeps_the_homes_lock_target() {
+        let home = Path::new("/home/u/.kimi-code");
+        let auth =
+            KimiCodeAuth::with_credentials_path(home, PathBuf::from("/elsewhere/kimi-code.json"));
+        assert_eq!(
+            auth.credentials_path,
+            PathBuf::from("/elsewhere/kimi-code.json")
+        );
+        assert_eq!(auth.lock_target, oauth::lock_target_in(home));
     }
 }

--- a/src/kimi/lock.rs
+++ b/src/kimi/lock.rs
@@ -1,0 +1,233 @@
+//! Cross-process lock around a Kimi Code CLI credential refresh, speaking the
+//! CLI's own lock protocol.
+//!
+//! Unlike every other lock in this codebase (which guards a file ai-usagebar
+//! owns and therefore uses `flock` via `cache::acquire_lock_async`), this one
+//! guards a file **another program** owns and refreshes on its own schedule.
+//! kimi-code locks its credential store with `proper-lockfile`, whose contract
+//! is a *directory*: `lock(target)` succeeds by `mkdir`ing `<target>.lock`, an
+//! existing lock directory whose mtime is older than `stale` may be stolen, and
+//! the holder keeps refreshing that mtime while it works. `flock` here would be
+//! invisible to the CLI and both processes would rotate the same refresh token
+//! at once, so this speaks the protocol the other side actually implements.
+//!
+//! Windows is deliberately unlocked: kimi-code disables its own lock there
+//! (`if (process.platform === "win32") return undefined`), so taking one would
+//! only be a lock against ourselves.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use crate::error::{AppError, Result};
+
+/// proper-lockfile's default `stale` for kimi-code's OAuth lock (5 s), after
+/// which an abandoned lock directory may be taken over.
+pub const STALE: Duration = Duration::from_secs(5);
+/// How often the holder touches the lock directory. proper-lockfile refreshes
+/// at `stale / 2`; matching that keeps a slow refresh from looking abandoned.
+const HEARTBEAT: Duration = Duration::from_millis(2_500);
+const POLL: Duration = Duration::from_millis(250);
+/// Long enough to outlast a peer's refresh round-trip, short enough that a
+/// widget tick never hangs on it.
+pub const ACQUIRE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// The directory `proper-lockfile` actually creates for `target`.
+pub fn lock_dir_for(target: &Path) -> PathBuf {
+    let mut dir = target.as_os_str().to_os_string();
+    dir.push(".lock");
+    PathBuf::from(dir)
+}
+
+/// Held lock. Dropping it releases the lock and stops the heartbeat.
+#[derive(Debug)]
+pub struct OauthLock {
+    dir: PathBuf,
+    heartbeat: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Drop for OauthLock {
+    fn drop(&mut self) {
+        if let Some(handle) = self.heartbeat.take() {
+            handle.abort();
+        }
+        // `remove_dir_all`, not `remove_dir`: an aborted heartbeat can leave
+        // its sentinel behind, and a lock directory we fail to remove would
+        // block the CLI for `STALE` on every one of its own refreshes.
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+/// Acquire the lock for `target` (kimi-code's `<home>/oauth/kimi-code`),
+/// stealing it only once it has been abandoned for [`STALE`].
+pub async fn acquire(target: &Path) -> Result<OauthLock> {
+    acquire_with(target, ACQUIRE_TIMEOUT, STALE, POLL).await
+}
+
+/// Seam for tests: they pass a tiny `stale`/`poll` so the steal path does not
+/// need a five-second wall-clock wait.
+pub async fn acquire_with(
+    target: &Path,
+    timeout: Duration,
+    stale: Duration,
+    poll: Duration,
+) -> Result<OauthLock> {
+    let dir = lock_dir_for(target);
+    if let Some(parent) = dir.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| AppError::io_at(parent, e))?;
+    }
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        match std::fs::create_dir(&dir) {
+            Ok(()) => return Ok(hold(dir)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if is_stale(&dir, stale) {
+                    // Best-effort steal: losing the race just means another
+                    // process took it over first, and the next loop waits.
+                    let _ = std::fs::remove_dir_all(&dir);
+                }
+            }
+            Err(e) => return Err(AppError::io_at(&dir, e)),
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(AppError::Transport(format!(
+                "timed out waiting for the Kimi Code CLI credential lock at {}",
+                crate::display::sanitize_untrusted_path(&dir)
+            )));
+        }
+        tokio::time::sleep(poll).await;
+    }
+}
+
+fn hold(dir: PathBuf) -> OauthLock {
+    let beat_dir = dir.clone();
+    let heartbeat = tokio::runtime::Handle::try_current().ok().map(|_| {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(HEARTBEAT).await;
+                touch(&beat_dir);
+            }
+        })
+    });
+    OauthLock { dir, heartbeat }
+}
+
+/// Bump the lock directory's mtime, which is what proper-lockfile reads to
+/// decide whether a lock was abandoned. Adding and removing an entry is how a
+/// POSIX directory's mtime moves — there is no `utimes` in `std`, and pulling a
+/// crate in for one syscall is not worth a dependency.
+fn touch(dir: &Path) {
+    let sentinel = dir.join(".ai-usagebar-heartbeat");
+    if std::fs::write(&sentinel, b"").is_ok() {
+        let _ = std::fs::remove_file(&sentinel);
+    }
+}
+
+fn is_stale(dir: &Path, stale: Duration) -> bool {
+    let Ok(modified) = std::fs::metadata(dir).and_then(|m| m.modified()) else {
+        // No mtime to trust: leave the lock alone rather than steal blindly.
+        return false;
+    };
+    SystemTime::now()
+        .duration_since(modified)
+        .is_ok_and(|age| age > stale)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn target(td: &TempDir) -> PathBuf {
+        td.path().join("oauth").join("kimi-code")
+    }
+
+    #[test]
+    fn lock_dir_matches_proper_lockfile_naming() {
+        assert_eq!(
+            lock_dir_for(Path::new("/home/u/.kimi-code/oauth/kimi-code")),
+            PathBuf::from("/home/u/.kimi-code/oauth/kimi-code.lock")
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_creates_the_lock_directory_and_drop_removes_it() {
+        let td = TempDir::new().unwrap();
+        let target = target(&td);
+        let dir = lock_dir_for(&target);
+        {
+            let _lock = acquire_with(&target, Duration::from_secs(1), STALE, POLL)
+                .await
+                .unwrap();
+            assert!(dir.is_dir());
+        }
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn a_fresh_foreign_lock_is_waited_out_not_stolen() {
+        let td = TempDir::new().unwrap();
+        let target = target(&td);
+        let dir = lock_dir_for(&target);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let err = acquire_with(
+            &target,
+            Duration::from_millis(60),
+            Duration::from_secs(3_600),
+            Duration::from_millis(10),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, AppError::Transport(_)), "{err:?}");
+        assert!(dir.is_dir(), "a live peer's lock must survive");
+    }
+
+    #[tokio::test]
+    async fn an_abandoned_lock_is_stolen_once_stale() {
+        let td = TempDir::new().unwrap();
+        let target = target(&td);
+        let dir = lock_dir_for(&target);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let lock = acquire_with(
+            &target,
+            Duration::from_secs(2),
+            Duration::ZERO,
+            Duration::from_millis(10),
+        )
+        .await
+        .unwrap();
+        assert!(dir.is_dir());
+        drop(lock);
+        assert!(!dir.exists());
+    }
+
+    #[tokio::test]
+    async fn a_leftover_heartbeat_sentinel_does_not_block_release() {
+        let td = TempDir::new().unwrap();
+        let target = target(&td);
+        let dir = lock_dir_for(&target);
+        {
+            let _lock = acquire_with(&target, Duration::from_secs(1), STALE, POLL)
+                .await
+                .unwrap();
+            std::fs::write(dir.join(".ai-usagebar-heartbeat"), b"").unwrap();
+        }
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn touch_moves_the_directory_mtime_forward() {
+        let td = TempDir::new().unwrap();
+        let dir = td.path().join("kimi-code.lock");
+        std::fs::create_dir(&dir).unwrap();
+        let before = std::fs::metadata(&dir).unwrap().modified().unwrap();
+        // Filesystem mtime granularity can be coarse; assert the touch is not
+        // *older*, and that the sentinel never outlives the call.
+        touch(&dir);
+        let after = std::fs::metadata(&dir).unwrap().modified().unwrap();
+        assert!(after >= before);
+        assert!(!dir.join(".ai-usagebar-heartbeat").exists());
+    }
+}

--- a/src/kimi/mod.rs
+++ b/src/kimi/mod.rs
@@ -1,5 +1,198 @@
+//! Kimi — weekly subscription quota + 5h rolling window from
+//! `/coding/v1/usages`.
+//!
+//! Two credentials reach the same endpoint: an API key, or the Kimi Code CLI's
+//! OAuth login — the one a subscriber already has locally, with no key to
+//! create or paste. `oauth.rs` owns the CLI's token file and its refresh;
+//! `lock.rs` keeps that refresh from racing the CLI's own.
+
 pub mod fetch;
+pub mod lock;
+pub mod oauth;
 pub mod types;
 pub mod vendor;
 
+use std::path::Path;
+
 pub use fetch::fetch_snapshot;
+
+use crate::config::KimiConfig;
+use crate::error::{AppError, Result};
+
+/// Pick the credential and the deployment for a configured Kimi vendor.
+///
+/// An API key wins when one is set: it is the explicit choice, it needs no
+/// local CLI, and it is what every pre-subscription install already has
+/// configured. Otherwise the Kimi Code CLI's login is used, and only if
+/// neither exists does this fail — with both remedies named, since which one
+/// applies depends on whether the user has a subscription or a platform
+/// account.
+pub fn resolve_auth(cfg: &KimiConfig) -> Result<(fetch::Auth, fetch::Endpoints)> {
+    let home = oauth::default_home()?;
+    let api_key = crate::config::optional_api_key(&cfg.api_key_env, cfg.api_key.as_deref());
+    resolve_auth_in(cfg, &home, api_key)
+}
+
+/// Test seam for [`resolve_auth`]: the kimi-code home and the resolved API key
+/// are injected, so no test reads a real `$HOME` or an ambient env var.
+pub fn resolve_auth_in(
+    cfg: &KimiConfig,
+    home: &Path,
+    api_key: Option<String>,
+) -> Result<(fetch::Auth, fetch::Endpoints)> {
+    let region = match oauth::Region::parse(&cfg.region) {
+        Some(region) => region,
+        // "auto" (and anything `validate` let through) follows the CLI's own
+        // install marker, defaulting to mainland exactly as kimi-code does.
+        None => oauth::read_region_marker(home).unwrap_or(oauth::Region::MainlandCn),
+    };
+    let endpoints = fetch::Endpoints::for_region(region);
+
+    if let Some(key) = api_key {
+        return Ok((fetch::Auth::ApiKey(key), endpoints));
+    }
+
+    let kimi_code = match cfg.credentials_path.clone() {
+        Some(path) => fetch::KimiCodeAuth::with_credentials_path(home, path),
+        None => fetch::KimiCodeAuth::in_home(home),
+    };
+    if oauth::is_logged_in(&kimi_code.credentials_path) {
+        return Ok((fetch::Auth::KimiCode(kimi_code), endpoints));
+    }
+
+    // Name the file that was actually checked, not just the remedy: with
+    // `credentials_path` or a relocated `KIMI_CODE_HOME` in play, "log in with
+    // the CLI" is useless advice if the user logged in somewhere this build
+    // never looked. Sanitized because the path can carry a configured value.
+    Err(AppError::Credentials(format!(
+        "Kimi: no credentials. Either log in with the Kimi Code CLI (`kimi`) — its login is \
+         read from {} — or set an API key in {} or `api_key` under [kimi] in {}.",
+        crate::display::sanitize_untrusted_path(&kimi_code.credentials_path),
+        cfg.api_key_env,
+        crate::config::config_path_hint()
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn logged_in_home(td: &TempDir) -> std::path::PathBuf {
+        let home = td.path().join(".kimi-code");
+        let path = oauth::credentials_path_in(&home);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(
+            &path,
+            r#"{"access_token":"at","refresh_token":"rt","expires_at":1,"expires_in":900,
+                "scope":"kimi-code","token_type":"Bearer"}"#,
+        )
+        .unwrap();
+        home
+    }
+
+    #[test]
+    fn an_api_key_wins_over_a_cli_login() {
+        let td = TempDir::new().unwrap();
+        let home = logged_in_home(&td);
+        let (auth, endpoints) =
+            resolve_auth_in(&KimiConfig::default(), &home, Some("sk-test".into())).unwrap();
+        assert!(matches!(auth, fetch::Auth::ApiKey(key) if key == "sk-test"));
+        assert_eq!(endpoints.usages, "https://api.kimi.com/coding/v1/usages");
+    }
+
+    #[test]
+    fn a_cli_login_is_used_when_no_api_key_is_set() {
+        let td = TempDir::new().unwrap();
+        let home = logged_in_home(&td);
+        let (auth, _) = resolve_auth_in(&KimiConfig::default(), &home, None).unwrap();
+        match auth {
+            fetch::Auth::KimiCode(kimi_code) => {
+                assert_eq!(
+                    kimi_code.credentials_path,
+                    oauth::credentials_path_in(&home)
+                );
+                assert_eq!(kimi_code.lock_target, oauth::lock_target_in(&home));
+            }
+            other => panic!("expected a Kimi Code login, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_key_and_no_login_names_both_remedies_and_the_path_checked() {
+        let td = TempDir::new().unwrap();
+        let err = resolve_auth_in(&KimiConfig::default(), td.path(), None).unwrap_err();
+        let message = err.to_string();
+        assert!(matches!(err, AppError::Credentials(_)), "{err:?}");
+        assert!(message.contains("Kimi Code CLI"), "{message}");
+        assert!(message.contains("KIMI_API_KEY"), "{message}");
+        // The file that was actually consulted, so "log in with the CLI" can be
+        // acted on when the home is not the default one.
+        assert!(message.contains("kimi-code.json"), "{message}");
+    }
+
+    #[test]
+    fn the_reported_path_follows_a_configured_credentials_path() {
+        let td = TempDir::new().unwrap();
+        let cfg = KimiConfig {
+            credentials_path: Some(td.path().join("relocated").join("creds.json")),
+            ..KimiConfig::default()
+        };
+        let message = resolve_auth_in(&cfg, td.path(), None)
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("relocated"), "{message}");
+        assert!(!message.contains("kimi-code.json"), "{message}");
+    }
+
+    #[test]
+    fn a_logged_out_cli_is_not_a_credential() {
+        let td = TempDir::new().unwrap();
+        let home = logged_in_home(&td);
+        std::fs::write(
+            oauth::credentials_path_in(&home),
+            r#"{"access_token":"","refresh_token":"","expires_at":0}"#,
+        )
+        .unwrap();
+        assert!(resolve_auth_in(&KimiConfig::default(), &home, None).is_err());
+    }
+
+    #[test]
+    fn the_region_marker_picks_the_deployment_and_config_overrides_it() {
+        let td = TempDir::new().unwrap();
+        let home = logged_in_home(&td);
+        std::fs::write(home.join("region"), "global").unwrap();
+
+        let (_, endpoints) = resolve_auth_in(&KimiConfig::default(), &home, None).unwrap();
+        assert_eq!(endpoints.usages, "https://api.kimi.ai/coding/v1/usages");
+        assert_eq!(endpoints.token, "https://auth.kimi.ai/api/oauth/token");
+
+        let pinned = KimiConfig {
+            region: "cn".into(),
+            ..KimiConfig::default()
+        };
+        let (_, endpoints) = resolve_auth_in(&pinned, &home, None).unwrap();
+        assert_eq!(endpoints.usages, "https://api.kimi.com/coding/v1/usages");
+    }
+
+    #[test]
+    fn a_configured_credentials_path_is_honored() {
+        let td = TempDir::new().unwrap();
+        let home = logged_in_home(&td);
+        let moved = td.path().join("elsewhere.json");
+        std::fs::copy(oauth::credentials_path_in(&home), &moved).unwrap();
+
+        let cfg = KimiConfig {
+            credentials_path: Some(moved.clone()),
+            ..KimiConfig::default()
+        };
+        let (auth, _) = resolve_auth_in(&cfg, &home, None).unwrap();
+        match auth {
+            fetch::Auth::KimiCode(kimi_code) => {
+                assert_eq!(kimi_code.credentials_path, moved);
+                assert_eq!(kimi_code.lock_target, oauth::lock_target_in(&home));
+            }
+            other => panic!("expected a Kimi Code login, got {other:?}"),
+        }
+    }
+}

--- a/src/kimi/oauth.rs
+++ b/src/kimi/oauth.rs
@@ -1,0 +1,539 @@
+//! Kimi Code CLI OAuth — the credential source for a *Kimi subscription*.
+//!
+//! `kimi` logs in through a device-code flow rather than an API key, and
+//! stores the resulting token in its own credential file
+//! (`~/.kimi-code/credentials/kimi-code.json`, mode 0600, snake_case wire
+//! shape). The subscription's quota endpoint is the same
+//! `/coding/v1/usages` this vendor already calls — only the bearer differs, so
+//! everything here is about obtaining and keeping that bearer valid.
+//!
+//! **Why the refreshed pair is written back to the CLI's own file** (unlike
+//! `kiro`, which keeps rotations in ai-usagebar's cache and never touches
+//! kiro-cli's database): auth.kimi.com rotates the refresh token on *every*
+//! grant. A private sidecar copy would therefore leave the CLI holding a
+//! superseded refresh token after each widget tick, and the next `kimi` run
+//! would find its session dead — ai-usagebar would be logging the user out of
+//! their own CLI every five minutes. One store, written under the CLI's own
+//! lock protocol (`lock.rs`), is the only shape that keeps both clients alive.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{AppError, Result};
+
+/// kimi-code's public device-flow client id (`KIMI_CODE_FLOW_CONFIG.clientId`),
+/// shared across regions. Not a secret: it identifies the CLI, and the refresh
+/// grant is authorized by the user's own refresh token.
+pub const CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
+
+/// Refresh this far ahead of the cached expiry so a slow round-trip never
+/// races the token's death. The access token only lives 15 minutes, so this is
+/// tighter than `kiro`/`openai`'s 300 s: a wider buffer would refresh on every
+/// single tick.
+pub const REFRESH_BUFFER_SECS: i64 = 120;
+
+pub const HOME_DIR_NAME: &str = ".kimi-code";
+/// kimi-code's own storage name for this provider; it names both the
+/// credential file and the lock target.
+const PROVIDER_NAME: &str = "kimi-code";
+const RE_LOGIN_HINT: &str = "run `kimi` and log in again";
+
+/// The two Kimi Code deployments. The OAuth client id is shared; the hosts are
+/// not, and a token minted by one is meaningless to the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Region {
+    MainlandCn,
+    Global,
+}
+
+impl Region {
+    pub fn api_base(self) -> &'static str {
+        match self {
+            Region::MainlandCn => "https://api.kimi.com/coding/v1",
+            Region::Global => "https://api.kimi.ai/coding/v1",
+        }
+    }
+
+    pub fn oauth_host(self) -> &'static str {
+        match self {
+            Region::MainlandCn => "https://auth.kimi.com",
+            Region::Global => "https://auth.kimi.ai",
+        }
+    }
+
+    /// Accepts both this project's spelling (`cn`, as `[moonshot] region`
+    /// uses) and kimi-code's own marker spelling (`mainland-cn`).
+    pub fn parse(value: &str) -> Option<Self> {
+        let value = value.trim();
+        if value.eq_ignore_ascii_case("cn") || value.eq_ignore_ascii_case("mainland-cn") {
+            Some(Region::MainlandCn)
+        } else if value.eq_ignore_ascii_case("global") {
+            Some(Region::Global)
+        } else {
+            None
+        }
+    }
+}
+
+pub fn default_home() -> Result<PathBuf> {
+    Ok(crate::cache::home_dir()?.join(HOME_DIR_NAME))
+}
+
+pub fn credentials_path_in(home: &Path) -> PathBuf {
+    home.join("credentials")
+        .join(format!("{PROVIDER_NAME}.json"))
+}
+
+/// The path `proper-lockfile` locks against inside kimi-code (`lock.rs` derives
+/// the actual `.lock` directory from it).
+pub fn lock_target_in(home: &Path) -> PathBuf {
+    home.join("oauth").join(PROVIDER_NAME)
+}
+
+/// kimi-code's install-channel marker (`<home>/region`), the CLI's own last
+/// resort before defaulting to mainland. Unknown contents are ignored, exactly
+/// as `readRegionMarker` does.
+pub fn read_region_marker(home: &Path) -> Option<Region> {
+    let raw = std::fs::read_to_string(home.join("region")).ok()?;
+    match raw.trim() {
+        "mainland-cn" => Some(Region::MainlandCn),
+        "global" => Some(Region::Global),
+        _ => None,
+    }
+}
+
+/// A token as kimi-code stores it. `extra` preserves any field this version
+/// does not know about, so writing a refreshed pair back never truncates the
+/// CLI's own file.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct Credentials {
+    pub access_token: String,
+    pub refresh_token: String,
+    /// Absolute unix seconds, the same field kimi-code persists.
+    pub expires_at: i64,
+    #[serde(default)]
+    pub expires_in: u64,
+    #[serde(default)]
+    pub scope: String,
+    #[serde(default = "default_token_type")]
+    pub token_type: String,
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+fn default_token_type() -> String {
+    "Bearer".to_string()
+}
+
+/// True when kimi-code has a usable login here. A logged-out CLI leaves a
+/// tombstone (empty access *and* refresh token) rather than deleting the file,
+/// so a bare `path.exists()` would misread it as logged in.
+pub fn is_logged_in(path: &Path) -> bool {
+    matches!(read_from(path), Ok(creds) if !creds.refresh_token.trim().is_empty())
+}
+
+pub fn read_from(path: &Path) -> Result<Credentials> {
+    let bytes = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AppError::Credentials(format!(
+                "Kimi: no Kimi Code CLI login at {} — {RE_LOGIN_HINT}, or set an API key",
+                crate::display::sanitize_untrusted_path(path)
+            )));
+        }
+        Err(e) => return Err(AppError::io_at(path, e)),
+    };
+    let creds: Credentials = serde_json::from_slice(&bytes).map_err(|e| {
+        AppError::Credentials(format!(
+            "Kimi: the Kimi Code CLI credentials at {} are malformed ({e}); {RE_LOGIN_HINT}",
+            crate::display::sanitize_untrusted_path(path)
+        ))
+    })?;
+    if creds.refresh_token.trim().is_empty() {
+        return Err(AppError::Credentials(format!(
+            "Kimi: the Kimi Code CLI is logged out ({}); {RE_LOGIN_HINT}",
+            crate::display::sanitize_untrusted_path(path)
+        )));
+    }
+    Ok(creds)
+}
+
+/// Replace kimi-code's credential file with `creds`, atomically and 0600 —
+/// matching the CLI's own write semantics (tmp file → rename, mode 0600).
+/// Callers must hold the lock from `lock.rs`.
+pub fn write_to(path: &Path, creds: &Credentials) -> Result<()> {
+    let mut bytes = serde_json::to_vec_pretty(creds)?;
+    bytes.push(b'\n');
+    crate::cache::atomic_write(path, &bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| AppError::io_at(path, e))?;
+    }
+    Ok(())
+}
+
+pub fn needs_refresh(expires_at_secs: i64, now_secs: i64) -> bool {
+    expires_at_secs < now_secs + REFRESH_BUFFER_SECS
+}
+
+pub fn token_endpoint(oauth_host: &str) -> String {
+    format!("{}/api/oauth/token", oauth_host.trim_end_matches('/'))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RefreshResponse {
+    #[serde(deserialize_with = "de_nonempty_string")]
+    pub access_token: String,
+    /// auth.kimi.com always rotates and always returns one; the field stays
+    /// optional so a server that stops rotating degrades to "keep the old one"
+    /// instead of failing the whole refresh.
+    #[serde(default, deserialize_with = "de_opt_nonempty_string")]
+    pub refresh_token: Option<String>,
+    #[serde(deserialize_with = "de_positive_u64")]
+    pub expires_in: u64,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub token_type: Option<String>,
+}
+
+fn de_nonempty_string<'de, D>(d: D) -> std::result::Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = String::deserialize(d)?;
+    if value.trim().is_empty() {
+        Err(serde::de::Error::custom("access_token cannot be empty"))
+    } else {
+        Ok(value)
+    }
+}
+
+fn de_opt_nonempty_string<'de, D>(d: D) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(d)?
+        .map(|value| {
+            if value.trim().is_empty() {
+                Err(serde::de::Error::custom("refresh_token cannot be empty"))
+            } else {
+                Ok(value)
+            }
+        })
+        .transpose()
+}
+
+fn de_positive_u64<'de, D>(d: D) -> std::result::Result<u64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = serde_json::Value::deserialize(d)?;
+    match v {
+        serde_json::Value::Number(n) => {
+            const MAX_SAFE: u64 = (i64::MAX as u64) / 2;
+            if let Some(value) = n.as_u64().filter(|value| (1..=MAX_SAFE).contains(value)) {
+                Ok(value)
+            } else {
+                Err(serde::de::Error::custom(
+                    "expires_in must be a positive integer in range",
+                ))
+            }
+        }
+        _ => Err(serde::de::Error::custom("expires_in must be a number")),
+    }
+}
+
+/// `POST <oauth host>/api/oauth/token`, form-encoded, exactly as kimi-code's
+/// own `refreshAccessToken` does. Never echoes the upstream body: an OAuth
+/// error response is not guaranteed to be free of account-identifying detail
+/// (same reasoning as `kiro::oauth::refresh`).
+pub async fn refresh(
+    client: &reqwest::Client,
+    endpoint: &str,
+    client_id: &str,
+    refresh_token: &str,
+) -> Result<RefreshResponse> {
+    let resp = client
+        .post(endpoint)
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", client_id),
+            ("grant_type", "refresh_token"),
+            ("refresh_token", refresh_token),
+        ])
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let body = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
+    if !status.is_success() {
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body: "Kimi Code CLI token refresh failed".into(),
+        });
+    }
+    serde_json::from_slice(&body)
+        .map_err(|e| AppError::Schema(format!("kimi token refresh response: {e}")))
+}
+
+/// Fold a refresh response into the stored credential, keeping every field the
+/// server did not restate (including unknown ones).
+pub fn apply_refresh(
+    prior: &Credentials,
+    refreshed: RefreshResponse,
+    now_secs: i64,
+) -> Credentials {
+    let expires_in = i64::try_from(refreshed.expires_in).unwrap_or(i64::MAX);
+    Credentials {
+        access_token: refreshed.access_token,
+        refresh_token: refreshed
+            .refresh_token
+            .unwrap_or_else(|| prior.refresh_token.clone()),
+        expires_at: now_secs.saturating_add(expires_in),
+        expires_in: refreshed.expires_in,
+        scope: refreshed.scope.unwrap_or_else(|| prior.scope.clone()),
+        token_type: refreshed
+            .token_type
+            .unwrap_or_else(|| prior.token_type.clone()),
+        extra: prior.extra.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_file(dir: &TempDir, json: &str) -> PathBuf {
+        let path = dir.path().join("kimi-code.json");
+        std::fs::write(&path, json).unwrap();
+        path
+    }
+
+    fn sample_creds() -> Credentials {
+        Credentials {
+            access_token: "at".into(),
+            refresh_token: "rt".into(),
+            expires_at: 1_000_000,
+            expires_in: 900,
+            scope: "kimi-code".into(),
+            token_type: "Bearer".into(),
+            extra: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn reads_the_cli_wire_shape() {
+        let td = TempDir::new().unwrap();
+        let path = sample_file(
+            &td,
+            r#"{"access_token":"at","refresh_token":"rt","expires_at":1000000,
+                "expires_in":900,"scope":"kimi-code","token_type":"Bearer"}"#,
+        );
+        let creds = read_from(&path).unwrap();
+        assert_eq!(creds, sample_creds());
+        assert!(is_logged_in(&path));
+    }
+
+    #[test]
+    fn a_logged_out_tombstone_is_not_a_login() {
+        let td = TempDir::new().unwrap();
+        let path = sample_file(
+            &td,
+            r#"{"access_token":"","refresh_token":"","expires_at":0,"expires_in":0,
+                "scope":"kimi-code","token_type":"Bearer"}"#,
+        );
+        assert!(!is_logged_in(&path));
+        let err = read_from(&path).unwrap_err();
+        assert!(matches!(err, AppError::Credentials(_)), "{err:?}");
+    }
+
+    #[test]
+    fn a_missing_or_malformed_file_names_the_re_login_step() {
+        let td = TempDir::new().unwrap();
+        let missing = td.path().join("nope.json");
+        assert!(!is_logged_in(&missing));
+        let err = read_from(&missing).unwrap_err().to_string();
+        assert!(err.contains("kimi"), "{err}");
+
+        let path = sample_file(&td, "{ not json");
+        let err = read_from(&path).unwrap_err().to_string();
+        assert!(err.contains("malformed"), "{err}");
+    }
+
+    #[test]
+    fn write_back_preserves_unknown_fields_and_stays_owner_only() {
+        let td = TempDir::new().unwrap();
+        let path = sample_file(
+            &td,
+            r#"{"access_token":"at","refresh_token":"rt","expires_at":1000000,
+                "expires_in":900,"scope":"kimi-code","token_type":"Bearer",
+                "future_field":{"kept":true}}"#,
+        );
+        let mut creds = read_from(&path).unwrap();
+        assert!(creds.extra.contains_key("future_field"));
+        creds.access_token = "at2".into();
+        write_to(&path, &creds).unwrap();
+
+        let reread: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        assert_eq!(reread["access_token"], "at2");
+        assert_eq!(reread["future_field"]["kept"], true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600, "credentials must stay owner-only");
+        }
+    }
+
+    #[test]
+    fn needs_refresh_uses_the_two_minute_buffer() {
+        let now = 1_000_000;
+        assert!(needs_refresh(now + 60, now));
+        assert!(needs_refresh(now + REFRESH_BUFFER_SECS - 1, now));
+        assert!(!needs_refresh(now + REFRESH_BUFFER_SECS + 1, now));
+    }
+
+    #[test]
+    fn regions_map_to_their_own_hosts() {
+        assert_eq!(Region::parse("cn"), Some(Region::MainlandCn));
+        assert_eq!(Region::parse("mainland-cn"), Some(Region::MainlandCn));
+        assert_eq!(Region::parse("GLOBAL"), Some(Region::Global));
+        assert_eq!(Region::parse("us"), None);
+        assert_eq!(
+            Region::MainlandCn.api_base(),
+            "https://api.kimi.com/coding/v1"
+        );
+        assert_eq!(Region::Global.api_base(), "https://api.kimi.ai/coding/v1");
+        assert_eq!(
+            token_endpoint(Region::Global.oauth_host()),
+            "https://auth.kimi.ai/api/oauth/token"
+        );
+        assert_eq!(
+            token_endpoint("https://auth.kimi.com/"),
+            "https://auth.kimi.com/api/oauth/token"
+        );
+    }
+
+    #[test]
+    fn region_marker_is_read_and_unknown_values_ignored() {
+        let td = TempDir::new().unwrap();
+        assert_eq!(read_region_marker(td.path()), None);
+        std::fs::write(td.path().join("region"), "global\n").unwrap();
+        assert_eq!(read_region_marker(td.path()), Some(Region::Global));
+        std::fs::write(td.path().join("region"), "mainland-cn").unwrap();
+        assert_eq!(read_region_marker(td.path()), Some(Region::MainlandCn));
+        std::fs::write(td.path().join("region"), "atlantis").unwrap();
+        assert_eq!(read_region_marker(td.path()), None);
+    }
+
+    #[test]
+    fn cli_paths_follow_kimi_codes_layout() {
+        let home = Path::new("/home/u/.kimi-code");
+        assert_eq!(
+            credentials_path_in(home),
+            PathBuf::from("/home/u/.kimi-code/credentials/kimi-code.json")
+        );
+        assert_eq!(
+            lock_target_in(home),
+            PathBuf::from("/home/u/.kimi-code/oauth/kimi-code")
+        );
+    }
+
+    #[test]
+    fn malformed_refresh_responses_are_rejected_not_defaulted() {
+        for body in [
+            r#"{"access_token":"","expires_in":900}"#,
+            r#"{"access_token":"a","expires_in":"900"}"#,
+            r#"{"access_token":"a","expires_in":0}"#,
+            r#"{"access_token":"a","expires_in":-1}"#,
+            r#"{"access_token":"a"}"#,
+            r#"{"access_token":"a","refresh_token":" ","expires_in":900}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<RefreshResponse>(body).is_err(),
+                "{body}"
+            );
+        }
+    }
+
+    #[test]
+    fn apply_refresh_keeps_what_the_server_did_not_restate() {
+        let mut prior = sample_creds();
+        prior.extra.insert("future".into(), serde_json::json!(1));
+        let refreshed: RefreshResponse =
+            serde_json::from_str(r#"{"access_token":"at2","expires_in":900}"#).unwrap();
+        let next = apply_refresh(&prior, refreshed, 5_000);
+        assert_eq!(next.access_token, "at2");
+        assert_eq!(next.refresh_token, "rt", "no rotation → keep the old one");
+        assert_eq!(next.expires_at, 5_900);
+        assert_eq!(next.scope, "kimi-code");
+        assert_eq!(next.token_type, "Bearer");
+        assert_eq!(next.extra["future"], serde_json::json!(1));
+    }
+
+    #[tokio::test]
+    async fn refresh_posts_the_form_kimi_code_posts() {
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("POST", "/api/oauth/token")
+            .match_header("content-type", "application/x-www-form-urlencoded")
+            .match_body(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("client_id".into(), CLIENT_ID.into()),
+                mockito::Matcher::UrlEncoded("grant_type".into(), "refresh_token".into()),
+                mockito::Matcher::UrlEncoded("refresh_token".into(), "old-rt".into()),
+            ]))
+            .with_status(200)
+            .with_body(
+                r#"{"access_token":"new-at","refresh_token":"new-rt","expires_in":900,
+                    "scope":"kimi-code","token_type":"Bearer"}"#,
+            )
+            .create_async()
+            .await;
+
+        let out = refresh(
+            &reqwest::Client::new(),
+            &token_endpoint(&server.url()),
+            CLIENT_ID,
+            "old-rt",
+        )
+        .await
+        .unwrap();
+        m.assert_async().await;
+        assert_eq!(out.access_token, "new-at");
+        assert_eq!(out.refresh_token.as_deref(), Some("new-rt"));
+        assert_eq!(out.expires_in, 900);
+    }
+
+    #[tokio::test]
+    async fn a_rejected_refresh_does_not_echo_the_body() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("POST", "/api/oauth/token")
+            .with_status(401)
+            .with_body(r#"{"error":"invalid_grant","error_description":"sensitive detail"}"#)
+            .create_async()
+            .await;
+
+        let err = refresh(
+            &reqwest::Client::new(),
+            &token_endpoint(&server.url()),
+            CLIENT_ID,
+            "old-rt",
+        )
+        .await
+        .unwrap_err();
+        match err {
+            AppError::Http { status, body } => {
+                assert_eq!(status, 401);
+                assert!(!body.contains("sensitive detail"), "{body}");
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+}

--- a/src/kimi/types.rs
+++ b/src/kimi/types.rs
@@ -76,7 +76,14 @@ impl NumericOrString {
 
 impl UsagesResponse {
     pub fn into_snapshot(self) -> Result<KimiSnapshot> {
-        let plan = self.user.and_then(|u| u.membership).and_then(|m| m.level);
+        // The raw membership enum ("LEVEL_INTERMEDIATE") is a wire value, not
+        // something to put on a status bar. `fetch` overwrites this with the
+        // vendor's own tier name from `/me` when that call succeeds.
+        let plan = self
+            .user
+            .and_then(|u| u.membership)
+            .and_then(|m| m.level)
+            .map(|level| humanize_membership_level(&level));
 
         let usage = self
             .usage
@@ -138,6 +145,60 @@ fn extract_block(block: UsageBlock) -> Result<(u64, u64, u64, Option<DateTime<Ut
     Ok((limit, used, remaining, reset))
 }
 
+/// The profile response from `/coding/v1/me`, read for exactly one field.
+///
+/// That endpoint also returns the account's email, phone, nickname, avatar and
+/// ids. **None of them are deserialized here** — serde drops unknown fields, so
+/// the personal data never enters a snapshot, the cache, or an error message.
+/// Keep it that way: the plan label is the only thing this vendor needs.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default)]
+pub struct UserInfoResponse {
+    /// The subscription tier's own name — "Andante", "Moderato",
+    /// "Allegretto", "Allegro". Kimi names its plans after tempo markings, so
+    /// this reads as a product name and not as a gamification badge.
+    user_level_name: Option<String>,
+}
+
+impl UserInfoResponse {
+    pub fn plan_label(&self) -> Option<String> {
+        self.user_level_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string)
+    }
+}
+
+/// Make a raw membership enum readable when the vendor's own label is
+/// unavailable (`/me` unreachable, or an API key whose account has no coding
+/// profile). `LEVEL_INTERMEDIATE` → `Intermediate`.
+///
+/// Deliberately *not* a table mapping levels onto tier names: the enum-to-tier
+/// correspondence is not published anywhere, and inventing "Allegretto" for a
+/// level that might mean something else would put a wrong plan on screen with
+/// full confidence. Prettifying what the vendor said is the honest fallback.
+pub fn humanize_membership_level(level: &str) -> String {
+    let trimmed = level.trim();
+    let body = trimmed.strip_prefix("LEVEL_").unwrap_or(trimmed);
+    if body.is_empty() {
+        return trimmed.to_string();
+    }
+    body.split('_')
+        .filter(|word| !word.is_empty())
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                Some(first) => {
+                    first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase()
+                }
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 /// Kimi documents the rolling window as 300 minutes. Accept only equivalent
 /// spellings used by protobuf/JSON gateways, not arbitrary duration units.
 fn is_five_hour_window(window: &Window) -> bool {
@@ -171,6 +232,52 @@ mod tests {
     use super::*;
 
     #[test]
+    fn membership_levels_are_humanized_not_invented() {
+        assert_eq!(
+            humanize_membership_level("LEVEL_INTERMEDIATE"),
+            "Intermediate"
+        );
+        assert_eq!(
+            humanize_membership_level("LEVEL_SUPER_ADVANCED"),
+            "Super Advanced"
+        );
+        // No LEVEL_ prefix, mixed case, and surrounding space still read well.
+        assert_eq!(humanize_membership_level("  basic  "), "Basic");
+        // Degenerate inputs are returned rather than turned into an empty label.
+        assert_eq!(humanize_membership_level("LEVEL_"), "LEVEL_");
+        assert_eq!(humanize_membership_level(""), "");
+    }
+
+    #[test]
+    fn the_profile_response_yields_only_the_tier_name() {
+        let raw = r#"{
+            "user_id": "u-1", "nickname": "someone", "email": "someone@example.com",
+            "phone": {"country_code": "55", "number": "999999999"},
+            "user_level": 25, "user_level_name": "Allegretto",
+            "domain_name": "DOMAIN_NEXUS"
+        }"#;
+        let me: UserInfoResponse = serde_json::from_str(raw).unwrap();
+        assert_eq!(me.plan_label(), Some("Allegretto".into()));
+        // The struct has no field to hold the personal data, so nothing else
+        // can leak into a snapshot or a Debug line.
+        let rendered = format!("{me:?}");
+        assert!(!rendered.contains("example.com"), "{rendered}");
+        assert!(!rendered.contains("999999999"), "{rendered}");
+    }
+
+    #[test]
+    fn a_blank_or_absent_tier_name_is_no_label() {
+        for raw in [
+            r#"{"user_level_name": ""}"#,
+            r#"{"user_level_name": "  "}"#,
+            "{}",
+        ] {
+            let me: UserInfoResponse = serde_json::from_str(raw).unwrap();
+            assert_eq!(me.plan_label(), None, "{raw}");
+        }
+    }
+
+    #[test]
     fn parses_representative_json_with_string_numbers() {
         let raw = r#"{
             "user": { "membership": { "level": "LEVEL_INTERMEDIATE" } },
@@ -186,7 +293,7 @@ mod tests {
             .unwrap()
             .into_snapshot()
             .unwrap();
-        assert_eq!(snap.plan, Some("LEVEL_INTERMEDIATE".into()));
+        assert_eq!(snap.plan, Some("Intermediate".into()));
         assert_eq!(snap.weekly_limit, 100);
         assert_eq!(snap.weekly_used, 26);
         assert_eq!(snap.weekly_remaining, 74);
@@ -215,7 +322,7 @@ mod tests {
             .unwrap()
             .into_snapshot()
             .unwrap();
-        assert_eq!(snap.plan, Some("LEVEL_ADVANCED".into()));
+        assert_eq!(snap.plan, Some("Advanced".into()));
         assert_eq!(snap.weekly_limit, 500);
         assert_eq!(snap.weekly_used, 123);
         assert_eq!(snap.weekly_remaining, 377);

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -37,7 +37,9 @@ pub fn warning_kind(code: u16, message: &str) -> WarningKind {
     }
 }
 
-pub const DEFAULT_FORMAT: &str = "{kimi_weekly_pct}% · {kimi_weekly_reset}";
+/// Kimi has two independent quota percentages. Keep both on the individual
+/// widget in the same order as the detail panel: current 5h window, then 7d.
+pub const DEFAULT_FORMAT: &str = "5h {kimi_window_pct}% · 7d {kimi_weekly_pct}%";
 
 /// Kimi reports the weekly quota's reset instant but never its length; the
 /// subscription bucket rolls every 7 days.
@@ -306,18 +308,14 @@ mod tests {
     }
 
     #[test]
-    fn default_render_has_exactly_one_percent() {
+    fn default_render_has_one_percent_for_each_quota() {
         let snap = sample_snap();
         let outcome = sample_outcome(snap.clone());
         let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
-        // "26%" should appear exactly once and there must be no double percent.
+        assert!(out.text.contains("15%"), "text: {}", out.text);
         assert!(out.text.contains("26%"), "text: {}", out.text);
-        assert!(
-            !out.text.contains("%%"),
-            "double percent in text: {}",
-            out.text
-        );
-        assert_eq!(out.text.matches('%').count(), 1, "text: {}", out.text);
+        assert!(!out.text.contains("%%"), "text: {}", out.text);
+        assert_eq!(out.text.matches('%').count(), 2, "text: {}", out.text);
     }
 
     #[test]
@@ -567,13 +565,12 @@ mod tests {
         }
     }
 
-    /// `{pct}% · {reset}` is what every other percentage vendor puts on the
-    /// bar; Kimi printed a bare `26%`.
+    /// Kimi's compact surface must not discard either independent quota.
     #[test]
-    fn default_bar_text_pairs_the_percentage_with_its_reset() {
+    fn default_bar_text_shows_the_rolling_and_weekly_quotas() {
         let snap = sample_snap();
         let outcome = sample_outcome(snap.clone());
         let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
-        assert!(out.text.contains("26% · 4d 0h"), "{}", out.text);
+        assert!(out.text.contains("5h 15% · 7d 26%"), "{}", out.text);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -540,16 +540,16 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             Ok(outcome.into())
         }
         VendorId::Kimi => {
-            let api_key = crate::config::resolve_api_key(
-                "Kimi",
-                &config.kimi.api_key_env,
-                config.kimi.api_key.as_deref(),
-            )?;
+            let (auth, endpoints) = crate::kimi::resolve_auth(&config.kimi)?;
             let cache = crate::cache::Cache::for_vendor("kimi")?;
-            let endpoints = crate::kimi::fetch::Endpoints::default();
-            let outcome =
-                crate::kimi::fetch_snapshot(client, &api_key, &cache, &endpoints, DEFAULT_TTL)
-                    .await?;
+            let outcome = crate::kimi::fetch::fetch_snapshot_with_auth(
+                client,
+                &auth,
+                &cache,
+                &endpoints,
+                DEFAULT_TTL,
+            )
+            .await?;
             Ok(outcome.into())
         }
         VendorId::Kilo => {

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -1024,9 +1024,13 @@ fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, _tol: u32) 
             label: "Weekly quota".into(),
             pct: weekly_pct,
             severity: severity_for(s.weekly_pct()),
-            value_label: format!("{} / {}", s.weekly_used, s.weekly_limit),
+            // Same `{pct}%` every other vendor shows; the request counts stay
+            // on the footnote.
+            value_label: format!("{weekly_pct}%"),
             footnote: format!(
-                "{} remaining · reset {}",
+                "{} / {} · {} remaining · reset {}",
+                s.weekly_used,
+                s.weekly_limit,
                 s.weekly_remaining,
                 countdown::format(s.weekly_reset_at, now)
             ),
@@ -1042,9 +1046,11 @@ fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, _tol: u32) 
                 label: "Rolling window (5h)".into(),
                 pct: window_pct,
                 severity: severity_for(s.window_pct()),
-                value_label: format!("{} / {}", s.window_used, s.window_limit),
+                value_label: format!("{window_pct}%"),
                 footnote: format!(
-                    "{} remaining · reset {}",
+                    "{} / {} · {} remaining · reset {}",
+                    s.window_used,
+                    s.window_limit,
                     s.window_remaining,
                     countdown::format(s.window_reset_at, now)
                 ),
@@ -1662,7 +1668,8 @@ mod tests {
         };
 
         let (weekly_value, weekly_footnote) = find_footnote("Weekly quota");
-        assert_eq!(weekly_value, "26 / 100");
+        assert_eq!(weekly_value, "26%");
+        assert!(weekly_footnote.contains("26 / 100"));
         assert!(weekly_footnote.contains("74 remaining"));
         assert!(
             weekly_footnote.contains("4d 0h"),
@@ -1671,7 +1678,8 @@ mod tests {
         assert!(!weekly_footnote.contains("2026-05-27T")); // not a raw RFC3339
 
         let (window_value, window_footnote) = find_footnote("Rolling window (5h)");
-        assert_eq!(window_value, "15 / 100");
+        assert_eq!(window_value, "15%");
+        assert!(window_footnote.contains("15 / 100"));
         assert!(window_footnote.contains("85 remaining"));
         assert!(
             window_footnote.contains("2h 00m"),

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -2,7 +2,10 @@
 //! the primary vendor and paste an API key for any key-authenticated vendor
 //! (including Z.AI, Kimi, MiniMax, and the balance vendors) without hand-editing
 //! config.toml. Anthropic, OpenAI, Cursor, and Antigravity authenticate through
-//! local product state, so they have no key field here.
+//! local product state, so they have no key field here. Kimi keeps its key
+//! field because a platform key is still one of its two credentials, but a
+//! subscriber whose credential is the Kimi Code CLI login has nothing to paste
+//! and enables `[kimi]` in config.toml instead.
 //!
 //! Persistence uses `toml_edit` so the existing config keeps its comments,
 //! whitespace, and unrelated fields. Writing a key also flips that vendor's

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -724,20 +724,22 @@ async fn deepseek_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
 }
 
 async fn kimi_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
-    let api_key = crate::config::resolve_api_key(
-        "Kimi",
-        &config.kimi.api_key_env,
-        config.kimi.api_key.as_deref(),
-    )?;
+    let (auth, endpoints) = kimi::resolve_auth(&config.kimi)?;
     let client = http_client()?;
     let cache = vendor_cache(cli, "kimi")?;
-    let endpoints = kimi::fetch::Endpoints::default();
-    let outcome =
-        match kimi::fetch_snapshot(&client, &api_key, &cache, &endpoints, DEFAULT_TTL).await {
-            Ok(o) => o,
-            Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
-            Err(e) => return Err(e),
-        };
+    let outcome = match kimi::fetch::fetch_snapshot_with_auth(
+        &client,
+        &auth,
+        &cache,
+        &endpoints,
+        DEFAULT_TTL,
+    )
+    .await
+    {
+        Ok(o) => o,
+        Err(e) if e.is_transient() => return Ok(WaybarOutput::loading(cli.icon.as_deref())),
+        Err(e) => return Err(e),
+    };
 
     let theme = theme_from_cli(cli);
     let snap = outcome.snapshot.clone();

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -40,6 +40,11 @@
 //!   window are optional, so the smoke test validates their public fields only
 //!   when present; the snapshot does not expose raw wire duration/unit.
 //!   `kimi_live` skips when optional `KIMI_API_KEY` is unset.
+//! - **Kimi (subscription)**: reads the Kimi Code CLI's own OAuth session,
+//!   refreshing it (and writing the rotation back to the CLI's credential
+//!   file) when it is close to expiry, then asserts the same public snapshot
+//!   fields. `kimi_subscription_live` skips when the CLI is not logged in and
+//!   `KIMI_CODE_HOME` is unset.
 //! - **Cursor**: reads the session token from the local `state.vscdb`, then
 //!   asserts `premium_pct` is 0..=100 and a future `premium_reset_at` was
 //!   derived from `startOfMonth`. `cursor_live` skips when there is no Cursor
@@ -325,6 +330,66 @@ async fn kimi_live() {
         out.snapshot.window_limit,
         out.snapshot.window_remaining,
         out.snapshot.window_reset_at,
+    );
+}
+
+#[tokio::test]
+#[ignore = "live API; run with --ignored"]
+async fn kimi_subscription_live() {
+    // The subscription path has no API key — the credential is the OAuth
+    // session the Kimi Code CLI stored after its device-code login. So this
+    // test needs `kimi` installed and logged in (or `KIMI_CODE_HOME` pointing
+    // at a copy of that home) and skips otherwise, like `kiro_live`.
+    //
+    // It exercises the refresh too whenever the stored access token is inside
+    // its 2-minute buffer, which for a 15-minute token is most runs — and that
+    // rotation is written back to the CLI's own credential file, exactly as
+    // production does. Point `KIMI_CODE_HOME` at a copy if that matters to you.
+    let home = match std::env::var("KIMI_CODE_HOME") {
+        Ok(p) if !p.trim().is_empty() => std::path::PathBuf::from(p),
+        _ => kimi::oauth::default_home().expect("resolve home dir"),
+    };
+    let credentials = kimi::oauth::credentials_path_in(&home);
+    if !kimi::oauth::is_logged_in(&credentials) {
+        eprintln!(
+            "kimi_subscription_live: no Kimi Code CLI login at {} — skipping (run `kimi` and log in, or set KIMI_CODE_HOME)",
+            credentials.display()
+        );
+        return;
+    }
+
+    let region = kimi::oauth::read_region_marker(&home).unwrap_or(kimi::oauth::Region::MainlandCn);
+    let cache = xdg_cache_for("kimi-subscription");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .unwrap();
+    let out = kimi::fetch::fetch_snapshot_with_auth(
+        &client,
+        &kimi::fetch::Auth::KimiCode(kimi::fetch::KimiCodeAuth::in_home(&home)),
+        &cache,
+        &kimi::fetch::Endpoints::for_region(region),
+        Duration::from_secs(0),
+    )
+    .await
+    .expect("kimi subscription fetch should succeed against the real API");
+
+    assert_pct("kimi.weekly", out.snapshot.weekly_pct());
+    if out.snapshot.window_limit > 0 {
+        assert_pct("kimi.window", out.snapshot.window_pct());
+    }
+    // The refresh must never leave the CLI without a usable login.
+    assert!(
+        kimi::oauth::is_logged_in(&credentials),
+        "the Kimi Code CLI credential file must still hold a login afterwards"
+    );
+    println!(
+        "✅ kimi (subscription) — plan={:?}, weekly={} / {}, window={} / {}",
+        out.snapshot.plan,
+        out.snapshot.weekly_used,
+        out.snapshot.weekly_limit,
+        out.snapshot.window_used,
+        out.snapshot.window_limit,
     );
 }
 


### PR DESCRIPTION
Use the Kimi Code CLI's own OAuth session as a Kimi credential, so a subscriber who works through `kimi` has nothing to create or paste. An API key still takes precedence wherever one is set, and existing installs are untouched.

Same endpoint either way — verified live: `GET api.kimi.com/coding/v1/usages` with the CLI's bearer returns `200` and the same payload an API key gets.

This is the shape ai-usagebar already uses for **Cursor, Kiro CLI, SuperGrok and Antigravity**: read the local product's own session instead of asking for a credential the user maintains by hand.

## What this adds

- No API key configured → use the OAuth session kimi-code already stored at `~/.kimi-code/credentials/kimi-code.json`.
- `[kimi] credentials_path` — override for a relocated `KIMI_CODE_HOME`, mirroring `[cursor] db_path` / `[kiro] db_path`.
- `[kimi] region` — `auto` (default) follows kimi-code's own `~/.kimi-code/region` marker; `cn` pins api.kimi.com, `global` pins api.kimi.ai. A token minted by one deployment means nothing to the other.
- The plan label now comes from `/coding/v1/me` (`Allegretto`) instead of the raw `LEVEL_*` enum, with the humanized enum as fallback.
- `fetch_snapshot` keeps its signature; the OAuth path is a new `fetch_snapshot_with_auth`.

## One deliberate departure from the Kiro precedent

CLAUDE.md says rotated credentials go to ai-usagebar's own cache, never back to the CLI's store. This writes them **back into kimi-code's credential file**, because `auth.kimi.com` rotates the refresh token on *every* grant (verified: two consecutive grants, two different refresh tokens). The access token lives 15 minutes, so with a private sidecar a 300 s widget tick would leave the CLI holding a superseded token every few minutes and eventually log the user out of their own CLI. Kiro's store is a live sqlite database and its refresh response makes `refreshToken` optional; neither is true here.

The write matches kimi-code's own semantics (atomic, 0600, unknown fields preserved) and runs under the lock kimi-code itself takes — `src/kimi/lock.rs` speaks `proper-lockfile`'s directory-lock protocol rather than `flock`, which would be invisible to the CLI. The file is re-read *inside* the lock, so a refresh that landed while we queued is used instead of redone.

If writing into another tool's credential store is a line the project would rather not cross, say so and I'll cut this back to the display work alone.

## Tests

Unit tests cover the wire shape and logout tombstone, write-back preserving unknown fields and mode 0600, the refresh buffer, region resolution, a rejected refresh that does not echo the body, lock acquire/release plus stale takeover, and — in `fetch` — a valid token used as-is, an expiring one refreshed with the rotation landing in the CLI's file, and a peer refresh picked up instead of rotating again. `tests/live.rs` adds `kimi_subscription_live`, `#[ignore]`d and skipping when the CLI is not logged in, like `kiro_live`.

All tests inject paths and a clock; none reads a real `$HOME` or an ambient env var. `make test` (1170 passing), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean, and the whole path was exercised against a real Kimi For Coding subscription including the expired-token refresh.

---

*Correction: this PR originally claimed a Kimi For Coding subscription issues no API key. That was wrong — one can be created at `kimi.com/code/console`, as @lucasliet pointed out. The claim is removed from the code, README, docs and CHANGELOG.*
