### PR TITLE
Add GitHub Copilot usage provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Copilot** is supported as a vendor, selectable with
+  `--vendor copilot` and enabled with `[copilot]` in config. It shows the
+  premium-request, Chat and Completions quotas with their reset, from the
+  `api.github.com/copilot_internal/user` endpoint the VS Code extension uses.
+  There is no key to paste: the OAuth token comes from `gh auth token`, so an
+  existing `gh auth login` is the whole setup, and `GITHUB_COPILOT_TOKEN`
+  overrides it. `gh` is looked up on `PATH` — it has no canonical install
+  location — so `[copilot] gh_binary` pins the executable when that matters.
+  The token is only ever read: it is used in one outgoing `Authorization`
+  header and never copied, cached, logged, or echoed in an error.
+
+### Fixed
+
+- A credential typed into the Omarchy settings panel is now scrubbed from the
+  panel's memory even when the save *fails*. It was only cleared on the success
+  path, so a failed save left the pasted value in a long-lived QML shell. This
+  affects every key-authenticated vendor, not just the new one.
+
 ## [1.9.1] — 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-usagebar
 
-Native Omarchy Quattro panel, Waybar widget, and tabbed TUI for AI plan usage across **Claude**, **Codex/ChatGPT**, **Z.AI (GLM)**, **OpenRouter**, **DeepSeek**, **Kimi**, **Nous Research**, **OpenCode Go**, **Command Code**, and other supported AI coding services.
+Native Omarchy Quattro panel, Waybar widget, and tabbed TUI for AI plan usage across **Claude**, **Codex/ChatGPT**, **GitHub Copilot**, **Z.AI (GLM)**, **OpenRouter**, **DeepSeek**, **Kimi**, **Nous Research**, **OpenCode Go**, **Command Code**, and other supported AI coding services.
 
 ai-usagebar began as a Rust port of
 [`claudebar`](https://github.com/mryll/claudebar) and remains drop-in
@@ -211,6 +211,7 @@ come from environment variables or `config.toml`.
 | Claude | OAuth from `~/.claude/.credentials.json` or the macOS login Keychain | Run `claude` once. Tokens refresh automatically. |
 | Anthropic API | Organization Admin key | Opt in with `ANTHROPIC_ADMIN_KEY` or `[anthropic_api] api_key`. Inference and Claude Code keys do not work. |
 | Codex | OAuth, read from `~/.codex/auth.json` | Run `codex login` once. Token auto-refreshes. |
+| GitHub Copilot | GitHub OAuth token from environment | Set `GITHUB_COPILOT_TOKEN` to a GitHub OAuth token and enable `[copilot]`. The token is sent only to GitHub Copilot's quota endpoint; it is never read from credential stores or saved in config. |
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
 | OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. Named keys are supported. |
 | DeepSeek | API key (`DEEPSEEK_API_KEY` or config) | Set either and opt in. |
@@ -293,8 +294,9 @@ rather than silently querying the wrong URL.
 
 ### Enabling a vendor
 
-`enabled = true` is what makes a vendor fetch. Anthropic API, DeepSeek, Kimi,
-Kilo, Novita, Moonshot, Grok, SuperGrok, Antigravity, Cursor, MiniMax, and Kiro CLI all default to **disabled** so that existing
+`enabled = true` is what makes a vendor fetch. Anthropic API, GitHub Copilot,
+DeepSeek, Kimi, Kilo, Novita, Moonshot, Grok, SuperGrok, Antigravity, Cursor,
+MiniMax, and Kiro CLI all default to **disabled** so that existing
 installs are unaffected until you opt in. Use either method:
 
 - Use the gear or `s` in the Omarchy panel, or run
@@ -310,6 +312,20 @@ Vendors that authenticate through a local login rather than a key — Cursor,
 Kiro CLI, SuperGrok, Antigravity, and Kimi when you have a Kimi For Coding
 subscription — have no key to save, so enable them with `enabled = true` in
 `config.toml`.
+
+GitHub Copilot is also configured outside the settings key form: export a
+GitHub OAuth token before the bar/TUI process starts, then enable it:
+
+```toml
+[copilot]
+enabled = true
+token_env = "GITHUB_COPILOT_TOKEN" # optional override; no inline token field
+```
+
+The token is used exclusively for `GET https://api.github.com/copilot_internal/user`.
+ai-usagebar sends VS Code-compatible client headers, retains only normalized
+quota data in its cache, and never parses VS Code, GitHub CLI, or browser
+credential stores.
 
 ### Credential resolution order (for API-key vendors)
 
@@ -372,6 +388,7 @@ display option, account path, region, and API-key setting.
 ai-usagebar                        # uses [ui] primary (defaults to anthropic)
 ai-usagebar --vendor anthropic_api
 ai-usagebar --vendor openai
+ai-usagebar --vendor copilot
 ai-usagebar --vendor zai
 ai-usagebar --vendor openrouter
 ai-usagebar --vendor deepseek

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ come from environment variables or `config.toml`.
 | Claude | OAuth from `~/.claude/.credentials.json` or the macOS login Keychain | Run `claude` once. Tokens refresh automatically. |
 | Anthropic API | Organization Admin key | Opt in with `ANTHROPIC_ADMIN_KEY` or `[anthropic_api] api_key`. Inference and Claude Code keys do not work. |
 | Codex | OAuth, read from `~/.codex/auth.json` | Run `codex login` once. Token auto-refreshes. |
-| GitHub Copilot | GitHub OAuth token from environment | Set `GITHUB_COPILOT_TOKEN` to a GitHub OAuth token and enable `[copilot]`. The token is sent only to GitHub Copilot's quota endpoint; it is never read from credential stores or saved in config. |
+| GitHub Copilot | GitHub OAuth token | Paste a token into the Settings credential card or set `[copilot] token`, then enable `[copilot]`. A non-empty `GITHUB_COPILOT_TOKEN` takes priority. The token is sent only to GitHub Copilot's quota endpoint and is never read from credential stores. |
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
 | OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. Named keys are supported. |
 | DeepSeek | API key (`DEEPSEEK_API_KEY` or config) | Set either and opt in. |
@@ -313,19 +313,22 @@ Kiro CLI, SuperGrok, Antigravity, and Kimi when you have a Kimi For Coding
 subscription — have no key to save, so enable them with `enabled = true` in
 `config.toml`.
 
-GitHub Copilot is also configured outside the settings key form: export a
-GitHub OAuth token before the bar/TUI process starts, then enable it:
+GitHub Copilot has a password-masked credential card in the Omarchy and
+terminal Settings forms. Paste a GitHub OAuth token and save; this writes
+`[copilot] token` and enables the provider. You can also set it manually:
 
 ```toml
 [copilot]
 enabled = true
-token_env = "GITHUB_COPILOT_TOKEN" # optional override; no inline token field
+token_env = "GITHUB_COPILOT_TOKEN" # optional environment-variable override
+token = "github-oauth-token"       # fallback when the environment is unset
 ```
 
-The token is used exclusively for `GET https://api.github.com/copilot_internal/user`.
-ai-usagebar sends VS Code-compatible client headers, retains only normalized
-quota data in its cache, and never parses VS Code, GitHub CLI, or browser
-credential stores.
+`GITHUB_COPILOT_TOKEN` (or the environment variable named by `token_env`) takes
+priority over the saved token. The token is used exclusively for
+`GET https://api.github.com/copilot_internal/user`. ai-usagebar sends
+VS Code-compatible client headers, retains only normalized quota data in its
+cache, and never parses local editor or browser credential stores.
 
 ### Credential resolution order (for API-key vendors)
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ come from environment variables or `config.toml`.
 | Claude | OAuth from `~/.claude/.credentials.json` or the macOS login Keychain | Run `claude` once. Tokens refresh automatically. |
 | Anthropic API | Organization Admin key | Opt in with `ANTHROPIC_ADMIN_KEY` or `[anthropic_api] api_key`. Inference and Claude Code keys do not work. |
 | Codex | OAuth, read from `~/.codex/auth.json` | Run `codex login` once. Token auto-refreshes. |
-| GitHub Copilot | GitHub OAuth token | Paste a token into the Settings credential card or set `[copilot] token`, then enable `[copilot]`. A non-empty `GITHUB_COPILOT_TOKEN` takes priority. The token is sent only to GitHub Copilot's quota endpoint and is never read from credential stores. |
+| GitHub Copilot | GitHub CLI OAuth | Run `gh auth login --web`, then choose GitHub Copilot as the primary provider in Settings. ai-usagebar gets the token only with `gh auth token`; `GITHUB_COPILOT_TOKEN` is an optional explicit override. |
 | Z.AI | API key (`ZAI_API_KEY` env or `[zai] api_key` in config) | Set either. |
 | OpenRouter | API key (`OPENROUTER_API_KEY` env or `[openrouter] api_key` in config) | Set either. Named keys are supported. |
 | DeepSeek | API key (`DEEPSEEK_API_KEY` or config) | Set either and opt in. |
@@ -305,30 +305,23 @@ installs are unaffected until you opt in. Use either method:
   `config.toml`.
 - Add `enabled = true` to the vendor's config section alongside the key.
 
-The primary-vendor selector only offers vendors that are currently enabled, so a
-vendor you haven't opted into cannot be set as primary.
+The primary-vendor selector only offers enabled vendors, except GitHub Copilot:
+after signing in with GitHub CLI, selecting it as primary explicitly enables
+`[copilot]` at the same time.
 
 Vendors that authenticate through a local login rather than a key — Cursor,
 Kiro CLI, SuperGrok, Antigravity, and Kimi when you have a Kimi For Coding
 subscription — have no key to save, so enable them with `enabled = true` in
 `config.toml`.
 
-GitHub Copilot has a password-masked credential card in the Omarchy and
-terminal Settings forms. Paste a GitHub OAuth token and save; this writes
-`[copilot] token` and enables the provider. You can also set it manually:
-
-```toml
-[copilot]
-enabled = true
-token_env = "GITHUB_COPILOT_TOKEN" # optional environment-variable override
-token = "github-oauth-token"       # fallback when the environment is unset
-```
-
-`GITHUB_COPILOT_TOKEN` (or the environment variable named by `token_env`) takes
-priority over the saved token. The token is used exclusively for
-`GET https://api.github.com/copilot_internal/user`. ai-usagebar sends
-VS Code-compatible client headers, retains only normalized quota data in its
-cache, and never parses local editor or browser credential stores.
+GitHub Copilot has no token field in the Omarchy or terminal Settings forms.
+Run `gh auth login --web`, then select **GitHub Copilot** under **Primary
+Provider** and save. That enables `[copilot]` and sets it as primary, making it
+fetchable. At fetch time ai-usagebar runs only the fixed, structured
+`gh auth token` command; it never parses GitHub CLI configuration, credential
+stores, editor state, or browser state, and never writes the token to config or
+cache. `GITHUB_COPILOT_TOKEN` is an optional explicit environment override and
+takes precedence over GitHub CLI OAuth.
 
 ### Credential resolution order (for API-key vendors)
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -112,11 +112,12 @@ enabled = true
 
 [copilot]
 # Disabled by default. GitHub Copilot quota comes from the private endpoint
-# used by VS Code. Set a GitHub OAuth token only in this environment variable;
-# ai-usagebar does not read VS Code/GitHub credential stores or save the token.
+# used by VS Code. GITHUB_COPILOT_TOKEN takes priority when it is non-empty.
+# Otherwise save a GitHub OAuth token with the settings form or set `token`.
+# ai-usagebar does not read VS Code/GitHub credential stores.
 enabled = false
 token_env = "GITHUB_COPILOT_TOKEN"
-# export GITHUB_COPILOT_TOKEN="github-oauth-token"
+# token = "github-oauth-token" # settings writes this file with mode 0600
 
 [zai]
 enabled = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,7 +8,7 @@
 [ui]
 # Which vendor the widget shows when `--vendor` is omitted, AND which tab
 # is selected when the TUI opens. Comment out to default to Anthropic.
-# Valid: anthropic | anthropic_api | openai | zai | openrouter | deepseek
+# Valid: anthropic | anthropic_api | openai | copilot | zai | openrouter | deepseek
 #        | kimi | kilo | novita | moonshot | grok | supergrok | antigravity
 #        | cursor | minimax | kiro | nous | opencode-go | commandcode
 # When unset, the TUI opens on the Overview (all vendors at once); set this to
@@ -109,6 +109,14 @@ enabled = true
 # [[openai.accounts]]
 # label = "work"
 # codex_auth_path = "~/.config/ai-usagebar/accounts/work-codex/auth.json"
+
+[copilot]
+# Disabled by default. GitHub Copilot quota comes from the private endpoint
+# used by VS Code. Set a GitHub OAuth token only in this environment variable;
+# ai-usagebar does not read VS Code/GitHub credential stores or save the token.
+enabled = false
+token_env = "GITHUB_COPILOT_TOKEN"
+# export GITHUB_COPILOT_TOKEN="github-oauth-token"
 
 [zai]
 enabled = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -119,6 +119,10 @@ enabled = true
 # Set GITHUB_COPILOT_TOKEN only as an optional explicit environment override.
 # In Omarchy Settings, select GitHub Copilot as Primary Provider to enable it.
 enabled = false
+# Path to the official GitHub CLI. Unset looks `gh` up on PATH, which is how it
+# is normally installed; set this to pin the executable that runs on every
+# refresh.
+# gh_binary = "/usr/bin/gh"
 
 [zai]
 enabled = true

--- a/config.example.toml
+++ b/config.example.toml
@@ -112,12 +112,13 @@ enabled = true
 
 [copilot]
 # Disabled by default. GitHub Copilot quota comes from the private endpoint
-# used by VS Code. GITHUB_COPILOT_TOKEN takes priority when it is non-empty.
-# Otherwise save a GitHub OAuth token with the settings form or set `token`.
-# ai-usagebar does not read VS Code/GitHub credential stores.
+# used by VS Code. Sign in with the official GitHub CLI first:
+#   gh auth login --web
+# ai-usagebar obtains the OAuth token only by running `gh auth token`; it never
+# reads, copies, or stores a GitHub CLI, editor, or browser credential.
+# Set GITHUB_COPILOT_TOKEN only as an optional explicit environment override.
+# In Omarchy Settings, select GitHub Copilot as Primary Provider to enable it.
 enabled = false
-token_env = "GITHUB_COPILOT_TOKEN"
-# token = "github-oauth-token" # settings writes this file with mode 0600
 
 [zai]
 enabled = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,9 +37,8 @@ enabled = true
 # codex_auth_path = "/home/you/.codex/auth.json"
 
 [copilot]
-enabled = false           # opt in after saving or exporting a GitHub OAuth token
-token_env = "GITHUB_COPILOT_TOKEN"
-# token = "github-oauth-token" # fallback when GITHUB_COPILOT_TOKEN is unset
+enabled = false           # opt in after `gh auth login --web`
+# Uses `gh auth token`; GITHUB_COPILOT_TOKEN is an optional explicit override.
 
 [zai]
 enabled = true
@@ -140,6 +139,19 @@ enabled = true             # disabled by default; enable once you've run `kiro-c
 For more than one OpenRouter key, see the
 [OpenRouter account guide](openrouter-accounts.md). The existing singular
 `[openrouter]` key remains the default account and needs no migration.
+
+### GitHub Copilot
+
+GitHub Copilot uses the OAuth login managed by the official GitHub CLI. Run
+`gh auth login --web`, then select **GitHub Copilot** under **Primary Provider**
+in the Omarchy settings form and save; this enables `[copilot]` and sets it as
+the primary provider. The normal fetch path runs only the fixed structured
+command `gh auth token`. ai-usagebar never parses GitHub CLI configuration or
+credential stores and never writes the OAuth token to its config or cache.
+
+`GITHUB_COPILOT_TOKEN` is an optional explicit environment override. It takes
+precedence over `gh auth token`, which can be useful for a managed runtime that
+provides its own short-lived token. Do not put that token in `config.toml`.
 
 For more than one Codex login, add `[[openai.accounts]]` — a label and that
 login's own `auth.json`, the same shape `[[anthropic.accounts]]` uses:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,11 +37,9 @@ enabled = true
 # codex_auth_path = "/home/you/.codex/auth.json"
 
 [copilot]
-enabled = false           # opt in after exporting a GitHub OAuth token
-# Environment-only by design: ai-usagebar does not parse editor credential stores
-# or persist this token in config.toml.
+enabled = false           # opt in after saving or exporting a GitHub OAuth token
 token_env = "GITHUB_COPILOT_TOKEN"
-# export GITHUB_COPILOT_TOKEN="github-oauth-token"
+# token = "github-oauth-token" # fallback when GITHUB_COPILOT_TOKEN is unset
 
 [zai]
 enabled = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,10 +10,10 @@ settings.
 # Which vendor the widget shows when --vendor is omitted, AND which tab
 # is selected when the TUI opens. Defaults to anthropic when not set.
 # Only a vendor that is enabled can be primary.
-# primary = "anthropic"   # anthropic | anthropic_api | openai | zai
-#                         # | openrouter | deepseek | kimi | kilo | novita
+# primary = "anthropic"   # anthropic | anthropic_api | openai | copilot
+#                         # | zai | openrouter | deepseek | kimi | kilo | novita
 #                         # | moonshot | grok | supergrok | antigravity | cursor
-#                         # | minimax | kiro
+#                         # | minimax | kiro | nous | opencode-go | commandcode
 
 [context]
 enabled = false           # opt in, then press c in ai-usagebar-tui
@@ -35,6 +35,13 @@ api_key_env = "ANTHROPIC_ADMIN_KEY"
 [openai]
 enabled = true
 # codex_auth_path = "/home/you/.codex/auth.json"
+
+[copilot]
+enabled = false           # opt in after exporting a GitHub OAuth token
+# Environment-only by design: ai-usagebar does not parse editor credential stores
+# or persist this token in config.toml.
+token_env = "GITHUB_COPILOT_TOKEN"
+# export GITHUB_COPILOT_TOKEN="github-oauth-token"
 
 [zai]
 enabled = true

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -10,15 +10,15 @@ metrics expand to an empty string unless noted otherwise.
 | Provider | Value | Provider | Value |
 |---|---:|---|---:|
 | Claude | `cld` | Codex | `gpt` |
-| Z.AI | `zai` | OpenRouter | `opr` |
-| DeepSeek | `dsk` | Kimi | `kmi` |
-| Kilo | `klo` | Novita | `nvt` |
-| Moonshot | `msh` | Grok | `grk` |
-| SuperGrok | `sgk` | Anthropic API | `aac` |
-| Antigravity | `agy` | Cursor | `cur` |
-| MiniMax | `mmx` | Kiro CLI | `kir` |
-| Nous Research | `nrs` | OpenCode Go | `ocg` |
-| Command Code | `cmc` | | |
+| GitHub Copilot | `ghc` | Z.AI | `zai` |
+| OpenRouter | `opr` | DeepSeek | `dsk` |
+| Kimi | `kmi` | Kilo | `klo` |
+| Novita | `nvt` | Moonshot | `msh` |
+| Grok | `grk` | SuperGrok | `sgk` |
+| Anthropic API | `aac` | Antigravity | `agy` |
+| Cursor | `cur` | MiniMax | `mmx` |
+| Kiro CLI | `kir` | Nous Research | `nrs` |
+| OpenCode Go | `ocg` | Command Code | `cmc` |
 
 The same codes ride the `ai-usagebar usage --json` report as each entry's
 `short_name`, so a native frontend can draw a Waybar-style provider tag without
@@ -64,6 +64,20 @@ window is absent, it returns neutral empty, `0`, or `—` values as appropriate.
 
 Session and weekly families are empty when the API omits that window. The
 default widget automatically uses weekly values for a weekly-only response.
+
+## GitHub Copilot
+
+`{copilot_plan}`, `{copilot_reset}`, `{copilot_premium_pct}`,
+`{copilot_premium_used}`, `{copilot_premium_limit}`, `{copilot_chat_pct}`,
+`{copilot_chat_used}`, `{copilot_chat_limit}`, `{copilot_completions_pct}`,
+`{copilot_completions_used}`, `{copilot_completions_limit}`
+
+These represent the `premium_interactions`, `chat`, and `completions` quota
+snapshots that GitHub reports. The default bar format is
+`{copilot_premium_pct}% · {copilot_reset}`. `{session_*}` aliases Premium and
+`{weekly_*}` aliases Chat so one cross-provider format can still render it;
+both use Copilot's account-wide quota reset, not a weekly window. Missing
+quota buckets expand to `—`.
 
 ## Z.AI
 

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -34,7 +34,7 @@ defensive and includes opt-in live tests for catching response changes.
 |---|---|
 | Claude | Undocumented usage endpoint, but used by the official `claude` CLI. Less fragile than a scraped web page. |
 | Codex | Undocumented ChatGPT usage endpoint used by the official `codex` CLI. Windows are identified by duration instead of response position. |
-| GitHub Copilot | Private endpoint used by VS Code. It requires a GitHub OAuth token and VS Code-compatible client headers; a non-empty configured environment variable takes priority, otherwise the protected `[copilot] token` saved through Settings is used. |
+| GitHub Copilot | Private endpoint used by VS Code. It requires a GitHub OAuth token and VS Code-compatible client headers; ai-usagebar gets it from the official `gh auth token` command after `gh auth login --web`. A non-empty `GITHUB_COPILOT_TOKEN` is an optional explicit override. GitHub CLI/editor/browser credentials are never parsed, copied, or stored. |
 | Z.AI | Reverse-engineered from a third-party plugin. Treat this as the most fragile integration. |
 | Kimi | Community-confirmed `/coding/v1/usages` route used by third-party quota tools. Drift is possible. The refresh grant is the Kimi Code CLI's own documented-by-behaviour device-flow token endpoint, using the CLI's public client id. |
 | Cursor | Undocumented endpoint called by Cursor's dashboard. Its shape may change with Cursor pricing. |

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -34,7 +34,7 @@ defensive and includes opt-in live tests for catching response changes.
 |---|---|
 | Claude | Undocumented usage endpoint, but used by the official `claude` CLI. Less fragile than a scraped web page. |
 | Codex | Undocumented ChatGPT usage endpoint used by the official `codex` CLI. Windows are identified by duration instead of response position. |
-| GitHub Copilot | Private endpoint used by VS Code. It requires a GitHub OAuth token and VS Code-compatible client headers; the token is read only from the configured environment variable and is never persisted. |
+| GitHub Copilot | Private endpoint used by VS Code. It requires a GitHub OAuth token and VS Code-compatible client headers; a non-empty configured environment variable takes priority, otherwise the protected `[copilot] token` saved through Settings is used. |
 | Z.AI | Reverse-engineered from a third-party plugin. Treat this as the most fragile integration. |
 | Kimi | Community-confirmed `/coding/v1/usages` route used by third-party quota tools. Drift is possible. The refresh grant is the Kimi Code CLI's own documented-by-behaviour device-flow token endpoint, using the CLI's public client id. |
 | Cursor | Undocumented endpoint called by Cursor's dashboard. Its shape may change with Cursor pricing. |

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -9,6 +9,7 @@ defensive and includes opt-in live tests for catching response changes.
 |---|---|---|---|
 | **Claude** | `api.anthropic.com/api/oauth/usage` (undocumented) | Session (5h), Weekly (7d), model-scoped weekly (e.g. Fable), Extra usage $ | Yes |
 | **Codex** | `chatgpt.com/backend-api/wham/usage` (undocumented; used by official `codex` CLI) | Codex 5h and/or weekly, Code-review weekly, Credits | Yes |
+| **GitHub Copilot** | `api.github.com/copilot_internal/user` (private; used by VS Code) | Premium requests, Chat, and Completions quota %, counts when supplied, plan, reset | Yes |
 | **Z.AI** | `api.z.ai/api/monitor/usage/quota/limit` (undocumented) | Session 5h, Weekly 7d, MCP tools monthly | Yes |
 | **OpenRouter** | `openrouter.ai/api/v1/{credits,key}` (documented) | Balance, today/week/month spend, free vs paid tier | Yes |
 | **DeepSeek** | `api.deepseek.com/user/balance` (documented) | Balance, granted, topped-up credits | Yes |
@@ -33,6 +34,7 @@ defensive and includes opt-in live tests for catching response changes.
 |---|---|
 | Claude | Undocumented usage endpoint, but used by the official `claude` CLI. Less fragile than a scraped web page. |
 | Codex | Undocumented ChatGPT usage endpoint used by the official `codex` CLI. Windows are identified by duration instead of response position. |
+| GitHub Copilot | Private endpoint used by VS Code. It requires a GitHub OAuth token and VS Code-compatible client headers; the token is read only from the configured environment variable and is never persisted. |
 | Z.AI | Reverse-engineered from a third-party plugin. Treat this as the most fragile integration. |
 | Kimi | Community-confirmed `/coding/v1/usages` route used by third-party quota tools. Drift is possible. The refresh grant is the Kimi Code CLI's own documented-by-behaviour device-flow token endpoint, using the CLI's public client id. |
 | Cursor | Undocumented endpoint called by Cursor's dashboard. Its shape may change with Cursor pricing. |

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -362,6 +362,7 @@ function parseSettingsSnapshot(raw) {
         id: keyId,
         label: cleanText(key.label, 120) || keyId,
         environment: cleanText(key.environment, 160),
+        secret_label: cleanText(key.secret_label, 120),
         note: cleanText(key.note, 240),
         configured: key.configured === true,
         inline_configured: key.inline_configured === true,
@@ -402,8 +403,8 @@ function buildSettingsPatch(primary, changes) {
       keys[id] = { action: "clear" }
     } else if (change.action === "set") {
       var value = String(change.value || "")
-      if (value === "") return { ok: false, error: "An edited API key is empty.", payload: "" }
-      if (value.length > 16384) return { ok: false, error: "An API key is too long.", payload: "" }
+      if (value === "") return { ok: false, error: "An edited credential is empty.", payload: "" }
+      if (value.length > 16384) return { ok: false, error: "A credential is too long.", payload: "" }
       keys[id] = { action: "set", value: value }
     } else return { ok: false, error: "A settings row has an invalid action.", payload: "" }
   }

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -178,11 +178,6 @@ Panel {
       bar.run("omarchy-launch-floating-terminal-with-presentation ai-usagebar auth nous login")
   }
 
-  function openCopilotLogin() {
-    if (bar && typeof bar.run === "function")
-      bar.run("omarchy-launch-floating-terminal-with-presentation gh auth login --web")
-  }
-
   function switchPanel(direction) {
     if (bar && typeof bar.switchPanelFrom === "function")
       return bar.switchPanelFrom(barIdentity, direction)
@@ -389,7 +384,6 @@ Panel {
             onShowProviderRequested: function(enabled) { root.setShowProvider(enabled) }
             onFallbackRequested: root.openTerminalSettings()
             onNousLoginRequested: root.openNousLogin()
-            onCopilotLoginRequested: root.openCopilotLogin()
             onCloseRequested: root.closeSettings()
           }
 

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -178,6 +178,11 @@ Panel {
       bar.run("omarchy-launch-floating-terminal-with-presentation ai-usagebar auth nous login")
   }
 
+  function openCopilotLogin() {
+    if (bar && typeof bar.run === "function")
+      bar.run("omarchy-launch-floating-terminal-with-presentation gh auth login --web")
+  }
+
   function switchPanel(direction) {
     if (bar && typeof bar.switchPanelFrom === "function")
       return bar.switchPanelFrom(barIdentity, direction)
@@ -384,6 +389,7 @@ Panel {
             onShowProviderRequested: function(enabled) { root.setShowProvider(enabled) }
             onFallbackRequested: root.openTerminalSettings()
             onNousLoginRequested: root.openNousLogin()
+            onCopilotLoginRequested: root.openCopilotLogin()
             onCloseRequested: root.closeSettings()
           }
 

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -73,18 +73,15 @@ value, or use its clear button to remove an inline key. Saving a new key also
 enables that provider, matching the terminal overlay.
 
 Not every provider has a credential field, and a missing one is not an omission.
-Claude, Codex, Cursor, Kiro, Antigravity, and Command Code authenticate through
-a login that already exists on the machine, so they appear in the provider
-selector but never in the key list — enable them in `config.toml` and they work
-with nothing to paste. GitHub Copilot has a password-masked credential card:
-paste its GitHub OAuth token and save. The shell receives only presence
-metadata, then passes the changed token over stdin to the Rust settings owner;
-it never receives the saved value. The token is stored as `[copilot] token`;
-a non-empty `GITHUB_COPILOT_TOKEN` (or the environment variable named by
-`token_env`) takes priority. ai-usagebar does not read local editor or browser
-credential stores.
-After saving, refresh the settings panel and select **GitHub Copilot** under
-**Primary Provider** to make it the app-wide default.
+Claude, Codex, GitHub Copilot, Cursor, Kiro, Antigravity, and Command Code
+authenticate through an existing official or local login, so they never appear
+in the key list. For GitHub Copilot, click **Log in with GitHub Copilot** to
+run `gh auth login --web` in a terminal. Complete the login, then choose
+**GitHub Copilot** under **Primary Provider** and save. That explicitly enables
+`[copilot]` and makes it the app-wide default. The fetcher obtains OAuth only
+through the fixed `gh auth token` command; it never parses GitHub CLI, editor,
+or browser credential stores and never saves a token. A non-empty
+`GITHUB_COPILOT_TOKEN` is an optional explicit override.
 
 Existing installations need no migration: `config.toml`, environment-variable
 precedence, the TUI, Waybar, macOS, and Windows behavior are unchanged. If the

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -79,7 +79,9 @@ selector but never in the key list — enable them in `config.toml` and they wor
 with nothing to paste. GitHub Copilot is similarly absent from the key list,
 but requires an explicitly exported GitHub OAuth token named by
 `[copilot] token_env` (default `GITHUB_COPILOT_TOKEN`); it is never passed
-through the shell or stored in config.
+through the shell or stored in config. The **Log in with GitHub Copilot**
+button opens the standard `gh auth login --web` flow; finish it in the browser,
+then refresh the panel.
 
 Existing installations need no migration: `config.toml`, environment-variable
 precedence, the TUI, Waybar, macOS, and Windows behavior are unchanged. If the

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -83,6 +83,8 @@ it never receives the saved value. The token is stored as `[copilot] token`;
 a non-empty `GITHUB_COPILOT_TOKEN` (or the environment variable named by
 `token_env`) takes priority. ai-usagebar does not read local editor or browser
 credential stores.
+After saving, refresh the settings panel and select **GitHub Copilot** under
+**Primary Provider** to make it the app-wide default.
 
 Existing installations need no migration: `config.toml`, environment-variable
 precedence, the TUI, Waybar, macOS, and Windows behavior are unchanged. If the

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -76,7 +76,10 @@ Not every provider has a key field, and a missing one is not an omission.
 Claude, Codex, Cursor, Kiro, Antigravity, and Command Code authenticate through
 a login that already exists on the machine, so they appear in the provider
 selector but never in the key list — enable them in `config.toml` and they work
-with nothing to paste.
+with nothing to paste. GitHub Copilot is similarly absent from the key list,
+but requires an explicitly exported GitHub OAuth token named by
+`[copilot] token_env` (default `GITHUB_COPILOT_TOKEN`); it is never passed
+through the shell or stored in config.
 
 Existing installations need no migration: `config.toml`, environment-variable
 precedence, the TUI, Waybar, macOS, and Windows behavior are unchanged. If the

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -72,16 +72,17 @@ rather than argv or the environment. Leave a field blank to keep its current
 value, or use its clear button to remove an inline key. Saving a new key also
 enables that provider, matching the terminal overlay.
 
-Not every provider has a key field, and a missing one is not an omission.
+Not every provider has a credential field, and a missing one is not an omission.
 Claude, Codex, Cursor, Kiro, Antigravity, and Command Code authenticate through
 a login that already exists on the machine, so they appear in the provider
 selector but never in the key list — enable them in `config.toml` and they work
-with nothing to paste. GitHub Copilot is similarly absent from the key list,
-but requires an explicitly exported GitHub OAuth token named by
-`[copilot] token_env` (default `GITHUB_COPILOT_TOKEN`); it is never passed
-through the shell or stored in config. The **Log in with GitHub Copilot**
-button opens the standard `gh auth login --web` flow; finish it in the browser,
-then refresh the panel.
+with nothing to paste. GitHub Copilot has a password-masked credential card:
+paste its GitHub OAuth token and save. The shell receives only presence
+metadata, then passes the changed token over stdin to the Rust settings owner;
+it never receives the saved value. The token is stored as `[copilot] token`;
+a non-empty `GITHUB_COPILOT_TOKEN` (or the environment variable named by
+`token_env`) takes priority. ai-usagebar does not read local editor or browser
+credential stores.
 
 Existing installations need no migration: `config.toml`, environment-variable
 precedence, the TUI, Waybar, macOS, and Windows behavior are unchanged. If the

--- a/omarchy/SettingsView.qml
+++ b/omarchy/SettingsView.qml
@@ -37,6 +37,7 @@ Column {
   signal saved()
   signal fallbackRequested()
   signal nousLoginRequested()
+  signal copilotLoginRequested()
   signal showValueRequested(bool enabled)
   signal showProviderRequested(bool enabled)
   signal closeRequested()
@@ -334,7 +335,7 @@ Column {
     }
     Text {
       width: parent.width
-      text: "Nous Research uses OAuth. Login opens in a terminal. Leave the terminal open until login completes, then return here and press Refresh."
+      text: "OAuth login opens in a terminal. Complete it, then return here, choose the provider as primary, save, and press Refresh."
       textFormat: Text.PlainText
       color: root.dim
       font.family: root.fontFamily
@@ -353,6 +354,20 @@ Column {
       onClicked: {
         root.statusText = "Nous Research login is opening in a terminal."
         root.nousLoginRequested()
+      }
+    }
+    Button {
+      width: parent.width
+      text: "Log in with GitHub Copilot"
+      iconText: "󰊤"
+      bordered: true
+      focusable: true
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      enabled: !root.saving
+      onClicked: {
+        root.statusText = "GitHub sign-in is opening in a terminal. Complete it, then choose GitHub Copilot as primary and save."
+        root.copilotLoginRequested()
       }
     }
   }

--- a/omarchy/SettingsView.qml
+++ b/omarchy/SettingsView.qml
@@ -37,7 +37,6 @@ Column {
   signal saved()
   signal fallbackRequested()
   signal nousLoginRequested()
-  signal copilotLoginRequested()
   signal showValueRequested(bool enabled)
   signal showProviderRequested(bool enabled)
   signal closeRequested()
@@ -122,11 +121,13 @@ Column {
 
   function finishApply() {
     saving = false
+    // The Rust process has consumed the stdin patch. Do not retain credentials
+    // in this long-lived shell, even if the save failed.
+    scrubSecrets()
     if (applyExitCode !== 0 || !Model.parseSettingsApplyResult(applyStdout)) {
       errorText = Model.errorMessage(applyStderr || "The settings command did not confirm the save.")
       return
     }
-    scrubSecrets()
     saved()
     load()
     // load() clears stale status before refreshing the snapshot, so set the
@@ -354,20 +355,6 @@ Column {
         root.nousLoginRequested()
       }
     }
-    Button {
-      width: parent.width
-      text: "Log in with GitHub Copilot"
-      iconText: "󰊤"
-      bordered: true
-      focusable: true
-      foreground: root.foreground
-      fontFamily: root.fontFamily
-      enabled: !root.saving
-      onClicked: {
-        root.statusText = "GitHub sign-in is opening in a terminal. Complete it, then return here and press Refresh."
-        root.copilotLoginRequested()
-      }
-    }
   }
 
   Column {
@@ -380,13 +367,13 @@ Column {
       foreground: root.foreground
     }
     PanelSectionHeader {
-      text: "API KEYS"
+      text: "CREDENTIALS"
       foreground: root.foreground
       fontFamily: root.fontFamily
     }
     Text {
       width: parent.width
-      text: "Stored values are never loaded into the shell. Leave a field blank to keep its current value, or use the clear button to remove an inline key. Environment variables take precedence."
+      text: "Stored values are never loaded into the shell. Leave a field blank to keep its current value, or use the clear button to remove an inline credential. Environment variables take precedence."
       textFormat: Text.PlainText
       color: root.dim
       font.family: root.fontFamily
@@ -463,6 +450,7 @@ Column {
             text: {
               var parts = []
               if (keyCard.modelData.environment) parts.push(root.safe(keyCard.modelData.environment))
+              if (keyCard.modelData.secret_label) parts.push(root.safe(keyCard.modelData.secret_label))
               if (keyCard.modelData.note) parts.push(root.safe(keyCard.modelData.note))
               return parts.join(" · ")
             }
@@ -483,7 +471,8 @@ Column {
               password: true
               enabled: !root.saving && keyCard.pendingAction !== "clear"
               placeholderText: keyCard.modelData.configured
-                ? "Leave blank to keep current key" : "Paste API key"
+                ? "Leave blank to keep current credential"
+                : "Paste " + (keyCard.modelData.secret_label || "credential")
               foreground: root.foreground
               onTextEdited: keyCard.pendingAction = text.length > 0 ? "set" : "unchanged"
               Keys.onEscapePressed: focus = false

--- a/omarchy/SettingsView.qml
+++ b/omarchy/SettingsView.qml
@@ -37,6 +37,7 @@ Column {
   signal saved()
   signal fallbackRequested()
   signal nousLoginRequested()
+  signal copilotLoginRequested()
   signal showValueRequested(bool enabled)
   signal showProviderRequested(bool enabled)
   signal closeRequested()
@@ -351,6 +352,20 @@ Column {
       onClicked: {
         root.statusText = "Nous Research login is opening in a terminal."
         root.nousLoginRequested()
+      }
+    }
+    Button {
+      width: parent.width
+      text: "Log in with GitHub Copilot"
+      iconText: "󰊤"
+      bordered: true
+      focusable: true
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      enabled: !root.saving
+      onClicked: {
+        root.statusText = "GitHub sign-in is opening in a terminal. Complete it, then return here and press Refresh."
+        root.copilotLoginRequested()
       }
     }
   }

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -55,23 +55,23 @@ assert.match(settingsViewSource, /command:\s*\["ai-usagebar",\s*"settings",\s*"s
 assert.match(settingsViewSource, /command:\s*\["ai-usagebar",\s*"settings",\s*"apply"\]/);
 assert.match(settingsViewSource, /stdinEnabled:\s*true/);
 assert.match(settingsViewSource, /write\(root\.pendingPayload\s*\+\s*"\\n"\)/);
+assert.match(settingsViewSource, /password:\s*true/);
+assert.match(settingsViewSource, /function\s+finishApply\s*\(\)\s*\{[\s\S]*?scrubSecrets\(\)[\s\S]*?if\s*\(applyExitCode/s);
 assert.match(settingsViewSource, /signal\s+nousLoginRequested\(\)/);
-assert.match(settingsViewSource, /signal\s+copilotLoginRequested\(\)/);
 assert.match(settingsViewSource, /signal\s+showValueRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show usage value in the top bar"/);
 assert.match(settingsViewSource, /signal\s+showProviderRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show provider name in the top bar"/);
 assert.match(panelSource, /onShowProviderRequested/);
 assert.match(settingsViewSource, /Log in with Nous Research/);
-assert.match(settingsViewSource, /Log in with GitHub Copilot/);
 assert.match(settingsViewSource, /Leave the terminal open until login completes/);
 assert.match(settingsViewSource, /model:\s*root\.snapshot\.keys/);
+assert.match(settingsViewSource, /Paste\s*"\s*\+\s*\(keyCard\.modelData\.secret_label/);
 assert.match(panelSource, /function\s+openNousLogin\s*\(/);
 assert.match(panelSource, /ai-usagebar auth nous login/);
 assert.match(panelSource, /onNousLoginRequested/);
-assert.match(panelSource, /function\s+openCopilotLogin\s*\(/);
-assert.match(panelSource, /gh auth login --web/);
-assert.match(panelSource, /onCopilotLoginRequested/);
+assert.doesNotMatch(settingsViewSource, /copilotLoginRequested|Log in with GitHub Copilot/);
+assert.doesNotMatch(panelSource, /openCopilotLogin|onCopilotLoginRequested/);
 assert.doesNotMatch(settingsViewSource, /command:\s*\[[^\]]*(?:api.?key|secret|pendingPayload)/i);
 
 const raw = JSON.stringify({primary: 'openai', entries: [

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -58,20 +58,24 @@ assert.match(settingsViewSource, /write\(root\.pendingPayload\s*\+\s*"\\n"\)/);
 assert.match(settingsViewSource, /password:\s*true/);
 assert.match(settingsViewSource, /function\s+finishApply\s*\(\)\s*\{[\s\S]*?scrubSecrets\(\)[\s\S]*?if\s*\(applyExitCode/s);
 assert.match(settingsViewSource, /signal\s+nousLoginRequested\(\)/);
+assert.match(settingsViewSource, /signal\s+copilotLoginRequested\(\)/);
 assert.match(settingsViewSource, /signal\s+showValueRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show usage value in the top bar"/);
 assert.match(settingsViewSource, /signal\s+showProviderRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show provider name in the top bar"/);
 assert.match(panelSource, /onShowProviderRequested/);
 assert.match(settingsViewSource, /Log in with Nous Research/);
-assert.match(settingsViewSource, /Leave the terminal open until login completes/);
+assert.match(settingsViewSource, /Log in with GitHub Copilot/);
+assert.match(settingsViewSource, /choose GitHub Copilot as primary and save/);
 assert.match(settingsViewSource, /model:\s*root\.snapshot\.keys/);
 assert.match(settingsViewSource, /Paste\s*"\s*\+\s*\(keyCard\.modelData\.secret_label/);
 assert.match(panelSource, /function\s+openNousLogin\s*\(/);
 assert.match(panelSource, /ai-usagebar auth nous login/);
 assert.match(panelSource, /onNousLoginRequested/);
-assert.doesNotMatch(settingsViewSource, /copilotLoginRequested|Log in with GitHub Copilot/);
-assert.doesNotMatch(panelSource, /openCopilotLogin|onCopilotLoginRequested/);
+assert.match(panelSource, /function\s+openCopilotLogin\s*\(/);
+assert.match(panelSource, /gh auth login --web/);
+assert.match(panelSource, /onCopilotLoginRequested/);
+assert.doesNotMatch(settingsViewSource, /GitHub OAuth token|GITHUB_COPILOT_TOKEN/);
 assert.doesNotMatch(settingsViewSource, /command:\s*\[[^\]]*(?:api.?key|secret|pendingPayload)/i);
 
 const raw = JSON.stringify({primary: 'openai', entries: [
@@ -325,6 +329,14 @@ const noEnabled = model.parseSettingsSnapshot(JSON.stringify({
 }));
 assert.equal(noEnabled.ok, true);
 assert.equal(noEnabled.primary, '');
+const copilotPrimary = model.parseSettingsSnapshot(JSON.stringify({
+  schema_version: 1, primary: 'anthropic',
+  primary_choices: [{id: 'anthropic', label: 'Claude'}, {id: 'copilot', label: 'GitHub Copilot'}],
+  keys: []
+}));
+assert.equal(copilotPrimary.ok, true);
+assert.equal(copilotPrimary.primary_choices[1].id, 'copilot');
+assert.equal(copilotPrimary.keys.some(key => key.id === 'copilot'), false);
 
 const patch = model.buildSettingsPatch('openai', [
   {id: 'kimi', action: 'set', value: 'secret-value'},

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -56,17 +56,22 @@ assert.match(settingsViewSource, /command:\s*\["ai-usagebar",\s*"settings",\s*"a
 assert.match(settingsViewSource, /stdinEnabled:\s*true/);
 assert.match(settingsViewSource, /write\(root\.pendingPayload\s*\+\s*"\\n"\)/);
 assert.match(settingsViewSource, /signal\s+nousLoginRequested\(\)/);
+assert.match(settingsViewSource, /signal\s+copilotLoginRequested\(\)/);
 assert.match(settingsViewSource, /signal\s+showValueRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show usage value in the top bar"/);
 assert.match(settingsViewSource, /signal\s+showProviderRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show provider name in the top bar"/);
 assert.match(panelSource, /onShowProviderRequested/);
 assert.match(settingsViewSource, /Log in with Nous Research/);
+assert.match(settingsViewSource, /Log in with GitHub Copilot/);
 assert.match(settingsViewSource, /Leave the terminal open until login completes/);
 assert.match(settingsViewSource, /model:\s*root\.snapshot\.keys/);
 assert.match(panelSource, /function\s+openNousLogin\s*\(/);
 assert.match(panelSource, /ai-usagebar auth nous login/);
 assert.match(panelSource, /onNousLoginRequested/);
+assert.match(panelSource, /function\s+openCopilotLogin\s*\(/);
+assert.match(panelSource, /gh auth login --web/);
+assert.match(panelSource, /onCopilotLoginRequested/);
 assert.doesNotMatch(settingsViewSource, /command:\s*\[[^\]]*(?:api.?key|secret|pendingPayload)/i);
 
 const raw = JSON.stringify({primary: 'openai', entries: [

--- a/src/active.rs
+++ b/src/active.rs
@@ -102,6 +102,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "anthropic" => Some(VendorId::Anthropic),
         "anthropic_api" => Some(VendorId::AnthropicApi),
         "openai" => Some(VendorId::Openai),
+        "copilot" => Some(VendorId::Copilot),
         "zai" => Some(VendorId::Zai),
         "openrouter" => Some(VendorId::Openrouter),
         "deepseek" => Some(VendorId::Deepseek),

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@
 //! ```toml
 //! [anthropic]  enabled = true
 //! [openai]     enabled = true   # Codex OAuth from ~/.codex/auth.json
-//! [copilot]    enabled = false  # GitHub OAuth token from env or config.toml
+//! [copilot]    enabled = false  # GitHub CLI OAuth, or an explicit env override
 //! [zai]        enabled = true
 //! [openrouter] enabled = true
 //! [deepseek]   enabled = false
@@ -527,44 +527,39 @@ impl Default for OpenAiConfig {
     }
 }
 
-/// GitHub Copilot quota from the private endpoint used by VS Code. The OAuth
-/// token may be supplied by the environment or saved in this app's protected
-/// config file; this app never scans editor credential stores.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// GitHub Copilot quota from the private endpoint used by VS Code. The token
+/// comes from an explicit environment override or the official GitHub CLI;
+/// this app never reads, copies, or writes GitHub credential stores.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CopilotConfig {
     pub enabled: bool,
-    /// Name of the environment variable carrying a GitHub OAuth token.
-    pub token_env: String,
-    /// Fallback OAuth token saved by the settings forms. A non-empty
-    /// environment value always takes precedence.
-    pub token: Option<String>,
-}
-
-impl Default for CopilotConfig {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            token_env: "GITHUB_COPILOT_TOKEN".to_string(),
-            token: None,
-        }
-    }
 }
 
 impl CopilotConfig {
     pub fn resolve_token(&self) -> Result<String> {
-        if let Some(token) = optional_api_key(&self.token_env, self.token.as_deref()) {
-            return Ok(token);
+        self.resolve_token_with(
+            |name| std::env::var_os(name),
+            &crate::copilot::credentials::SystemGhAuthTokenRunner,
+        )
+    }
+
+    fn resolve_token_with(
+        &self,
+        environment: impl Fn(&str) -> Option<std::ffi::OsString>,
+        runner: &impl crate::copilot::credentials::GhAuthTokenRunner,
+    ) -> Result<String> {
+        if let Some(value) = environment("GITHUB_COPILOT_TOKEN") {
+            let token = value.into_string().map_err(|_| {
+                AppError::Credentials(
+                    "GitHub Copilot: GITHUB_COPILOT_TOKEN is not valid UTF-8.".into(),
+                )
+            })?;
+            if !token.is_empty() {
+                return Ok(token);
+            }
         }
-        let advice = if is_valid_env_var_name(&self.token_env) {
-            "set a GitHub OAuth token in the environment variable named by `token_env` or set `token`"
-        } else {
-            "set `token_env` to a valid environment-variable name or set `token`"
-        };
-        Err(AppError::Credentials(format!(
-            "GitHub Copilot: no GitHub OAuth token. Either {advice} under [copilot] in {}.",
-            config_path_hint()
-        )))
+        crate::copilot::credentials::resolve_with(runner)
     }
 }
 
@@ -1111,7 +1106,6 @@ impl Config {
             self.grok.api_key.as_deref(),
             self.anthropic_api.api_key.as_deref(),
             self.opencode_go.api_key.as_deref(),
-            self.copilot.token.as_deref(),
         ]
         .into_iter()
         .chain(
@@ -1484,8 +1478,6 @@ mod tests {
         assert_eq!(config.opencode_go.api_key_env, "OPENCODE_GO_API_KEY");
         assert!(config.opencode_go.api_key.is_none());
         assert!(!config.is_enabled(VendorId::Copilot));
-        assert_eq!(config.copilot.token_env, "GITHUB_COPILOT_TOKEN");
-        assert!(config.copilot.token.is_none());
     }
 
     #[cfg(unix)]
@@ -1816,29 +1808,46 @@ enabled = false
     }
 
     #[test]
-    fn copilot_token_prefers_environment_over_saved_token() {
-        let _g = env_guard();
-        let variable = "AI_USAGEBAR_TEST_COPILOT_TOKEN_PRECEDENCE";
-        unsafe { std::env::set_var(variable, "from-environment") };
-        let config = CopilotConfig {
-            token_env: variable.into(),
-            token: Some("from-config".into()),
-            ..CopilotConfig::default()
-        };
-        assert_eq!(config.resolve_token().unwrap(), "from-environment");
-        unsafe { std::env::remove_var(variable) };
-        assert_eq!(config.resolve_token().unwrap(), "from-config");
+    fn copilot_token_prefers_explicit_environment_over_gh_cli() {
+        struct NeverRun;
+        impl crate::copilot::credentials::GhAuthTokenRunner for NeverRun {
+            fn run(
+                &self,
+                _: &crate::copilot::credentials::GhAuthTokenCommand,
+            ) -> std::io::Result<crate::copilot::credentials::GhAuthTokenOutput> {
+                panic!("environment override must not invoke gh")
+            }
+        }
+
+        let token = CopilotConfig::default()
+            .resolve_token_with(
+                |name| (name == "GITHUB_COPILOT_TOKEN").then(|| "from-environment".into()),
+                &NeverRun,
+            )
+            .unwrap();
+        assert_eq!(token, "from-environment");
     }
 
     #[test]
-    fn copilot_token_errors_do_not_echo_token_env_value() {
-        let config = CopilotConfig {
-            token_env: "github-pasted-token".into(),
-            ..CopilotConfig::default()
-        };
-        let error = config.resolve_token().unwrap_err().to_string();
-        assert!(error.contains("token_env"));
-        assert!(!error.contains("github-pasted-token"));
+    fn copilot_token_uses_injected_gh_cli_and_hides_failure_output() {
+        struct FailedGh;
+        impl crate::copilot::credentials::GhAuthTokenRunner for FailedGh {
+            fn run(
+                &self,
+                _: &crate::copilot::credentials::GhAuthTokenCommand,
+            ) -> std::io::Result<crate::copilot::credentials::GhAuthTokenOutput> {
+                Ok(crate::copilot::credentials::GhAuthTokenOutput {
+                    success: false,
+                    stdout: b"never-echo-gh-output".to_vec(),
+                })
+            }
+        }
+        let error = CopilotConfig::default()
+            .resolve_token_with(|_| None, &FailedGh)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("gh auth login --web"));
+        assert!(!error.contains("never-echo-gh-output"));
     }
 
     #[test]
@@ -1972,20 +1981,6 @@ enabled = false
         assert_eq!(c.openrouter.api_key.as_deref(), Some("sk-or-inline"));
     }
 
-    #[cfg(unix)]
-    #[test]
-    fn config_parses_and_protects_inline_copilot_token() {
-        let file = write_toml("[copilot]\ntoken = \"test-token\"\n");
-        std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o644)).unwrap();
-
-        let config = Config::load_from(file.path()).unwrap();
-
-        assert_eq!(config.copilot.token.as_deref(), Some("test-token"));
-        assert_eq!(
-            std::fs::metadata(file.path()).unwrap().mode() & 0o777,
-            0o600
-        );
-    }
     #[test]
     fn openrouter_named_accounts_preserve_the_default_contract() {
         let f = write_toml(

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 //! ```toml
 //! [anthropic]  enabled = true
 //! [openai]     enabled = true   # Codex OAuth from ~/.codex/auth.json
+//! [copilot]    enabled = false  # GitHub OAuth token from an explicit env var
 //! [zai]        enabled = true
 //! [openrouter] enabled = true
 //! [deepseek]   enabled = false
@@ -41,6 +42,7 @@ pub struct Config {
     pub anthropic: AnthropicConfig,
     pub anthropic_api: AnthropicApiConfig,
     pub openai: OpenAiConfig,
+    pub copilot: CopilotConfig,
     pub zai: ZaiConfig,
     pub openrouter: OpenRouterConfig,
     pub deepseek: DeepseekConfig,
@@ -525,6 +527,38 @@ impl Default for OpenAiConfig {
     }
 }
 
+/// GitHub Copilot quota from the private endpoint used by VS Code. The OAuth
+/// token is deliberately environment-only: this app neither scans editor
+/// credential stores nor persists a GitHub credential of its own.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct CopilotConfig {
+    pub enabled: bool,
+    /// Name of the environment variable carrying a GitHub OAuth token.
+    pub token_env: String,
+}
+
+impl Default for CopilotConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            token_env: "GITHUB_COPILOT_TOKEN".to_string(),
+        }
+    }
+}
+
+impl CopilotConfig {
+    pub fn resolve_token(&self) -> Result<String> {
+        resolve_env_secret(
+            "GitHub Copilot",
+            "[copilot]",
+            "token_env",
+            &self.token_env,
+            "GitHub OAuth token",
+        )
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct NousConfig {
@@ -972,6 +1006,33 @@ pub fn optional_api_key(env_var_name: &str, inline: Option<&str>) -> Option<Stri
     inline.filter(|v| !v.is_empty()).map(str::to_string)
 }
 
+/// Resolve an environment-only credential. This is intentionally separate from
+/// API-key resolution so OAuth providers cannot acquire an inline fallback by
+/// accident, and callers get setup advice naming their actual config field.
+fn resolve_env_secret(
+    vendor_label: &str,
+    section: &str,
+    field: &str,
+    env_var_name: &str,
+    credential_label: &str,
+) -> Result<String> {
+    if is_valid_env_var_name(env_var_name)
+        && let Ok(value) = std::env::var(env_var_name)
+        && !value.is_empty()
+    {
+        return Ok(value);
+    }
+    let advice = if is_valid_env_var_name(env_var_name) {
+        format!("set {credential_label} in the environment variable named by `{field}`")
+    } else {
+        format!("set `{field}` to a valid environment-variable name")
+    };
+    Err(AppError::Credentials(format!(
+        "{vendor_label}: no {credential_label}. Either {advice} under {section} in {}.",
+        config_path_hint()
+    )))
+}
+
 fn resolve_api_key_in_section(
     vendor_label: &str,
     section: &str,
@@ -1106,6 +1167,7 @@ impl Config {
             VendorId::Anthropic => self.anthropic.enabled,
             VendorId::AnthropicApi => self.anthropic_api.enabled,
             VendorId::Openai => self.openai.enabled,
+            VendorId::Copilot => self.copilot.enabled,
             VendorId::Zai => self.zai.enabled,
             VendorId::Openrouter => self.openrouter.enabled,
             VendorId::Deepseek => self.deepseek.enabled,
@@ -1413,6 +1475,7 @@ mod tests {
         assert!(c.is_enabled(VendorId::Openrouter));
         for opt_in in [
             VendorId::AnthropicApi,
+            VendorId::Copilot,
             VendorId::Deepseek,
             VendorId::Kimi,
             VendorId::Kilo,
@@ -1436,6 +1499,8 @@ mod tests {
         assert!(!config.is_enabled(VendorId::OpenCodeGo));
         assert_eq!(config.opencode_go.api_key_env, "OPENCODE_GO_API_KEY");
         assert!(config.opencode_go.api_key.is_none());
+        assert!(!config.is_enabled(VendorId::Copilot));
+        assert_eq!(config.copilot.token_env, "GITHUB_COPILOT_TOKEN");
     }
 
     #[cfg(unix)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -534,6 +534,9 @@ impl Default for OpenAiConfig {
 #[serde(default)]
 pub struct CopilotConfig {
     pub enabled: bool,
+    /// Path to the official GitHub CLI. Unset looks `gh` up on `PATH`, which
+    /// is how `gh` is normally installed; set it to pin the executable.
+    pub gh_binary: Option<PathBuf>,
 }
 
 impl CopilotConfig {
@@ -559,7 +562,7 @@ impl CopilotConfig {
                 return Ok(token);
             }
         }
-        crate::copilot::credentials::resolve_with(runner)
+        crate::copilot::credentials::resolve_with(runner, self.gh_binary.as_deref())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@
 //! ```toml
 //! [anthropic]  enabled = true
 //! [openai]     enabled = true   # Codex OAuth from ~/.codex/auth.json
-//! [copilot]    enabled = false  # GitHub OAuth token from an explicit env var
+//! [copilot]    enabled = false  # GitHub OAuth token from env or config.toml
 //! [zai]        enabled = true
 //! [openrouter] enabled = true
 //! [deepseek]   enabled = false
@@ -528,14 +528,17 @@ impl Default for OpenAiConfig {
 }
 
 /// GitHub Copilot quota from the private endpoint used by VS Code. The OAuth
-/// token is deliberately environment-only: this app neither scans editor
-/// credential stores nor persists a GitHub credential of its own.
+/// token may be supplied by the environment or saved in this app's protected
+/// config file; this app never scans editor credential stores.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CopilotConfig {
     pub enabled: bool,
     /// Name of the environment variable carrying a GitHub OAuth token.
     pub token_env: String,
+    /// Fallback OAuth token saved by the settings forms. A non-empty
+    /// environment value always takes precedence.
+    pub token: Option<String>,
 }
 
 impl Default for CopilotConfig {
@@ -543,19 +546,25 @@ impl Default for CopilotConfig {
         Self {
             enabled: false,
             token_env: "GITHUB_COPILOT_TOKEN".to_string(),
+            token: None,
         }
     }
 }
 
 impl CopilotConfig {
     pub fn resolve_token(&self) -> Result<String> {
-        resolve_env_secret(
-            "GitHub Copilot",
-            "[copilot]",
-            "token_env",
-            &self.token_env,
-            "GitHub OAuth token",
-        )
+        if let Some(token) = optional_api_key(&self.token_env, self.token.as_deref()) {
+            return Ok(token);
+        }
+        let advice = if is_valid_env_var_name(&self.token_env) {
+            "set a GitHub OAuth token in the environment variable named by `token_env` or set `token`"
+        } else {
+            "set `token_env` to a valid environment-variable name or set `token`"
+        };
+        Err(AppError::Credentials(format!(
+            "GitHub Copilot: no GitHub OAuth token. Either {advice} under [copilot] in {}.",
+            config_path_hint()
+        )))
     }
 }
 
@@ -1006,33 +1015,6 @@ pub fn optional_api_key(env_var_name: &str, inline: Option<&str>) -> Option<Stri
     inline.filter(|v| !v.is_empty()).map(str::to_string)
 }
 
-/// Resolve an environment-only credential. This is intentionally separate from
-/// API-key resolution so OAuth providers cannot acquire an inline fallback by
-/// accident, and callers get setup advice naming their actual config field.
-fn resolve_env_secret(
-    vendor_label: &str,
-    section: &str,
-    field: &str,
-    env_var_name: &str,
-    credential_label: &str,
-) -> Result<String> {
-    if is_valid_env_var_name(env_var_name)
-        && let Ok(value) = std::env::var(env_var_name)
-        && !value.is_empty()
-    {
-        return Ok(value);
-    }
-    let advice = if is_valid_env_var_name(env_var_name) {
-        format!("set {credential_label} in the environment variable named by `{field}`")
-    } else {
-        format!("set `{field}` to a valid environment-variable name")
-    };
-    Err(AppError::Credentials(format!(
-        "{vendor_label}: no {credential_label}. Either {advice} under {section} in {}.",
-        config_path_hint()
-    )))
-}
-
 fn resolve_api_key_in_section(
     vendor_label: &str,
     section: &str,
@@ -1083,7 +1065,7 @@ impl Config {
                 config.expand_paths();
                 config.validate()?;
                 #[cfg(unix)]
-                config.protect_inline_api_keys(path)?;
+                config.protect_inline_secrets(path)?;
                 Ok(config)
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
@@ -1112,10 +1094,11 @@ impl Config {
         }
     }
 
-    /// Explicitly enumerate every inline API-key field. Adding a new API-key
-    /// vendor must add it here so its config file receives the same protection.
+    /// Explicitly enumerate every inline credential field. Adding a new
+    /// credential vendor must add it here so its config receives the same
+    /// protection.
     #[cfg(unix)]
-    fn has_inline_api_keys(&self) -> bool {
+    fn has_inline_secrets(&self) -> bool {
         [
             self.zai.api_key.as_deref(),
             self.openrouter.api_key.as_deref(),
@@ -1128,6 +1111,7 @@ impl Config {
             self.grok.api_key.as_deref(),
             self.anthropic_api.api_key.as_deref(),
             self.opencode_go.api_key.as_deref(),
+            self.copilot.token.as_deref(),
         ]
         .into_iter()
         .chain(
@@ -1140,21 +1124,21 @@ impl Config {
     }
 
     #[cfg(unix)]
-    fn protect_inline_api_keys(&self, path: &Path) -> Result<()> {
-        if !self.has_inline_api_keys() {
+    fn protect_inline_secrets(&self, path: &Path) -> Result<()> {
+        if !self.has_inline_secrets() {
             return Ok(());
         }
 
         let metadata = std::fs::metadata(path).map_err(|_| {
             AppError::Credentials(format!(
-                "config at {} contains inline api_key values but its permissions could not be checked; fix permissions or move keys to environment variables",
+                "config at {} contains inline credentials but its permissions could not be checked; fix permissions or move credentials to environment variables",
                 path.display()
             ))
         })?;
         if inline_key_permission_decision(metadata.mode()) == InlineKeyPermissionDecision::Tighten {
             std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600)).map_err(|_| {
                 AppError::Credentials(format!(
-                    "config at {} contains inline api_key values but is group/other-readable and could not be tightened to 0600; fix permissions or move keys to environment variables",
+                    "config at {} contains inline credentials but is group/other-readable and could not be tightened to 0600; fix permissions or move credentials to environment variables",
                     path.display()
                 ))
             })?;
@@ -1501,14 +1485,15 @@ mod tests {
         assert!(config.opencode_go.api_key.is_none());
         assert!(!config.is_enabled(VendorId::Copilot));
         assert_eq!(config.copilot.token_env, "GITHUB_COPILOT_TOKEN");
+        assert!(config.copilot.token.is_none());
     }
 
     #[cfg(unix)]
     #[test]
-    fn opencode_go_inline_key_is_protected_like_other_api_keys() {
+    fn inline_credentials_are_protected() {
         let mut config = Config::default();
         config.opencode_go.api_key = Some("<redacted>".to_string());
-        assert!(config.has_inline_api_keys());
+        assert!(config.has_inline_secrets());
     }
 
     #[cfg(unix)]
@@ -1520,7 +1505,7 @@ mod tests {
             api_key_env: None,
             api_key: Some("<redacted>".into()),
         });
-        assert!(config.has_inline_api_keys());
+        assert!(config.has_inline_secrets());
     }
 
     #[test]
@@ -1831,6 +1816,32 @@ enabled = false
     }
 
     #[test]
+    fn copilot_token_prefers_environment_over_saved_token() {
+        let _g = env_guard();
+        let variable = "AI_USAGEBAR_TEST_COPILOT_TOKEN_PRECEDENCE";
+        unsafe { std::env::set_var(variable, "from-environment") };
+        let config = CopilotConfig {
+            token_env: variable.into(),
+            token: Some("from-config".into()),
+            ..CopilotConfig::default()
+        };
+        assert_eq!(config.resolve_token().unwrap(), "from-environment");
+        unsafe { std::env::remove_var(variable) };
+        assert_eq!(config.resolve_token().unwrap(), "from-config");
+    }
+
+    #[test]
+    fn copilot_token_errors_do_not_echo_token_env_value() {
+        let config = CopilotConfig {
+            token_env: "github-pasted-token".into(),
+            ..CopilotConfig::default()
+        };
+        let error = config.resolve_token().unwrap_err().to_string();
+        assert!(error.contains("token_env"));
+        assert!(!error.contains("github-pasted-token"));
+    }
+
+    #[test]
     fn resolve_api_key_errors_when_both_missing() {
         let _g = env_guard();
         let var = "AI_USAGEBAR_TEST_BOTH_MISSING";
@@ -1961,6 +1972,20 @@ enabled = false
         assert_eq!(c.openrouter.api_key.as_deref(), Some("sk-or-inline"));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn config_parses_and_protects_inline_copilot_token() {
+        let file = write_toml("[copilot]\ntoken = \"test-token\"\n");
+        std::fs::set_permissions(file.path(), std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let config = Config::load_from(file.path()).unwrap();
+
+        assert_eq!(config.copilot.token.as_deref(), Some("test-token"));
+        assert_eq!(
+            std::fs::metadata(file.path()).unwrap().mode() & 0o777,
+            0o600
+        );
+    }
     #[test]
     fn openrouter_named_accounts_preserve_the_default_contract() {
         let f = write_toml(

--- a/src/copilot/credentials.rs
+++ b/src/copilot/credentials.rs
@@ -12,15 +12,19 @@ use crate::vendor::vendor_secret_env_vars_to_remove;
 /// inspectable in tests and prevents a shell from entering this path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GhAuthTokenCommand {
-    pub program: &'static str,
+    pub program: std::path::PathBuf,
     pub args: [&'static str; 2],
     pub env_remove: Vec<&'static str>,
 }
 
 impl GhAuthTokenCommand {
-    pub fn standard() -> Self {
+    /// `gh` has no canonical install path across distributions, so unlike
+    /// `grok` it is looked up on `PATH` by default. That makes the binary an
+    /// ambient choice, which is why `[copilot] gh_binary` exists: point it at
+    /// the trusted executable and the lookup stops being ambient.
+    pub fn standard(gh_binary: Option<&std::path::Path>) -> Self {
         Self {
-            program: "gh",
+            program: gh_binary.map_or_else(|| std::path::PathBuf::from("gh"), Into::into),
             args: ["auth", "token"],
             // `gh auth token` must use its saved OAuth login, rather than an
             // arbitrary provider token inherited from this process.
@@ -45,7 +49,7 @@ pub struct SystemGhAuthTokenRunner;
 
 impl GhAuthTokenRunner for SystemGhAuthTokenRunner {
     fn run(&self, command: &GhAuthTokenCommand) -> io::Result<GhAuthTokenOutput> {
-        let mut process = Command::new(command.program);
+        let mut process = Command::new(&command.program);
         process
             .args(command.args)
             .stdin(Stdio::null())
@@ -62,8 +66,11 @@ impl GhAuthTokenRunner for SystemGhAuthTokenRunner {
     }
 }
 
-pub fn resolve_with(runner: &impl GhAuthTokenRunner) -> Result<String> {
-    let command = GhAuthTokenCommand::standard();
+pub fn resolve_with(
+    runner: &impl GhAuthTokenRunner,
+    gh_binary: Option<&std::path::Path>,
+) -> Result<String> {
+    let command = GhAuthTokenCommand::standard(gh_binary);
     let output = match runner.run(&command) {
         Ok(output) => output,
         Err(error) if error.kind() == io::ErrorKind::NotFound => {
@@ -120,14 +127,44 @@ mod tests {
             command: RefCell::new(None),
         };
 
-        assert_eq!(resolve_with(&runner).unwrap(), "test-github-oauth-token");
+        assert_eq!(
+            resolve_with(&runner, None).unwrap(),
+            "test-github-oauth-token"
+        );
         let command = runner.command.into_inner().unwrap();
-        assert_eq!(command.program, "gh");
+        assert_eq!(command.program, std::path::Path::new("gh"));
         assert_eq!(command.args, ["auth", "token"]);
         assert!(command.env_remove.contains(&"ZAI_API_KEY"));
         assert!(command.env_remove.contains(&"GITHUB_COPILOT_TOKEN"));
         assert!(command.env_remove.contains(&"GH_TOKEN"));
         assert!(command.env_remove.contains(&"GITHUB_TOKEN"));
+    }
+
+    /// `gh` has no canonical path, so `PATH` is the sensible default — but it
+    /// is still an ambient choice about which binary runs on every refresh.
+    /// `[copilot] gh_binary` is how a user pins it, so the setting has to
+    /// actually reach the spawned command.
+    #[test]
+    fn a_configured_gh_binary_replaces_the_path_lookup() {
+        let pinned = std::path::Path::new("/opt/github/bin/gh");
+        assert_eq!(
+            GhAuthTokenCommand::standard(Some(pinned)).program,
+            pinned,
+            "a pinned binary must be used verbatim"
+        );
+        assert_eq!(
+            GhAuthTokenCommand::standard(None).program,
+            std::path::Path::new("gh"),
+            "unset still means the PATH lookup"
+        );
+        // The rest of the boundary is fixed either way.
+        for command in [
+            GhAuthTokenCommand::standard(Some(pinned)),
+            GhAuthTokenCommand::standard(None),
+        ] {
+            assert_eq!(command.args, ["auth", "token"]);
+            assert!(command.env_remove.contains(&"GITHUB_TOKEN"));
+        }
     }
 
     #[test]
@@ -140,7 +177,7 @@ mod tests {
             command: RefCell::new(None),
         };
 
-        let error = resolve_with(&runner).unwrap_err().to_string();
+        let error = resolve_with(&runner, None).unwrap_err().to_string();
         assert!(error.contains("gh auth login --web"));
         assert!(!error.contains("private-token-or-error"));
     }

--- a/src/copilot/credentials.rs
+++ b/src/copilot/credentials.rs
@@ -1,0 +1,147 @@
+//! Obtain a GitHub OAuth token from the official GitHub CLI without handling
+//! its credential files ourselves.
+
+use std::io;
+use std::process::{Command, Stdio};
+
+use crate::error::{AppError, Result};
+use crate::vendor::vendor_secret_env_vars_to_remove;
+
+/// The deliberately narrow process description used to obtain the current
+/// GitHub CLI OAuth token. Keeping it data makes the subprocess boundary
+/// inspectable in tests and prevents a shell from entering this path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GhAuthTokenCommand {
+    pub program: &'static str,
+    pub args: [&'static str; 2],
+    pub env_remove: Vec<&'static str>,
+}
+
+impl GhAuthTokenCommand {
+    pub fn standard() -> Self {
+        Self {
+            program: "gh",
+            args: ["auth", "token"],
+            // `gh auth token` must use its saved OAuth login, rather than an
+            // arbitrary provider token inherited from this process.
+            env_remove: vendor_secret_env_vars_to_remove(&[]),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GhAuthTokenOutput {
+    pub success: bool,
+    pub stdout: Vec<u8>,
+}
+
+/// Injectable command boundary. Tests supply a fake runner, so they never
+/// execute `gh`, inspect a real GitHub config directory, or use ambient env.
+pub trait GhAuthTokenRunner {
+    fn run(&self, command: &GhAuthTokenCommand) -> io::Result<GhAuthTokenOutput>;
+}
+
+pub struct SystemGhAuthTokenRunner;
+
+impl GhAuthTokenRunner for SystemGhAuthTokenRunner {
+    fn run(&self, command: &GhAuthTokenCommand) -> io::Result<GhAuthTokenOutput> {
+        let mut process = Command::new(command.program);
+        process
+            .args(command.args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        for variable in &command.env_remove {
+            process.env_remove(variable);
+        }
+        let output = process.output()?;
+        Ok(GhAuthTokenOutput {
+            success: output.status.success(),
+            stdout: output.stdout,
+        })
+    }
+}
+
+pub fn resolve_with(runner: &impl GhAuthTokenRunner) -> Result<String> {
+    let command = GhAuthTokenCommand::standard();
+    let output = match runner.run(&command) {
+        Ok(output) => output,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Err(login_error(
+                "GitHub CLI (`gh`) is not installed. Install it, then run",
+            ));
+        }
+        Err(_) => return Err(login_error("GitHub CLI could not be started. Run")),
+    };
+    if !output.success {
+        return Err(login_error("GitHub CLI is not logged in. Run"));
+    }
+    let token = String::from_utf8(output.stdout)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| login_error("GitHub CLI returned no OAuth token. Run"))?;
+    Ok(token)
+}
+
+fn login_error(prefix: &str) -> AppError {
+    AppError::Credentials(format!(
+        "GitHub Copilot: {prefix} `gh auth login --web`, then select GitHub Copilot as the primary provider in Settings."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    struct FakeRunner {
+        result: io::Result<GhAuthTokenOutput>,
+        command: RefCell<Option<GhAuthTokenCommand>>,
+    }
+
+    impl GhAuthTokenRunner for FakeRunner {
+        fn run(&self, command: &GhAuthTokenCommand) -> io::Result<GhAuthTokenOutput> {
+            *self.command.borrow_mut() = Some(command.clone());
+            self.result
+                .as_ref()
+                .map(Clone::clone)
+                .map_err(|error| io::Error::new(error.kind(), "fake gh failure"))
+        }
+    }
+
+    #[test]
+    fn runs_only_fixed_gh_auth_token_command_and_returns_trimmed_token() {
+        let runner = FakeRunner {
+            result: Ok(GhAuthTokenOutput {
+                success: true,
+                stdout: b"test-github-oauth-token\n".to_vec(),
+            }),
+            command: RefCell::new(None),
+        };
+
+        assert_eq!(resolve_with(&runner).unwrap(), "test-github-oauth-token");
+        let command = runner.command.into_inner().unwrap();
+        assert_eq!(command.program, "gh");
+        assert_eq!(command.args, ["auth", "token"]);
+        assert!(command.env_remove.contains(&"ZAI_API_KEY"));
+        assert!(command.env_remove.contains(&"GITHUB_COPILOT_TOKEN"));
+        assert!(command.env_remove.contains(&"GH_TOKEN"));
+        assert!(command.env_remove.contains(&"GITHUB_TOKEN"));
+    }
+
+    #[test]
+    fn login_failure_never_echoes_gh_output() {
+        let runner = FakeRunner {
+            result: Ok(GhAuthTokenOutput {
+                success: false,
+                stdout: b"private-token-or-error".to_vec(),
+            }),
+            command: RefCell::new(None),
+        };
+
+        let error = resolve_with(&runner).unwrap_err().to_string();
+        assert!(error.contains("gh auth login --web"));
+        assert!(!error.contains("private-token-or-error"));
+    }
+}

--- a/src/copilot/fetch.rs
+++ b/src/copilot/fetch.rs
@@ -1,0 +1,300 @@
+//! GitHub Copilot quota fetch with cache isolation and no credential storage.
+
+use std::fmt::Write as _;
+use std::time::Duration;
+
+use sha2::{Digest, Sha256};
+
+use crate::cache::{Cache, acquire_lock_async};
+use crate::error::{AppError, Result};
+use crate::vendor::{MAX_BODY_BYTES, read_body_capped};
+
+use super::types::{Response, Snapshot, to_snapshot};
+
+pub const USER_URL: &str = "https://api.github.com/copilot_internal/user";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+const SCHEMA_ERROR: &str = "GitHub Copilot quota response schema mismatch";
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub user: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            user: USER_URL.to_string(),
+        }
+    }
+}
+
+pub type FetchOutcome = crate::outcome::Outcome<Snapshot>;
+
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    token: &str,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+    let target = target_key(endpoints, token);
+    if let Some(bytes) = cache.fresh_payload(ttl)?
+        && let Ok(snapshot) = parse_cache(&bytes, &target)
+    {
+        return Ok(crate::outcome::Outcome::cached(snapshot, cache, false));
+    }
+    match fetch_live(client, token, endpoints).await {
+        Ok(snapshot) => {
+            let bytes = serde_json::to_vec(&serde_json::json!({
+                "target": target,
+                "snapshot": snapshot,
+            }))?;
+            cache.write_payload(&bytes)?;
+            Ok(crate::outcome::Outcome::fresh(snapshot))
+        }
+        Err(error @ AppError::Transport(_)) => fallback_or_error(cache, None, &target, error),
+        Err(AppError::Http { status, .. }) => {
+            let message = status_message(status).to_string();
+            cache.mark_stale();
+            let diagnostic = cache.write_last_error(status, &message);
+            fallback_or_error(
+                cache,
+                Some(diagnostic),
+                &target,
+                AppError::Http {
+                    status,
+                    body: message,
+                },
+            )
+        }
+        Err(AppError::Schema(_)) => {
+            cache.mark_stale();
+            let diagnostic = cache.write_last_error(0, SCHEMA_ERROR);
+            fallback_or_error(
+                cache,
+                Some(diagnostic),
+                &target,
+                AppError::Schema(SCHEMA_ERROR.to_string()),
+            )
+        }
+        Err(error) => fallback_or_error(cache, None, &target, error),
+    }
+}
+
+async fn fetch_live(
+    client: &reqwest::Client,
+    token: &str,
+    endpoints: &Endpoints,
+) -> Result<Snapshot> {
+    let response = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(&endpoints.user)
+            .header(reqwest::header::AUTHORIZATION, format!("token {token}"))
+            .header(reqwest::header::ACCEPT, "application/json")
+            .header("Editor-Version", "vscode/1.96.2")
+            .header("Editor-Plugin-Version", "copilot-chat/0.26.7")
+            .header(reqwest::header::USER_AGENT, "GitHubCopilotChat/0.26.7")
+            .header("X-GitHub-Api-Version", "2025-04-01")
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport("GitHub Copilot request timed out".into()))??;
+    let status = response.status();
+    let bytes = read_body_capped(response, MAX_BODY_BYTES).await?;
+    if !status.is_success() {
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body: status_message(status.as_u16()).into(),
+        });
+    }
+    let response: Response =
+        serde_json::from_slice(&bytes).map_err(|_| AppError::Schema(SCHEMA_ERROR.to_string()))?;
+    to_snapshot(response)
+}
+
+/// Bind cache reuse to both endpoint and token without writing either raw
+/// credential or the full response to disk.
+fn target_key(endpoints: &Endpoints, token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    let mut fingerprint = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(fingerprint, "{byte:02x}");
+    }
+    format!("{}|token:{fingerprint}", endpoints.user)
+}
+
+fn parse_cache(bytes: &[u8], target: &str) -> Result<Snapshot> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|_| AppError::Schema("GitHub Copilot cache is invalid".into()))?;
+    if value.get("target").and_then(serde_json::Value::as_str) != Some(target) {
+        return Err(AppError::Schema(
+            "GitHub Copilot cache belongs to a different account".into(),
+        ));
+    }
+    serde_json::from_value(
+        value.get("snapshot").cloned().ok_or_else(|| {
+            AppError::Schema("GitHub Copilot cache is missing its snapshot".into())
+        })?,
+    )
+    .map_err(|_| AppError::Schema("GitHub Copilot cache has an invalid snapshot".into()))
+}
+
+fn fallback_or_error(
+    cache: &Cache,
+    diagnostic: Option<(u16, String)>,
+    target: &str,
+    error: AppError,
+) -> Result<FetchOutcome> {
+    crate::outcome::fallback(cache, diagnostic, error, |bytes| parse_cache(bytes, target))
+}
+
+fn status_message(status: u16) -> &'static str {
+    match status {
+        401 | 403 => crate::error::AUTH_FAILURE_MESSAGE,
+        429 => "GitHub Copilot rate limited the quota request",
+        500..=599 => "GitHub Copilot quota endpoint is unavailable",
+        _ => "GitHub Copilot quota request failed",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::copilot::types::Quota;
+
+    fn cache_in(dir: &std::path::Path) -> Cache {
+        Cache::at(dir.join("copilot"))
+    }
+
+    #[tokio::test]
+    async fn requests_vs_code_endpoint_with_only_copilot_token_and_normalizes_quotas() {
+        let mut server = mockito::Server::new_async().await;
+        let request = server
+            .mock("GET", "/copilot_internal/user")
+            .expect(1)
+            .match_header("authorization", "token mock-oauth-token")
+            .match_header("accept", "application/json")
+            .match_header("editor-version", "vscode/1.96.2")
+            .match_header("editor-plugin-version", "copilot-chat/0.26.7")
+            .match_header("user-agent", "GitHubCopilotChat/0.26.7")
+            .match_header("x-github-api-version", "2025-04-01")
+            .with_status(200)
+            .with_body(
+                r#"{"copilot_plan":"pro","quota_reset_date":"2026-09-15","quota_snapshots":{"premium_interactions":{"entitlement":300,"remaining":45,"percent_remaining":15},"chat":{"entitlement":1000,"remaining":250},"completions":{"unlimited":true}}}"#,
+            )
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache = cache_in(dir.path());
+        let endpoints = Endpoints {
+            user: format!("{}/copilot_internal/user", server.url()),
+        };
+        let outcome = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mock-oauth-token",
+            &cache,
+            &endpoints,
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        let cached = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mock-oauth-token",
+            &cache,
+            &endpoints,
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        request.assert_async().await;
+        assert_eq!(outcome.snapshot.premium.unwrap().used_pct(), 85);
+        assert!(!cached.stale);
+        assert!(cached.cache_age.is_some());
+        assert_eq!(
+            outcome.snapshot.chat.unwrap().used_and_entitlement(),
+            Some((750, 1000))
+        );
+        assert!(outcome.snapshot.completions.unwrap().unlimited);
+    }
+
+    #[tokio::test]
+    async fn rejected_refresh_uses_stale_cache_without_storing_token_or_response() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/copilot_internal/user")
+            .with_status(401)
+            .with_body(r#"{"message":"contains private account data"}"#)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let cache = cache_in(dir.path());
+        let endpoints = Endpoints {
+            user: format!("{}/copilot_internal/user", server.url()),
+        };
+        let target = target_key(&endpoints, "mock-oauth-token");
+        let snapshot = Snapshot {
+            plan: "pro".into(),
+            premium: Some(Quota {
+                percent_remaining: 80,
+                entitlement: Some(300),
+                remaining: Some(240),
+                unlimited: false,
+            }),
+            chat: None,
+            completions: None,
+            reset_at: None,
+        };
+        cache
+            .write_payload(
+                serde_json::json!({"target": target, "snapshot": snapshot})
+                    .to_string()
+                    .as_bytes(),
+            )
+            .unwrap();
+
+        let outcome = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mock-oauth-token",
+            &cache,
+            &endpoints,
+            Duration::ZERO,
+        )
+        .await
+        .unwrap();
+        assert!(outcome.stale);
+        assert_eq!(outcome.last_error.unwrap().0, 401);
+        assert_eq!(outcome.snapshot.premium.unwrap().used_pct(), 20);
+        let cached = std::fs::read_to_string(cache.payload_path()).unwrap();
+        assert!(!cached.contains("mock-oauth-token"));
+        assert!(!cached.contains("private account data"));
+    }
+
+    #[tokio::test]
+    async fn invalid_success_body_is_schema_error_on_a_cold_cache() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/copilot_internal/user")
+            .with_status(200)
+            .with_body(r#"{"quota_snapshots":{}}"#)
+            .create_async()
+            .await;
+        let dir = tempfile::tempdir().unwrap();
+        let error = fetch_snapshot(
+            &reqwest::Client::new(),
+            "mock-oauth-token",
+            &cache_in(dir.path()),
+            &Endpoints {
+                user: format!("{}/copilot_internal/user", server.url()),
+            },
+            Duration::ZERO,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, AppError::Schema(message) if message == SCHEMA_ERROR));
+    }
+}

--- a/src/copilot/mod.rs
+++ b/src/copilot/mod.rs
@@ -1,0 +1,7 @@
+//! GitHub Copilot quota via the private endpoint used by VS Code.
+
+pub mod fetch;
+pub mod types;
+pub mod vendor;
+
+pub use fetch::{FetchOutcome, fetch_snapshot};

--- a/src/copilot/mod.rs
+++ b/src/copilot/mod.rs
@@ -1,5 +1,6 @@
 //! GitHub Copilot quota via the private endpoint used by VS Code.
 
+pub mod credentials;
 pub mod fetch;
 pub mod types;
 pub mod vendor;

--- a/src/copilot/types.rs
+++ b/src/copilot/types.rs
@@ -1,0 +1,212 @@
+//! Defensive wire parsing for GitHub Copilot's VS Code quota response.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{AppError, Result};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Quota {
+    pub percent_remaining: i32,
+    pub entitlement: Option<u64>,
+    pub remaining: Option<u64>,
+    pub unlimited: bool,
+}
+
+impl Quota {
+    pub fn used_pct(&self) -> i32 {
+        if self.unlimited {
+            0
+        } else {
+            100 - self.percent_remaining
+        }
+    }
+
+    pub fn used_and_entitlement(&self) -> Option<(u64, u64)> {
+        Some((
+            self.entitlement?.saturating_sub(self.remaining?),
+            self.entitlement?,
+        ))
+    }
+}
+
+/// Normalized and cacheable fields only. Raw GitHub responses can include
+/// account metadata, which is neither needed for display nor retained.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Snapshot {
+    pub plan: String,
+    pub premium: Option<Quota>,
+    pub chat: Option<Quota>,
+    pub completions: Option<Quota>,
+    pub reset_at: Option<DateTime<Utc>>,
+}
+
+impl Snapshot {
+    pub fn quotas(&self) -> impl Iterator<Item = (&'static str, &Quota)> {
+        [
+            ("Premium requests", self.premium.as_ref()),
+            ("Chat", self.chat.as_ref()),
+            ("Completions", self.completions.as_ref()),
+        ]
+        .into_iter()
+        .filter_map(|(label, quota)| quota.map(|quota| (label, quota)))
+    }
+
+    pub fn worst_pct(&self) -> i32 {
+        self.quotas()
+            .map(|(_, quota)| quota.used_pct())
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Response {
+    pub copilot_plan: Option<String>,
+    pub quota_reset_date: Option<String>,
+    pub quota_reset_date_utc: Option<String>,
+    pub quota_snapshots: Option<QuotaSnapshots>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct QuotaSnapshots {
+    pub premium_interactions: Option<Value>,
+    pub chat: Option<Value>,
+    pub completions: Option<Value>,
+}
+
+pub fn to_snapshot(response: Response) -> Result<Snapshot> {
+    let quotas = response.quota_snapshots.unwrap_or_default();
+    let premium = parse_quota(quotas.premium_interactions.as_ref());
+    let chat = parse_quota(quotas.chat.as_ref());
+    let completions = parse_quota(quotas.completions.as_ref());
+    if premium.is_none() && chat.is_none() && completions.is_none() {
+        return Err(AppError::Schema(
+            "GitHub Copilot response contains no usable quota snapshots".into(),
+        ));
+    }
+    let plan = response
+        .copilot_plan
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "GitHub Copilot".to_string());
+    let reset_at = response
+        .quota_reset_date_utc
+        .as_deref()
+        .and_then(parse_reset)
+        .or_else(|| response.quota_reset_date.as_deref().and_then(parse_reset));
+    Ok(Snapshot {
+        plan,
+        premium,
+        chat,
+        completions,
+        reset_at,
+    })
+}
+
+/// One malformed optional bucket must not hide usable data in another. The
+/// caller still rejects a response where every known bucket is unusable.
+fn parse_quota(value: Option<&Value>) -> Option<Quota> {
+    let object = value?.as_object()?;
+    let unlimited = object
+        .get("unlimited")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let entitlement = object.get("entitlement").and_then(nonnegative_integer);
+    let remaining = object.get("remaining").and_then(nonnegative_integer);
+    let percent_remaining = object
+        .get("percent_remaining")
+        .and_then(percent)
+        .or_else(|| {
+            entitlement
+                .zip(remaining)
+                .and_then(|(entitlement, remaining)| {
+                    (entitlement > 0).then(|| ((remaining * 100) / entitlement).min(100) as i32)
+                })
+        });
+    (unlimited || percent_remaining.is_some()).then_some(Quota {
+        percent_remaining: percent_remaining.unwrap_or(100),
+        entitlement,
+        remaining,
+        unlimited,
+    })
+}
+
+fn nonnegative_integer(value: &Value) -> Option<u64> {
+    value
+        .as_u64()
+        .or_else(|| value.as_str()?.trim().parse().ok())
+}
+
+fn percent(value: &Value) -> Option<i32> {
+    let value = value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())?;
+    value
+        .is_finite()
+        .then(|| value.round().clamp(0.0, 100.0) as i32)
+}
+
+/// GitHub has returned both RFC3339 `quota_reset_date_utc` and date-only
+/// `quota_reset_date`. A date-only reset means midnight UTC of that date.
+fn parse_reset(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|value| value.with_timezone(&Utc))
+        .or_else(|| {
+            NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()?
+                .and_hms_opt(0, 0, 0)
+                .map(|value| value.and_utc())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_quota_buckets_and_date_only_reset() {
+        let response: Response = serde_json::from_str(
+            r#"{
+                "copilot_plan":"business",
+                "quota_reset_date":"2026-09-15",
+                "quota_snapshots":{
+                    "premium_interactions":{"entitlement":300,"remaining":45,"percent_remaining":15},
+                    "chat":{"entitlement":"1000","remaining":"250"},
+                    "completions":{"unlimited":true}
+                }
+            }"#,
+        )
+        .unwrap();
+        let snapshot = to_snapshot(response).unwrap();
+        assert_eq!(snapshot.plan, "business");
+        assert_eq!(snapshot.premium.unwrap().used_pct(), 85);
+        assert_eq!(
+            snapshot.chat.unwrap().used_and_entitlement(),
+            Some((750, 1000))
+        );
+        assert!(snapshot.completions.unwrap().unlimited);
+        assert_eq!(
+            snapshot.reset_at.unwrap().to_rfc3339(),
+            "2026-09-15T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn accepts_one_good_bucket_and_rejects_an_empty_schema() {
+        let partial: Response = serde_json::from_str(
+            r#"{"quota_snapshots":{"chat":{"percent_remaining":"not-a-number"},"completions":{"remaining":4,"entitlement":8}}}"#,
+        )
+        .unwrap();
+        let snapshot = to_snapshot(partial).unwrap();
+        assert!(snapshot.chat.is_none());
+        assert_eq!(snapshot.completions.unwrap().used_pct(), 50);
+
+        let empty: Response = serde_json::from_str(r#"{"quota_snapshots":{}}"#).unwrap();
+        assert!(to_snapshot(empty).is_err());
+    }
+}

--- a/src/copilot/vendor.rs
+++ b/src/copilot/vendor.rs
@@ -1,0 +1,241 @@
+//! GitHub Copilot Waybar renderer.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::pacing::PaceSeverity;
+use crate::pango::{color_span, escape, severity_color, severity_for};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, render_bordered};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+use super::types::Snapshot;
+
+pub const DEFAULT_FORMAT: &str = "{copilot_premium_pct}% · {copilot_reset}";
+const UNAVAILABLE: &str = "—";
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(outcome: FetchOutcome) -> Self {
+        outcome.map(crate::usage::VendorSnapshot::Copilot)
+    }
+}
+
+pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'static str, String> {
+    let premium = quota_values(snap.premium.as_ref());
+    let chat = quota_values(snap.chat.as_ref());
+    let completions = quota_values(snap.completions.as_ref());
+    let reset = countdown::format(snap.reset_at, now);
+    placeholders([
+        ("icon", "󰊤".to_string()),
+        ("vendor_short", VendorId::Copilot.short_name().to_string()),
+        ("plan", crate::display::sanitize_untrusted_field(&snap.plan)),
+        ("session_pct", premium.percent.clone()),
+        ("session_reset", reset.clone()),
+        ("weekly_pct", chat.percent.clone()),
+        ("weekly_reset", reset.clone()),
+        (
+            "copilot_plan",
+            crate::display::sanitize_untrusted_field(&snap.plan),
+        ),
+        ("copilot_reset", reset),
+        ("copilot_premium_pct", premium.percent),
+        ("copilot_premium_used", premium.used),
+        ("copilot_premium_limit", premium.limit),
+        ("copilot_chat_pct", chat.percent),
+        ("copilot_chat_used", chat.used),
+        ("copilot_chat_limit", chat.limit),
+        ("copilot_completions_pct", completions.percent),
+        ("copilot_completions_used", completions.used),
+        ("copilot_completions_limit", completions.limit),
+    ])
+}
+
+struct QuotaValues {
+    percent: String,
+    used: String,
+    limit: String,
+}
+
+fn quota_values(quota: Option<&super::types::Quota>) -> QuotaValues {
+    let Some(quota) = quota else {
+        return QuotaValues {
+            percent: UNAVAILABLE.into(),
+            used: UNAVAILABLE.into(),
+            limit: UNAVAILABLE.into(),
+        };
+    };
+    if quota.unlimited {
+        return QuotaValues {
+            percent: "0".into(),
+            used: "0".into(),
+            limit: "unlimited".into(),
+        };
+    }
+    let (used, limit) = quota
+        .used_and_entitlement()
+        .map(|(used, limit)| (used.to_string(), limit.to_string()))
+        .unwrap_or_else(|| (UNAVAILABLE.into(), UNAVAILABLE.into()));
+    QuotaValues {
+        percent: quota.used_pct().to_string(),
+        used,
+        limit,
+    }
+}
+
+pub fn severity(snap: &Snapshot) -> PaceSeverity {
+    severity_for(snap.worst_pct())
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &Snapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let severity = severity(snap);
+    let format = opts.format.as_deref().unwrap_or(DEFAULT_FORMAT);
+    let mut values = build_placeholders(snap, now);
+    for key in ["plan", "copilot_plan"] {
+        if let Some(value) = values.get_mut(key) {
+            *value = escape(value);
+        }
+    }
+    let mut text = substitute(format, &values);
+    if outcome.stale {
+        text.push_str(" ⏸");
+    }
+    let icon = opts
+        .icon
+        .as_deref()
+        .filter(|icon| !icon.is_empty())
+        .map(|icon| format!("{} ", escape(icon)))
+        .unwrap_or_default();
+    let tooltip = opts
+        .tooltip_format
+        .as_deref()
+        .map(|format| substitute(format, &values))
+        .unwrap_or_else(|| render_tooltip(outcome, snap, theme, now));
+    WaybarOutput {
+        text: color_span(severity_color(severity, theme), &format!("{icon}{text}")),
+        tooltip,
+        class: Class::from(severity),
+    }
+}
+
+fn render_tooltip(
+    outcome: &VendorOutcome,
+    snap: &Snapshot,
+    theme: &Theme,
+    now: DateTime<Utc>,
+) -> String {
+    let mut lines = vec![TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{}'>GitHub Copilot {}</span>",
+        theme.blue,
+        escape(&crate::display::sanitize_untrusted_field(&snap.plan))
+    ))];
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(String::new()));
+    for (label, quota) in snap.quotas() {
+        let usage = if quota.unlimited {
+            "Unlimited".to_string()
+        } else if let Some((used, entitlement)) = quota.used_and_entitlement() {
+            format!("{}% · {used} of {entitlement} used", quota.used_pct())
+        } else {
+            format!(
+                "{}% · {}% remaining",
+                quota.used_pct(),
+                quota.percent_remaining
+            )
+        };
+        lines.push(TooltipLine::Body(format!("  {label}  {}", escape(&usage))));
+    }
+    lines.push(TooltipLine::Body(format!(
+        "  Resets  {}",
+        escape(&countdown::format(snap.reset_at, now))
+    )));
+    if outcome.stale {
+        lines.push(TooltipLine::Body(String::new()));
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{}'>  ⏸  Showing cached data</span>",
+            theme.orange
+        )));
+    }
+    if let Some((code, message)) = outcome.last_error.as_ref()
+        && *code != 0
+    {
+        lines.push(TooltipLine::Body(String::new()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{}'>  HTTP {code}: {}</span>",
+            theme.orange,
+            escape(message)
+        )));
+    }
+    lines.push(TooltipLine::Body(String::new()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{}'>  Updated {}</span>",
+        theme.dim,
+        updated_at_hm(now, outcome.cache_age)
+    )));
+    render_bordered(&lines, theme)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::copilot::types::Quota;
+
+    fn sample() -> Snapshot {
+        Snapshot {
+            plan: "Pro".into(),
+            premium: Some(Quota {
+                percent_remaining: 15,
+                entitlement: Some(300),
+                remaining: Some(45),
+                unlimited: false,
+            }),
+            chat: None,
+            completions: None,
+            reset_at: None,
+        }
+    }
+
+    #[test]
+    fn exposes_provider_and_generic_quota_placeholders() {
+        let values = build_placeholders(&sample(), Utc::now());
+        assert_eq!(values["vendor_short"], "ghc");
+        assert_eq!(values["copilot_premium_pct"], "85");
+        assert_eq!(values["copilot_premium_used"], "255");
+        assert_eq!(values["session_pct"], "85");
+        assert_eq!(values["weekly_pct"], UNAVAILABLE);
+    }
+
+    #[test]
+    fn renderer_uses_the_premium_quota_and_canonical_provider_name() {
+        let snap = sample();
+        let outcome = VendorOutcome::fresh(crate::usage::VendorSnapshot::Copilot(snap.clone()));
+        let output = render(
+            &outcome,
+            &snap,
+            &Theme::default(),
+            &RenderOpts {
+                format: None,
+                tooltip_format: None,
+                icon: None,
+                pace_tolerance: 5,
+                format_pace_color: false,
+                tooltip_pace_pts: false,
+            },
+            Utc::now(),
+        );
+        assert!(output.text.contains("85%"));
+        assert!(output.tooltip.contains("GitHub Copilot Pro"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod claude_desktop;
 pub mod commandcode;
 pub mod config;
 pub mod context;
+pub mod copilot;
 pub mod countdown;
 pub mod cursor;
 pub mod deepseek;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -526,6 +526,15 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
                     .await?;
             Ok(outcome.into())
         }
+        VendorId::Copilot => {
+            let token = config.copilot.resolve_token()?;
+            let cache = crate::cache::Cache::for_vendor("copilot")?;
+            let endpoints = crate::copilot::fetch::Endpoints::default();
+            let outcome =
+                crate::copilot::fetch_snapshot(client, &token, &cache, &endpoints, DEFAULT_TTL)
+                    .await?;
+            Ok(outcome.into())
+        }
         VendorId::Deepseek => {
             let api_key = crate::config::resolve_api_key(
                 "DeepSeek",

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -140,6 +140,12 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
             }
             (s.plan.clone(), cells)
         }
+        VendorSnapshot::Copilot(s) => (
+            s.plan.clone(),
+            s.quotas()
+                .map(|(label, quota)| pct(label, quota.used_pct()))
+                .collect(),
+        ),
         VendorSnapshot::Zai(s) => {
             let mut cells = Vec::new();
             if let Some(w) = &s.session {
@@ -243,6 +249,7 @@ pub fn headline_pct(snapshot: &VendorSnapshot) -> Option<i32> {
         .into_iter()
         .flatten()
         .max(),
+        VendorSnapshot::Copilot(s) => s.quotas().map(|(_, quota)| quota.used_pct()).max(),
         VendorSnapshot::Zai(s) => [
             s.session.as_ref().map(|w| w.utilization_pct),
             s.weekly.as_ref().map(|w| w.utilization_pct),
@@ -330,6 +337,7 @@ pub(crate) fn sections_with_metadata_for(
                 VendorSnapshot::Anthropic(s) => anthropic_sections(s, now, pace_tolerance),
                 VendorSnapshot::AnthropicApi(s) => anthropic_api_sections(s),
                 VendorSnapshot::Openai(s) => openai_sections(s, now, pace_tolerance),
+                VendorSnapshot::Copilot(s) => copilot_sections(s, now),
                 VendorSnapshot::Zai(s) => zai_sections(s, now, pace_tolerance),
                 VendorSnapshot::Openrouter(s) => openrouter_sections(s),
                 VendorSnapshot::Deepseek(s) => deepseek_sections(s),
@@ -584,6 +592,45 @@ fn openai_sections(
         });
     }
     v
+}
+
+fn copilot_sections(s: &crate::copilot::types::Snapshot, now: DateTime<Utc>) -> SectionBuilder {
+    let mut sections = SectionBuilder::new(vec![Section::Title {
+        left: format!("GitHub Copilot {}", s.plan),
+        right: None,
+    }]);
+    for (label, quota) in s.quotas() {
+        let pct = quota.used_pct();
+        let detail = if quota.unlimited {
+            "Unlimited".to_string()
+        } else {
+            quota
+                .used_and_entitlement()
+                .map(|(used, entitlement)| format!("{used} of {entitlement} used"))
+                .unwrap_or_else(|| format!("{}% remaining", quota.percent_remaining))
+        };
+        sections.push(Section::Spacer);
+        sections.push_metric(
+            Section::Metric {
+                label: label.to_string(),
+                pct: pct.clamp(0, 100) as u16,
+                severity: severity_for(pct),
+                value_label: if quota.unlimited {
+                    "Unlimited".to_string()
+                } else {
+                    format!("{pct}%")
+                },
+                footnote: detail,
+            },
+            s.reset_at,
+        );
+    }
+    sections.push(Section::Spacer);
+    sections.push(Section::Text {
+        label: "Resets".into(),
+        value: countdown::format(s.reset_at, now),
+    });
+    sections
 }
 
 fn zai_sections(s: &crate::usage::ZaiSnapshot, now: DateTime<Utc>, tol: u32) -> SectionBuilder {
@@ -1390,6 +1437,41 @@ mod tests {
             last_error: None,
             fetched_at: Some(now() - chrono::Duration::seconds(15)),
         }))
+    }
+
+    #[test]
+    fn copilot_sections_carry_quota_reset_metadata() {
+        let reset_at = now() + chrono::Duration::days(4);
+        let snapshot = VendorSnapshot::Copilot(crate::copilot::types::Snapshot {
+            plan: "Pro".into(),
+            premium: Some(crate::copilot::types::Quota {
+                percent_remaining: 25,
+                entitlement: Some(300),
+                remaining: Some(75),
+                unlimited: false,
+            }),
+            chat: None,
+            completions: None,
+            reset_at: Some(reset_at),
+        });
+        let sections = sections_with_metadata_for(&ready(snapshot), now(), 5);
+        assert!(matches!(
+            &sections[0].section,
+            Section::Title { left, .. } if left == "GitHub Copilot Pro"
+        ));
+        let metric = sections
+            .iter()
+            .find(|projection| matches!(&projection.section, Section::Metric { .. }))
+            .expect("premium metric");
+        assert_eq!(metric.reset_at, Some(reset_at));
+        assert!(matches!(
+            &metric.section,
+            Section::Metric { label, pct, value_label, footnote, .. }
+                if label == "Premium requests"
+                    && *pct == 75
+                    && value_label == "75%"
+                    && footnote == "225 of 300 used"
+        ));
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -1,9 +1,10 @@
 //! Settings overlay — opened from the TUI by pressing `s`. Lets the user pick
-//! the primary vendor and paste a credential for any credential-authenticated vendor
+//! the primary vendor and paste a credential for any API-key-authenticated vendor
 //! (including Z.AI, Kimi, MiniMax, and the balance vendors) without hand-editing
-//! config.toml. Anthropic, OpenAI, Cursor, Kiro, Antigravity, and Command Code
-//! authenticate through local product state, so they have no credential field here —
-//! there is nothing to paste, and a field would only imply otherwise. Kimi keeps
+//! config.toml. Anthropic, OpenAI, GitHub Copilot, Cursor, Kiro, Antigravity, and
+//! Command Code authenticate through official or local product state, so they have
+//! no credential field here — there is nothing to paste, and a field would only
+//! imply otherwise. Kimi keeps
 //! its credential field because a platform key is still one of its two credentials, but
 //! a subscriber whose credential is the Kimi Code CLI login has nothing to paste
 //! and enables `[kimi]` in config.toml instead.
@@ -149,15 +150,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         secret_label: "API key",
         note: "usage quota",
     },
-    KeyVendor {
-        id: VendorId::Copilot,
-        label: "GitHub Copilot",
-        env: "GITHUB_COPILOT_TOKEN",
-        section: "copilot",
-        config_key: "token",
-        secret_label: "GitHub OAuth token",
-        note: "",
-    },
 ];
 
 /// Read the inline credential currently in config, so the field opens
@@ -175,7 +167,6 @@ fn config_inline_key<'a>(cfg: &'a Config, vendor: &KeyVendor) -> Option<&'a str>
         "grok" => cfg.grok.api_key.as_deref(),
         "minimax" => cfg.minimax.api_key.as_deref(),
         "opencode-go" => cfg.opencode_go.api_key.as_deref(),
-        "copilot" => cfg.copilot.token.as_deref(),
         _ => None,
     }
 }
@@ -321,14 +312,23 @@ impl SettingsState {
             .iter()
             .map(|kv| KeyInput::from_config(config_inline_key(cfg, kv)))
             .collect();
-        let primary_choices = cfg.enabled_vendors();
+        let mut primary_choices = cfg.enabled_vendors();
+        // Copilot credentials belong to GitHub CLI, so a login cannot write a
+        // local key that would also opt it in. Offer it explicitly instead:
+        // selecting it persists both the primary and `enabled = true`.
+        if !primary_choices.contains(&VendorId::Copilot) {
+            primary_choices.push(VendorId::Copilot);
+        }
         // A configured but disabled primary is ineffective. Display the first
         // enabled vendor instead; when none are enabled retain the historical
         // Anthropic fallback in memory without inventing a persisted primary.
         let primary = cfg
             .ui
             .primary
-            .filter(|vendor| primary_choices.contains(vendor))
+            .filter(|vendor| {
+                primary_choices.contains(vendor)
+                    && (*vendor != VendorId::Copilot || cfg.copilot.enabled)
+            })
             .or_else(|| primary_choices.first().copied())
             .unwrap_or_else(|| cfg.ui.primary.unwrap_or(VendorId::Anthropic));
         Self {
@@ -509,11 +509,25 @@ pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
         })?
     };
 
-    // Do not write a disabled primary as a side effect of saving an API key.
-    // With no enabled vendors, leave any existing value alone so the legacy
-    // resolver's Anthropic fallback remains intact.
+    // Remove fields written by the short-lived inline Copilot-token design.
+    // GitHub CLI owns the OAuth credential now; retaining a secret this app
+    // neither reads nor supports would be misleading and unsafe.
+    if let Some(table) = doc
+        .get_mut("copilot")
+        .and_then(toml_edit::Item::as_table_mut)
+    {
+        table.remove("token");
+        table.remove("token_env");
+    }
+
+    // Only Copilot is deliberately offered before it is enabled: choosing it
+    // is the explicit opt-in after the GitHub CLI login. All other choices
+    // remain enabled-only, so no failed provider is persisted as primary.
     if state.primary_choices.contains(&state.primary) {
         set_string(&mut doc, "ui", "primary", state.primary.slug())?;
+        if state.primary == VendorId::Copilot {
+            set_bool(&mut doc, "copilot", "enabled", true)?;
+        }
     }
 
     for (i, kv) in KEY_VENDORS.iter().enumerate() {
@@ -676,7 +690,6 @@ fn configured_key_env<'a>(cfg: &'a Config, section: &str, fallback: &'a str) -> 
         "grok" => &cfg.grok.api_key_env,
         "minimax" => &cfg.minimax.api_key_env,
         "opencode-go" => &cfg.opencode_go.api_key_env,
-        "copilot" => &cfg.copilot.token_env,
         _ => fallback,
     }
 }
@@ -1118,7 +1131,6 @@ mod tests {
             VendorId::Novita,
             VendorId::Moonshot,
             VendorId::Grok,
-            VendorId::Copilot,
         ] {
             assert!(
                 KEY_VENDORS.iter().any(|kv| kv.id == id),
@@ -1140,25 +1152,26 @@ mod tests {
     }
 
     #[test]
-    fn from_config_prefills_existing_copilot_token() {
-        let mut cfg = Config::default();
-        cfg.copilot.token = Some("saved-copilot-token".into());
-        let state = SettingsState::from_config(&cfg);
-        assert_eq!(
-            state.keys[key_index(VendorId::Copilot)].buf,
-            "saved-copilot-token"
+    fn copilot_has_no_editable_credential_field() {
+        assert!(
+            !KEY_VENDORS
+                .iter()
+                .any(|vendor| vendor.id == VendorId::Copilot)
         );
-        assert!(!state.keys[key_index(VendorId::Copilot)].dirty);
     }
 
     #[test]
     fn from_config_offers_enabled_vendors_only() {
         let cfg = Config::default();
         let s = SettingsState::from_config(&cfg);
-        assert_eq!(s.primary_choices, cfg.enabled_vendors());
-        // Opt-in vendors are disabled by default and must not be offered.
+        let mut expected = cfg.enabled_vendors();
+        expected.push(VendorId::Copilot);
+        assert_eq!(s.primary_choices, expected);
+        // API-key opt-in vendors are disabled by default and must not be
+        // offered. Copilot is the exception: choosing it enables it safely.
         assert!(!s.primary_choices.contains(&VendorId::Grok));
         assert!(s.primary_choices.contains(&s.primary));
+        assert!(s.primary_choices.contains(&VendorId::Copilot));
     }
 
     #[test]
@@ -1389,6 +1402,16 @@ api_key_env = "OPENROUTER_WORK_API_KEY"
     }
 
     #[test]
+    fn disabled_copilot_is_offered_but_not_shown_as_the_current_primary() {
+        let mut cfg = Config::default();
+        cfg.ui.primary = Some(VendorId::Copilot);
+        let state = SettingsState::from_config(&cfg);
+
+        assert!(state.primary_choices.contains(&VendorId::Copilot));
+        assert_eq!(state.primary, VendorId::Anthropic);
+    }
+
+    #[test]
     fn save_does_not_write_a_disabled_primary() {
         // Saving an API key must not persist a primary the resolver would
         // ignore; an existing value in the file stays untouched.
@@ -1597,24 +1620,24 @@ api_key_env = "OPENROUTER_WORK_API_KEY"
     }
 
     #[test]
-    fn native_snapshot_reports_copilot_presence_without_serializing_token() {
-        let mut cfg = Config::default();
-        cfg.copilot.token = Some("never-leak-this-copilot-token".into());
-        let raw = settings_snapshot_json_with(&cfg, |name| name == "GITHUB_COPILOT_TOKEN").unwrap();
+    fn native_snapshot_offers_copilot_primary_without_a_token_field() {
+        let cfg = Config::default();
+        let raw = settings_snapshot_json_with(&cfg, |_| false).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
-        let copilot = parsed["keys"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .find(|row| row["id"] == "copilot")
-            .unwrap();
-        assert_eq!(copilot["configured"], true);
-        assert_eq!(copilot["inline_configured"], true);
-        assert_eq!(copilot["environment_configured"], true);
-        assert_eq!(copilot["environment"], "GITHUB_COPILOT_TOKEN");
-        assert_eq!(copilot["secret_label"], "GitHub OAuth token");
-        assert!(!raw.contains("never-leak-this-copilot-token"));
-        assert!(parsed.get("token").is_none());
+        assert!(
+            parsed["primary_choices"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|row| row["id"] == "copilot")
+        );
+        assert!(
+            !parsed["keys"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|row| row["id"] == "copilot")
+        );
     }
 
     #[test]
@@ -1690,25 +1713,21 @@ enabled = true
     }
 
     #[test]
-    fn native_patch_saves_and_clears_copilot_token() {
-        let (_dir, path) = temp_config(Some("[copilot]\nenabled = false\n"));
+    fn native_primary_selection_enables_copilot_without_writing_a_token() {
+        let (_dir, path) = temp_config(Some(
+            "[copilot]\nenabled = false\ntoken = \"legacy-value\"\ntoken_env = \"OLD_TOKEN\"\n",
+        ));
         let cfg = Config::load_from(&path).unwrap();
-        let save = serde_json::json!({
+        let select = serde_json::json!({
             "schema_version": 1,
-            "keys": {"copilot": {"action": "set", "value": "saved-copilot-token"}}
+            "primary": "copilot"
         });
-        apply_settings_json_to_path(&cfg, &save.to_string(), &path).unwrap();
+        apply_settings_json_to_path(&cfg, &select.to_string(), &path).unwrap();
         let raw = std::fs::read_to_string(&path).unwrap();
-        assert!(raw.contains("token = \"saved-copilot-token\""));
         assert!(raw.contains("enabled = true"));
-
-        let cfg = Config::load_from(&path).unwrap();
-        let clear = serde_json::json!({
-            "schema_version": 1,
-            "keys": {"copilot": {"action": "clear"}}
-        });
-        apply_settings_json_to_path(&cfg, &clear.to_string(), &path).unwrap();
-        assert!(!std::fs::read_to_string(&path).unwrap().contains("token ="));
+        assert!(raw.contains("primary = \"copilot\""));
+        assert!(!raw.contains("token ="));
+        assert!(!raw.contains("token_env ="));
     }
 
     #[test]

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -1,17 +1,17 @@
 //! Settings overlay — opened from the TUI by pressing `s`. Lets the user pick
-//! the primary vendor and paste an API key for any key-authenticated vendor
+//! the primary vendor and paste a credential for any credential-authenticated vendor
 //! (including Z.AI, Kimi, MiniMax, and the balance vendors) without hand-editing
 //! config.toml. Anthropic, OpenAI, Cursor, Kiro, Antigravity, and Command Code
-//! authenticate through local product state, so they have no key field here —
+//! authenticate through local product state, so they have no credential field here —
 //! there is nothing to paste, and a field would only imply otherwise. Kimi keeps
-//! its key field because a platform key is still one of its two credentials, but
+//! its credential field because a platform key is still one of its two credentials, but
 //! a subscriber whose credential is the Kimi Code CLI login has nothing to paste
 //! and enables `[kimi]` in config.toml instead.
 //!
 //! Persistence uses `toml_edit` so the existing config keeps its comments,
 //! whitespace, and unrelated fields. Writing a key also flips that vendor's
 //! `enabled = true` (the opt-in vendors are disabled by default), so "paste the
-//! key and save" is all it takes. Files with inline keys are atomically written
+//! credential and save" is all it takes. Files with inline credentials are atomically written
 //! and `chmod 600`ed.
 
 use std::collections::BTreeMap;
@@ -33,14 +33,18 @@ use crate::theme::Theme;
 use crate::tui::style::bubble_theme;
 use crate::vendor::VendorId;
 
-/// A vendor that authenticates with an inline API key (vs. OAuth). The order of
-/// this table is the tab order of the key fields and the layout of the state's
-/// `keys` vec.
+/// A vendor that authenticates with an inline credential. The order of this
+/// table is the tab order of the credential fields and the layout of the
+/// state's `keys` vec.
 pub struct KeyVendor {
     pub id: VendorId,
     pub label: &'static str,
     pub env: &'static str,
     pub section: &'static str,
+    /// Config field that stores the credential (`api_key` for most vendors).
+    pub config_key: &'static str,
+    /// Human-readable name shown in the native settings form.
+    pub secret_label: &'static str,
     /// Extra hint after the env var (e.g. "management key"). Empty for none.
     pub note: &'static str,
 }
@@ -51,6 +55,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Anthropic API",
         env: "ANTHROPIC_ADMIN_KEY",
         section: "anthropic_api",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "admin key — monthly spend",
     },
     KeyVendor {
@@ -58,6 +64,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Z.AI",
         env: "ZAI_API_KEY",
         section: "zai",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "",
     },
     KeyVendor {
@@ -65,6 +73,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "OpenRouter",
         env: "OPENROUTER_API_KEY",
         section: "openrouter",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "",
     },
     KeyVendor {
@@ -72,6 +82,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "DeepSeek",
         env: "DEEPSEEK_API_KEY",
         section: "deepseek",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "",
     },
     KeyVendor {
@@ -79,6 +91,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Kimi",
         env: "KIMI_API_KEY",
         section: "kimi",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "coding-plan usage",
     },
     KeyVendor {
@@ -86,6 +100,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Kilo",
         env: "KILO_API_KEY",
         section: "kilo",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "",
     },
     KeyVendor {
@@ -93,6 +109,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Novita",
         env: "NOVITA_API_KEY",
         section: "novita",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "",
     },
     KeyVendor {
@@ -100,6 +118,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Moonshot",
         env: "MOONSHOT_API_KEY",
         section: "moonshot",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "account balance",
     },
     KeyVendor {
@@ -107,6 +127,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "Grok",
         env: "XAI_MANAGEMENT_KEY",
         section: "grok",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "management key, not the inference key",
     },
     KeyVendor {
@@ -114,6 +136,8 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "MiniMax",
         env: "MINIMAX_API_KEY",
         section: "minimax",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "Token Plan subscription key",
     },
     KeyVendor {
@@ -121,14 +145,25 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         label: "OpenCode Go",
         env: "OPENCODE_GO_API_KEY",
         section: "opencode-go",
+        config_key: "api_key",
+        secret_label: "API key",
         note: "usage quota",
+    },
+    KeyVendor {
+        id: VendorId::Copilot,
+        label: "GitHub Copilot",
+        env: "GITHUB_COPILOT_TOKEN",
+        section: "copilot",
+        config_key: "token",
+        secret_label: "GitHub OAuth token",
+        note: "",
     },
 ];
 
-/// Read the inline `api_key` currently in config for a given section, so the
-/// field opens pre-filled (masked) when one is already set.
-fn config_inline_key<'a>(cfg: &'a Config, section: &str) -> Option<&'a str> {
-    match section {
+/// Read the inline credential currently in config, so the field opens
+/// pre-filled (masked) when one is already set.
+fn config_inline_key<'a>(cfg: &'a Config, vendor: &KeyVendor) -> Option<&'a str> {
+    match vendor.section {
         "anthropic_api" => cfg.anthropic_api.api_key.as_deref(),
         "zai" => cfg.zai.api_key.as_deref(),
         "openrouter" => cfg.openrouter.api_key.as_deref(),
@@ -140,6 +175,7 @@ fn config_inline_key<'a>(cfg: &'a Config, section: &str) -> Option<&'a str> {
         "grok" => cfg.grok.api_key.as_deref(),
         "minimax" => cfg.minimax.api_key.as_deref(),
         "opencode-go" => cfg.opencode_go.api_key.as_deref(),
+        "copilot" => cfg.copilot.token.as_deref(),
         _ => None,
     }
 }
@@ -283,7 +319,7 @@ impl SettingsState {
     pub fn from_config(cfg: &Config) -> Self {
         let keys = KEY_VENDORS
             .iter()
-            .map(|kv| KeyInput::from_config(config_inline_key(cfg, kv.section)))
+            .map(|kv| KeyInput::from_config(config_inline_key(cfg, kv)))
             .collect();
         let primary_choices = cfg.enabled_vendors();
         // A configured but disabled primary is ineffective. Display the first
@@ -458,7 +494,7 @@ fn save_to_config_default(state: &SettingsState) -> Result<()> {
 }
 
 /// Same as `save_to_config_default` but with an explicit path — exposed for
-/// tests. Writing a non-empty key also sets that vendor's `enabled = true`.
+/// tests. Writing a non-empty credential also sets that vendor's `enabled = true`.
 pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
     let original = match std::fs::read_to_string(path) {
         Ok(contents) => contents,
@@ -484,7 +520,7 @@ pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
         let Some(input) = state.keys.get(i) else {
             continue;
         };
-        update_key(&mut doc, kv.section, input)?;
+        update_key(&mut doc, kv, input)?;
     }
 
     let bytes = doc.to_string();
@@ -502,22 +538,26 @@ pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Apply one key field to the document. Untouched fields are left alone; a
-/// field the user cleared is *removed*, so an inline secret can be deleted
-/// from the overlay rather than lingering in the file. Writing a non-empty key
-/// also opts the vendor in — the opt-in vendors would otherwise never fetch.
-fn update_key(doc: &mut DocumentMut, section: &str, input: &KeyInput) -> Result<()> {
+/// Apply one credential field to the document. Untouched fields are left
+/// alone; a field the user cleared is *removed*, so an inline secret can be
+/// deleted from the overlay rather than lingering in the file. Writing a
+/// non-empty credential also opts the vendor in — the opt-in vendors would
+/// otherwise never fetch.
+fn update_key(doc: &mut DocumentMut, vendor: &KeyVendor, input: &KeyInput) -> Result<()> {
     if !input.dirty {
         return Ok(());
     }
     if input.buf.is_empty() {
-        if let Some(table) = doc.get_mut(section).and_then(toml_edit::Item::as_table_mut) {
-            table.remove("api_key");
+        if let Some(table) = doc
+            .get_mut(vendor.section)
+            .and_then(toml_edit::Item::as_table_mut)
+        {
+            table.remove(vendor.config_key);
         }
         return Ok(());
     }
-    set_string(doc, section, "api_key", &input.buf)?;
-    set_bool(doc, section, "enabled", true)
+    set_string(doc, vendor.section, vendor.config_key, &input.buf)?;
+    set_bool(doc, vendor.section, "enabled", true)
 }
 
 /// Set or update a string field in a TOML section, preserving comments and
@@ -593,6 +633,7 @@ struct KeyStatus {
     id: String,
     label: String,
     environment: String,
+    secret_label: String,
     note: String,
     configured: bool,
     inline_configured: bool,
@@ -635,6 +676,7 @@ fn configured_key_env<'a>(cfg: &'a Config, section: &str, fallback: &'a str) -> 
         "grok" => &cfg.grok.api_key_env,
         "minimax" => &cfg.minimax.api_key_env,
         "opencode-go" => &cfg.opencode_go.api_key_env,
+        "copilot" => &cfg.copilot.token_env,
         _ => fallback,
     }
 }
@@ -656,13 +698,13 @@ fn snapshot_from_config_with(
         .iter()
         .map(|vendor| {
             let environment = configured_key_env(cfg, vendor.section, vendor.env);
-            let inline_configured =
-                config_inline_key(cfg, vendor.section).is_some_and(|v| !v.is_empty());
+            let inline_configured = config_inline_key(cfg, vendor).is_some_and(|v| !v.is_empty());
             let environment_configured = environment_configured(environment);
             KeyStatus {
                 id: vendor.id.slug().to_string(),
                 label: vendor.label.to_string(),
                 environment: environment.to_string(),
+                secret_label: vendor.secret_label.to_string(),
                 note: vendor.note.to_string(),
                 configured: inline_configured || environment_configured,
                 inline_configured,
@@ -725,23 +767,26 @@ fn state_from_apply_request(cfg: &Config, raw: &str) -> Result<SettingsState> {
         let index = KEY_VENDORS
             .iter()
             .position(|vendor| vendor.id.slug() == id)
-            .ok_or_else(|| AppError::Other(format!("unknown API-key vendor {id:?}")))?;
+            .ok_or_else(|| AppError::Other(format!("unknown credential vendor {id:?}")))?;
         let input = &mut state.keys[index];
         match mutation {
             KeyMutation::Set { value } => {
                 if value.is_empty() {
                     return Err(AppError::Other(format!(
-                        "API key for {id:?} is empty; use the clear action to remove it"
+                        "{} for {id:?} is empty; use the clear action to remove it",
+                        KEY_VENDORS[index].secret_label
                     )));
                 }
                 if value.len() > MAX_API_KEY_BYTES {
                     return Err(AppError::Other(format!(
-                        "API key for {id:?} exceeds {MAX_API_KEY_BYTES} bytes"
+                        "{} for {id:?} exceeds {MAX_API_KEY_BYTES} bytes",
+                        KEY_VENDORS[index].secret_label
                     )));
                 }
                 if value.chars().any(char::is_control) {
                     return Err(AppError::Other(format!(
-                        "API key for {id:?} contains control characters"
+                        "{} for {id:?} contains control characters",
+                        KEY_VENDORS[index].secret_label
                     )));
                 }
                 input.buf = value;
@@ -826,14 +871,14 @@ pub fn render(f: &mut Frame, area: Rect, state: &SettingsState, theme: &Theme) {
         .constraints([Constraint::Min(0), Constraint::Length(1)])
         .split(inner);
 
-    // — Primary vendor + API keys header —
+    // — Primary vendor + credentials header —
     let mut lines: Vec<Line> = vec![
         section_header("Primary vendor", "shown first on the bar / TUI", &bubble),
         primary_line(state, &bubble),
         Line::from(""),
         section_header(
-            "API keys",
-            "pick a row, type the key, then Ctrl-S — Claude & Codex use CLI login",
+            "Credentials",
+            "pick a row, type the credential, then Ctrl-S — Claude & Codex use CLI login",
             &bubble,
         ),
     ];
@@ -1073,6 +1118,7 @@ mod tests {
             VendorId::Novita,
             VendorId::Moonshot,
             VendorId::Grok,
+            VendorId::Copilot,
         ] {
             assert!(
                 KEY_VENDORS.iter().any(|kv| kv.id == id),
@@ -1091,6 +1137,18 @@ mod tests {
         let s = SettingsState::from_config(&cfg);
         assert_eq!(s.keys[key_index(VendorId::Kilo)].buf, "sk-kilo");
         assert!(!s.keys[key_index(VendorId::Kilo)].dirty);
+    }
+
+    #[test]
+    fn from_config_prefills_existing_copilot_token() {
+        let mut cfg = Config::default();
+        cfg.copilot.token = Some("saved-copilot-token".into());
+        let state = SettingsState::from_config(&cfg);
+        assert_eq!(
+            state.keys[key_index(VendorId::Copilot)].buf,
+            "saved-copilot-token"
+        );
+        assert!(!state.keys[key_index(VendorId::Copilot)].dirty);
     }
 
     #[test]
@@ -1539,6 +1597,27 @@ api_key_env = "OPENROUTER_WORK_API_KEY"
     }
 
     #[test]
+    fn native_snapshot_reports_copilot_presence_without_serializing_token() {
+        let mut cfg = Config::default();
+        cfg.copilot.token = Some("never-leak-this-copilot-token".into());
+        let raw = settings_snapshot_json_with(&cfg, |name| name == "GITHUB_COPILOT_TOKEN").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap();
+        let copilot = parsed["keys"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == "copilot")
+            .unwrap();
+        assert_eq!(copilot["configured"], true);
+        assert_eq!(copilot["inline_configured"], true);
+        assert_eq!(copilot["environment_configured"], true);
+        assert_eq!(copilot["environment"], "GITHUB_COPILOT_TOKEN");
+        assert_eq!(copilot["secret_label"], "GitHub OAuth token");
+        assert!(!raw.contains("never-leak-this-copilot-token"));
+        assert!(parsed.get("token").is_none());
+    }
+
+    #[test]
     fn native_key_only_patch_does_not_require_or_replace_primary() {
         let cfg = Config::default();
         let original_primary = SettingsState::from_config(&cfg).primary;
@@ -1608,6 +1687,28 @@ enabled = true
         let raw = std::fs::read_to_string(&path).unwrap();
         assert!(!raw.contains("remove-me"));
         assert!(raw.contains("keep-me"));
+    }
+
+    #[test]
+    fn native_patch_saves_and_clears_copilot_token() {
+        let (_dir, path) = temp_config(Some("[copilot]\nenabled = false\n"));
+        let cfg = Config::load_from(&path).unwrap();
+        let save = serde_json::json!({
+            "schema_version": 1,
+            "keys": {"copilot": {"action": "set", "value": "saved-copilot-token"}}
+        });
+        apply_settings_json_to_path(&cfg, &save.to_string(), &path).unwrap();
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.contains("token = \"saved-copilot-token\""));
+        assert!(raw.contains("enabled = true"));
+
+        let cfg = Config::load_from(&path).unwrap();
+        let clear = serde_json::json!({
+            "schema_version": 1,
+            "keys": {"copilot": {"action": "clear"}}
+        });
+        apply_settings_json_to_path(&cfg, &clear.to_string(), &path).unwrap();
+        assert!(!std::fs::read_to_string(&path).unwrap().contains("token ="));
     }
 
     #[test]

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -334,6 +334,7 @@ impl KimiSnapshot {
 pub enum VendorSnapshot {
     Anthropic(AnthropicSnapshot),
     Openai(OpenAiSnapshot),
+    Copilot(crate::copilot::types::Snapshot),
     Zai(ZaiSnapshot),
     Openrouter(OpenRouterSnapshot),
     Deepseek(DeepseekSnapshot),

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -38,6 +38,8 @@ pub(crate) const VENDOR_SECRET_ENV_VARS: &[&str] = &[
     "OPENCODE_GO_API_KEY",
     "COMMANDCODE_API_KEY",
     "GITHUB_COPILOT_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
 ];
 
 pub(crate) fn vendor_secret_env_vars_to_remove(keep: &[&str]) -> Vec<&'static str> {

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -37,6 +37,7 @@ pub(crate) const VENDOR_SECRET_ENV_VARS: &[&str] = &[
     "GROK_API_KEY",
     "OPENCODE_GO_API_KEY",
     "COMMANDCODE_API_KEY",
+    "GITHUB_COPILOT_TOKEN",
 ];
 
 pub(crate) fn vendor_secret_env_vars_to_remove(keep: &[&str]) -> Vec<&'static str> {
@@ -112,6 +113,7 @@ pub enum VendorId {
     #[serde(rename = "anthropic_api")]
     AnthropicApi,
     Openai,
+    Copilot,
     Zai,
     Openrouter,
     Deepseek,
@@ -139,6 +141,7 @@ impl VendorId {
             VendorId::Anthropic => "anthropic",
             VendorId::AnthropicApi => "anthropic_api",
             VendorId::Openai => "openai",
+            VendorId::Copilot => "copilot",
             VendorId::Zai => "zai",
             VendorId::Openrouter => "openrouter",
             VendorId::Deepseek => "deepseek",
@@ -166,6 +169,7 @@ impl VendorId {
             VendorId::Anthropic => "Claude",
             VendorId::AnthropicApi => "Anthropic API",
             VendorId::Openai => "Codex",
+            VendorId::Copilot => "GitHub Copilot",
             VendorId::Zai => "Z.AI",
             VendorId::Openrouter => "OpenRouter",
             VendorId::Deepseek => "DeepSeek",
@@ -194,6 +198,7 @@ impl VendorId {
             VendorId::Anthropic => "cld",
             VendorId::AnthropicApi => "aac",
             VendorId::Openai => "gpt",
+            VendorId::Copilot => "ghc",
             VendorId::Zai => "zai",
             VendorId::Openrouter => "opr",
             VendorId::Deepseek => "dsk",
@@ -218,6 +223,7 @@ impl VendorId {
             VendorId::Anthropic,
             VendorId::AnthropicApi,
             VendorId::Openai,
+            VendorId::Copilot,
             VendorId::Zai,
             VendorId::Openrouter,
             VendorId::Deepseek,
@@ -331,6 +337,7 @@ mod tests {
             "MOONSHOT_API_KEY",
             "XAI_MANAGEMENT_KEY",
             "ANTHROPIC_ADMIN_KEY",
+            "GITHUB_COPILOT_TOKEN",
         ];
         for name in configured_defaults {
             assert!(VENDOR_SECRET_ENV_VARS.contains(&name), "missing {name}");
@@ -345,6 +352,12 @@ mod tests {
         assert!(removed.contains(&"ANTHROPIC_ADMIN_KEY"));
         assert!(removed.contains(&"OPENROUTER_API_KEY"));
         assert_eq!(removed.len(), VENDOR_SECRET_ENV_VARS.len() - 2);
+    }
+
+    #[test]
+    fn copilot_token_is_removed_before_unrelated_subprocesses_launch() {
+        let removed = vendor_secret_env_vars_to_remove(&[]);
+        assert!(removed.contains(&"GITHUB_COPILOT_TOKEN"));
     }
 
     #[tokio::test]

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -281,6 +281,7 @@ pub enum Vendor {
     #[value(name = "anthropic_api")]
     AnthropicApi,
     Openai,
+    Copilot,
     Zai,
     Openrouter,
     Deepseek,
@@ -308,6 +309,7 @@ impl Vendor {
             Vendor::Anthropic => crate::vendor::VendorId::Anthropic,
             Vendor::AnthropicApi => crate::vendor::VendorId::AnthropicApi,
             Vendor::Openai => crate::vendor::VendorId::Openai,
+            Vendor::Copilot => crate::vendor::VendorId::Copilot,
             Vendor::Zai => crate::vendor::VendorId::Zai,
             Vendor::Openrouter => crate::vendor::VendorId::Openrouter,
             Vendor::Deepseek => crate::vendor::VendorId::Deepseek,
@@ -399,6 +401,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::Anthropic => Vendor::Anthropic,
         crate::vendor::VendorId::AnthropicApi => Vendor::AnthropicApi,
         crate::vendor::VendorId::Openai => Vendor::Openai,
+        crate::vendor::VendorId::Copilot => Vendor::Copilot,
         crate::vendor::VendorId::Zai => Vendor::Zai,
         crate::vendor::VendorId::Openrouter => Vendor::Openrouter,
         crate::vendor::VendorId::Deepseek => Vendor::Deepseek,
@@ -467,6 +470,8 @@ mod tests {
         assert_eq!(nous.vendor, Some(Vendor::NousResearch));
         let opencode = Cli::parse_from(["ai-usagebar", "--vendor", "opencode-go"]);
         assert_eq!(opencode.vendor, Some(Vendor::OpenCodeGo));
+        let copilot = Cli::parse_from(["ai-usagebar", "--vendor", "copilot"]);
+        assert_eq!(copilot.vendor, Some(Vendor::Copilot));
         let login = Cli::parse_from(["ai-usagebar", "auth", "nous", "login"]);
         assert!(matches!(login.command, Some(Command::Auth { .. })));
     }

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -13,6 +13,7 @@ use crate::anthropic_api;
 use crate::antigravity;
 use crate::cache::{Cache, DEFAULT_TTL};
 use crate::config::Config;
+use crate::copilot;
 use crate::cursor;
 use crate::deepseek;
 use crate::error::{AppError, Result};
@@ -146,6 +147,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::AnthropicApi => anthropic_api_output(cli, &config).await,
         Vendor::Openrouter => openrouter_output(cli, &config).await,
         Vendor::Openai => openai_output(cli, &config).await,
+        Vendor::Copilot => copilot_output(cli, &config).await,
         Vendor::Zai => zai_output(cli, &config).await,
         Vendor::Deepseek => deepseek_output(cli, &config).await,
         Vendor::Kimi => kimi_output(cli, &config).await,
@@ -656,6 +658,30 @@ async fn openai_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
         &theme,
         &opts,
         chrono::Utc::now(),
+    ))
+}
+
+async fn copilot_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let token = config.copilot.resolve_token()?;
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "copilot")?;
+    let endpoints = copilot::fetch::Endpoints::default();
+    let outcome =
+        match copilot::fetch_snapshot(&client, &token, &cache, &endpoints, DEFAULT_TTL).await {
+            Ok(outcome) => outcome,
+            Err(error) if error.is_transient() => {
+                return Ok(WaybarOutput::loading(cli.icon.as_deref()));
+            }
+            Err(error) => return Err(error),
+        };
+    let snapshot = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    Ok(copilot::vendor::render(
+        &vendor_outcome,
+        &snapshot,
+        &theme_from_cli(cli),
+        &RenderOpts::from_cli(cli),
+        Utc::now(),
     ))
 }
 


### PR DESCRIPTION
## Summary
- add opt-in GitHub Copilot quota reporting for Premium requests, Chat, and Completions
- reuse the official GitHub CLI login via a fixed `gh auth token` subprocess; no token is stored, parsed from credential files, cached, or passed through the UI
- add a native Settings action that opens `gh auth login --web`, and let GitHub Copilot be selected as the primary provider (which enables it)
- add widget placeholders, TUI sections, report integration, configuration, and endpoint documentation

## Validation
- `make test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo machete`
- `omarchy plugin validate .`