### PR TITLE
fix(kimi): lead with the rolling 5h window, weekly under it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- Kimi leads with its rolling 5h window and carries the weekly quota under it,
+  the order every other two-window vendor uses — Claude's `Session (5h)` above
+  `Weekly (7d)`, Codex's `Codex 5h` above `Codex weekly`, GLM's `Session (5h)`
+  above `Weekly`. It was the one provider drawing the long window first, so a
+  glance across vendors compared different rows. The Waybar tooltip and the
+  shared panel projection both move, which carries the Omarchy Quattro panel,
+  the KDE plasmoid, the TUI detail panel, the TUI Overview row (`5h` before
+  `wk`) and `usage --json` with them. Kimi's Waybar bar text, the macOS menu
+  bar and the GNOME dropdown already read the 5h window off the `session_*`
+  alias and are unchanged.
+
 ## [1.9.1] — 2026-08-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,16 @@ Each release is also published at
   alias and are unchanged.
 
 - Kimi's quota rows drop their `55 / 100 · 45 left` counters and show the
-  plain `Resets in 3d 20h` every other window row shows. Kimi reports each
-  quota as used/limit against a limit of 100, so the pair was the percentage
-  in longhand — the bar and its `55%` directly above already said it, three
+  plain `Resets in 3d 20h` every other window row shows. Kimi was the only
+  vendor spelling a ratio out beside the bar that already draws it, and the
+  raw figures stay available through the `{kimi_*_used}`, `{kimi_*_limit}`
+  and `{kimi_*_remaining}` placeholders for anyone who wants them in a
+  custom format — the bar and its `55%` directly above already said it, three
   times over. Kimi's rows now go through the shared `push_window` instead of
   a hand-rolled near-copy of it, so the panel and the Waybar tooltip cannot
-  drift apart again. The tooltip is 16 columns narrower for it.
+  drift apart again. The tooltip is 16 columns narrower for it. The shared
+  `WindowRow::with_detail` hook the old rows used goes with them — Kimi was
+  its only caller.
 
 ## [1.9.1] — 2026-08-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Each release is also published at
   bar and the GNOME dropdown already read the 5h window off the `session_*`
   alias and are unchanged.
 
+- Kimi's quota rows drop their `55 / 100 · 45 left` counters and show the
+  plain `Resets in 3d 20h` every other window row shows. Kimi reports each
+  quota as used/limit against a limit of 100, so the pair was the percentage
+  in longhand — the bar and its `55%` directly above already said it, three
+  times over. Kimi's rows now go through the shared `push_window` instead of
+  a hand-rolled near-copy of it, so the panel and the Waybar tooltip cannot
+  drift apart again. The tooltip is 16 columns narrower for it.
+
 ## [1.9.1] — 2026-08-30
 
 ### Fixed

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -118,8 +118,9 @@ currencies are present; otherwise they use CNY.
 
 These cover the subscription quota and rolling five-hour window from
 `api.kimi.com/coding/v1/usages`. The default format is
-`{kimi_weekly_pct}% · {kimi_weekly_reset}`. Generic aliases are `{plan}` for the
-plan, `{weekly_pct}` for weekly usage, and `{session_pct}` for the five-hour
+`5h {kimi_window_pct}% · 7d {kimi_weekly_pct}%`, shortest window first like
+every other two-window vendor. Generic aliases are `{plan}` for the plan,
+`{weekly_pct}` for weekly usage, and `{session_pct}` for the five-hour
 window.
 
 ## Kilo

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -178,29 +178,12 @@ fn render_tooltip(
         escape(plan)
     )));
 
