### PR TITLE
fix(supergrok): call the documented billing endpoint when the ACP extension is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Each release is also published at
   both transports fail, the direct error is reported because it reflects the
   actual login state. Response parsing is unchanged: the proxy returns the
   same camelCase `BillingConfig` shape the strict wire types already accept.
+  The endpoint is fixed: `GROK_CLI_CHAT_PROXY_BASE_URL` still scopes the
+  cache (it changes which login is in play) but does not choose where the
+  key is sent.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- SuperGrok works again with grok CLI 1.0.13, which dropped the `x.ai/billing`
+  ACP extension the vendor was built on (`-32601 Method not found`, probed
+  directly, after a session handshake, and in leader mode). The vendor now
+  calls the CLI's documented `cli-chat-proxy.grok.com/v1/billing` endpoint
+  first, using the long-lived `key` already stored in the login's `auth.json`
+  — read-only, size-bounded, used only inside one outgoing `Authorization`
+  header, never copied, cached, logged, or echoed in an error — and falls back
+  to the ACP process for CLI builds where the endpoint is unavailable. When
+  both transports fail, the direct error is reported because it reflects the
+  actual login state. Response parsing is unchanged: the proxy returns the
+  same camelCase `BillingConfig` shape the strict wire types already accept.
+
 ### Changed
 
 - Internal: `account.rs` grew from 7 tests to 22 by splitting its decisions

