### PR TITLE
fix(openai): make named Codex accounts reachable end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Named Codex accounts (`[[openai.accounts]]`, added in 1.8.0) are now actually
+  reachable: `--vendor openai --account <label>` was rejected by CLI validation
+  before it could dispatch, `~` in an account's `codex_auth_path` was never
+  expanded, and the TUI and `usage` report skipped openai named accounts
+  entirely. All three paths now mirror the OpenRouter account handling — one
+  tab/report entry per named account, each with its own isolated cache — and
+  openai account labels are validated and de-duplicated on config load like the
+  other multi-account vendors.
+
 ### Changed
 
 - Internal: `account.rs` grew from 7 tests to 22 by splitting its decisions

--- a/src/config.rs
+++ b/src/config.rs
@@ -1046,6 +1046,9 @@ impl Config {
         for account in &mut self.anthropic.accounts {
             account.credentials_path = expand_tilde(&account.credentials_path);
         }
+        for account in &mut self.openai.accounts {
+            account.codex_auth_path = expand_tilde(&account.codex_auth_path);
+        }
     }
 
     /// Explicitly enumerate every inline API-key field. Adding a new API-key
@@ -1187,6 +1190,16 @@ impl Config {
             if !labels.insert(&account.label) {
                 return Err(AppError::Credentials(format!(
                     "duplicate anthropic account label {:?}",
+                    account.label
+                )));
+            }
+        }
+        let mut openai_labels = HashSet::new();
+        for account in &self.openai.accounts {
+            validate_account_label_for("openai", &account.label)?;
+            if !openai_labels.insert(&account.label) {
+                return Err(AppError::Credentials(format!(
+                    "duplicate openai account label {:?}",
                     account.label
                 )));
             }
@@ -2308,6 +2321,23 @@ enabled = false
             ..Default::default()
         };
         assert!(cfg.all_accounts().is_empty());