-    // Kimi counts requests rather than reporting a percentage, which is why
-    // this block used to print bare `26 / 100  (26%)` pairs. The percentage is
-    // right there — project each quota onto a window and it draws like every
-    // other vendor, with the counts riding along on the reset line.
-    lines.push(TooltipLine::Body("".into()));
-    // `remaining` is the vendor's own number, not `limit - used`: `extract_block`
-    // keeps both when the wire reports both. Dropping it would lose the figure a
-    // request-counting quota is actually read for.
-    let weekly_detail = format!(
-        "{used} / {limit} · {remaining} left",
-        used = snap.weekly_used,
-        limit = snap.weekly_limit,
-        remaining = snap.weekly_remaining
-    );
-    push_window_with_row(
-        &mut lines,
-        "  󰅄  Weekly quota",
-        &window(weekly_pct, snap.weekly_reset_at, WEEKLY_WINDOW),
-        theme,
-        now,
-        WindowRow::default().with_detail(&weekly_detail),
-    );
-
+    // Kimi counts requests rather than reporting a percentage, but the
+    // percentage is right there: each quota projects onto a window and draws
+    // like every other vendor's, with the counts riding along on the reset
+    // line. `remaining` is the vendor's own number, not `limit - used` —
+    // `extract_block` keeps both when the wire reports both, and dropping it
+    // would lose the figure a request-counting quota is actually read for.
     if snap.window_limit > 0 {
         lines.push(TooltipLine::Body("".into()));
         let window_detail = format!(
@@ -218,6 +201,22 @@ fn render_tooltip(
             WindowRow::default().with_detail(&window_detail),
         );
     }
+
+    lines.push(TooltipLine::Body("".into()));
+    let weekly_detail = format!(
+        "{used} / {limit} · {remaining} left",
+        used = snap.weekly_used,
+        limit = snap.weekly_limit,
+        remaining = snap.weekly_remaining
+    );
+    push_window_with_row(
+        &mut lines,
+        "  󰅄  Weekly quota",
+        &window(weekly_pct, snap.weekly_reset_at, WEEKLY_WINDOW),
+        theme,
+        now,
+        WindowRow::default().with_detail(&weekly_detail),
+    );
 
     if let Some((code, msg)) = outcome.last_error.as_ref() {
         let (label, icon, ecolor) = match warning_kind(*code, msg) {
@@ -558,6 +557,26 @@ mod tests {
         for glyph in ['↑', '→', '↓'] {
             assert!(!out.tooltip.contains(glyph), "{}", out.tooltip);
         }
+    }
+
+    /// The tooltip runs shortest window first, the way Claude's and Codex's
+    /// both open on their 5h row. Kimi's rolling bucket is that window, so it
+    /// sits above the weekly quota — the same order `DEFAULT_FORMAT` and the
+    /// detail panel use.
+    #[test]
+    fn tooltip_puts_the_rolling_window_above_the_weekly_quota() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
+        let rolling = out
+            .tooltip
+            .find("Rolling window (5h)")
+            .unwrap_or_else(|| panic!("no rolling row: {}", out.tooltip));
+        let weekly = out
+            .tooltip
+            .find("Weekly quota")
+            .unwrap_or_else(|| panic!("no weekly row: {}", out.tooltip));
+        assert!(rolling < weekly, "{}", out.tooltip);
     }
 
     /// Kimi's compact surface must not discard either independent quota.

--- a/src/kimi/vendor.rs
+++ b/src/kimi/vendor.rs
@@ -43,10 +43,10 @@ pub const DEFAULT_FORMAT: &str = "5h {kimi_window_pct}% · 7d {kimi_weekly_pct}%
 
 /// Kimi reports the weekly quota's reset instant but never its length; the
 /// subscription bucket rolls every 7 days.
-const WEEKLY_WINDOW: chrono::Duration = chrono::Duration::days(7);
+pub const WEEKLY_WINDOW: chrono::Duration = chrono::Duration::days(7);
 /// The rolling bucket's length *is* advertised — 300 minutes — and only that
 /// spelling is accepted on the way in (`types::is_five_hour_window`).
-const ROLLING_WINDOW: chrono::Duration = chrono::Duration::hours(5);
+pub const ROLLING_WINDOW: chrono::Duration = chrono::Duration::hours(5);
 
 /// Project a quota pair onto the shared window shape the tooltip helper draws.
 fn window(pct: i32, resets_at: Option<DateTime<Utc>>, duration: chrono::Duration) -> UsageWindow {
@@ -178,44 +178,29 @@ fn render_tooltip(
         escape(plan)
     )));
 
-    // Kimi counts requests rather than reporting a percentage, but the
-    // percentage is right there: each quota projects onto a window and draws
-    // like every other vendor's, with the counts riding along on the reset
-    // line. `remaining` is the vendor's own number, not `limit - used` —
-    // `extract_block` keeps both when the wire reports both, and dropping it
-    // would lose the figure a request-counting quota is actually read for.
+    // Kimi reports each quota as used/limit against a limit of 100, so the
+    // pair is the percentage in longhand: project it onto a window and the
+    // bar carries it, like every other vendor's.
     if snap.window_limit > 0 {
         lines.push(TooltipLine::Body("".into()));
-        let window_detail = format!(
-            "{used} / {limit} · {remaining} left",
-            used = snap.window_used,
-            limit = snap.window_limit,
-            remaining = snap.window_remaining
-        );
         push_window_with_row(
             &mut lines,
             "  󰅁  Rolling window (5h)",
             &window(snap.window_pct(), snap.window_reset_at, ROLLING_WINDOW),
             theme,
             now,
-            WindowRow::default().with_detail(&window_detail),
+            WindowRow::default(),
         );
     }
 
     lines.push(TooltipLine::Body("".into()));
-    let weekly_detail = format!(
-        "{used} / {limit} · {remaining} left",
-        used = snap.weekly_used,
-        limit = snap.weekly_limit,
-        remaining = snap.weekly_remaining
-    );
     push_window_with_row(
         &mut lines,
         "  󰅄  Weekly quota",
         &window(weekly_pct, snap.weekly_reset_at, WEEKLY_WINDOW),
         theme,
         now,
-        WindowRow::default().with_detail(&weekly_detail),
+        WindowRow::default(),
     );
 
     if let Some((code, msg)) = outcome.last_error.as_ref() {
@@ -455,9 +440,9 @@ mod tests {
         assert!(out.tooltip.contains("Kimi"));
         assert!(out.tooltip.contains("LEVEL_INTERMEDIATE"));
         assert!(out.tooltip.contains("Weekly quota"));
-        assert!(out.tooltip.contains("26 / 100"));
         assert!(out.tooltip.contains("Rolling window"));
-        assert!(out.tooltip.contains("15 / 100"));
+        assert!(out.tooltip.contains("26%"));
+        assert!(out.tooltip.contains("15%"));
         // Reset should be a countdown, not raw RFC3339.
         assert!(!out.tooltip.contains("2026-02-11T17:32:50"));
         assert!(!out.tooltip.contains("2026-02-07T12:32:50"));
@@ -512,39 +497,23 @@ mod tests {
         assert!(out.tooltip.contains("Resets in"), "{}", out.tooltip);
     }
 
-    /// The counters the old hand-rolled rows carried ride the reset line now —
-    /// the bar replaces the `26 / 100  (26%)` pair, it does not drop it.
+    /// Kimi reports each quota as used/limit against a limit of 100, so the
+    /// counters are the percentage in longhand — the bar above already shows
+    /// it. The reset line carries the countdown alone, like every other
+    /// vendor's row.
     #[test]
-    fn tooltip_keeps_the_raw_counts_on_the_reset_line() {
+    fn tooltip_reset_line_carries_the_countdown_alone() {
         let snap = sample_snap();
         let outcome = sample_outcome(snap.clone());
         let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
-        assert!(out.tooltip.contains("· 26 / 100"), "{}", out.tooltip);
-        assert!(out.tooltip.contains("· 15 / 100"), "{}", out.tooltip);
-    }
-
-    /// `remaining` is what a request-counting quota is read for, and it is the
-    /// vendor's own figure rather than `limit - used` — `extract_block` keeps
-    /// both when the wire reports both, so it cannot be recovered by
-    /// subtraction. The fixture makes them disagree to prove which one is
-    /// rendered.
-    #[test]
-    fn tooltip_keeps_the_vendors_own_remaining_count() {
-        let mut snap = sample_snap();
-        snap.weekly_remaining = 70; // not 100 - 26
-        snap.window_remaining = 80; // not 100 - 15
-        let outcome = sample_outcome(snap.clone());
-        let out = render(&outcome, &snap, &Theme::default(), &opts(), now());
-        assert!(
-            out.tooltip.contains("· 26 / 100 · 70 left"),
-            "{}",
-            out.tooltip
-        );
-        assert!(
-            out.tooltip.contains("· 15 / 100 · 80 left"),
-            "{}",
-            out.tooltip
-        );
+        for line in out.tooltip.lines().filter(|l| l.contains("Resets in")) {
+            assert_eq!(
+                line.matches('·').count(),
+                0,
+                "reset line carries more than the countdown: {line}"
+            );
+        }
+        assert!(!out.tooltip.contains("100"), "{}", out.tooltip);
     }
 
     /// Kimi opts out of pacing, like Codex; the rows must not sprout a glyph

--- a/src/report.rs
+++ b/src/report.rs
@@ -549,16 +549,30 @@ mod tests {
             fetched_at: None,
         }));
         let projected = entry_from_state(&TabId::vendor(VendorId::Kimi), &state, Utc::now());
+        // Pair each reset with its own row rather than pinning the row order —
+        // that order is `panels::kimi_sections`' to choose, and pinning it here
+        // would only duplicate the test that owns it.
         let resets: Vec<_> = projected
             .sections
             .iter()
             .filter_map(|section| match section {
-                ReportSection::Metric { reset_at, .. } => Some(*reset_at),
+                ReportSection::Metric {
+                    label, reset_at, ..
+                } => Some((label.as_str(), *reset_at)),
                 _ => None,
             })
             .collect();
 
-        assert_eq!(resets, vec![Some(weekly_reset), Some(window_reset)]);
+        assert_eq!(
+            resets
+                .iter()
+                .copied()
+                .collect::<std::collections::HashMap<_, _>>(),
+            std::collections::HashMap::from([
+                ("Weekly quota", Some(weekly_reset)),
+                ("Rolling window (5h)", Some(window_reset)),
+            ])
+        );
     }
 
     #[test]

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -30,22 +30,17 @@ pub enum Line {
 /// plain row every vendor drew before pacing reached the tooltip: bar +
 /// percentage, then `⏱  Resets in …`.
 ///
-/// `glyph` and `detail` are inserted into Pango markup as-is, so a caller
-/// passing anything vendor-reported must [`escape`] it first.
+/// `glyph` is inserted into Pango markup as-is, so a caller passing anything
+/// vendor-reported must [`escape`] it first.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct WindowRow<'a> {
+pub struct WindowRow {
     /// Elapsed-time marker drawn inside the bar (`--tooltip-pace-pts`).
     pub marker_pct: Option<i32>,
     /// Pace glyph appended after the bold percentage (`↑` / `→` / `↓`).
     pub glyph: Option<&'static str>,
-    /// Extra dim text appended to the reset line, for a figure the bar's
-    /// percentage cannot express. No vendor needs one today: Kimi's counters
-    /// were the last caller, and against its limit of 100 they only restated
-    /// the percentage already drawn above them.
-    pub detail: Option<&'a str>,
 }
 
-impl<'a> WindowRow<'a> {
+impl WindowRow {
     /// The Anthropic tooltip's pace convention in one place (mirrors
     /// `widget::render::pick_pace_glyph`): the ratio glyph by default, and with
     /// `point_mode` (`--tooltip-pace-pts`) the point-delta glyph plus the
@@ -69,15 +64,6 @@ impl<'a> WindowRow<'a> {
             } else {
                 p.ratio_pace.glyph()
             }),
-            detail: None,
-        }
-    }
-
-    /// Same row, carrying an extra dim fragment on the reset line.
-    pub fn with_detail(self, detail: &'a str) -> Self {
-        Self {
-            detail: Some(detail),
-            ..self
         }
     }
 }
