### PR TITLE
feat(quattro): opt-in provider tag in the Quattro bar entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- The Omarchy Quattro plugin can show which provider the bar entry is about.
+  **Show provider name in the top bar** — a new opt-in toggle beside the
+  existing usage-value one, or `omarchy bar set akitaonrails.ai-usagebar
+  showProvider true --json` — prefixes the label with the provider's
+  three-letter code, the same one Waybar's `{vendor_short}` prints
+  (`󰚩  cld 29%`, `󰚩  gpt 95%`). It matters most on a bar that cycles several
+  providers, where the percentage alone never said whose it was. Off by
+  default, so an existing bar entry keeps the label it has today; with the
+  usage value turned off the entry reads `󰚩  cld`, and a vertical bar still
+  shows the icon alone.
+- `ai-usagebar usage --json` reports each entry's `short_name`. It is the field
+  the toggle above draws, and it is additive like the rest of the report.
+
+### Changed
+
+- `{vendor_short}` is now `VendorId::short_name` for every provider instead of
+  a literal repeated in eighteen renderers, so the report, the placeholder and
+  the native panels cannot drift apart. The codes themselves are unchanged, and
+  a test now rejects a duplicate or a non-three-letter one.
+- The `{vendor_short}` reference table lists Nous Research (`nrs`) and OpenCode
+  Go (`ocg`), which both shipped codes without ever being written down.
+
 ## [1.7.0] — 2026-08-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@ Each release is also published at
   **Show provider name in the top bar** — a new opt-in toggle beside the
   existing usage-value one, or `omarchy bar set akitaonrails.ai-usagebar
   showProvider true --json` — prefixes the label with the provider's
-  three-letter code, the same one Waybar's `{vendor_short}` prints
-  (`󰚩  cld 29%`, `󰚩  gpt 95%`). It matters most on a bar that cycles several
-  providers, where the percentage alone never said whose it was. Off by
-  default, so an existing bar entry keeps the label it has today; with the
-  usage value turned off the entry reads `󰚩  cld`, and a vertical bar still
-  shows the icon alone.
+  three-letter code, the same one Waybar's `{vendor_short}` prints, so the
+  entry reads `cld 29%` or `gpt 95%` after the icon. It matters most on a bar
+  that cycles several providers, where the percentage alone never said whose
+  it was. Off by default, so an existing bar entry keeps the label it has
+  today; with the usage value turned off the entry keeps the icon and the
+  code alone, and a vertical bar still shows the icon alone.
 - `ai-usagebar usage --json` reports each entry's `short_name`. It is the field
   the toggle above draws, and it is additive like the rest of the report.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ QML settings page. **Right-click intentionally opens `ai-usagebar-tui` in a
 terminal**; it is not the settings shortcut. Middle-click or use the mouse
 wheel to switch providers. In QML settings, turn off **Show usage value in the
 top bar** for an icon-only widget; the panel and tooltip keep the full details.
+Turn on **Show provider name in the top bar** to prefix the entry with the same
+three-letter code Waybar's `{vendor_short}` prints, so a bar cycling several
+providers says which one it is showing.
 
 The source-built `ai-usagebar` AUR package can replace `ai-usagebar-bin` in
 the first command.
@@ -366,9 +369,11 @@ The JSON report has two views of each provider:
   grouped rows, and spacers. Rows without a percentage do not invent one.
 
 The report also includes the configured `primary` id. Each entry has
-`display_name`, `status`, `stale`, and `fetched_at`; metric rows may add
-`severity` and an absolute `reset_at`. These fields are additive, so existing
-consumers remain compatible.
+`display_name`, `short_name`, `status`, `stale`, and `fetched_at`; metric rows
+may add `severity` and an absolute `reset_at`. These fields are additive, so
+existing consumers remain compatible. `short_name` is the same three-letter
+code `{vendor_short}` prints, so a frontend that wants a compact provider tag
+takes it from the report instead of keeping its own table.
 
 ## Standalone TUI
 
@@ -405,6 +410,8 @@ The widget reads the providers and accounts already enabled in
 - The gear or `s` opens QML settings.
 - QML settings can hide the bar's percentage or balance for an icon-only
   widget; this applies immediately and preserves the full panel and tooltip.
+- QML settings can also show the provider's `{vendor_short}` code before that
+  value (`cld 29%`). It is off by default and applies immediately.
 - Right-click launches the TUI.
 - Middle-click or the mouse wheel switches providers.
 - The selected provider or named account is remembered across shell reloads

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -17,6 +17,11 @@ metrics expand to an empty string unless noted otherwise.
 | SuperGrok | `sgk` | Anthropic API | `aac` |
 | Antigravity | `agy` | Cursor | `cur` |
 | MiniMax | `mmx` | Kiro CLI | `kir` |
+| Nous Research | `nrs` | OpenCode Go | `ocg` |
+
+The same codes ride the `ai-usagebar usage --json` report as each entry's
+`short_name`, so a native frontend can draw a Waybar-style provider tag without
+restating the table. Every account of one provider shares that provider's code.
 
 Use `{session_pct}`, `{session_reset}`, `{weekly_pct}`, and `{weekly_reset}`
 when one format must work across providers. Providers without matching time

