### PR TITLE
fix(zai): pace GLM's rows in quattro native panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Z.AI's rows in the native panels — Omarchy Quattro, GNOME, KDE and the TUI —
+  carry the pace footnote every other percentage vendor's rows carry
+  (`60% elapsed · 20pts under`) instead of a bare `Resets in 2h 00m`. GLM's
+  session, weekly and monthly MCP windows each report a duration and a reset,
+  so all three pace, off the same `pacing::calc` the `{zai_*_pace}`
+  placeholders already use. Each surface keeps its own way of showing it, so
+  nothing else moves: the arrow stays the widget's, the bar tick the macOS
+  menu bar's, the footnote the panels'.
+
 ## [1.8.0] — 2026-08-28
 
 ### Added

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -316,7 +316,7 @@ pub(crate) fn sections_with_metadata_for(
                 VendorSnapshot::Anthropic(s) => anthropic_sections(s, now, pace_tolerance),
                 VendorSnapshot::AnthropicApi(s) => anthropic_api_sections(s),
                 VendorSnapshot::Openai(s) => openai_sections(s, now, pace_tolerance),
-                VendorSnapshot::Zai(s) => zai_sections(s, now),
+                VendorSnapshot::Zai(s) => zai_sections(s, now, pace_tolerance),
                 VendorSnapshot::Openrouter(s) => openrouter_sections(s),
                 VendorSnapshot::Deepseek(s) => deepseek_sections(s),
                 VendorSnapshot::Kimi(s) => kimi_sections(s, now, pace_tolerance),
@@ -571,19 +571,19 @@ fn openai_sections(
     v
 }
 
-fn zai_sections(s: &crate::usage::ZaiSnapshot, now: DateTime<Utc>) -> SectionBuilder {
+fn zai_sections(s: &crate::usage::ZaiSnapshot, now: DateTime<Utc>, tol: u32) -> SectionBuilder {
     let mut v = SectionBuilder::new(vec![Section::Title {
         left: s.plan.clone(),
         right: None,
     }]);
     if let Some(w) = &s.session {
-        push_window(&mut v, "Session (5h)", w, now, 5, false);
+        push_window(&mut v, "Session (5h)", w, now, tol, true);
     }
     if let Some(w) = &s.weekly {
-        push_window(&mut v, "Weekly", w, now, 5, false);
+        push_window(&mut v, "Weekly", w, now, tol, true);
     }
     if let Some(w) = &s.mcp {
-        push_window(&mut v, "MCP tools (monthly)", w, now, 5, false);
+        push_window(&mut v, "MCP tools (monthly)", w, now, tol, true);
     }
     if s.session.is_none() && s.weekly.is_none() && s.mcp.is_none() {
         v.push(Section::Spacer);
@@ -1510,6 +1510,42 @@ mod tests {
         // ...and the same number in the dense Overview list.
         let (_, cells) = compact_cells(&VendorSnapshot::Openrouter(snap));
         assert_eq!(cells[0].0, "-$5.71");
+    }
+
+    /// The panels express pace as a footnote on the row; the arrow is the
+    /// widget's idiom and the bar tick the menu bar's. All three Z.AI windows
+    /// report a duration and a reset, so all three carry one.
+    #[test]
+    fn zai_windows_are_paced_like_every_other_percentage_vendor() {
+        let window = |pct: i32, hours: i64, span: chrono::Duration| crate::usage::UsageWindow {
+            utilization_pct: pct,
+            resets_at: Some(now() + chrono::Duration::hours(hours)),
+            window_duration: span,
+        };
+        let snap = ZaiSnapshot {
+            plan: "GLM Coding Pro".into(),
+            session: Some(window(40, 2, chrono::Duration::hours(5))),
+            weekly: Some(window(60, 48, chrono::Duration::days(7))),
+            mcp: Some(window(10, 200, chrono::Duration::days(30))),
+        };
+
+        let footnotes: Vec<String> = sections_for(&ready(VendorSnapshot::Zai(snap)), now(), 5)
+            .into_iter()
+            .filter_map(|section| match section {
+                Section::Metric { footnote, .. } => Some(footnote),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(footnotes.len(), 3, "{footnotes:?}");
+        for footnote in &footnotes {
+            assert!(footnote.contains("% elapsed"), "{footnote}");
+        }
+        // 40% used with 60% of a 5h window gone: behind pace, not ahead.
+        assert_eq!(
+            footnotes[0], "Resets in 2h 00m · 60% elapsed · 20pts under",
+            "{footnotes:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

GLM was the one percentage vendor whose row in the native panels — Omarchy
Quattro, GNOME, KDE, and the TUI's own — read `Resets in 2h 00m` and stopped
there. Claude, Codex and MiniMax have all shown `60% elapsed · 20pts under`
beside theirs since those panels existed.

It was not a gap in what Z.AI reports. Its session, weekly and monthly MCP
windows each carry a real duration (5h / 7d / 30d) and their own reset, and
`{zai_*_pace}` has paced exactly those windows since it was added — which is
why the widget tooltip and the macOS menu bar have both been showing GLM's
pace for releases. Only this one call site opted out, and it hardcoded a
tolerance of `5` instead of honouring `--pace-tolerance`.

## What

`zai_sections` takes `pace_tolerance` and asks `push_window` for the paced
footnote on all three windows. That is the whole code change:

```diff
-fn zai_sections(s: &ZaiSnapshot, now: DateTime<Utc>) -> SectionBuilder {
+fn zai_sections(s: &ZaiSnapshot, now: DateTime<Utc>, tol: u32) -> SectionBuilder {
-        push_window(&mut v, "Session (5h)", w, now, 5, false);
+        push_window(&mut v, "Session (5h)", w, now, tol, true);
```

Every surface keeps its own way of expressing pace, so nothing renders
differently anywhere else: the arrow stays the widget tooltip's idiom, the tick
inside the bar stays the menu bar's, and the panels' is this footnote — the
same one Claude's rows already use, from the same `pacing::calc`. No frontend
needed a change to pick it up; GNOME, KDE and the TUI panels inherit it from
the shared projection.

## Result

Verified end to end by feeding a real `usage --json` payload through the
Omarchy plugin's own `Model.js`, which is what draws the panel:

```
Session (5h)            40%
  60% elapsed · 20pts under
  Resets in 1h 59m · Aug 29 00:19
Weekly                  60%
  71% elapsed · 11pts under
MCP tools (monthly)     10%
  72% elapsed · 62pts under
```

## Scope

Deliberately only Z.AI. An audit of every `push_window` call site found:

- **MiniMax** already passes `show_pacing: true` on all four pools and already
  threads `tol` — nothing to do, confirmed with the same end-to-end probe.
- **Antigravity** also hardcodes `5, false`, but it emits no `{*_pace}`
  placeholders at all and its tooltip uses the unpaced `push_window`, so pace
  there would be new behavior rather than restoring parity. Left alone.
- Claude's `Sonnet only` and Codex's `Code review` stay unpaced; they are
  secondary windows riding the weekly reset, not the same case.

## Tests

`zai_windows_are_paced_like_every_other_percentage_vendor` asserts all three
windows gain a `% elapsed` fragment and pins the exact footnote
(`Resets in 2h 00m · 60% elapsed · 20pts under`) for a 40%-used session with
60% of its window gone.

Ran green: `cargo fmt --check`, `cargo clippy --all-targets --locked -D
warnings`, `cargo test --all-targets --locked` (1176 tests), `cargo +1.88.0
check --all-targets --locked` (the MSRV job), `make desktop-test`, `make
plugin-test`. No existing test needed changing, which is itself evidence that
nothing depended on the unpaced footnote.

Not runnable in the sandbox: the nix, macOS and Windows CI jobs, and
`omarchy plugin validate .`. `cargo machete` cannot regress — `Cargo.toml` and
`Cargo.lock` are untouched.

No version bump; `CHANGELOG.md` gets an `[Unreleased] / Fixed` entry.