@@ -87,7 +73,7 @@ impl<'a> WindowRow<'a> {
 ///
 /// `elapsed` draws the pace marker inside the bar; pass `None` for a plain bar.
 /// Keep this signature stable for library callers — a row that also wants the
-/// pace glyph or a detail fragment goes through [`push_window_with_row`].
+/// pace glyph goes through [`push_window_with_row`].
 pub fn push_window(
     lines: &mut Vec<Line>,
     label: &str,
@@ -116,14 +102,13 @@ pub fn push_window_with_row(
     w: &UsageWindow,
     theme: &Theme,
     now: DateTime<Utc>,
-    row: WindowRow<'_>,
+    row: WindowRow,
 ) {
     let color = severity_color(severity_for(w.utilization_pct), theme);
     let bar = pango::progress_bar(w.utilization_pct, color, theme, row.marker_pct);
     let fg = &theme.fg;
     let dim = &theme.dim;
     let glyph = row.glyph.map(|g| format!(" {g}")).unwrap_or_default();
-    let detail = row.detail.map(|d| format!(" · {d}")).unwrap_or_default();
     lines.push(Line::Body(format!(
         " <span foreground='{fg}'>{label}</span>"
     )));
@@ -132,7 +117,7 @@ pub fn push_window_with_row(
         pct = w.utilization_pct
     )));
     lines.push(Line::Body(format!(
-        " <span foreground='{dim}'>  ⏱  Resets in {cd}{detail}</span>",
+        " <span foreground='{dim}'>  ⏱  Resets in {cd}</span>",
         cd = escape(&countdown::format(w.resets_at, now))
     )));
 }