--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,8 @@
     "defaults": {
       "provider": "",
       "refreshIntervalSec": 300,
-      "showValue": true
+      "showValue": true,
+      "showProvider": false
     },
     "schema": [
       {
@@ -52,6 +53,13 @@
         "label": "Show usage value",
         "description": "Show the selected provider's percentage or balance next to the icon in the top bar.",
         "defaultValue": true
+      },
+      {
+        "key": "showProvider",
+        "type": "boolean",
+        "label": "Show provider name",
+        "description": "Show the selected provider's short code (cld, gpt, zai, agy) before the usage value, the way Waybar's {vendor_short} does. Off by default.",
+        "defaultValue": false
       }
     ]
   }

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -85,6 +85,7 @@ function normalizeEntry(raw) {
     id: id,
     name: cleanText(raw.name, 240),
     display_name: cleanText(raw.display_name, 240),
+    short_name: cleanText(raw.short_name, 24),
     plan: cleanText(raw.plan, 240),
     status: error !== "" || raw.status === "error" ? "error" : "ready",
     error: error,
@@ -123,6 +124,16 @@ function providerName(entry) {
   var title = cleanText(entry.display_name || entry.name, 240).trim()
   if (title === "") title = baseProvider(entry.id).replace(/_/g, " ") || "AI usage"
   return autoTextSafe(title)
+}
+
+// The Waybar-style provider tag. `VendorId::short_name` in Rust owns the codes
+// and ships them as `short_name`; a binary older than that field has none, so
+// the machine id's vendor half stands in rather than a table living here.
+function providerShort(entry) {
+  if (!entry) return ""
+  var code = cleanText(entry.short_name, 24).trim()
+  if (code === "") code = baseProvider(entry.id).replace(/_/g, "-")
+  return autoTextSafe(code).trim()
 }
 
 function filteredEntries(entries, configuredProvider) {
@@ -189,14 +200,23 @@ function booleanSetting(value, fallback) {
   return fallback === true
 }
 
-function barLabel(alarming, vertical, showValue, loading, hasEntry, summaryText) {
+// `providerLabel` is already resolved by the caller: empty when the opt-in
+// provider switch is off, so the icon-and-value label is unchanged for everyone
+// who never turns it on. A vertical bar has no width for either field and
+// keeps showing the icon alone.
+function barLabel(alarming, vertical, showValue, loading, hasEntry, summaryText,
+                  providerLabel) {
   var icon = "󰚩"
   if (vertical) return alarming ? "󰅙" : icon
   if (loading && !hasEntry) return icon + "  …"
   if (!hasEntry) return alarming ? "󰅙" : icon
-  if (!showValue) return icon
-  var summary = autoTextSafe(summaryText).trim()
-  return summary === "" ? icon : icon + "  " + summary
+  var provider = autoTextSafe(providerLabel).trim()
+  var summary = showValue ? autoTextSafe(summaryText).trim() : ""
+  if (provider === "") return summary === "" ? icon : icon + "  " + summary
+  // One space between tag and value, matching Waybar's
+  // `{vendor_short} {session_pct}%`; the wider gap stays next to the icon.
+  return summary === "" ? icon + "  " + provider
+    : icon + "  " + provider + " " + summary
 }
 
 function headline(entry) {

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -43,6 +43,7 @@ Panel {
   readonly property string configuredProvider: String(setting("provider", "") || "").trim()
   readonly property string rememberedEntryId: String(setting("lastSelectedEntryId", "") || "").trim()
   readonly property bool showValue: Model.booleanSetting(setting("showValue", true), true)
+  readonly property bool showProvider: Model.booleanSetting(setting("showProvider", false), false)
   readonly property var visibleEntries: Model.filteredEntries(entries, configuredProvider)
   readonly property int entryIndex: Model.selectedIndex(visibleEntries, selectedEntryId)
   readonly property var entry: entryIndex >= 0 ? visibleEntries[entryIndex] : null
@@ -103,6 +104,12 @@ Panel {
     var next = enabled === true
     if (next === showValue) return
     persistWidgetSettings({ showValue: next })
+  }
+
+  function setShowProvider(enabled) {
+    var next = enabled === true
+    if (next === showProvider) return
+    persistWidgetSettings({ showProvider: next })
   }
 
   function selectEntry(index) {
@@ -201,7 +208,7 @@ Panel {
 
   function barText() {
     return Model.barLabel(alarming, vertical, showValue, loading,
-      entry !== null, summary.text)
+      entry !== null, summary.text, showProvider ? Model.providerShort(entry) : "")
   }
 
   function tooltipText() {
@@ -371,8 +378,10 @@ Panel {
             urgent: root.urgent
             fontFamily: root.fontFamily
             showValue: root.showValue
+            showProvider: root.showProvider
             onSaved: root.startRefresh()
             onShowValueRequested: function(enabled) { root.setShowValue(enabled) }
+            onShowProviderRequested: function(enabled) { root.setShowProvider(enabled) }
             onFallbackRequested: root.openTerminalSettings()
             onNousLoginRequested: root.openNousLogin()
             onCloseRequested: root.closeSettings()

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -46,7 +46,9 @@ omarchy plugin remove akitaonrails.ai-usagebar
 - Panel: click the gear or press `s` to open the native QML settings page.
   Its **Show usage value in the top bar** toggle switches between the normal
   icon-and-value label and a compact icon-only label without hiding panel or
-  tooltip details.
+  tooltip details. Its **Show provider name in the top bar** toggle adds the
+  provider's three-letter code in front of that value — the same code Waybar's
+  `{vendor_short}` prints — and is off by default.
   `h`/`l` or Left/Right switches provider, `j`/`k` or Up/Down scrolls, `r`,
   Enter, or Space refreshes, Tab moves to the neighboring bar panel, and Esc
   closes.
@@ -91,12 +93,26 @@ omarchy bar set akitaonrails.ai-usagebar refreshIntervalSec 300 --json
 
 # Booleans also need --json. The default is true for drop-in compatibility.
 omarchy bar set akitaonrails.ai-usagebar showValue false --json
+
+# Opt in to the Waybar-style provider tag. The default is false.
+omarchy bar set akitaonrails.ai-usagebar showProvider true --json
 ```
 
 The refresh interval is clamped to 30–3600 seconds. The `provider` setting
 prefers an exact entry id; if there is no exact match, a base id such as
-`anthropic` selects all accounts for that provider. `showValue` changes only
-the top-bar label; it never hides report details or changes provider fetching.
+`anthropic` selects all accounts for that provider. `showValue` and
+`showProvider` change only the top-bar label; neither hides report details or
+changes provider fetching.
+
+`showProvider` draws the `short_name` the Rust report ships for the selected
+entry, so the codes never fork from Waybar's `{vendor_short}`: `cld 29%`,
+`gpt 95%`, `agy 81%`. Every account of one provider shares that provider's
+code — the panel and tooltip remain the place that tells `Claude · work` from
+`Claude · personal`. With both toggles on the bar reads `󰚩  cld 29%`; with
+`showValue` off it reads `󰚩  cld`. A vertical bar has room for neither and
+keeps showing the icon alone. Against an `ai-usagebar` older than the
+`short_name` field the tag falls back to the entry id's provider half
+(`anthropic 29%`) until the binary is updated.
 
 ## Development checks
 

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -108,9 +108,9 @@ changes provider fetching.
 entry, so the codes never fork from Waybar's `{vendor_short}`: `cld 29%`,
 `gpt 95%`, `agy 81%`. Every account of one provider shares that provider's
 code — the panel and tooltip remain the place that tells `Claude · work` from
-`Claude · personal`. With both toggles on the bar reads `󰚩  cld 29%`; with
-`showValue` off it reads `󰚩  cld`. A vertical bar has room for neither and
-keeps showing the icon alone. Against an `ai-usagebar` older than the
+`Claude · personal`. With both toggles on the bar reads icon + `cld 29%`; with
+`showValue` off it is the icon and `cld`. A vertical bar has room for neither
+and keeps showing the icon alone. Against an `ai-usagebar` older than the
 `short_name` field the tag falls back to the entry id's provider half
 (`anthropic 29%`) until the binary is updated.
 

--- a/omarchy/SettingsView.qml
+++ b/omarchy/SettingsView.qml
@@ -15,6 +15,7 @@ Column {
   property color urgent: Color.urgent
   property string fontFamily: Style.font.family
   property bool showValue: true
+  property bool showProvider: false
   readonly property color dim: Qt.darker(foreground, 1.45)
 
   property var snapshot: ({ primary_choices: [], keys: [] })
@@ -37,6 +38,7 @@ Column {
   signal fallbackRequested()
   signal nousLoginRequested()
   signal showValueRequested(bool enabled)
+  signal showProviderRequested(bool enabled)
   signal closeRequested()
 
   spacing: Style.space(12)
@@ -221,6 +223,16 @@ Column {
       fontFamily: root.fontFamily
       enabled: !root.saving
       onClicked: root.showValueRequested(!root.showValue)
+    }
+    Toggle {
+      width: parent.width
+      label: "Show provider name in the top bar"
+      description: "Turn this on to prefix the bar entry with the provider's short code — cld, gpt, zai, agy — the way Waybar's {vendor_short} does. Off by default. Applies immediately."
+      checked: root.showProvider
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      enabled: !root.saving
+      onClicked: root.showProviderRequested(!root.showProvider)
     }
   }
 

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -17,6 +17,12 @@ assert.equal(manifest.barWidget.defaults.showValue, true);
 const showValueSchema = manifest.barWidget.schema.find(row => row.key === 'showValue');
 assert.equal(showValueSchema.type, 'boolean');
 assert.equal(showValueSchema.defaultValue, true);
+// Opt-in, so an existing bar entry that has never seen this key keeps the
+// label it has today.
+assert.equal(manifest.barWidget.defaults.showProvider, false);
+const showProviderSchema = manifest.barWidget.schema.find(row => row.key === 'showProvider');
+assert.equal(showProviderSchema.type, 'boolean');
+assert.equal(showProviderSchema.defaultValue, false);
 
 const barWidgetSource = fs.readFileSync(new URL('./BarWidget.qml', import.meta.url), 'utf8');
 assert.match(barWidgetSource, /^BarWidget\s*\{/m);
@@ -36,6 +42,8 @@ assert.match(panelSource, /SettingsView\s*\{/);
 assert.match(panelSource, /function\s+openSettings\s*\(/);
 assert.match(panelSource, /setting\("lastSelectedEntryId",\s*""\)/);
 assert.match(panelSource, /setting\("showValue",\s*true\)/);
+assert.match(panelSource, /setting\("showProvider",\s*false\)/);
+assert.match(panelSource, /showProvider\s*\?\s*Model\.providerShort\(entry\)\s*:\s*""/);
 assert.match(panelSource, /function\s+persistSelection\s*\(/);
 assert.match(panelSource, /Model\.settingsWithOverrides\(root\.settings,\s*root\.moduleName,\s*values\)/);
 assert.match(panelSource, /bar\.shell\.updateEntryInline\(root\.moduleName,\s*entry\)/);
@@ -50,6 +58,9 @@ assert.match(settingsViewSource, /write\(root\.pendingPayload\s*\+\s*"\\n"\)/);
 assert.match(settingsViewSource, /signal\s+nousLoginRequested\(\)/);
 assert.match(settingsViewSource, /signal\s+showValueRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show usage value in the top bar"/);
+assert.match(settingsViewSource, /signal\s+showProviderRequested\(bool\s+enabled\)/);
+assert.match(settingsViewSource, /label:\s*"Show provider name in the top bar"/);
+assert.match(panelSource, /onShowProviderRequested/);
 assert.match(settingsViewSource, /Log in with Nous Research/);
 assert.match(settingsViewSource, /Leave the terminal open until login completes/);
 assert.match(settingsViewSource, /model:\s*root\.snapshot\.keys/);
@@ -63,6 +74,7 @@ const raw = JSON.stringify({primary: 'openai', entries: [
     id: 'anthropic@work',
     name: 'anthropic · work',
     display_name: 'Claude · work',
+    short_name: 'cld',
     plan: 'Claude Max 20x',
     status: 'ready',
     error: null,
@@ -78,7 +90,7 @@ const raw = JSON.stringify({primary: 'openai', entries: [
     ]
   },
   {
-    id: 'openai', name: 'openai', display_name: 'Codex', plan: 'Plus', error: null,
+    id: 'openai', name: 'openai', display_name: 'Codex', short_name: 'gpt', plan: 'Plus', error: null,
     sections: [{type: 'metric', label: 'Codex weekly', percent: 95, value: '95%', detail: '', severity: 'critical'}]
   }
 ]});
@@ -137,6 +149,12 @@ const hiddenValueSettings = model.settingsWithOverrides(
 assert.equal(hiddenValueSettings.showValue, false);
 assert.equal(hiddenValueSettings.lastSelectedEntryId, 'openrouter@personal');
 assert.equal(selectedWidgetSettings.showValue, undefined);
+const shownProviderSettings = model.settingsWithOverrides(
+  hiddenValueSettings, 'akitaonrails.ai-usagebar', {showProvider: true});
+assert.equal(shownProviderSettings.showProvider, true);
+assert.equal(shownProviderSettings.showValue, false);
+assert.equal(shownProviderSettings.lastSelectedEntryId, 'openrouter@personal');
+assert.equal(hiddenValueSettings.showProvider, undefined);
 const protectedSettings = model.settingsWithOverrides({}, 'akitaonrails.ai-usagebar', {
   id: 'wrong-id', constructor: 'ignored', prototype: 'ignored', showValue: false
 });
@@ -157,6 +175,34 @@ assert.equal(model.barLabel(true, false, true, false, false, ''), '󰅙');
 assert.equal(model.barLabel(false, true, true, false, true, '29%'), '󰚩');
 assert.equal(model.barLabel(true, true, true, false, true, '95%'), '󰅙');
 assert.equal(model.barLabel(false, false, true, true, false, ''), '󰚩  …');
+
+// The provider tag is opt-in and arrives already resolved, so every call
+// above — no seventh argument at all — has to keep its historical label.
+assert.equal(model.barLabel(false, false, true, false, true, '29%', 'gpt'), '󰚩  gpt 29%');
+// Tag on, value off: the icon-only label grows the tag and nothing else.
+assert.equal(model.barLabel(false, false, false, false, true, '29%', 'gpt'), '󰚩  gpt');
+assert.equal(model.barLabel(true, false, true, false, true, '95%', 'cld'), '󰚩  cld 95%');
+// An entry with no headline still names its provider.
+assert.equal(model.barLabel(false, false, true, false, true, '', 'agy'), '󰚩  agy');
+// A vertical bar has no width for either field.
+assert.equal(model.barLabel(false, true, true, false, true, '29%', 'gpt'), '󰚩');
+// Before the first report there is no provider to name.
+assert.equal(model.barLabel(false, false, true, true, false, '', 'gpt'), '󰚩  …');
+assert.equal(model.barLabel(true, false, true, false, false, '', 'gpt'), '󰅙');
+// A tag that sanitizes down to nothing degrades to the label without one.
+assert.equal(model.barLabel(false, false, true, false, true, '29%', '   '), '󰚩  29%');
+assert.equal(model.barLabel(false, false, true, false, true, '29%', undefined), '󰚩  29%');
+
+// The codes come from Rust's VendorId::short_name via the report; the vendor
+// half of the machine id only stands in for a binary that predates the field.
+assert.equal(model.providerShort(parsed.entries[0]), 'cld');
+assert.equal(model.providerShort(parsed.entries[1]), 'gpt');
+assert.equal(model.providerShort({id: 'anthropic@work'}), 'anthropic');
+assert.equal(model.providerShort({id: 'anthropic_api'}), 'anthropic-api');
+assert.equal(model.providerShort({id: 'zai', short_name: '   '}), 'zai');
+assert.equal(model.providerShort(null), '');
+// Provider-controlled text can never reach Text.AutoText as markup.
+assert.equal(model.providerShort({id: 'x', short_name: '<b>x</b>'}), '‹b›x‹/b›');
 
 assert.equal(model.headline(parsed.entries[0]).text, '29%');
 assert.equal(model.headline(parsed.entries[1]).severity, 'critical');

--- a/src/anthropic_api/vendor.rs
+++ b/src/anthropic_api/vendor.rs
@@ -12,7 +12,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::AnthropicApiSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -37,7 +37,10 @@ pub fn build_placeholders(snap: &AnthropicApiSnapshot) -> HashMap<&'static str, 
     let pct = snap.pct().unwrap_or(0);
     placeholders(vec![
         ("icon", "󰢗".to_string()),
-        ("vendor_short", "aac".to_string()),
+        (
+            "vendor_short",
+            VendorId::AnthropicApi.short_name().to_string(),
+        ),
         // Cross-vendor aliases — spend% maps to the session/weekly slots.
         ("session_pct", pct.to_string()),
         ("session_reset", "—".to_string()),

--- a/src/antigravity/vendor.rs
+++ b/src/antigravity/vendor.rs
@@ -18,7 +18,7 @@ use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
 use crate::usage::{AntigravitySnapshot, UsageWindow};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 pub const DEFAULT_FORMAT: &str = "{icon} {session_pct}% · {weekly_pct}%";
@@ -78,7 +78,10 @@ pub fn build_placeholders(
 
     placeholders(vec![
         ("icon", "󰧑".to_string()),
-        ("vendor_short", "agy".to_string()),
+        (
+            "vendor_short",
+            VendorId::Antigravity.short_name().to_string(),
+        ),
         ("plan", snap.plan.clone()),
         // Naming the primary rows is what puts the native dropdown into its
         // grouped layout; no other vendor emits these.

--- a/src/cursor/vendor.rs
+++ b/src/cursor/vendor.rs
@@ -13,7 +13,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::CursorSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -31,7 +31,7 @@ pub fn build_placeholders(
     let reset = countdown::format(snap.reset_at, now);
     placeholders(vec![
         ("icon", DEFAULT_ICON.to_string()),
-        ("vendor_short", "cur".to_string()),
+        ("vendor_short", VendorId::Cursor.short_name().to_string()),
         // Cross-vendor aliases: the two pools map onto the two generic windows
         // (session = Cursor Models, weekly = Other Models) so a shared format
         // and the macOS menu bar show both. Severity still keys on the worst.

--- a/src/deepseek/vendor.rs
+++ b/src/deepseek/vendor.rs
@@ -10,7 +10,7 @@ use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::DeepseekSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -22,7 +22,7 @@ pub fn build_placeholders(snap: &DeepseekSnapshot) -> HashMap<&'static str, Stri
     let balance = money(snap.balance, &snap.currency);
     placeholders(vec![
         ("icon", "󰧑".to_string()),
-        ("vendor_short", "dsk".to_string()),
+        ("vendor_short", VendorId::Deepseek.short_name().to_string()),
         // Cross-vendor aliases — DeepSeek has neither rate-limit windows nor a
         // spend denominator (`/user/balance` reports only money *remaining*),
         // so these percentages are structurally meaningless for this vendor.

--- a/src/grok/vendor.rs
+++ b/src/grok/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::GrokSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -21,7 +21,7 @@ pub const DEFAULT_FORMAT: &str = "{grok_balance}";
 pub fn build_placeholders(snap: &GrokSnapshot) -> HashMap<&'static str, String> {
     placeholders(vec![
         ("icon", "󰇷".to_string()),
-        ("vendor_short", "grk".to_string()),
+        ("vendor_short", VendorId::Grok.short_name().to_string()),
         ("session_pct", "0".to_string()),
         ("session_reset", "—".to_string()),
         ("weekly_pct", "0".to_string()),

--- a/src/kilo/vendor.rs
+++ b/src/kilo/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::KiloSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -21,7 +21,7 @@ pub const DEFAULT_FORMAT: &str = "{kilo_balance}";
 pub fn build_placeholders(snap: &KiloSnapshot) -> HashMap<&'static str, String> {
     placeholders(vec![
         ("icon", "󰭟".to_string()),
-        ("vendor_short", "klo".to_string()),
+        ("vendor_short", VendorId::Kilo.short_name().to_string()),
         // Cross-vendor aliases — Kilo has no rate-limit windows.
         ("session_pct", "0".to_string()),
         ("session_reset", "—".to_string()),

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
 use crate::usage::{KimiSnapshot, UsageWindow};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::{FetchOutcome, SCHEMA_DRIFT_MESSAGE};
@@ -64,7 +64,7 @@ pub fn build_placeholders(
     let window_pct = snap.window_pct();
     placeholders(vec![
         ("icon", "󰚩".to_string()),
-        ("vendor_short", "kmi".to_string()),
+        ("vendor_short", VendorId::Kimi.short_name().to_string()),
         // Cross-vendor aliases.
         ("plan", plan.to_string()),
         ("weekly_pct", weekly_pct.to_string()),

--- a/src/kiro/vendor.rs
+++ b/src/kiro/vendor.rs
@@ -13,7 +13,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::KiroSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -42,7 +42,7 @@ pub fn build_placeholders(
     let reset = countdown::format(snap.reset_at, now);
     placeholders(vec![
         ("icon", DEFAULT_ICON.to_string()),
-        ("vendor_short", "kir".to_string()),
+        ("vendor_short", VendorId::Kiro.short_name().to_string()),
         // Cross-vendor aliases: one pool, so it fills both generic slots.
         ("plan", snap.plan.clone()),
         ("session_pct", pct.to_string()),

--- a/src/minimax/vendor.rs
+++ b/src/minimax/vendor.rs
@@ -16,7 +16,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
 use crate::usage::{MinimaxSnapshot, UsageWindow};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -68,7 +68,7 @@ fn build_placeholders_with_tolerance(
 
     placeholders(vec![
         ("icon", "󰚩".to_string()),
-        ("vendor_short", "mmx".to_string()),
+        ("vendor_short", VendorId::Minimax.short_name().to_string()),
         // Cross-vendor aliases — what the desktop surfaces read.
         ("plan", snap.plan.clone()),
         ("session_pct", session_pct.to_string()),

--- a/src/moonshot/vendor.rs
+++ b/src/moonshot/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::MoonshotSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -21,7 +21,7 @@ pub const DEFAULT_FORMAT: &str = "{km_balance}";
 pub fn build_placeholders(snap: &MoonshotSnapshot) -> HashMap<&'static str, String> {
     placeholders(vec![
         ("icon", "󰚩".to_string()),
-        ("vendor_short", "msh".to_string()),
+        ("vendor_short", VendorId::Moonshot.short_name().to_string()),
         // Cross-vendor aliases — Kimi has no rate-limit windows here.
         ("session_pct", "0".to_string()),
         ("session_reset", "—".to_string()),

--- a/src/nous/vendor.rs
+++ b/src/nous/vendor.rs
@@ -4,10 +4,12 @@ use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
 
+use crate::vendor::VendorId;
+
 use super::types::AccountSnapshot;
 
 pub const DISPLAY_NAME: &str = "Nous Research";
-pub const VENDOR_SHORT: &str = "nrs";
+pub const VENDOR_SHORT: &str = VendorId::NousResearch.short_name();
 pub const DEFAULT_FORMAT: &str = "{nous_pct}% · {nous_renewal}";
 pub const NEUTRAL_UNAVAILABLE: &str = "—";
 

--- a/src/novita/vendor.rs
+++ b/src/novita/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{color_span, escape, severity_color};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::NovitaSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -21,7 +21,7 @@ pub const DEFAULT_FORMAT: &str = "{nv_balance}";
 pub fn build_placeholders(snap: &NovitaSnapshot) -> HashMap<&'static str, String> {
     placeholders(vec![
         ("icon", "󰄔".to_string()),
-        ("vendor_short", "nvt".to_string()),
+        ("vendor_short", VendorId::Novita.short_name().to_string()),
         // Cross-vendor aliases — Novita has no rate-limit windows.
         ("session_pct", "0".to_string()),
         ("session_reset", "—".to_string()),

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -12,7 +12,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, push_window, render_bordered};
 use crate::usage::{OpenAiSnapshot, OpenAiSource, UsageWindow};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -53,7 +53,7 @@ pub fn build_placeholders(
 
     placeholders(vec![
         ("icon", "󱢆".to_string()),
-        ("vendor_short", "gpt".to_string()),
+        ("vendor_short", VendorId::Openai.short_name().to_string()),
         // Cross-vendor aliases — same names work across all vendors so a
         // single `--format '{vendor_short} {session_pct}% · {session_reset}'`
         // renders correctly during scroll-cycle.

--- a/src/opencode_go/vendor.rs
+++ b/src/opencode_go/vendor.rs
@@ -9,7 +9,7 @@ use crate::pacing::PaceSeverity;
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -45,7 +45,10 @@ pub fn build_placeholders_with_plan(
     let monthly = window_values(usage.monthly.as_ref(), now);
 
     placeholders([
-        ("vendor_short", "ocg".to_string()),
+        (
+            "vendor_short",
+            VendorId::OpenCodeGo.short_name().to_string(),
+        ),
         ("plan", plan.clone()),
         ("ocg_plan", plan),
         ("session_pct", rolling.percent.clone()),

--- a/src/openrouter/vendor.rs
+++ b/src/openrouter/vendor.rs
@@ -10,7 +10,7 @@ use crate::pango::{self, color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::OpenRouterSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -21,7 +21,10 @@ pub const DEFAULT_FORMAT: &str = "${or_balance} · ${or_used_today}";
 pub fn build_placeholders(snap: &OpenRouterSnapshot) -> HashMap<&'static str, String> {
     placeholders(vec![
         ("icon", "󱙺".to_string()),
-        ("vendor_short", "opr".to_string()),
+        (
+            "vendor_short",
+            VendorId::Openrouter.short_name().to_string(),
+        ),
         // Cross-vendor aliases — for OpenRouter the "session" concept maps
         // to "credit consumed %", and there's no reset time so we render "—".
         ("session_pct", snap.consumed_pct().to_string()),

--- a/src/report.rs
+++ b/src/report.rs
@@ -31,6 +31,9 @@ struct Entry {
     id: String,
     name: String,
     display_name: String,
+    /// The vendor's `{vendor_short}` code. Frontends that want a Waybar-style
+    /// provider tag take it from here rather than keeping their own table.
+    short_name: String,
     plan: Option<String>,
     sections: Vec<ReportSection>,
     error: Option<String>,
@@ -128,6 +131,7 @@ fn entry_from_state(tab: &TabId, state: &TabState, now: chrono::DateTime<Utc>) -
         id: tab_id(tab),
         name: tab_name(tab),
         display_name: tab_display_name(tab),
+        short_name: tab.vendor.short_name().to_string(),
         plan: None,
         sections: Vec::new(),
         error: match &state {
@@ -239,6 +243,7 @@ fn render_json_for_primary(entries: &[Entry], primary: Option<&str>) -> String {
                 "id": entry.id,
                 "name": entry.name,
                 "display_name": entry.display_name,
+                "short_name": entry.short_name,
                 "plan": entry.plan,
                 "status": if entry.error.is_some() { "error" } else { "ready" },
                 "error": entry.error,
@@ -346,6 +351,7 @@ mod tests {
             id: name.into(),
             name: name.into(),
             display_name: name.into(),
+            short_name: VendorId::Anthropic.short_name().into(),
             plan: Some("Claude Max 20x".into()),
             sections,
             error: None,
@@ -381,6 +387,28 @@ mod tests {
         assert_eq!(tab_id(&openrouter), "openrouter@work");
         assert_eq!(tab_name(&openrouter), "openrouter · work");
         assert_eq!(tab_display_name(&openrouter), "OpenRouter · work");
+    }
+
+    /// The Omarchy bar can be set to draw the provider tag and nothing else,
+    /// so every entry — a failed one included — has to carry a code, and every
+    /// account of one vendor has to carry that vendor's code rather than a
+    /// per-account one.
+    #[test]
+    fn every_entry_carries_its_vendor_short_code() {
+        let now = Utc::now();
+        let failed = TabState::Error("not signed in".into());
+
+        let account = entry_from_state(&TabId::account("gmail"), &failed, now);
+        assert_eq!(account.short_name, "cld");
+        let other_account = entry_from_state(&TabId::account("work"), &failed, now);
+        assert_eq!(other_account.short_name, account.short_name);
+
+        let cursor = entry_from_state(&TabId::vendor(VendorId::Cursor), &failed, now);
+        assert_eq!(cursor.short_name, "cur");
+
+        let rendered = render_json_for_primary(&[cursor], None);
+        let value: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(value["entries"][0]["short_name"], "cur");
     }
 
     #[test]
@@ -447,6 +475,7 @@ mod tests {
         let first = &value["entries"][0];
         assert_eq!(first["plan"], "Claude Max 20x");
         assert_eq!(first["display_name"], "anthropic · gmail");
+        assert_eq!(first["short_name"], "cld");
         assert_eq!(first["metrics"][0]["percent"], 29);
         assert_eq!(first["metrics"][0]["detail"], "Resets in 0h 50m");
         assert!(first["error"].is_null());

--- a/src/supergrok/vendor.rs
+++ b/src/supergrok/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{self, color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, render_bordered};
 use crate::usage::SuperGrokSnapshot;
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -30,7 +30,7 @@ pub fn build_placeholders(
 
     placeholders(vec![
         ("icon", DEFAULT_ICON.to_string()),
-        ("vendor_short", "sgk".to_string()),
+        ("vendor_short", VendorId::Supergrok.short_name().to_string()),
         // Cross-vendor compatibility aliases for the single current pool.
         ("plan", snap.plan.clone()),
         ("session_pct", pct.clone()),

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -180,6 +180,33 @@ impl VendorId {
         }
     }
 
+    /// Compact three-letter code for the bar. This is the single source for
+    /// `{vendor_short}` in every renderer, the `usage --json` `short_name`
+    /// field, and any frontend that wants a Waybar-style provider tag; a
+    /// second copy in a placeholder map or a QML file is how the table forks.
+    pub const fn short_name(self) -> &'static str {
+        match self {
+            VendorId::Anthropic => "cld",
+            VendorId::AnthropicApi => "aac",
+            VendorId::Openai => "gpt",
+            VendorId::Zai => "zai",
+            VendorId::Openrouter => "opr",
+            VendorId::Deepseek => "dsk",
+            VendorId::Kimi => "kmi",
+            VendorId::Kilo => "klo",
+            VendorId::Novita => "nvt",
+            VendorId::Moonshot => "msh",
+            VendorId::Grok => "grk",
+            VendorId::Supergrok => "sgk",
+            VendorId::Antigravity => "agy",
+            VendorId::Cursor => "cur",
+            VendorId::Minimax => "mmx",
+            VendorId::Kiro => "kir",
+            VendorId::NousResearch => "nrs",
+            VendorId::OpenCodeGo => "ocg",
+        }
+    }
+
     pub fn all() -> &'static [VendorId] {
         &[
             VendorId::Anthropic,
@@ -252,6 +279,28 @@ mod tests {
         assert_eq!(VendorId::Anthropic.display_name(), "Claude");
         assert_eq!(VendorId::Openai.display_name(), "Codex");
         assert_eq!(VendorId::Zai.display_name(), "Z.AI");
+    }
+
+    /// `{vendor_short}` is a documented format placeholder and now also rides
+    /// the `usage --json` report, so a duplicate or a re-typed code would make
+    /// two providers indistinguishable in a bar that shows nothing else.
+    #[test]
+    fn every_vendor_short_name_is_a_unique_three_letter_code() {
+        let mut seen = std::collections::BTreeSet::new();
+        for vendor in VendorId::all() {
+            let short = vendor.short_name();
+            assert_eq!(short.len(), 3, "{} is not three letters", vendor.slug());
+            assert!(
+                short.chars().all(|c| c.is_ascii_lowercase()),
+                "{} is not lowercase ascii",
+                vendor.slug()
+            );
+            assert!(seen.insert(short), "{short} is used by two vendors");
+        }
+        assert_eq!(VendorId::Anthropic.short_name(), "cld");
+        assert_eq!(VendorId::Openai.short_name(), "gpt");
+        assert_eq!(VendorId::Zai.short_name(), "zai");
+        assert_eq!(VendorId::Antigravity.short_name(), "agy");
     }
 
     #[test]

--- a/src/widget/render.rs
+++ b/src/widget/render.rs
@@ -16,6 +16,7 @@ use crate::pango::{self, color_span, escape, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{self, Line};
 use crate::usage::{ExtraUsage, anthropic_severity};
+use crate::vendor::VendorId;
 use crate::waybar::{Class, WaybarOutput};
 
 /// Default format string when `--format` is omitted (claudebar:55).
@@ -170,7 +171,7 @@ fn build_placeholders(input: &RenderInput) -> HashMap<&'static str, String> {
 
     let mut v = placeholders(vec![
         ("icon", "󰚩".to_string()),
-        ("vendor_short", "cld".to_string()),
+        ("vendor_short", VendorId::Anthropic.short_name().to_string()),
         ("plan", snap.plan.clone()),
         ("session_pct", snap.session.utilization_pct.to_string()),
         (

--- a/src/zai/vendor.rs
+++ b/src/zai/vendor.rs
@@ -11,7 +11,7 @@ use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
 use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
 use crate::usage::{UsageWindow, ZaiSnapshot};
-use crate::vendor::{RenderOpts, VendorOutcome};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
 use crate::waybar::{Class, WaybarOutput};
 
 use super::fetch::FetchOutcome;
@@ -46,7 +46,7 @@ fn build_placeholders_with_tolerance(
     let mcp = window_pacing(snap.mcp.as_ref(), pace_tolerance, now);
     placeholders(vec![
         ("icon", "󰚩".to_string()),
-        ("vendor_short", "zai".to_string()),
+        ("vendor_short", VendorId::Zai.short_name().to_string()),
         // Cross-vendor aliases for scroll-cycle friendly formats.
         ("session_pct", session_pct.to_string()),
         (


### PR DESCRIPTION
## Why

The Quattro bar entry says how much quota is left but never whose. On a bar
cycling several providers — the setup the scroll gesture exists for — `󰚩  29%`
is ambiguous until the panel is opened. Waybar has solved this since forever
with `{vendor_short}`; the native plugin had no equivalent.

The plugin already has an opt-**out** for the usage value (**Show usage value
in the top bar**). This adds the matching opt-**in** for the provider.

## What

**Show provider name in the top bar** — a new toggle beside the existing one in
QML settings, or `omarchy bar set akitaonrails.ai-usagebar showProvider true
--json`. It prefixes the label with the provider's three-letter code, exactly
the one Waybar prints:

| `showProvider` | `showValue` | bar entry |
|---|---|---|
| off (default) | on | `󰚩  29%` |
| on | on | `󰚩  cld 29%` |
| on | off | `󰚩  cld` |
| off | off | `󰚩` |

Off by default, so an existing bar entry keeps the label it has today. A
vertical bar has room for neither field and still shows the icon alone; loading
and error labels are untouched. Applies immediately, like the sibling toggle,
and never changes panel details, tooltips or fetching.

## Where the codes come from

Per the *frontend adapters stay thin* invariant in `CLAUDE.md`, the QML side
gets no provider table of its own:

- `VendorId::short_name` is now the single source for `{vendor_short}`.
  Eighteen renderers each carried their own literal (`"cld"`, `"gpt"`, `"agy"`,
  …); they now call it. **The codes themselves are unchanged.**
- `ai-usagebar usage --json` reports each entry's `short_name`, additive like
  the rest of the report.
- `Model.providerShort` draws only what the report hands it. Against an
  `ai-usagebar` older than the field it falls back to the entry id's provider
  half (`anthropic 29%`) rather than restating the table.

Every account of one provider shares that provider's code — telling
`Claude · work` from `Claude · personal` stays the panel's job, as it already
is for `display_name`.

## Tests

- `vendor.rs` — a new test rejects a duplicate or a non-three-letter code
  across every `VendorId::all()`.
- `report.rs` — every entry carries a code, failed ones included, and two
  accounts of one vendor carry the same one.
- `omarchy/model.test.mjs` — the manifest default/schema, the Panel and
  SettingsView wiring, `providerShort`'s fallback and sanitizing, and every
  `barLabel` combination. The pre-existing six-argument `barLabel` assertions
  are kept verbatim to prove the historical label is byte-for-byte unchanged
  when the toggle is never turned on.

Ran green: `cargo fmt --check`, `cargo clippy --all-targets --locked -D
warnings`, `cargo test --all-targets --locked` (1128 tests), `make
desktop-test`, `make plugin-test`.

Not run here — no dependency or version change, and no Omarchy host in the
sandbox: `cargo machete` (no deps added; CI covers it) and `omarchy plugin
validate .` (the manifest's structure is asserted by `model.test.mjs`).

No version bump: `CHANGELOG.md` gets an `[Unreleased]` section,
`kde-plasmoid/` is untouched.