--- a/src/supergrok/direct.rs
+++ b/src/supergrok/direct.rs
@@ -1,0 +1,187 @@
+//! Direct HTTPS billing fallback for Grok Build CLI versions whose ACP agent
+//! no longer exposes the `x.ai/billing` extension (observed on grok 1.0.13).
+//!
+//! Reads the CLI's own `auth.json` and uses only its long-lived `key` entry,
+//! placing it solely inside the `Authorization` header of one request to the
+//! documented `cli-chat-proxy.grok.com/v1/billing` endpoint. The key is never
+//! copied, cached, logged, or echoed in an error message; login files remain
+//! the CLI's property and are not written back.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use crate::error::{AppError, Result};
+use crate::vendor::{
+    HTTP_CLIENT_TIMEOUT, MAX_BODY_BYTES, read_body_capped, same_origin_redirect_policy,
+};
+
+use super::types::BillingResponse;
+
+const DEFAULT_BASE_URL: &str = "https://cli-chat-proxy.grok.com";
+const TOKEN_AUTH_HEADER: &str = "xai-grok-cli";
+const MAX_AUTH_FILE_BYTES: u64 = 2 * 1024 * 1024;
+
+pub async fn fetch_billing(auth_path: &Path) -> Result<BillingResponse> {
+    let base = std::env::var("GROK_CLI_CHAT_PROXY_BASE_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+    fetch_billing_with(auth_path, &base).await
+}
+
+pub async fn fetch_billing_with(auth_path: &Path, base_url: &str) -> Result<BillingResponse> {
+    let key = read_billing_key(auth_path)?;
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_CLIENT_TIMEOUT)
+        .redirect(same_origin_redirect_policy())
+        .build()
+        .map_err(|_| AppError::Other("failed to build the Grok billing HTTP client".into()))?;
+    let resp = client
+        .get(format!("{base_url}/v1/billing?format=credits"))
+        .header("X-XAI-Token-Auth", TOKEN_AUTH_HEADER)
+        .header("Authorization", format!("Bearer {key}"))
+        .send()
+        .await
+        .map_err(|e| AppError::Transport(format!("Grok billing request failed: {e}")))?;
+
+    let status = resp.status();
+    let bytes = read_body_capped(resp, MAX_BODY_BYTES).await?;
+    if !status.is_success() {
+        let body: String = String::from_utf8_lossy(&bytes).chars().take(200).collect();
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    serde_json::from_slice(&bytes)
+        .map_err(|_| AppError::Schema("Grok Build billing response does not match the expected schema".into()))
+}
+
+/// Locate the Grok Build login's long-lived `key` in `auth.json`.
+///
+/// The file maps issuer-prefixed client ids to login records that carry a
+/// `key`. The first non-empty key wins; parsing stays bounded so a replaced
+/// or oversized file cannot stall or exhaust the fetch.
+fn read_billing_key(auth_path: &Path) -> Result<String> {
+    let metadata = std::fs::metadata(auth_path)
+        .map_err(|_| AppError::Credentials("Grok Build login file not found; run `grok login`".into()))?;
+    if !metadata.is_file() || metadata.len() > MAX_AUTH_FILE_BYTES {
+        return Err(AppError::Credentials(
+            "Grok Build login file is not a readable auth.json; run `grok login`".into(),
+        ));
+    }
+    let bytes = std::fs::read(auth_path)
+        .map_err(|_| AppError::Credentials("Grok Build login file could not be read; run `grok login`".into()))?;
+    let parsed: Value = serde_json::from_slice(&bytes).map_err(|_| {
+        AppError::Credentials("Grok Build login file is not valid JSON; run `grok login`".into())
+    })?;
+
+    let Some(entries) = parsed.as_object() else {
+        return Err(AppError::Credentials(
+            "Grok Build login file has an unexpected shape; run `grok login`".into(),
+        ));
+    };
+    for entry in entries.values() {
+        if let Some(key) = entry.get("key").and_then(Value::as_str) {
+            let key = key.trim();
+            if !key.is_empty() {
+                return Ok(key.to_string());
+            }
+        }
+    }
+    Err(AppError::Credentials(
+        "Grok Build login file has no billing key; run `grok login`".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn auth_file(contents: &[u8]) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(contents).unwrap();
+        file
+    }
+
+    #[tokio::test]
+    async fn billing_key_is_read_from_the_issuer_scoped_login_record() {
+        let file = auth_file(
+            br#"{"https://auth.x.ai::client-a":{"auth_mode":"oidc","key":"  secret-key  ","user_id":"person@example.test"}}"#,
+        );
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/v1/billing?format=credits")
+            .match_header("X-XAI-Token-Auth", "xai-grok-cli")
+            .match_header("Authorization", "Bearer secret-key")
+            .with_body(r#"{"config":{"creditUsagePercent":10.0,"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","end":"2026-09-05T18:45:31Z"}}}"#)
+            .create_async()
+            .await;
+        let response = fetch_billing_with(file.path(), &server.url()).await.unwrap();
+        m.assert_async().await;
+        drop(response);
+    }
+
+    #[tokio::test]
+    async fn an_http_error_becomes_an_in_band_http_error_without_the_key() {
+        let file = auth_file(br#"{"issuer::client":{"key":"secret-key"}}"#);
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/v1/billing?format=credits")
+            .with_status(401)
+            .with_body(r#"{"error":"bad token"}"#)
+            .create_async()
+            .await;
+        let error = fetch_billing_with(file.path(), &server.url()).await.unwrap_err();
+        m.assert_async().await;
+        let rendered = error.to_string();
+        assert!(!rendered.contains("secret-key"));
+    }
+
+    #[test]
+    fn missing_empty_or_malformed_logins_have_actionable_errors() {
+        for contents in [
+            &b"{}"[..],
+            br#"{"issuer::client":{"key":""}}"#,
+            br#"{"issuer::client":{"refresh_token":"x"}}"#,
+            b"not json",
+        ] {
+            let file = auth_file(contents);
+            let error = read_billing_key(file.path()).unwrap_err();
+            assert!(matches!(error, AppError::Credentials(_)));
+            assert!(error.to_string().contains("grok login"));
+        }
+    }
+
+    #[test]
+    fn missing_login_file_names_the_login_step_without_echoing_the_path() {
+        let error = read_billing_key(Path::new("/nonexistent/auth.json")).unwrap_err();
+        assert!(matches!(error, AppError::Credentials(_)));
+        assert!(!error.to_string().contains("/nonexistent"));
+    }
+
+    #[tokio::test]
+    async fn oversized_login_files_fail_closed() {
+        let mut file = NamedTempFile::new().unwrap();
+        file.write_all(&vec![b'a'; MAX_AUTH_FILE_BYTES as usize + 1]).unwrap();
+        assert!(read_billing_key(file.path()).is_err());
+    }
+
+    #[tokio::test]
+    async fn oversized_billing_bodies_are_refused() {
+        let file = auth_file(br#"{"issuer::client":{"key":"secret-key"}}"#);
+        let mut server = mockito::Server::new_async().await;
+        let m = server
+            .mock("GET", "/v1/billing?format=credits")
+            .with_body("x".repeat(MAX_BODY_BYTES + 1))
+            .create_async()
+            .await;
+        assert!(fetch_billing_with(file.path(), &server.url()).await.is_err());
+        m.assert_async().await;
+    }
+}

--- a/src/supergrok/direct.rs
+++ b/src/supergrok/direct.rs
@@ -22,13 +22,11 @@ const DEFAULT_BASE_URL: &str = "https://cli-chat-proxy.grok.com";
 const TOKEN_AUTH_HEADER: &str = "xai-grok-cli";
 const MAX_AUTH_FILE_BYTES: u64 = 2 * 1024 * 1024;
 
+/// The base URL is fixed. Tests reach the seam through [`fetch_billing_with`],
+/// so an environment override would buy nothing and would let one variable
+/// redirect the login's long-lived key to a host of its choosing.
 pub async fn fetch_billing(auth_path: &Path) -> Result<BillingResponse> {
-    let base = std::env::var("GROK_CLI_CHAT_PROXY_BASE_URL")
-        .ok()
-        .map(|value| value.trim().to_string())
-        .filter(|value| !value.is_empty())
-        .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
-    fetch_billing_with(auth_path, &base).await
+    fetch_billing_with(auth_path, DEFAULT_BASE_URL).await
 }
 
 pub async fn fetch_billing_with(auth_path: &Path, base_url: &str) -> Result<BillingResponse> {
@@ -56,8 +54,9 @@ pub async fn fetch_billing_with(auth_path: &Path, base_url: &str) -> Result<Bill
         });
     }
 
-    serde_json::from_slice(&bytes)
-        .map_err(|_| AppError::Schema("Grok Build billing response does not match the expected schema".into()))
+    serde_json::from_slice(&bytes).map_err(|_| {
+        AppError::Schema("Grok Build billing response does not match the expected schema".into())
+    })
 }
 
 /// Locate the Grok Build login's long-lived `key` in `auth.json`.
@@ -66,15 +65,17 @@ pub async fn fetch_billing_with(auth_path: &Path, base_url: &str) -> Result<Bill
 /// `key`. The first non-empty key wins; parsing stays bounded so a replaced
 /// or oversized file cannot stall or exhaust the fetch.
 fn read_billing_key(auth_path: &Path) -> Result<String> {
-    let metadata = std::fs::metadata(auth_path)
-        .map_err(|_| AppError::Credentials("Grok Build login file not found; run `grok login`".into()))?;
+    let metadata = std::fs::metadata(auth_path).map_err(|_| {
+        AppError::Credentials("Grok Build login file not found; run `grok login`".into())
+    })?;
     if !metadata.is_file() || metadata.len() > MAX_AUTH_FILE_BYTES {
         return Err(AppError::Credentials(
             "Grok Build login file is not a readable auth.json; run `grok login`".into(),
         ));
     }
-    let bytes = std::fs::read(auth_path)
-        .map_err(|_| AppError::Credentials("Grok Build login file could not be read; run `grok login`".into()))?;
+    let bytes = std::fs::read(auth_path).map_err(|_| {
+        AppError::Credentials("Grok Build login file could not be read; run `grok login`".into())
+    })?;
     let parsed: Value = serde_json::from_slice(&bytes).map_err(|_| {
         AppError::Credentials("Grok Build login file is not valid JSON; run `grok login`".into())
     })?;
@@ -122,7 +123,9 @@ mod tests {
             .with_body(r#"{"config":{"creditUsagePercent":10.0,"currentPeriod":{"type":"USAGE_PERIOD_TYPE_WEEKLY","end":"2026-09-05T18:45:31Z"}}}"#)
             .create_async()
             .await;
-        let response = fetch_billing_with(file.path(), &server.url()).await.unwrap();
+        let response = fetch_billing_with(file.path(), &server.url())
+            .await
+            .unwrap();
         m.assert_async().await;
         drop(response);
     }
@@ -137,7 +140,9 @@ mod tests {
             .with_body(r#"{"error":"bad token"}"#)
             .create_async()
             .await;
-        let error = fetch_billing_with(file.path(), &server.url()).await.unwrap_err();
+        let error = fetch_billing_with(file.path(), &server.url())
+            .await
+            .unwrap_err();
         m.assert_async().await;
         let rendered = error.to_string();
         assert!(!rendered.contains("secret-key"));
@@ -168,7 +173,8 @@ mod tests {
     #[tokio::test]
     async fn oversized_login_files_fail_closed() {
         let mut file = NamedTempFile::new().unwrap();
-        file.write_all(&vec![b'a'; MAX_AUTH_FILE_BYTES as usize + 1]).unwrap();
+        file.write_all(&vec![b'a'; MAX_AUTH_FILE_BYTES as usize + 1])
+            .unwrap();
         assert!(read_billing_key(file.path()).is_err());
     }
 
@@ -181,7 +187,26 @@ mod tests {
             .with_body("x".repeat(MAX_BODY_BYTES + 1))
             .create_async()
             .await;
-        assert!(fetch_billing_with(file.path(), &server.url()).await.is_err());
+        assert!(
+            fetch_billing_with(file.path(), &server.url())
+                .await
+                .is_err()
+        );
         m.assert_async().await;
+    }
+    /// `GROK_CLI_CHAT_PROXY_BASE_URL` is a real Grok CLI variable — `scope.rs`
+    /// hashes it into the cache digest for exactly that reason. Honouring it
+    /// *here* would be different: this is the one request that carries the
+    /// login's long-lived key, so an ambient variable in whatever environment
+    /// Waybar inherited would choose where that key is sent. The destination
+    /// stays pinned; tests reach the seam through `fetch_billing_with`.
+    #[test]
+    fn the_billing_destination_is_not_environment_controlled() {
+        let source = include_str!("direct.rs");
+        assert!(
+            !crate::guard::production_code(source).contains("env::var"),
+            "the credential-bearing request must not take its host from the environment"
+        );
+        assert_eq!(DEFAULT_BASE_URL, "https://cli-chat-proxy.grok.com");
     }
 }

--- a/src/supergrok/fetch.rs
+++ b/src/supergrok/fetch.rs
@@ -12,7 +12,7 @@ use crate::error::{AppError, Result};
 use crate::usage::{SuperGrokPeriod, SuperGrokSnapshot};
 
 use super::scope::ScopePaths;
-use super::{acp, scope, types};
+use super::{acp, direct, scope, types};
 
 const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
 const CACHE_SCHEMA: u8 = 2;
@@ -32,9 +32,28 @@ pub async fn fetch_snapshot(
         cache_ttl,
         Utc::now(),
         || scope::fingerprint(scope_paths),
-        || acp::fetch_billing(grok_binary),
+        || fetch_billing_any(grok_binary, scope_paths),
     )
     .await
+}
+
+/// Direct HTTPS billing first, the ACP process as fallback.
+///
+/// Grok Build CLI 1.0.13 removed the `x.ai/billing` ACP extension, so the
+/// documented proxy endpoint is now the primary transport; the ACP path keeps
+/// serving builds where that endpoint is unavailable. When both fail, the
+/// direct error is reported — it reflects the actual login state.
+async fn fetch_billing_any(
+    grok_binary: &Path,
+    scope_paths: &ScopePaths,
+) -> Result<types::BillingResponse> {
+    match direct::fetch_billing(&scope_paths.auth).await {
+        Ok(response) => Ok(response),
+        Err(direct_error) => match acp::fetch_billing(grok_binary).await {
+            Ok(response) => Ok(response),
+            Err(_) => Err(direct_error),
+        },
+    }
 }
 
 async fn fetch_snapshot_with<S, F, Fut>(

--- a/src/supergrok/mod.rs
+++ b/src/supergrok/mod.rs
@@ -1,16 +1,24 @@
 //! SuperGrok (xAI subscription OAuth) usage through the official Grok Build
-//! CLI's `x.ai/billing` ACP extension.
+//! CLI's billing surface.
 //!
-//! ai-usagebar never parses, copies, caches, refreshes, or places Grok tokens
-//! in ACP messages. Grok Build owns account selection, OIDC issuer discovery, external auth
-//! providers, proxy settings, token rotation, and its `auth.json.lock`; this
-//! module only parses the extension's credential-free billing response. Login
-//! files are read solely as opaque bytes for a one-way cache-scope digest.
+//! Two transports, same credential-free billing response:
+//! - `direct` — one HTTPS call to the documented `cli-chat-proxy.grok.com`
+//!   billing endpoint using the login's long-lived `key` (needed since grok
+//!   CLI 1.0.13 dropped the ACP extension; primary path).
+//! - `acp` — the CLI's `x.ai/billing` ACP extension (fallback for CLI builds
+//!   where the proxy endpoint is unreachable or reshaped).
+//!
+//! ai-usagebar never copies, caches, refreshes, or writes Grok tokens. The
+//! `key` exists only inside one outgoing Authorization header; login files
+//! are read solely as bytes (key lookup or one-way cache-scope digest) and
+//! account selection, OIDC rotation, and `auth.json.lock` stay with Grok
+//! Build.
 //!
 //! Distinct from the `grok` vendor, which reads **prepaid Management API**
 //! balance with a management key — SuperGrok is the subscription quota path.
 
 pub mod acp;
+pub mod direct;
 pub mod fetch;
 pub mod scope;
 pub mod types;

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -410,9 +410,9 @@ async fn grok_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     ))
 }
 
-/// SuperGrok delegates auth and billing transport to the official Grok Build
-/// ACP process — no token or API key is parsed, cached, refreshed, or placed
-/// in an ACP message by ai-usagebar.
+/// SuperGrok reads billing over the CLI's documented HTTPS endpoint (or, as a
+/// fallback, its ACP process). The login's `key` is used only inside one
+/// outgoing Authorization header — never cached, refreshed, or written back.
 async fn supergrok_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
     let cache = vendor_cache(cli, "supergrok")?;
     let scope_paths = supergrok::scope::ScopePaths::with_overrides(


### PR DESCRIPTION
## Problem

grok CLI **1.0.13** removed the `x.ai/billing` ACP extension that the SuperGrok vendor delegates to. Every handshake variant returns `-32601 Method not found`:

- direct `agent --no-leader stdio` probe
- after a `session/new` handshake
- in leader-connected `agent stdio` mode
- with extension-capability hints in `initialize` `_meta`

The binary still contains the billing types (`BillingConfig`, `BillingPeriodUsage`, `check_subscription`) but no longer registers the method for external ACP clients, so the vendor's only transport is dead and the widget shows `Credentials error` forever.

## Fix

Use the CLI's **documented HTTPS endpoint** as the primary transport — the same one the original SuperGrok vendor proposal (and community OMP usage tracking) used:

`GET https://cli-chat-proxy.grok.com/v1/billing?format=credits` with `X-XAI-Token-Auth: xai-grok-cli` and `Authorization: Bearer <key>`, where `key` is the long-lived credential the CLI itself already stores in `~/.grok/auth.json` after `grok login`.

Verified live against a logged-in grok 1.0.13 install: `HTTP 200` with the full `BillingConfig` payload.

The ACP process remains as a **fallback** for CLI builds where the proxy endpoint is unavailable or reshaped. When both transports fail, the direct error is reported because it reflects the actual login state.

## Secret discipline

- the `key` is read from `auth.json` **read-only**, with the same 2 MiB size bound used for scope fingerprinting
- it exists only inside one outgoing `Authorization` header — never copied, cached, logged, or written back
- error messages name the login step (`run \`grok login\``) without echoing the key or the file path
- redirects follow the existing `same_origin_redirect_policy`, response bodies are capped by the shared `read_body_capped`, timeouts by the shared `HTTP_CLIENT_TIMEOUT`
- token rotation, account selection, and `auth.json.lock` stay entirely with Grok Build

## Parsing

Unchanged. The proxy returns the same camelCase `BillingConfig` shape (`creditUsagePercent`, `currentPeriod`, `prepaidBalance`) the strict wire types already accept, and a missing `subscription_tier` already defaults to `SuperGrok`.

## Tests

6 new tests in `src/supergrok/direct.rs`: key extraction from the issuer-scoped login record (headers asserted via mockito), HTTP errors become in-band `AppError::Http` without echoing the key, missing/empty/malformed/oversized login files fail closed with actionable `grok login` guidance, and oversized billing bodies are refused. Full suite: 1250 passed, `cargo clippy --all-targets -- -D warnings` clean, no new dependencies.