@@ -281,7 +266,7 @@ mod tests {
         }
     }
 
-    fn row_markup(w: &UsageWindow, row: WindowRow<'_>) -> String {
+    fn row_markup(w: &UsageWindow, row: WindowRow) -> String {
         let mut lines = Vec::new();
         push_window_with_row(&mut lines, "  L", w, &theme(), at(12), row);
         render_bordered(&lines, &theme())
@@ -340,13 +325,13 @@ mod tests {
     }
 
     #[test]
-    fn the_glyph_and_detail_reach_the_rendered_row() {
+    fn the_glyph_reaches_the_rendered_row() {
         let w = window(40, 3);
-        let out = row_markup(
-            &w,
-            WindowRow::paced(&w, at(12), 5, false).with_detail("2 of 100"),
-        );
+        let out = row_markup(&w, WindowRow::paced(&w, at(12), 5, false));
         assert!(out.contains("40% →"), "{out}");
-        assert!(out.contains("Resets in 3h 00m · 2 of 100"), "{out}");
+        assert!(out.contains("Resets in 3h 00m"), "{out}");
+        // The reset line carries nothing after the countdown now that no
+        // vendor appends a fragment to it.
+        assert!(!out.contains("Resets in 3h 00m ·"), "{out}");
     }
 }

--- a/src/tooltip.rs
+++ b/src/tooltip.rs
@@ -38,8 +38,10 @@ pub struct WindowRow<'a> {
     pub marker_pct: Option<i32>,
     /// Pace glyph appended after the bold percentage (`↑` / `→` / `↓`).
     pub glyph: Option<&'static str>,
-    /// Extra dim text appended to the reset line — Kimi's `2 / 100` counters,
-    /// which the bar's percentage summarises but does not spell out.
+    /// Extra dim text appended to the reset line, for a figure the bar's
+    /// percentage cannot express. No vendor needs one today: Kimi's counters
+    /// were the last caller, and against its limit of 100 they only restated
+    /// the percentage already drawn above them.
     pub detail: Option<&'a str>,
 }
 
@@ -342,9 +344,9 @@ mod tests {
         let w = window(40, 3);
         let out = row_markup(
             &w,
-            WindowRow::paced(&w, at(12), 5, false).with_detail("2 / 100"),
+            WindowRow::paced(&w, at(12), 5, false).with_detail("2 of 100"),
         );
         assert!(out.contains("40% →"), "{out}");
-        assert!(out.contains("Resets in 3h 00m · 2 / 100"), "{out}");
+        assert!(out.contains("Resets in 3h 00m · 2 of 100"), "{out}");
     }
 }

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -157,7 +157,7 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
         VendorSnapshot::Deepseek(s) => (String::new(), vec![money_cell(s.balance, &s.currency)]),
         VendorSnapshot::Kimi(s) => (
             s.plan.clone().unwrap_or_default(),
-            vec![pct("wk", s.weekly_pct()), pct("5h", s.window_pct())],
+            vec![pct("5h", s.window_pct()), pct("wk", s.weekly_pct())],
         ),
         VendorSnapshot::Kilo(s) => (String::new(), vec![usd_cell(s.balance)]),
         VendorSnapshot::Novita(s) => (String::new(), vec![usd_cell(s.available)]),