+    }
+
+    #[test]
+    fn openai_account_auth_paths_are_tilde_expanded_on_load() {
+        let f = write_toml(
+            r#"
+            [[openai.accounts]]
+            label = "work"
+            codex_auth_path = "~/.codex-work/auth.json"
+            "#,
+        );
+        let c = Config::load_from(f.path()).unwrap();
+        let home = crate::cache::home_dir().unwrap();
+        assert_eq!(
+            c.openai.accounts[0].codex_auth_path,
+            home.join(".codex-work/auth.json")
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -83,9 +83,9 @@ impl TabId {
     }
 }
 
-/// Expand enabled vendors into the tab list. Claude and OpenRouter yield their
-/// default account followed by configured named accounts; every other vendor
-/// is a single tab. With no extra accounts the result equals
+/// Expand enabled vendors into the tab list. Claude, OpenRouter, and Codex
+/// (OpenAI) yield their default account followed by configured named accounts;
+/// every other vendor is a single tab. With no extra accounts the result equals
 /// `config.enabled_vendors()`, preserving the historical tab set and order.
 ///
 /// Config-only and pure — no Desktop profiles. Production uses
@@ -144,6 +144,11 @@ fn build_tabs(config: &Config, desktop_labels: &[String]) -> Vec<TabId> {
                 tabs.push(TabId::vendor(vendor));
             }
             for account in &config.openrouter.accounts {
+                tabs.push(TabId::account_for(vendor, account.label.clone()));
+            }
+        } else if vendor == VendorId::Openai {
+            tabs.push(TabId::vendor(vendor));
+            for account in &config.openai.accounts {
                 tabs.push(TabId::account_for(vendor, account.label.clone()));
             }
         } else {
@@ -509,12 +514,12 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             Ok(outcome.into())
         }
         VendorId::Openai => {
-            let cache = crate::cache::Cache::for_vendor("openai")?;
-            let creds_path = config
-                .openai
-                .codex_auth_path
-                .clone()
-                .unwrap_or_else(|| crate::openai::creds::default_path().unwrap_or_default());
+            let label = tab.account.as_deref();
+            let cache = match label {
+                Some(label) => crate::cache::Cache::for_vendor_account("openai", label)?,
+                None => crate::cache::Cache::for_vendor("openai")?,
+            };
+            let creds_path = config.openai.resolve_auth_path(label)?;
             let endpoints = crate::openai::fetch::Endpoints::default();
             let outcome =
                 crate::openai::fetch_snapshot(client, &creds_path, &cache, &endpoints, DEFAULT_TTL)
@@ -976,6 +981,25 @@ mod tests {
                 TabId::vendor(VendorId::Openrouter),
                 TabId::account_for(VendorId::Openrouter, "work"),
                 TabId::account_for(VendorId::Openrouter, "personal"),
+            ]
+        );
+    }
+
+    #[test]
+    fn openai_named_accounts_get_their_own_tabs_after_the_default() {
+        let mut config = Config::default();
+        config.anthropic.enabled = false;
+        config.zai.enabled = false;
+        config.openrouter.enabled = false;
+        config.openai.accounts.push(crate::config::OpenAiAccount {
+            label: "work".into(),
+            codex_auth_path: "/tmp/codex-work/auth.json".into(),
+        });
+        assert_eq!(
+            tabs_from_config(&config),
+            vec![
+                TabId::vendor(VendorId::Openai),
+                TabId::account_for(VendorId::Openai, "work"),
             ]
         );
     }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -116,7 +116,7 @@ pub struct Cli {
     #[arg(long, value_name = "FILE")]
     pub creds_path: Option<std::path::PathBuf>,
 
-    /// Select a named Claude or OpenRouter account from the matching
+    /// Select a named Claude, OpenRouter, or Codex (OpenAI) account from the matching
     /// `[[...accounts]]` config array. Without it, the vendor's default account
     /// and original cache path are unchanged. For Claude it conflicts with the
     /// lower-level `--creds-path` because both select a credential source.

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -165,9 +165,14 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
 }
 
 fn validate_vendor_options(cli: &Cli, vendor: Vendor) -> Result<()> {
-    if cli.account.is_some() && !matches!(vendor, Vendor::Anthropic | Vendor::Openrouter) {
+    if cli.account.is_some()
+        && !matches!(
+            vendor,
+            Vendor::Anthropic | Vendor::Openrouter | Vendor::Openai
+        )
+    {
         return Err(AppError::Other(
-            "--account is supported only for Claude and OpenRouter".into(),
+            "--account is supported only for Claude, OpenRouter, and Codex (OpenAI)".into(),
         ));
     }
     if cli.desktop && vendor != Vendor::Anthropic {
@@ -1256,6 +1261,7 @@ mod tests {
         assert!(validate_vendor_options(&cli, Vendor::Zai).is_err());
         assert!(validate_vendor_options(&cli, Vendor::Anthropic).is_ok());
         assert!(validate_vendor_options(&cli, Vendor::Openrouter).is_ok());
+        assert!(validate_vendor_options(&cli, Vendor::Openai).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`[[openai.accounts]]` (added in 1.8.0, #134) resolves `--account` to its own auth file and isolated cache in `openai_target`, but the feature is unreachable as shipped:

1. `validate_vendor_options` still rejects `--account` for the openai vendor, so `ai-usagebar --vendor openai --account work` (the exact README example) errors with *"--account is supported only for Claude and OpenRouter"* before `openai_target` can dispatch.
2. `expand_paths` never expands `~` in an account's `codex_auth_path`, while both README.md and docs/configuration.md document tilde paths — the literal `~/...` path then fails with an I/O error.
3. `build_tabs` never emits openai account tabs and `build_outcome`'s `VendorId::Openai` branch ignored `tab.account`, so the TUI, `ai-usagebar usage`, and with it the Omarchy panel only ever show the default login.

## Fix

All three paths now mirror the existing OpenRouter account handling:

- `--account` is accepted for openai (error message updated to match);
- account `codex_auth_path` gets the same tilde expansion as `[[anthropic.accounts]]` credentials;
- one tab / report entry per named account (`openai@<label>`), credentials via the existing `OpenAiConfig::resolve_auth_path`, cache isolated under `openai/<label>` via the existing `Cache::for_vendor_account`.

`Config::validate` also validates and de-duplicates openai account labels like the other multi-account vendors, since the label feeds `Cache::for_vendor_account`'s path join (a label like `../anthropic` or `usage.json` would otherwise escape or collide with another cache).

## Testing

- New: `--account` accepted for openai in `account_flag_rejects_unrelated_vendors`; `openai_named_accounts_get_their_own_tabs_after_the_default`; `openai_account_auth_paths_are_tilde_expanded_on_load`.
- `cargo test --lib`: 1246 passed. `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
- Verified live with two ChatGPT subscriptions: default and `openai@<label>` both appear in `usage` and in the Omarchy panel, each refreshing from its own `auth.json` and cache dir.