@@ -1084,27 +1084,6 @@ fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, _tol: u32) 
         right: None,
     }]);
 
-    let weekly_pct = s.weekly_pct().clamp(0, 100) as u16;
-    v.push(Section::Spacer);
-    v.push_metric(
-        Section::Metric {
-            label: "Weekly quota".into(),
-            pct: weekly_pct,
-            severity: severity_for(s.weekly_pct()),
-            // Same `{pct}%` every other vendor shows; the request counts stay
-            // on the footnote.
-            value_label: format!("{weekly_pct}%"),
-            footnote: format!(
-                "{} / {} · {} remaining · reset {}",
-                s.weekly_used,
-                s.weekly_limit,
-                s.weekly_remaining,
-                countdown::format(s.weekly_reset_at, now)
-            ),
-        },
-        s.weekly_reset_at,
-    );
-
     if s.window_limit > 0 {
         let window_pct = s.window_pct().clamp(0, 100) as u16;
         v.push(Section::Spacer);
@@ -1113,6 +1092,8 @@ fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, _tol: u32) 
                 label: "Rolling window (5h)".into(),
                 pct: window_pct,
                 severity: severity_for(s.window_pct()),
+                // Same `{pct}%` every other vendor shows; the request counts
+                // stay on the footnote.
                 value_label: format!("{window_pct}%"),
                 footnote: format!(
                     "{} / {} · {} remaining · reset {}",
@@ -1125,6 +1106,25 @@ fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, _tol: u32) 
             s.window_reset_at,
         );
     }
+
+    let weekly_pct = s.weekly_pct().clamp(0, 100) as u16;
+    v.push(Section::Spacer);
+    v.push_metric(
+        Section::Metric {
+            label: "Weekly quota".into(),
+            pct: weekly_pct,
+            severity: severity_for(s.weekly_pct()),
+            value_label: format!("{weekly_pct}%"),
+            footnote: format!(
+                "{} / {} · {} remaining · reset {}",
+                s.weekly_used,
+                s.weekly_limit,
+                s.weekly_remaining,
+                countdown::format(s.weekly_reset_at, now)
+            ),
+        },
+        s.weekly_reset_at,
+    );
 
     v
 }
@@ -1789,6 +1789,41 @@ mod tests {
             "window reset countdown: {window_footnote}"
         );
         assert!(!window_footnote.contains("2026-05-23T14")); // not a raw RFC3339
+    }
+
+    /// Every vendor holding both a short and a long window opens on the short
+    /// one — Claude's `Session (5h)`, Codex's `Codex 5h`, GLM's `Session (5h)`,
+    /// OpenCode Go's `Rolling`. Kimi's rolling bucket is that window, so it
+    /// leads both projections this module feeds: the section list the Quattro
+    /// panel and the KDE plasmoid render in order, and the Overview's compact
+    /// cells.
+    #[test]
+    fn kimi_leads_with_the_rolling_window_like_every_other_two_window_vendor() {
+        let now = now();
+        let snap = KimiSnapshot {
+            plan: Some("LEVEL_INTERMEDIATE".into()),
+            weekly_limit: 100,
+            weekly_used: 26,
+            weekly_remaining: 74,
+            weekly_reset_at: Some(now + chrono::Duration::days(4)),
+            window_limit: 100,
+            window_used: 15,
+            window_remaining: 85,
+            window_reset_at: Some(now + chrono::Duration::hours(2)),
+        };
+        let sections = sections_for(&ready(VendorSnapshot::Kimi(snap.clone())), now, 5);
+        let labels: Vec<&str> = sections
+            .iter()
+            .filter_map(|s| match s {
+                Section::Metric { label, .. } => Some(label.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(labels, ["Rolling window (5h)", "Weekly quota"]);
+
+        let (_, cells) = compact_cells(&VendorSnapshot::Kimi(snap));
+        let texts: Vec<&str> = cells.iter().map(|(text, _)| text.as_str()).collect();
+        assert_eq!(texts, ["5h 15%", "wk 26%"]);
     }
 
     #[test]

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -1077,54 +1077,30 @@ fn deepseek_sections(s: &crate::usage::DeepseekSnapshot) -> SectionBuilder {
     v
 }
 
-fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, _tol: u32) -> SectionBuilder {
+/// Kimi reports each quota as used/limit against a limit of 100, so the pair
+/// is the percentage in longhand. Projecting both onto a `UsageWindow` lets
+/// the shared `push_window` draw them, which is what keeps the row identical
+/// to every other vendor's instead of a hand-rolled near-copy.
+fn kimi_sections(s: &crate::usage::KimiSnapshot, now: DateTime<Utc>, tol: u32) -> SectionBuilder {
+    use crate::kimi::vendor::{ROLLING_WINDOW, WEEKLY_WINDOW};
+
     let plan = s.plan.as_deref().unwrap_or("Kimi");
     let mut v = SectionBuilder::new(vec![Section::Title {
         left: plan.into(),
         right: None,
     }]);
+    let window = |pct, resets_at, window_duration| crate::usage::UsageWindow {
+        utilization_pct: pct,
+        resets_at,
+        window_duration,
+    };
 
     if s.window_limit > 0 {
-        let window_pct = s.window_pct().clamp(0, 100) as u16;
-        v.push(Section::Spacer);
-        v.push_metric(
-            Section::Metric {
-                label: "Rolling window (5h)".into(),
-                pct: window_pct,
-                severity: severity_for(s.window_pct()),
-                // Same `{pct}%` every other vendor shows; the request counts
-                // stay on the footnote.
-                value_label: format!("{window_pct}%"),
-                footnote: format!(
-                    "{} / {} · {} remaining · reset {}",
-                    s.window_used,
-                    s.window_limit,
-                    s.window_remaining,
-                    countdown::format(s.window_reset_at, now)
-                ),
-            },
-            s.window_reset_at,
-        );
+        let w = window(s.window_pct(), s.window_reset_at, ROLLING_WINDOW);
+        push_window(&mut v, "Rolling window (5h)", &w, now, tol, false);
     }
-
-    let weekly_pct = s.weekly_pct().clamp(0, 100) as u16;
-    v.push(Section::Spacer);
-    v.push_metric(
-        Section::Metric {
-            label: "Weekly quota".into(),
-            pct: weekly_pct,
-            severity: severity_for(s.weekly_pct()),
-            value_label: format!("{weekly_pct}%"),
-            footnote: format!(
-                "{} / {} · {} remaining · reset {}",
-                s.weekly_used,
-                s.weekly_limit,
-                s.weekly_remaining,
-                countdown::format(s.weekly_reset_at, now)
-            ),
-        },
-        s.weekly_reset_at,
-    );
+    let w = window(s.weekly_pct(), s.weekly_reset_at, WEEKLY_WINDOW);
+    push_window(&mut v, "Weekly quota", &w, now, tol, false);
 
     v
 }
@@ -1770,25 +1746,16 @@ mod tests {
                 .unwrap_or_else(|| panic!("missing metric {label}"))
         };
 
+        // The bar carries the percentage, so the footnote is the plain
+        // `Resets in …` every other window row shows — not the counters, which
+        // against Kimi's limit of 100 only restate the percentage.
         let (weekly_value, weekly_footnote) = find_footnote("Weekly quota");
         assert_eq!(weekly_value, "26%");
-        assert!(weekly_footnote.contains("26 / 100"));
-        assert!(weekly_footnote.contains("74 remaining"));
-        assert!(
-            weekly_footnote.contains("4d 0h"),
-            "weekly reset countdown: {weekly_footnote}"
-        );
-        assert!(!weekly_footnote.contains("2026-05-27T")); // not a raw RFC3339
+        assert_eq!(weekly_footnote, "Resets in 4d 0h");
 
         let (window_value, window_footnote) = find_footnote("Rolling window (5h)");
         assert_eq!(window_value, "15%");
-        assert!(window_footnote.contains("15 / 100"));
-        assert!(window_footnote.contains("85 remaining"));
-        assert!(
-            window_footnote.contains("2h 00m"),
-            "window reset countdown: {window_footnote}"
-        );
-        assert!(!window_footnote.contains("2026-05-23T14")); // not a raw RFC3339
+        assert_eq!(window_footnote, "Resets in 2h 00m");
     }
 
     /// Every vendor holding both a short and a long window opens on the short

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -76,9 +76,9 @@ fn the_zai_mcp_placeholders_the_macos_menu_bar_reads_keep_their_names() {
 }
 
 /// `push_window` is the shared tooltip row helper. Its sixth argument stayed an
-/// `Option<i32>` marker when the row gained a pace glyph and a detail fragment:
-/// those live on `WindowRow` behind `push_window_with_row`, so a library caller
-/// written against the original six-argument form still compiles.
+/// `Option<i32>` marker when the row gained a pace glyph: that lives on
+/// `WindowRow` behind `push_window_with_row`, so a library caller written
+/// against the original six-argument form still compiles.
 #[test]
 fn push_window_keeps_its_option_marker_api() {
     let now = Utc.with_ymd_and_hms(2026, 8, 19, 12, 0, 0).unwrap();


### PR DESCRIPTION
Kimi's rows read differently from every other vendor's in two independent
ways: the order of its two windows, and a detail line carrying figures the
bar above it already draws. One commit each.

## 1. Lead with the rolling 5h window

Kimi was the one provider drawing its long window above its short one, so a
glance down a multi-vendor list compared Kimi's 7d row against everyone
else's 5h row.

```
Claude        Session (5h)  →  Weekly (7d)
Codex         Codex 5h      →  Codex weekly
GLM (Z.AI)    Session (5h)  →  Weekly       →  MCP tools (monthly)
MiniMax       Session       →  Weekly
Antigravity   Session       →  Weekly
Command Code  Session (5h)  →  Weekly
OpenCode Go   Rolling       →  Weekly       →  Monthly
Kimi          Weekly quota  →  Rolling window (5h)      ← the odd one out
```

Two call sites decided that order, and both now put the rolling bucket
first:

- **`panels::kimi_sections`** — the shared projection. Carries the Omarchy
  Quattro panel, the KDE plasmoid, the TUI detail panel and `usage --json`
  with it: Quattro's `Model.js` and the plasmoid's adapter both render
  `raw.sections` in the order Rust emits, so neither needed a change.
- **`kimi::vendor::render_tooltip`** — the Waybar tooltip.

`panels::compact_cells` moves too, so the TUI Overview row reads
`5h 0% · wk 55%`.

**Already right, untouched:** Kimi's Waybar bar text (`DEFAULT_FORMAT` is
`5h {kimi_window_pct}% · 7d {kimi_weekly_pct}%`), the macOS menu bar and the
GNOME dropdown — the latter two read their first bar off the generic
`session_*` alias, which Kimi already maps to the rolling bucket.
`DEFAULT_FORMAT`'s doc comment claims the widget matches the detail panel's
order; that only becomes true with this PR.

## 2. Drop the counters the bar already draws

The reset line carried `· 55 / 100 · 45 left`. Against Kimi's limit that
pair is the percentage in longhand — `weekly_pct()` is `used / limit`, and
both quotas report a limit of 100 (the captured response in
`parses_representative_json_with_string_numbers`, and a live Allegretto
account, agree; the one non-100 sample is a synthetic test proving the
parser takes JSON numbers as well as strings). So the bar, its bold `55%`,
and the counters were the same number three times over, on the widest row
in the tooltip.

`remaining` really is its own wire field rather than `limit - used`, which
is what the two removed tests were protecting. But against a limit of 100
it is the percentage's complement, so there is nothing in it the bar does
not already show. `WindowRow::detail` stays — it is public API with its own
test — and its doc now records that no vendor needs it.

With the counters gone the footnote is exactly what `push_window` builds,
so `kimi_sections` calls it instead of hand-rolling a near-copy: each quota
projects onto a `UsageWindow` and the shared helper draws the row. That is
what keeps the panel and the Waybar tooltip from drifting apart again, and
it removes the last per-vendor metric assembly for Kimi. Net −54 lines.

## Before / after

`ai-usagebar --vendor kimi`, same snapshot both sides:

```
  before                                       after

  󰅄  Weekly quota                              󰅁  Rolling window (5h)
  ███████████░░░░░░░░░  55%                    ░░░░░░░░░░░░░░░░░░░░  0%
  ⏱  Resets in 3d 20h · 55 / 100 · 45 left     ⏱  Resets in 1h 51m

  󰅁  Rolling window (5h)                       󰅄  Weekly quota
  ░░░░░░░░░░░░░░░░░░░░  0%                     ███████████░░░░░░░░░  55%
  ⏱  Resets in 1h 51m · 0 / 100 · 100 left     ⏱  Resets in 3d 20h
```

The panel row (Quattro / KDE / TUI / `usage --json`) is the same string as
the tooltip's now, because both come from the same helper:

```
  Rolling window (5h)   0%
    Resets in 1h 51m
  Weekly quota   55%
    Resets in 3d 20h
```

## Tests

- `kimi_leads_with_the_rolling_window_like_every_other_two_window_vendor`
  pins the projection's metric order and the Overview's compact cells.
- `tooltip_puts_the_rolling_window_above_the_weekly_quota` pins the Waybar
  tooltip's order.
- `tooltip_reset_line_carries_the_countdown_alone` replaces
  `tooltip_keeps_the_raw_counts_on_the_reset_line` and
  `tooltip_keeps_the_vendors_own_remaining_count`, whose premise the limit
  of 100 removes.
- The panel footnote assertions became exact equality
  (`assert_eq!(footnote, "Resets in 4d 0h")`) rather than `contains`.
- `report_reset_metadata_follows_multi_metric_order` pinned the old row
  order while asserting a different invariant — that each metric's absolute
  reset travels with its own row. It now pairs label to reset, so it proves
  that invariant without duplicating the ordering test above.

## Also

`docs/format-placeholders.md` documented a Kimi default format
(`{kimi_weekly_pct}% · {kimi_weekly_reset}`) that the code has never used.
Corrected to the real one.

## Gate

`make test` (1258 Rust tests + the GNOME, KDE and Omarchy contract suites),
`cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` — all clean.
No dependency changes.