### PR TITLE
feat: show banked Codex and SuperGrok reset credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,38 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Banked reset credits for Codex and SuperGrok.** Both providers let you earn
+  quota resets and redeem them by hand, on their own expiry clock — information
+  that existed nowhere in ai-usagebar, because it is not the window rollover
+  the `*_reset` placeholders already showed. The count and the next expiry now
+  appear in the Waybar tooltip, the TUI panel, and `ai-usagebar usage --json`
+  (and so in the Omarchy, GNOME and KDE frontends, which read that report) as
+  a list, one row per credit, with its own title and expiry — two Codex
+  "Full reset (Weekly + 5 hr)" credits that lapse hours apart on the same day
+  no longer collapse into a single "next expires" line. New placeholders are
+  `{oai_resets_available}` / `{oai_resets}` and `{sgk_resets_available}` /
+  `{sgk_resets}` (the compact count). A provider with none reports nothing
+  rather than a standing `0`.
+
+  Codex's count rides its usage response; the expiries come from
+  `wham/rate-limit-reset-credits`, called only when something is banked.
+  SuperGrok's come from `grok.com`'s `ConsumerUiSvc/GetRemainingResets`, a
+  gRPC-Web call authenticated with the Grok Build login's own key, parsed by a
+  bounded hand-written protobuf reader rather than a new dependency.
+
+  Read-only: **ai-usagebar never redeems a reset.** The redemption identifier
+  each provider returns beside the expiry is skipped during parsing rather than
+  parsed and dropped, so it reaches neither the cache nor the screen. Both
+  extra calls fail quietly — a broken one costs the expiry date and leaves
+  every quota figure beside it untouched.
+
 ### Changed
+
+- SuperGrok's panel no longer repeats the current period's rollover as a
+  standalone "Resets" row. That countdown already sits under the weekly
+  credits bar, the same way Codex 5h and Codex weekly do.
 
 - `README.md` documents the macOS Keychain prompt storm as a known issue, with
   the workaround, until #148 is fixed. Every release so far is affected on

--- a/README.md
+++ b/README.md
@@ -337,9 +337,11 @@ For each API-key vendor, ai-usagebar checks in this order:
   Redact them before committing that file to dotfiles. Environment variables
   remain the default and avoid storing keys in the config.
 - Claude and Codex credentials stay in files managed by their official CLIs.
-- SuperGrok credentials stay inside Grok Build. ai-usagebar receives a
-  credential-free billing result and hashes auth/config files only to separate
-  caches between logins.
+- SuperGrok credentials stay inside Grok Build. ai-usagebar reads the login's
+  `key` from `auth.json` and uses it in the outgoing `Authorization` headers
+  of the billing request and the remaining-resets RPC; it never copies,
+  caches, refreshes, or writes that key back. Auth/config files are also
+  hashed as opaque bytes to separate caches between logins.
 - Cursor's `state.vscdb` and `cursor-agent` fallback `auth.json` are read-only.
 - kiro-cli's `data.sqlite3` is read-only. Refreshed credentials go to an
   account-scoped `kiro/oauth.json` file, mode `600` on Unix.

--- a/config.example.toml
+++ b/config.example.toml
@@ -230,10 +230,12 @@ api_key_env = "XAI_MANAGEMENT_KEY" # checked first; if set + non-empty, used
 # reports an error saying so instead of querying the wrong team.
 # team_id = "..."
 
-# SuperGrok subscription usage — distinct from [grok] above. No API key enters
-# ai-usagebar: the official Grok Build CLI owns login, OIDC/provider refresh,
-# account scope, proxy settings, and credential locking. ai-usagebar invokes
-# its credential-free `x.ai/billing` ACP extension.
+# SuperGrok subscription usage — distinct from [grok] above. No API key of
+# its own: the official Grok Build CLI owns login, OIDC/provider refresh,
+# account scope, proxy settings, and credential locking. Billing and banked
+# resets use the `key` already in auth.json (read-only, sent in an
+# Authorization header, never copied or rewritten). The ACP `x.ai/billing`
+# extension is a fallback when the HTTPS billing endpoint is unavailable.
 [supergrok]
 # Disabled by default — enable after installing official Grok Build and running
 # `grok login` at least once.
@@ -241,8 +243,8 @@ enabled = false
 # Defaults to $GROK_HOME/bin/grok or ~/.grok/bin/grok, avoiding unrelated PATH
 # programs with the same name. Override only for a trusted official install.
 # grok_binary = "/opt/grok/bin/grok"
-# These files are hashed as opaque bytes only to invalidate cached usage when
-# the Grok login/scope changes. Their contents are never parsed or copied.
+# Cache-scope fingerprint inputs. config.toml is hashed as opaque bytes;
+# auth.json is also read for its billing `key`. Neither is copied or written.
 # auth_path = "/home/you/.grok/auth.json"
 # config_path = "/home/you/.grok/config.toml"
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,9 +109,10 @@ api_key_env = "XAI_MANAGEMENT_KEY"
 
 [supergrok]
 enabled = true             # disabled by default; enable once you've run `grok login`
-# No API key of its own: billing comes from Grok Build's documented HTTPS
-# endpoint using the `key` already in its auth.json (read-only, sent in one
-# Authorization header, never copied or rewritten), or from its ACP process.
+# No API key of its own: billing and banked resets use the `key` already in
+# its auth.json (read-only, sent in an Authorization header, never copied or
+# rewritten). Billing is Grok Build's documented HTTPS endpoint, or its ACP
+# process as fallback; remaining resets are a separate grok.com RPC.
 # Defaults to $GROK_HOME/bin/grok or ~/.grok/bin/grok. Override only when the
 # trusted official binary was installed elsewhere.
 # grok_binary = "/opt/grok/bin/grok"

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -62,10 +62,16 @@ window is absent, it returns neutral empty, `0`, or `—` values as appropriate.
 `{oai_session_elapsed}`, `{oai_session_pace}`,
 `{oai_session_pace_indicator}`, `{oai_weekly_*}`,
 `{oai_code_review_pct}`, `{oai_credit_balance}`, `{oai_local_msgs}`,
-`{oai_cloud_msgs}`
+`{oai_cloud_msgs}`, `{oai_resets_available}`, `{oai_resets}`
 
 Session and weekly families are empty when the API omits that window. The
 default widget automatically uses weekly values for a weekly-only response.
+
+`{oai_resets_available}` is the number of banked rate-limit reset credits —
+the ones Codex lets you redeem by hand, not the automatic window rollover in
+`{oai_session_reset}`. `{oai_resets}` is the compact count (`2 resets
+available`). The panel lists each credit on its own row with title and
+expiry. Accounts that have never earned one report `0`.
 
 ## GitHub Copilot
 
@@ -161,24 +167,28 @@ USD; the China service uses CNY.
 
 ## SuperGrok
 
-`{sgk_plan}`, `{sgk_pct}`, `{sgk_reset}`, `{sgk_period}`, `{sgk_prepaid}`
+`{sgk_plan}`, `{sgk_pct}`, `{sgk_reset}`, `{sgk_period}`, `{sgk_prepaid}`,
+`{sgk_resets_available}`, `{sgk_resets}`
 
 - `{sgk_period}` is `Weekly`, `Monthly`, or `Current period`.
 - The default bar format is `{sgk_pct}% · {sgk_reset}`.
 - `{session_pct}` and `{weekly_pct}` remain aliases for `sgk_pct`.
 - `{plan}` is the subscription tier when Grok Build supplies one.
+- `{sgk_resets_available}` is the number of banked resets you can redeem by
+  hand, and `{sgk_resets}` the compact count (`1 reset available`). These are
+  unrelated to `{sgk_reset}`, which is the current period's automatic rollover.
 
 SuperGrok is the subscription path. It is separate from the Grok Management
 API prepaid balance. Billing comes from Grok Build's documented
 `cli-chat-proxy.grok.com` endpoint, with the CLI's `x.ai/billing` ACP extension
 as a fallback for builds where that endpoint is unavailable.
 
-The HTTPS path reads the long-lived `key` from the login's `auth.json` and uses
-it inside one outgoing `Authorization` header. ai-usagebar never copies,
-caches, refreshes, logs, or writes that key back, and never echoes it in an
-error; account selection and token rotation stay with Grok Build. The config
-file is read only as opaque bytes for the one-way digest that keeps caches
-separate between logins.
+The HTTPS path reads the `key` from the login's `auth.json` and uses it inside
+the outgoing `Authorization` headers of the billing request and, separately,
+the remaining-resets RPC. ai-usagebar never copies, caches, refreshes, logs,
+or writes that key back, and never echoes it in an error; account selection
+and token rotation stay with Grok Build. The config file is read only as
+opaque bytes for the one-way digest that keeps caches separate between logins.
 
 The default executable is `$GROK_HOME/bin/grok`, or `~/.grok/bin/grok` when
 `GROK_HOME` is unset. ai-usagebar does not search `PATH`. Set

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -8,7 +8,7 @@ defensive and includes opt-in live tests for catching response changes.
 | Vendor | Endpoint | What you see | Native desktop selector (v0.13) |
 |---|---|---|---|
 | **Claude** | `api.anthropic.com/api/oauth/usage` (undocumented) | Session (5h), Weekly (7d), model-scoped weekly (e.g. Fable), Extra usage $ | Yes |
-| **Codex** | `chatgpt.com/backend-api/wham/usage` (undocumented; used by official `codex` CLI) | Codex 5h and/or weekly, Code-review weekly, Credits | Yes |
+| **Codex** | `chatgpt.com/backend-api/wham/usage`, plus `…/wham/rate-limit-reset-credits` when any are banked (undocumented; both used by the official `codex` CLI) | Codex 5h and/or weekly, Code-review weekly, Credits, banked reset credits + expiry | Yes |
 | **GitHub Copilot** | `api.github.com/copilot_internal/user` (private; used by VS Code) | Premium requests, Chat, and Completions quota %, counts when supplied, plan, reset | Yes |
 | **Z.AI** | `api.z.ai/api/monitor/usage/quota/limit` (undocumented) | Session 5h, Weekly 7d, MCP tools monthly | Yes |
 | **OpenRouter** | `openrouter.ai/api/v1/{credits,key}` (documented) | Balance, today/week/month spend, free vs paid tier | Yes |
@@ -19,7 +19,7 @@ defensive and includes opt-in live tests for catching response changes.
 | **Novita** | `api.novita.ai/openapi/v1/billing/balance/detail` (documented) | Remaining credit balance ($) | No — widget/TUI only |
 | **Moonshot** | `api.moonshot.ai\|.cn/v1/users/me/balance` (documented) | Account balance ($ on `.ai`, ¥ on `.cn`) | No — widget/TUI only |
 | **Grok (xAI)** | `management-api.x.ai/v1/billing/teams/{team}/prepaid/balance` (Management API; documented) | Prepaid credit balance ($) | No — widget/TUI only |
-| **SuperGrok** | `cli-chat-proxy.grok.com/v1/billing` with the Grok Build login's key, falling back to its `x.ai/billing` ACP extension | Current weekly/monthly included-credit %, prepaid API balance, reset | No — widget/TUI only |
+| **SuperGrok** | `cli-chat-proxy.grok.com/v1/billing` with the Grok Build login's key, falling back to its `x.ai/billing` ACP extension; `grok.com` `ConsumerUiSvc/GetRemainingResets` for banked resets | Current weekly/monthly included-credit %, prepaid API balance, reset, banked resets + expiry | No — widget/TUI only |
 | **Anthropic API** | `api.anthropic.com/v1/organizations/cost_report` (Admin API; documented) | Month-to-date spend ($, excludes Priority Tier), optional spend-vs-limit % | No — widget/TUI only |
 | **Google Antigravity** | A loopback RPC on the local Antigravity product's own port, discovered from `/proc` (Linux), `lsof` (macOS), or the process/TCP tables (Windows); no remote endpoint and no credential | Whichever quota windows the running product reports — Gemini and Claude/GPT pools, 5-hour and weekly | Yes |
 | **Cursor** | `cursor.com/api/usage-summary` (undocumented; the dashboard's own frontend) | Two included-usage pools this billing cycle — Cursor Models (Auto/Composer) % and Other Models (named/API) % — plus plan, reset, on-demand | Yes |
@@ -64,6 +64,25 @@ duration, not by `primary_window` or `secondary_window` position. This handles
 both the normal response and the temporary
 [weekly-only response](https://github.com/openai/codex/issues/32707) without a
 config switch.
+
+### Banked resets
+
+Codex and SuperGrok both let you *earn* quota resets and redeem them by hand,
+which is a different thing from the window rollover in the table above. Both
+report them behind a second endpoint, and both are read-only here:
+ai-usagebar shows what you have and when it lapses, and never redeems one. The
+redemption identifier each provider returns beside the expiry
+(`credits[].id`, `tokens[].token_id`) is skipped during parsing rather than
+parsed and dropped, so it reaches neither the cache nor the screen.
+
+| Provider | Endpoint | Notes |
+|---|---|---|
+| Codex | `GET chatgpt.com/backend-api/wham/rate-limit-reset-credits` | Called only when the usage response's `rate_limit_reset_credits.available_count` is non-zero. The count always comes from the usage response — that is the one consistent with the quota figures beside it. A failure of this call costs the expiry date and nothing else. |
+| SuperGrok | `POST grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets` | gRPC-Web (`application/grpc-web+proto`) with the Grok Build login's own bearer key — the same key `direct.rs` uses, in one outgoing header, never copied or cached. The response is a `repeated ConsumerResetToken` whose `validity_end` is the expiry; a hand-written bounded protobuf reader takes the count and that field, skipping everything else by wire type. gRPC reports failure in a trailer *behind* HTTP 200, so the trailer's `grpc-status` is checked before any count is believed. |
+
+Neither is documented, and both are more fragile than the usage endpoints they
+accompany. Both fail quietly by design: a broken reset call leaves the rest of
+the vendor's snapshot exactly as it was.
 
 ## Run the live tests
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -868,9 +868,9 @@ impl Default for GrokConfig {
     }
 }
 
-/// SuperGrok subscription auth — no API key. Asks the official Grok Build
-/// CLI for billing through its `x.ai/billing` ACP extension, leaving every
-/// credential, issuer, proxy, and token-rotation decision inside Grok Build.
+/// SuperGrok subscription auth — no API key of its own. Billing and banked
+/// resets use the `key` already in Grok Build's `auth.json` (read-only).
+/// Login, issuer, proxy, and token rotation stay inside Grok Build.
 ///
 /// Opt-in like Cursor/Kiro (`enabled` defaults to `false`): it requires a
 /// separate official executable and signed-in session, so it stays off until

--- a/src/format.rs
+++ b/src/format.rs
@@ -13,6 +13,8 @@ use std::time::Duration;
 
 use chrono::{DateTime, Local, Utc};
 
+use crate::usage::{ResetCredit, ResetCredits};
+
 /// A monetary amount, with the sign outside the symbol. `format!("${v:.2}")`
 /// puts it inside — `$-5.71` — which reads as a typo rather than as debt, and
 /// several providers let a balance go negative: OpenRouter overruns its
@@ -87,6 +89,59 @@ pub fn local_time_hms(when: DateTime<Utc>) -> String {
     when.with_timezone(&Local).format("%H:%M:%S").to_string()
 }
 
+pub fn local_date_hm(when: DateTime<Utc>) -> String {
+    when.with_timezone(&Local)
+        .format("%b %-d %H:%M")
+        .to_string()
+}
+
+/// Compact count for placeholders and tooltips that have to stay on one line.
+pub fn reset_credits(credits: &ResetCredits, _now: DateTime<Utc>) -> String {
+    let noun = if credits.available == 1 {
+        "reset"
+    } else {
+        "resets"
+    };
+    format!("{} {noun} available", credits.available)
+}
+
+/// One row per banked reset, soonest expiry first. This is what the panel,
+/// TUI, and tooltip list — a single "2 available · next expires Oct 4" line
+/// hides that two credits can lapse hours apart on the same day.
+pub fn reset_credit_lines(credits: &ResetCredits, now: DateTime<Utc>) -> Vec<String> {
+    let mut items = credits.credits.clone();
+    items.sort_by_key(|credit| credit.expires_at);
+    let mut lines: Vec<String> = items
+        .iter()
+        .map(|credit| reset_credit_line(credit, now))
+        .collect();
+    if lines.is_empty() && credits.available > 0 {
+        lines.push(reset_credits(credits, now));
+    }
+    lines
+}
+
+fn reset_credit_line(credit: &ResetCredit, now: DateTime<Utc>) -> String {
+    let expiry = match credit.expires_at {
+        Some(expires) if expires <= now => format!("expired {}", local_date_hm(expires)),
+        Some(expires) => format!(
+            "expires {} ({})",
+            local_date_hm(expires),
+            crate::countdown::format(Some(expires), now)
+        ),
+        None => "no expiry reported".into(),
+    };
+    match credit
+        .title
+        .as_deref()
+        .map(str::trim)
+        .filter(|title| !title.is_empty())
+    {
+        Some(title) => format!("{title} · {expiry}"),
+        None => capitalize(&expiry),
+    }
+}
+
 pub fn updated_at_hm(now: DateTime<Utc>, cache_age: Option<Duration>) -> String {
     match cache_age {
         Some(age) => local_time_hm(now - chrono::Duration::from_std(age).unwrap_or_default()),
@@ -145,6 +200,61 @@ mod tests {
 
     fn pm(pairs: &[(&'static str, &str)]) -> HashMap<&'static str, String> {
         placeholders(pairs.iter().map(|(k, v)| (*k, v.to_string())))
+    }
+
+    fn offer(title: Option<&str>, expires: &str) -> ResetCredit {
+        ResetCredit {
+            title: title.map(str::to_string),
+            expires_at: Some(expires.parse().unwrap()),
+        }
+    }
+
+    #[test]
+    fn a_reset_inventory_lists_each_credit_soonest_first() {
+        let now = "2026-07-04T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let credits = ResetCredits {
+            available: 2,
+            credits: vec![
+                offer(Some("Full reset (Weekly + 5 hr)"), "2026-08-01T00:00:00Z"),
+                offer(Some("Full reset (Weekly + 5 hr)"), "2026-07-17T00:00:00Z"),
+            ],
+        };
+        assert_eq!(reset_credits(&credits, now), "2 resets available");
+        let lines = reset_credit_lines(&credits, now);
+        assert_eq!(lines.len(), 2, "{lines:?}");
+        assert!(lines[0].contains("Full reset (Weekly + 5 hr)"), "{lines:?}");
+        assert!(lines[0].contains("(13d 0h)"), "{lines:?}");
+        assert!(lines[1].contains("(28d 0h)"), "{lines:?}");
+    }
+
+    #[test]
+    fn a_lapsed_deadline_reads_as_expired_rather_than_now() {
+        let now = "2026-07-04T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let lines = reset_credit_lines(
+            &ResetCredits {
+                available: 1,
+                credits: vec![offer(None, "2026-07-01T00:00:00Z")],
+            },
+            now,
+        );
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].starts_with("Expired "), "{lines:?}");
+        assert!(!lines[0].contains("(now)"), "{lines:?}");
+    }
+
+    #[test]
+    fn a_count_without_detail_still_renders_the_inventory() {
+        let now = "2026-07-04T00:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        assert_eq!(
+            reset_credit_lines(
+                &ResetCredits {
+                    available: 2,
+                    credits: vec![]
+                },
+                now
+            ),
+            vec!["2 resets available"]
+        );
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -96,7 +96,7 @@ pub fn local_date_hm(when: DateTime<Utc>) -> String {
 }
 
 /// Compact count for placeholders and tooltips that have to stay on one line.
-pub fn reset_credits(credits: &ResetCredits, _now: DateTime<Utc>) -> String {
+pub fn reset_credits(credits: &ResetCredits) -> String {
     let noun = if credits.available == 1 {
         "reset"
     } else {
@@ -116,7 +116,7 @@ pub fn reset_credit_lines(credits: &ResetCredits, now: DateTime<Utc>) -> Vec<Str
         .map(|credit| reset_credit_line(credit, now))
         .collect();
     if lines.is_empty() && credits.available > 0 {
-        lines.push(reset_credits(credits, now));
+        lines.push(reset_credits(credits));
     }
     lines
 }
@@ -219,7 +219,7 @@ mod tests {
                 offer(Some("Full reset (Weekly + 5 hr)"), "2026-07-17T00:00:00Z"),
             ],
         };
-        assert_eq!(reset_credits(&credits, now), "2 resets available");
+        assert_eq!(reset_credits(&credits), "2 resets available");
         let lines = reset_credit_lines(&credits, now);
         assert_eq!(lines.len(), 2, "{lines:?}");
         assert!(lines[0].contains("Full reset (Weekly + 5 hr)"), "{lines:?}");

--- a/src/openai/fetch.rs
+++ b/src/openai/fetch.rs
@@ -207,7 +207,7 @@ fn parse_payload(bytes: &[u8], plan_hint: Option<&str>) -> Result<OpenAiSnapshot
     r.into_snapshot(plan_hint)
 }
 
-async fn fetch_usage(client: &reqwest::Client, url: &str, t: &Tokens) -> Result<Vec<u8>> {
+fn authorized(client: &reqwest::Client, url: String, t: &Tokens) -> reqwest::RequestBuilder {
     let mut req = client
         .get(url)
         .header("Authorization", format!("Bearer {}", t.access_token))
@@ -215,7 +215,19 @@ async fn fetch_usage(client: &reqwest::Client, url: &str, t: &Tokens) -> Result<
     if let Some(aid) = t.account_id.as_deref() {
         req = req.header("ChatGPT-Account-Id", aid);
     }
-    let resp = req.send().await?;
+    req
+}
+
+/// Cache the usage payload, grafting on the reset-credit expiries from the
+/// second endpoint when they exist. The graft is a field insert into the
+/// original JSON: re-serializing our typed `UsageResponse` would drop every
+/// unknown key the API still sends (`user_id`, tomorrow's new window, …),
+/// and a cache holding only the usage bytes would keep the count while the
+/// deadline beside it vanished for the rest of the TTL. The inserted
+/// `credits` array is our typed projection — status + expiry, never the
+/// redemption `id`.
+async fn fetch_usage(client: &reqwest::Client, url: &str, t: &Tokens) -> Result<Vec<u8>> {
+    let resp = authorized(client, url.to_string(), t).send().await?;
     let status = resp.status();
     let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
 
@@ -226,10 +238,95 @@ async fn fetch_usage(client: &reqwest::Client, url: &str, t: &Tokens) -> Result<
             body,
         });
     }
-    let parsed: UsageResponse = serde_json::from_slice(&bytes)
+    let mut value: serde_json::Value = serde_json::from_slice(&bytes)
         .map_err(|e| AppError::Schema(format!("openai usage response: {e}")))?;
-    parsed.into_snapshot(None)?;
-    Ok(bytes)
+    let mut parsed: UsageResponse = serde_json::from_value(value.clone())
+        .map_err(|e| AppError::Schema(format!("openai usage response: {e}")))?;
+    parsed.rate_limit_reset_credits = enrich_reset_credits(client, url, t, &parsed).await;
+    parsed.clone().into_snapshot(None)?;
+    attach_reset_credit_expiries(&mut value, parsed.rate_limit_reset_credits.as_ref())?;
+    serde_json::to_vec(&value).map_err(AppError::Json)
+}
+
+fn attach_reset_credit_expiries(
+    value: &mut serde_json::Value,
+    block: Option<&super::types::ResetCreditsBlock>,
+) -> Result<()> {
+    let Some(credits) = block.map(|block| {
+        block
+            .credits
+            .iter()
+            .filter(|credit| credit.status == "available")
+            .cloned()
+            .collect::<Vec<_>>()
+    }) else {
+        return Ok(());
+    };
+    if credits.is_empty() {
+        return Ok(());
+    }
+    let Some(root) = value.as_object_mut() else {
+        return Ok(());
+    };
+    let entry = root
+        .entry("rate_limit_reset_credits")
+        .or_insert_with(|| serde_json::json!({}));
+    let Some(map) = entry.as_object_mut() else {
+        return Ok(());
+    };
+    map.insert(
+        "credits".into(),
+        serde_json::to_value(credits).map_err(AppError::Json)?,
+    );
+    Ok(())
+}
+
+/// The usage endpoint reports how many banked resets exist but not when they
+/// expire; a second call carries the per-credit detail. That call is strictly
+/// additive: its failure leaves the count exactly as the usage endpoint
+/// reported it, because a count with no deadline is still true, and it is not
+/// worth failing a whole refresh over the deadline alone. The count itself
+/// always stays the usage endpoint's — the two responses can disagree across a
+/// redemption, and the one that also carries the quota figures is the one the
+/// rest of the snapshot is consistent with.
+async fn enrich_reset_credits(
+    client: &reqwest::Client,
+    usage_url: &str,
+    t: &Tokens,
+    parsed: &UsageResponse,
+) -> Option<super::types::ResetCreditsBlock> {
+    let mut block = parsed.rate_limit_reset_credits.clone()?;
+    if block.available_count == 0 {
+        return Some(block);
+    }
+    if let Ok(details) = fetch_reset_credits(client, usage_url, t).await {
+        block.credits = details.credits;
+    }
+    Some(block)
+}
+
+async fn fetch_reset_credits(
+    client: &reqwest::Client,
+    usage_url: &str,
+    t: &Tokens,
+) -> Result<super::types::ResetCreditsBlock> {
+    let base = usage_url.strip_suffix("/usage").unwrap_or(usage_url);
+    let resp = authorized(client, format!("{base}/rate-limit-reset-credits"), t)
+        .send()
+        .await?;
+    let status = resp.status();
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
+    if !status.is_success() {
+        // The body is discarded rather than reported: this call is optional,
+        // its failure never reaches the user, and it would only carry an
+        // account-identifying error into a log.
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body: String::new(),
+        });
+    }
+    serde_json::from_slice(&bytes)
+        .map_err(|_| AppError::Schema("openai reset credits response is invalid".into()))
 }
 
 #[cfg(test)]
@@ -374,6 +471,148 @@ mod tests {
         .unwrap();
         assert_eq!(out.snapshot.session.as_ref().unwrap().utilization_pct, 37);
         assert!(!out.stale);
+    }
+
+    /// The expiry lives behind a second endpoint. It has to reach the cache
+    /// with the usage figures, or the deadline disappears for the rest of the
+    /// TTL while the count beside it stays on screen.
+    #[tokio::test]
+    async fn banked_reset_expiries_are_fetched_and_cached_with_the_usage_figures() {
+        let mut server = mockito::Server::new_async().await;
+        let usage = server
+            .mock("GET", "/backend-api/wham/usage")
+            .with_body(
+                r#"{"plan_type":"plus","future_field":true,"rate_limit":{
+                    "primary_window":{"used_percent":81,"limit_window_seconds":18000,"reset_at":1786536977}},
+                    "rate_limit_reset_credits":{"available_count":2}}"#,
+            )
+            .create_async()
+            .await;
+        let details = server
+            .mock("GET", "/backend-api/wham/rate-limit-reset-credits")
+            .with_body(
+                r#"{"available_count":2,"credits":[
+                    {"id":"c1","status":"available","title":"Full reset (Weekly + 5 hr)","expires_at":"2026-07-17T00:00:00Z"},
+                    {"id":"c2","status":"available","title":"Full reset (Weekly + 5 hr)","expires_at":"2026-08-01T00:00:00Z"}]}"#,
+            )
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let creds = future_creds();
+        let endpoints = Endpoints {
+            usage: format!("{}/backend-api/wham/usage", server.url()),
+            token: format!("{}/oauth/token", server.url()),
+        };
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            creds.path(),
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        usage.assert_async().await;
+        details.assert_async().await;
+        assert_eq!(out.snapshot.reset_credits.available, 2);
+        assert_eq!(
+            out.snapshot.reset_credits.next_expiry(),
+            Some("2026-07-17T00:00:00Z".parse().unwrap())
+        );
+
+        // The redemption id is what spends a credit; it must not be written to
+        // disk just because it shared a response with the expiry.
+        let cached = std::fs::read_to_string(cache.payload_path()).unwrap();
+        assert!(!cached.contains("\"c1\""), "{cached}");
+        assert!(
+            cached.contains("\"future_field\":true"),
+            "unknown usage fields must survive the expiry graft: {cached}"
+        );
+        let reused = parse_payload(cached.as_bytes(), None).unwrap();
+        assert_eq!(reused.reset_credits, out.snapshot.reset_credits);
+    }
+
+    /// The detail call is an extra. When it fails, the count the usage
+    /// endpoint reported is still true and still worth showing — refusing the
+    /// whole refresh over a missing deadline would cost the quota figures too.
+    #[tokio::test]
+    async fn a_failed_detail_call_keeps_the_count_from_the_usage_response() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/backend-api/wham/usage")
+            .with_body(
+                r#"{"plan_type":"plus","rate_limit":{
+                    "primary_window":{"used_percent":10,"limit_window_seconds":18000}},
+                    "rate_limit_reset_credits":{"available_count":1}}"#,
+            )
+            .create_async()
+            .await;
+        let details = server
+            .mock("GET", "/backend-api/wham/rate-limit-reset-credits")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let creds = future_creds();
+        let endpoints = Endpoints {
+            usage: format!("{}/backend-api/wham/usage", server.url()),
+            token: format!("{}/oauth/token", server.url()),
+        };
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            creds.path(),
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        details.assert_async().await;
+        assert!(!out.stale);
+        assert_eq!(out.snapshot.session.as_ref().unwrap().utilization_pct, 10);
+        assert_eq!(out.snapshot.reset_credits.available, 1);
+        assert!(out.snapshot.reset_credits.credits.is_empty());
+    }
+
+    /// With nothing banked there is nothing to detail. Asking anyway would
+    /// double every refresh's request count for every account that has none.
+    #[tokio::test]
+    async fn no_banked_resets_means_no_second_request() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/backend-api/wham/usage")
+            .with_body(
+                r#"{"plan_type":"plus","rate_limit":{
+                    "primary_window":{"used_percent":10,"limit_window_seconds":18000}},
+                    "rate_limit_reset_credits":{"available_count":0}}"#,
+            )
+            .create_async()
+            .await;
+        let details = server
+            .mock("GET", "/backend-api/wham/rate-limit-reset-credits")
+            .expect(0)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let creds = future_creds();
+        let endpoints = Endpoints {
+            usage: format!("{}/backend-api/wham/usage", server.url()),
+            token: format!("{}/oauth/token", server.url()),
+        };
+        let out = fetch_snapshot(
+            &reqwest::Client::new(),
+            creds.path(),
+            &cache,
+            &endpoints,
+            Duration::from_secs(0),
+        )
+        .await
+        .unwrap();
+        details.assert_async().await;
+        assert!(out.snapshot.reset_credits.is_empty());
     }
 
     #[tokio::test]

--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -13,14 +13,19 @@
 //!     "secondary_window": {"used_percent": 0, "limit_window_seconds": 604800, "reset_at": 1780184124}
 //!   },
 //!   "code_review_rate_limit": {...optional...},
-//!   "credits": {...optional...}
+//!   "credits": {...optional...},
+//!   "rate_limit_reset_credits": {"available_count": 2}
 //! }
 //! ```
 
-use serde::Deserialize;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, Result as AppResult};
-use crate::usage::{OpenAiCredits, OpenAiSnapshot, OpenAiSource, UsageWindow};
+use crate::usage::{
+    OpenAiCredits, OpenAiSnapshot, OpenAiSource, ResetCredit as BankedReset, ResetCredits,
+    UsageWindow,
+};
 
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default)]
@@ -29,6 +34,7 @@ pub struct UsageResponse {
     pub rate_limit: Option<RateLimit>,
     pub code_review_rate_limit: Option<RateLimit>,
     pub credits: Option<CreditsBlock>,
+    pub rate_limit_reset_credits: Option<ResetCreditsBlock>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -62,6 +68,31 @@ pub struct CreditsBlock {
     pub approx_local_messages: Option<Vec<i64>>,
     #[serde(default)]
     pub approx_cloud_messages: Option<Vec<i64>>,
+}
+
+/// Banked rate-limit reset credits. `available_count` rides along with the
+/// usage response; `credits` only ever arrives from the separate
+/// `/rate-limit-reset-credits` call, so it is routinely empty while the count
+/// is not. The redemption `id` each entry carries is deliberately not
+/// deserialized.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default)]
+pub struct ResetCreditsBlock {
+    pub available_count: u32,
+    pub credits: Vec<ResetCredit>,
+}
+
+/// Cached beside the usage payload. Status, title, and expiry are written
+/// back — the wire's redemption `id` is never deserialized.
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct ResetCredit {
+    /// "available", "redeemed", … — only an available credit is one you still
+    /// have, so a redeemed entry's expiry must not become a deadline on screen.
+    pub status: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 /// Accept a JSON number or numeric string without turning malformed, non-finite
@@ -176,6 +207,19 @@ where
     }
 }
 
+const MAX_RESET_TITLE_CHARS: usize = 80;
+
+fn checked_reset_title(value: Option<String>) -> Option<String> {
+    let value = value
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
+    if value.chars().count() > MAX_RESET_TITLE_CHARS || value.chars().any(char::is_control) {
+        None
+    } else {
+        Some(value)
+    }
+}
+
 impl UsageResponse {
     pub fn into_snapshot(self, plan_hint: Option<&str>) -> AppResult<OpenAiSnapshot> {
         let plan_type = self.plan_type.as_deref().or(plan_hint).unwrap_or("Unknown");
@@ -194,6 +238,21 @@ impl UsageResponse {
             approx_local_messages: range_from_vec(c.approx_local_messages),
             approx_cloud_messages: range_from_vec(c.approx_cloud_messages),
         });
+        let reset_credits = self
+            .rate_limit_reset_credits
+            .map(|credits| ResetCredits {
+                available: credits.available_count,
+                credits: credits
+                    .credits
+                    .into_iter()
+                    .filter(|credit| credit.status == "available")
+                    .map(|credit| BankedReset {
+                        title: checked_reset_title(credit.title),
+                        expires_at: credit.expires_at,
+                    })
+                    .collect(),
+            })
+            .unwrap_or_default();
 
         Ok(OpenAiSnapshot {
             plan,
@@ -201,6 +260,7 @@ impl UsageResponse {
             weekly,
             code_review,
             credits,
+            reset_credits,
             source: OpenAiSource::CodexOauth,
         })
     }
@@ -448,6 +508,56 @@ mod tests {
         assert!(c.has_credits);
         assert_eq!(c.approx_local_messages, Some((100, 200)));
         assert_eq!(c.approx_cloud_messages, Some((40, 60)));
+    }
+
+    /// The count travels with the usage response; the per-credit detail only
+    /// arrives from the second endpoint, so a snapshot must be able to report
+    /// "2 available" with no expiry attached to either of them.
+    #[test]
+    fn reset_credit_count_stands_on_its_own_without_the_detail_call() {
+        let body = r#"{"plan_type":"plus","rate_limit_reset_credits":{"available_count":2}}"#;
+        let s: UsageResponse = serde_json::from_str(body).unwrap();
+        let s = s.into_snapshot(None).unwrap();
+        assert_eq!(s.reset_credits.available, 2);
+        assert!(s.reset_credits.credits.is_empty());
+        assert!(!s.reset_credits.is_empty());
+    }
+
+    /// A redeemed credit still appears in the detail list. Its expiry is not a
+    /// deadline the user can act on, so it must not become the next one shown.
+    #[test]
+    fn only_an_available_credit_contributes_an_expiry() {
+        let body = r#"{
+            "rate_limit_reset_credits":{
+                "available_count":1,
+                "credits":[
+                    {"id":"c1","status":"redeemed","title":"Full reset (Weekly + 5 hr)","expires_at":"2026-07-01T00:00:00Z"},
+                    {"id":"c2","status":"available","title":"Full reset (Weekly + 5 hr)","expires_at":"2026-07-17T00:00:00Z"},
+                    {"id":"c3","status":"available","expires_at":null}
+                ]
+            }
+        }"#;
+        let s: UsageResponse = serde_json::from_str(body).unwrap();
+        let s = s.into_snapshot(None).unwrap();
+        assert_eq!(s.reset_credits.available, 1);
+        assert_eq!(s.reset_credits.credits.len(), 2);
+        assert_eq!(
+            s.reset_credits.credits[0].title.as_deref(),
+            Some("Full reset (Weekly + 5 hr)")
+        );
+        assert_eq!(
+            s.reset_credits.next_expiry(),
+            Some("2026-07-17T00:00:00Z".parse::<DateTime<Utc>>().unwrap())
+        );
+    }
+
+    /// Every other vendor's absent block means "none". This one is load-bearing
+    /// in the same way: a response from an account with no banked resets, or
+    /// from a Codex build that predates them, reports none rather than failing.
+    #[test]
+    fn an_absent_reset_block_is_no_credits_rather_than_an_error() {
+        let s: UsageResponse = serde_json::from_str(r#"{"plan_type":"plus"}"#).unwrap();
+        assert!(s.into_snapshot(None).unwrap().reset_credits.is_empty());
     }
 
     #[test]

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 
 use crate::countdown;
-use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::format::{placeholders, reset_credit_lines, reset_credits, substitute, updated_at_hm};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::{color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
@@ -50,6 +50,7 @@ pub fn build_placeholders(
         .and_then(|c| c.approx_cloud_messages)
         .map(|(a, b)| format!("{a}-{b}"))
         .unwrap_or_default();
+    let reset_summary = reset_credits(&snap.reset_credits, now);
 
     placeholders(vec![
         ("icon", "󱢆".to_string()),
@@ -79,6 +80,11 @@ pub fn build_placeholders(
         ("oai_credit_balance", credit_balance),
         ("oai_local_msgs", local_msgs),
         ("oai_cloud_msgs", cloud_msgs),
+        (
+            "oai_resets_available",
+            snap.reset_credits.available.to_string(),
+        ),
+        ("oai_resets", reset_summary),
     ])
 }
 
@@ -250,6 +256,20 @@ fn render_tooltip(
         }
     }
 
+    if snap.reset_credits.available > 0 {
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{fg}'>  󰁯  Reset credits</span>"
+        )));
+        for line in reset_credit_lines(&snap.reset_credits, now) {
+            lines.push(TooltipLine::Body(format!(
+                " <span foreground='{dim}'>     {}</span>",
+                escape(&line)
+            )));
+        }
+    }
+
     if matches!(snap.source, OpenAiSource::Unavailable) {
         lines.push(TooltipLine::Body("".into()));
         lines.push(TooltipLine::Sep);
@@ -316,6 +336,7 @@ mod tests {
             }),
             code_review: None,
             credits: None,
+            reset_credits: Default::default(),
             source: OpenAiSource::CodexOauth,
         }
     }
@@ -435,6 +456,42 @@ mod tests {
         assert!(out.tooltip.contains("$5.00"));
         assert!(out.tooltip.contains("100-200 local messages"));
         assert!(out.tooltip.contains("30-50 cloud messages"));
+    }
+
+    #[test]
+    fn tooltip_reports_banked_resets_and_stays_silent_without_them() {
+        let s = sample();
+        let quiet = render(&oc(s.clone()), &s, &Theme::default(), &opts(), Utc::now());
+        assert!(!quiet.tooltip.contains("available"), "{}", quiet.tooltip);
+
+        let mut s = s;
+        s.reset_credits = crate::usage::ResetCredits {
+            available: 2,
+            credits: vec![
+                crate::usage::ResetCredit {
+                    title: Some("Full reset (Weekly + 5 hr)".into()),
+                    expires_at: Some(Utc::now() + chrono::Duration::days(13)),
+                },
+                crate::usage::ResetCredit {
+                    title: Some("Full reset (Weekly + 5 hr)".into()),
+                    expires_at: Some(
+                        Utc::now() + chrono::Duration::days(13) + chrono::Duration::hours(6),
+                    ),
+                },
+            ],
+        };
+        let out = render(&oc(s.clone()), &s, &Theme::default(), &opts(), Utc::now());
+        assert!(out.tooltip.contains("Reset credits"), "{}", out.tooltip);
+        assert_eq!(
+            out.tooltip.matches("Full reset (Weekly + 5 hr)").count(),
+            2,
+            "{}",
+            out.tooltip
+        );
+
+        let values = build_placeholders(&s, &opts(), Utc::now());
+        assert_eq!(values["oai_resets_available"], "2");
+        assert_eq!(values["oai_resets"], "2 resets available");
     }
 
     #[test]

--- a/src/openai/vendor.rs
+++ b/src/openai/vendor.rs
@@ -50,7 +50,7 @@ pub fn build_placeholders(
         .and_then(|c| c.approx_cloud_messages)
         .map(|(a, b)| format!("{a}-{b}"))
         .unwrap_or_default();
-    let reset_summary = reset_credits(&snap.reset_credits, now);
+    let reset_summary = reset_credits(&snap.reset_credits);
 
     placeholders(vec![
         ("icon", "󱢆".to_string()),

--- a/src/supergrok/direct.rs
+++ b/src/supergrok/direct.rs
@@ -64,7 +64,7 @@ pub async fn fetch_billing_with(auth_path: &Path, base_url: &str) -> Result<Bill
 /// The file maps issuer-prefixed client ids to login records that carry a
 /// `key`. The first non-empty key wins; parsing stays bounded so a replaced
 /// or oversized file cannot stall or exhaust the fetch.
-fn read_billing_key(auth_path: &Path) -> Result<String> {
+pub(super) fn read_billing_key(auth_path: &Path) -> Result<String> {
     let metadata = std::fs::metadata(auth_path).map_err(|_| {
         AppError::Credentials("Grok Build login file not found; run `grok login`".into())
     })?;

--- a/src/supergrok/direct.rs
+++ b/src/supergrok/direct.rs
@@ -194,19 +194,10 @@ mod tests {
         );
         m.assert_async().await;
     }
-    /// `GROK_CLI_CHAT_PROXY_BASE_URL` is a real Grok CLI variable — `scope.rs`
-    /// hashes it into the cache digest for exactly that reason. Honouring it
-    /// *here* would be different: this is the one request that carries the
-    /// login's long-lived key, so an ambient variable in whatever environment
-    /// Waybar inherited would choose where that key is sent. The destination
-    /// stays pinned; tests reach the seam through `fetch_billing_with`.
+    /// The published host, pinned. (That neither module takes its host from
+    /// the environment is asserted once for the whole vendor in `mod.rs`.)
     #[test]
-    fn the_billing_destination_is_not_environment_controlled() {
-        let source = include_str!("direct.rs");
-        assert!(
-            !crate::guard::production_code(source).contains("env::var"),
-            "the credential-bearing request must not take its host from the environment"
-        );
+    fn the_billing_host_is_the_published_one() {
         assert_eq!(DEFAULT_BASE_URL, "https://cli-chat-proxy.grok.com");
     }
 }

--- a/src/supergrok/fetch.rs
+++ b/src/supergrok/fetch.rs
@@ -12,10 +12,10 @@ use crate::error::{AppError, Result};
 use crate::usage::{SuperGrokPeriod, SuperGrokSnapshot};
 
 use super::scope::ScopePaths;
-use super::{acp, direct, scope, types};
+use super::{acp, direct, resets, scope, types};
 
 const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
-const CACHE_SCHEMA: u8 = 2;
+const CACHE_SCHEMA: u8 = 3;
 
 /// This vendor's [`Outcome`](crate::outcome::Outcome) — the shared shape,
 /// specialised to its snapshot.
@@ -47,13 +47,15 @@ async fn fetch_billing_any(
     grok_binary: &Path,
     scope_paths: &ScopePaths,
 ) -> Result<types::BillingResponse> {
-    match direct::fetch_billing(&scope_paths.auth).await {
+    let mut response = match direct::fetch_billing(&scope_paths.auth).await {
         Ok(response) => Ok(response),
         Err(direct_error) => match acp::fetch_billing(grok_binary).await {
             Ok(response) => Ok(response),
             Err(_) => Err(direct_error),
         },
-    }
+    }?;
+    response.reset_credits = resets::fetch(&scope_paths.auth).await.unwrap_or_default();
+    Ok(response)
 }
 
 async fn fetch_snapshot_with<S, F, Fut>(
@@ -126,6 +128,8 @@ struct CachedSnapshot {
     period: String,
     reset_at: Option<DateTime<Utc>>,
     prepaid_balance: Option<f64>,
+    #[serde(default)]
+    reset_credits: crate::usage::ResetCredits,
 }
 
 impl CachedEnvelope {
@@ -144,6 +148,7 @@ impl CachedEnvelope {
                 period: period.to_string(),
                 reset_at: snapshot.reset_at,
                 prepaid_balance: snapshot.prepaid_balance,
+                reset_credits: snapshot.reset_credits.clone(),
             },
         }
     }
@@ -192,6 +197,15 @@ fn parse_cache(bytes: &[u8], account_scope: &str) -> Result<SuperGrokSnapshot> {
             "SuperGrok cached prepaid balance is invalid".into(),
         ));
     }
+    // The count comes from the tokens themselves, so more expiries than
+    // credits means the two disagree about what was in the response.
+    if cached.snapshot.reset_credits.credits.len()
+        > cached.snapshot.reset_credits.available as usize
+    {
+        return Err(AppError::Schema(
+            "SuperGrok cached reset credits are inconsistent".into(),
+        ));
+    }
 
     Ok(SuperGrokSnapshot {
         plan: cached.snapshot.plan,
@@ -200,6 +214,7 @@ fn parse_cache(bytes: &[u8], account_scope: &str) -> Result<SuperGrokSnapshot> {
         period,
         reset_at: cached.snapshot.reset_at,
         prepaid_balance: cached.snapshot.prepaid_balance,
+        reset_credits: cached.snapshot.reset_credits,
     })
 }
 
@@ -282,6 +297,87 @@ mod tests {
             "subscription_tier": "SuperGrok"
         }))
         .unwrap()
+    }
+
+    /// The reset inventory is fetched beside the billing response, so it has
+    /// to survive the cache with it: a hit that dropped it would show the
+    /// resets for one refresh and then quietly stop mentioning them.
+    #[tokio::test]
+    async fn banked_resets_survive_the_cache_round_trip() {
+        let (_td, cache) = fixture();
+        let expiry = Utc.with_ymd_and_hms(2026, 8, 12, 0, 0, 0).unwrap();
+        let mut response = weekly_response(10.0);
+        response.reset_credits = crate::usage::ResetCredits {
+            available: 2,
+            credits: vec![crate::usage::ResetCredit {
+                title: None,
+                expires_at: Some(expiry),
+            }],
+        };
+        let fresh = fetch_snapshot_with(
+            &cache,
+            Duration::from_secs(3600),
+            now(),
+            || Some("scope-a".into()),
+            || async { Ok(response) },
+        )
+        .await
+        .unwrap();
+        assert_eq!(fresh.snapshot.reset_credits.available, 2);
+
+        let cached = fetch_snapshot_with(
+            &cache,
+            Duration::from_secs(3600),
+            now(),
+            || Some("scope-a".into()),
+            || async { panic!("a fresh cache must not refetch") },
+        )
+        .await
+        .unwrap();
+        assert_eq!(cached.snapshot.reset_credits.available, 2);
+        assert_eq!(cached.snapshot.reset_credits.next_expiry(), Some(expiry));
+    }
+
+    #[test]
+    fn a_cache_claiming_more_expiries_than_credits_is_rejected() {
+        let cached = serde_json::json!({
+            "schema": CACHE_SCHEMA,
+            "scope": "scope-a",
+            "snapshot": {
+                "plan": "SuperGrok",
+                "percent": 5,
+                "period": "weekly",
+                "reset_at": null,
+                "prepaid_balance": null,
+                "reset_credits": {
+                    "available": 1,
+                    "credits": [
+                        {"expires_at": "2026-08-12T00:00:00Z"},
+                        {"expires_at": "2026-08-19T00:00:00Z"}
+                    ]
+                }
+            }
+        });
+        assert!(parse_cache(cached.to_string().as_bytes(), "scope-a").is_err());
+    }
+
+    /// A cache written before this vendor knew about banked resets is not
+    /// wrong, it is silent — it must still load, reporting none.
+    #[test]
+    fn a_cache_without_reset_credits_still_loads() {
+        let cached = serde_json::json!({
+            "schema": CACHE_SCHEMA,
+            "scope": "scope-a",
+            "snapshot": {
+                "plan": "SuperGrok",
+                "percent": 5,
+                "period": "weekly",
+                "reset_at": null,
+                "prepaid_balance": null
+            }
+        });
+        let snapshot = parse_cache(cached.to_string().as_bytes(), "scope-a").unwrap();
+        assert!(snapshot.reset_credits.is_empty());
     }
 
     #[tokio::test]

--- a/src/supergrok/mod.rs
+++ b/src/supergrok/mod.rs
@@ -29,3 +29,30 @@ pub mod types;
 pub mod vendor;
 
 pub use fetch::{FetchOutcome, fetch_snapshot};
+
+#[cfg(test)]
+mod guard_tests {
+    /// Both outgoing calls here carry the login's long-lived key, so neither
+    /// may take its host from the environment — an ambient variable in
+    /// whatever session Waybar inherited would choose where the key goes.
+    ///
+    /// One test over the whole module rather than a copy inside each file:
+    /// `direct.rs` and `resets.rs` each grew their own, and a third endpoint
+    /// would have grown a third. A new file is covered the moment it lands.
+    #[test]
+    fn no_credential_bearing_request_takes_its_host_from_the_environment() {
+        let mut offenders = Vec::new();
+        for file in crate::guard::rs_files_in("src/supergrok") {
+            let source = std::fs::read_to_string(&file).expect("readable module");
+            let production = crate::guard::production_code(&source);
+            if production.contains("Authorization") && production.contains("env::var") {
+                offenders.push(file.display().to_string());
+            }
+        }
+        assert!(
+            offenders.is_empty(),
+            "a request carrying the login key must use a fixed host; tests reach \
+             the seam through an explicit parameter. Found: {offenders:#?}"
+        );
+    }
+}

--- a/src/supergrok/mod.rs
+++ b/src/supergrok/mod.rs
@@ -1,18 +1,21 @@
 //! SuperGrok (xAI subscription OAuth) usage through the official Grok Build
 //! CLI's billing surface.
 //!
-//! Two transports, same credential-free billing response:
+//! Two transports for the usage figures, plus one for banked resets:
 //! - `direct` — one HTTPS call to the documented `cli-chat-proxy.grok.com`
-//!   billing endpoint using the login's long-lived `key` (needed since grok
-//!   CLI 1.0.13 dropped the ACP extension; primary path).
+//!   billing endpoint using the login's `key` (needed since grok CLI 1.0.13
+//!   dropped the ACP extension; primary path).
 //! - `acp` — the CLI's `x.ai/billing` ACP extension (fallback for CLI builds
 //!   where the proxy endpoint is unreachable or reshaped).
+//! - `resets` — `grok.com` `ConsumerUiSvc/GetRemainingResets`, a gRPC-Web
+//!   call authenticated with the same `key`. Failures are swallowed: a
+//!   broken extra call must not take the usage figures with it.
 //!
 //! ai-usagebar never copies, caches, refreshes, or writes Grok tokens. The
-//! `key` exists only inside one outgoing Authorization header; login files
-//! are read solely as bytes (key lookup or one-way cache-scope digest) and
-//! account selection, OIDC rotation, and `auth.json.lock` stay with Grok
-//! Build.
+//! `key` exists only inside the outgoing Authorization headers of those
+//! requests; login files are read solely as bytes (key lookup or one-way
+//! cache-scope digest) and account selection, OIDC rotation, and
+//! `auth.json.lock` stay with Grok Build.
 //!
 //! Distinct from the `grok` vendor, which reads **prepaid Management API**
 //! balance with a management key — SuperGrok is the subscription quota path.
@@ -20,6 +23,7 @@
 pub mod acp;
 pub mod direct;
 pub mod fetch;
+mod resets;
 pub mod scope;
 pub mod types;
 pub mod vendor;

--- a/src/supergrok/resets.rs
+++ b/src/supergrok/resets.rs
@@ -1,0 +1,403 @@
+//! Banked "remaining resets" from Grok's consumer billing RPC.
+//!
+//! Separate from `direct`'s billing call in every way that matters: a
+//! different host, a different service, and a protobuf body rather than JSON.
+//! The response is `ConsumerGetRemainingResetsResp { repeated ConsumerResetToken
+//! tokens = 10 }`, where a token carries `token_id = 10`, `validity_start = 20`
+//! and `validity_end = 30`.
+//!
+//! Only the count and `validity_end` are kept. `token_id` is the handle that
+//! *spends* a reset, so it is skipped during parsing rather than parsed and
+//! dropped — nothing downstream can leak what was never held.
+//!
+//! The parser here is deliberately a few dozen lines rather than a protobuf
+//! dependency: two message shapes, three fields, one of which is a well-known
+//! `Timestamp`. Everything it does not recognise it skips by wire type, so an
+//! added field cannot break it.
+
+use std::path::Path;
+
+use chrono::{DateTime, Utc};
+
+use crate::error::{AppError, Result};
+use crate::usage::{ResetCredit, ResetCredits};
+use crate::vendor::{MAX_BODY_BYTES, read_body_capped, same_origin_redirect_policy};
+
+/// Fixed for the same reason `direct`'s is: this request carries the login's
+/// key, so an ambient variable must not choose where the key is sent. Tests
+/// reach the seam through [`fetch_with`].
+const RESET_URL: &str = "https://grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets";
+
+pub async fn fetch(auth_path: &Path) -> Result<ResetCredits> {
+    fetch_with(auth_path, RESET_URL).await
+}
+
+async fn fetch_with(auth_path: &Path, url: &str) -> Result<ResetCredits> {
+    let key = super::direct::read_billing_key(auth_path)?;
+    let client = reqwest::Client::builder()
+        .timeout(crate::vendor::HTTP_CLIENT_TIMEOUT)
+        .redirect(same_origin_redirect_policy())
+        .build()
+        .map_err(|_| AppError::Other("failed to build the Grok reset HTTP client".into()))?;
+    let response = client
+        .post(url)
+        .header("Authorization", format!("Bearer {key}"))
+        .header("Content-Type", "application/grpc-web+proto")
+        .header("x-grpc-web", "1")
+        .header("Origin", "https://grok.com")
+        .body(vec![0; 5])
+        .send()
+        .await
+        .map_err(|e| AppError::Transport(format!("Grok reset request failed: {e}")))?;
+    let status = response.status();
+    let bytes = read_body_capped(response, MAX_BODY_BYTES).await?;
+    if !status.is_success() {
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body: String::new(),
+        });
+    }
+    parse_grpc_web(&bytes)
+}
+
+/// gRPC-Web frames a body as `[flags: u8][len: u32 BE][payload]`, repeated.
+/// A `0x80` flag marks the trailer frame, which is where a gRPC-level failure
+/// arrives — with HTTP 200 in front of it. Reading only the data frames would
+/// turn "your token was rejected" into an authoritative "0 resets", so the
+/// trailer's status is checked before any count is believed.
+fn parse_grpc_web(bytes: &[u8]) -> Result<ResetCredits> {
+    let mut offset = 0;
+    let mut credits = ResetCredits::default();
+    while offset < bytes.len() {
+        if bytes.len() - offset < 5 {
+            return Err(schema_error());
+        }
+        let flags = bytes[offset];
+        let len = u32::from_be_bytes(bytes[offset + 1..offset + 5].try_into().unwrap()) as usize;
+        offset += 5;
+        let end = offset
+            .checked_add(len)
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(schema_error)?;
+        if flags & 0x80 != 0 {
+            check_trailer(&bytes[offset..end])?;
+        } else if flags == 0 {
+            parse_response(&bytes[offset..end], &mut credits)?;
+        } else {
+            return Err(schema_error());
+        }
+        offset = end;
+    }
+    Ok(credits)
+}
+
+/// The trailer is HTTP-header text, not protobuf. A missing `grpc-status` is
+/// success by the spec's own default; anything else is a failed call.
+fn check_trailer(bytes: &[u8]) -> Result<()> {
+    let text = String::from_utf8_lossy(bytes);
+    for line in text.split(['\r', '\n']) {
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("grpc-status") && value.trim() != "0" {
+            return Err(AppError::Other(
+                "Grok declined the remaining-resets request".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn parse_response(bytes: &[u8], credits: &mut ResetCredits) -> Result<()> {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let key = read_varint(bytes, &mut offset)?;
+        if key == (10 << 3 | 2) {
+            let token = read_delimited(bytes, &mut offset)?;
+            credits.available = credits.available.checked_add(1).ok_or_else(schema_error)?;
+            credits.credits.push(ResetCredit {
+                title: None,
+                expires_at: parse_token(token)?,
+            });
+        } else {
+            skip_field(bytes, &mut offset, key & 7)?;
+        }
+    }
+    Ok(())
+}
+
+fn parse_token(bytes: &[u8]) -> Result<Option<DateTime<Utc>>> {
+    let mut offset = 0;
+    let mut expires_at = None;
+    while offset < bytes.len() {
+        let key = read_varint(bytes, &mut offset)?;
+        if key == (30 << 3 | 2) {
+            let timestamp = read_delimited(bytes, &mut offset)?;
+            expires_at = parse_timestamp(timestamp)?;
+        } else {
+            skip_field(bytes, &mut offset, key & 7)?;
+        }
+    }
+    Ok(expires_at)
+}
+
+fn parse_timestamp(bytes: &[u8]) -> Result<Option<DateTime<Utc>>> {
+    let mut offset = 0;
+    let mut seconds = None;
+    while offset < bytes.len() {
+        let key = read_varint(bytes, &mut offset)?;
+        if key == 8 {
+            seconds = Some(read_varint(bytes, &mut offset)? as i64);
+        } else {
+            skip_field(bytes, &mut offset, key & 7)?;
+        }
+    }
+    seconds
+        .map(|seconds| DateTime::from_timestamp(seconds, 0).ok_or_else(schema_error))
+        .transpose()
+}
+
+fn read_delimited<'a>(bytes: &'a [u8], offset: &mut usize) -> Result<&'a [u8]> {
+    let len = usize::try_from(read_varint(bytes, offset)?).map_err(|_| schema_error())?;
+    let end = offset
+        .checked_add(len)
+        .filter(|end| *end <= bytes.len())
+        .ok_or_else(schema_error)?;
+    let value = &bytes[*offset..end];
+    *offset = end;
+    Ok(value)
+}
+
+fn read_varint(bytes: &[u8], offset: &mut usize) -> Result<u64> {
+    let mut value = 0_u64;
+    for shift in (0..70).step_by(7) {
+        let byte = *bytes.get(*offset).ok_or_else(schema_error)?;
+        *offset += 1;
+        if shift == 63 && byte > 1 {
+            return Err(schema_error());
+        }
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+    }
+    Err(schema_error())
+}
+
+fn skip_field(bytes: &[u8], offset: &mut usize, wire_type: u64) -> Result<()> {
+    match wire_type {
+        0 => {
+            read_varint(bytes, offset)?;
+        }
+        1 => {
+            *offset = offset
+                .checked_add(8)
+                .filter(|end| *end <= bytes.len())
+                .ok_or_else(schema_error)?
+        }
+        2 => {
+            read_delimited(bytes, offset)?;
+        }
+        5 => {
+            *offset = offset
+                .checked_add(4)
+                .filter(|end| *end <= bytes.len())
+                .ok_or_else(schema_error)?
+        }
+        _ => return Err(schema_error()),
+    }
+    Ok(())
+}
+
+fn schema_error() -> AppError {
+    AppError::Schema("Grok reset response does not match the expected schema".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn varint(mut value: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return out;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    fn delimited(field: u64, payload: &[u8]) -> Vec<u8> {
+        let mut out = varint(field << 3 | 2);
+        out.extend(varint(payload.len() as u64));
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn timestamp(seconds: i64) -> Vec<u8> {
+        let mut out = varint(1 << 3);
+        out.extend(varint(seconds as u64));
+        out
+    }
+
+    /// `ConsumerResetToken { token_id = 10, validity_start = 20, validity_end = 30 }`.
+    fn token(id: &str, start: i64, end: i64) -> Vec<u8> {
+        let mut out = delimited(10, id.as_bytes());
+        out.extend(delimited(20, &timestamp(start)));
+        out.extend(delimited(30, &timestamp(end)));
+        out
+    }
+
+    fn data_frame(payload: &[u8]) -> Vec<u8> {
+        let mut out = vec![0];
+        out.extend((payload.len() as u32).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn trailer_frame(text: &str) -> Vec<u8> {
+        let mut out = vec![0x80];
+        out.extend((text.len() as u32).to_be_bytes());
+        out.extend_from_slice(text.as_bytes());
+        out
+    }
+
+    fn at(seconds: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(seconds, 0).unwrap()
+    }
+
+    #[test]
+    fn every_remaining_token_is_counted_with_its_own_expiry() {
+        let mut body = delimited(10, &token("restok_one", 1_786_560_540, 1_789_238_940));
+        body.extend(delimited(
+            10,
+            &token("restok_two", 1_786_560_540, 1_791_830_940),
+        ));
+        let parsed = parse_grpc_web(&data_frame(&body)).unwrap();
+
+        assert_eq!(parsed.available, 2);
+        assert_eq!(
+            parsed
+                .credits
+                .iter()
+                .filter_map(|credit| credit.expires_at)
+                .collect::<Vec<_>>(),
+            vec![at(1_789_238_940), at(1_791_830_940)]
+        );
+        assert_eq!(parsed.next_expiry(), Some(at(1_789_238_940)));
+    }
+
+    /// `token_id` spends the reset. It must not survive parsing, so that no
+    /// later cache write, tooltip, or error message can carry it.
+    #[test]
+    fn the_redemption_token_id_never_leaves_the_parser() {
+        let body = delimited(10, &token("restok_secret", 1, 1_789_238_940));
+        let parsed = parse_grpc_web(&data_frame(&body)).unwrap();
+        assert!(!format!("{parsed:?}").contains("restok_secret"));
+    }
+
+    /// gRPC reports failure with HTTP 200 and a trailer. Treating that as an
+    /// empty token list would state "0 resets available" on the strength of a
+    /// rejected request.
+    #[test]
+    fn a_rejected_call_in_a_trailer_is_not_read_as_zero_resets() {
+        let mut framed = data_frame(&[]);
+        framed.extend(trailer_frame(
+            "grpc-status:16\r\ngrpc-message:unauthenticated\r\n",
+        ));
+        assert!(parse_grpc_web(&framed).is_err());
+
+        let mut ok = data_frame(&delimited(10, &token("restok", 1, 1_789_238_940)));
+        ok.extend(trailer_frame("grpc-status:0\r\n"));
+        assert_eq!(parse_grpc_web(&ok).unwrap().available, 1);
+    }
+
+    #[test]
+    fn truncated_or_malformed_frames_are_rejected_rather_than_partially_believed() {
+        let body = delimited(10, &token("restok", 1, 1_789_238_940));
+        let framed = data_frame(&body);
+        for cut in [3, 6, framed.len() - 1] {
+            assert!(parse_grpc_web(&framed[..cut]).is_err(), "cut at {cut}");
+        }
+        // A length prefix that claims more than the frame holds.
+        let mut lying = vec![0u8];
+        lying.extend(255_u32.to_be_bytes());
+        lying.extend_from_slice(&body);
+        assert!(parse_grpc_web(&lying).is_err());
+        // Wire type 7 does not exist.
+        assert!(parse_grpc_web(&data_frame(&[0x0f, 0x00])).is_err());
+    }
+
+    #[test]
+    fn unknown_fields_are_skipped_instead_of_breaking_the_parse() {
+        let mut extended = token("restok", 1, 1_789_238_940);
+        extended.extend(delimited(40, b"a field this version has never seen"));
+        let mut fixed64 = varint(50 << 3 | 1);
+        fixed64.extend([0; 8]);
+        extended.extend(fixed64);
+        let parsed = parse_grpc_web(&data_frame(&delimited(10, &extended))).unwrap();
+        assert_eq!(parsed.available, 1);
+        assert_eq!(parsed.next_expiry(), Some(at(1_789_238_940)));
+    }
+
+    #[tokio::test]
+    async fn sends_an_empty_grpc_web_request_with_bearer_auth() {
+        let mut auth = tempfile::NamedTempFile::new().unwrap();
+        auth.write_all(br#"{"issuer::client":{"key":"secret-key"}}"#)
+            .unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/resets")
+            .match_header("Authorization", "Bearer secret-key")
+            .match_header("Content-Type", "application/grpc-web+proto")
+            .match_header("x-grpc-web", "1")
+            .match_body(vec![0u8, 0, 0, 0, 0])
+            .with_body(data_frame(&delimited(
+                10,
+                &token("restok", 1, 1_789_238_940),
+            )))
+            .create_async()
+            .await;
+        let result = fetch_with(auth.path(), &format!("{}/resets", server.url()))
+            .await
+            .unwrap();
+        mock.assert_async().await;
+        assert_eq!(result.available, 1);
+        assert_eq!(result.next_expiry(), Some(at(1_789_238_940)));
+    }
+
+    #[tokio::test]
+    async fn an_http_error_reports_no_credentials_and_no_body() {
+        let mut auth = tempfile::NamedTempFile::new().unwrap();
+        auth.write_all(br#"{"issuer::client":{"key":"secret-key"}}"#)
+            .unwrap();
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/resets")
+            .with_status(403)
+            .with_body("secret-key is not entitled")
+            .create_async()
+            .await;
+        let error = fetch_with(auth.path(), &format!("{}/resets", server.url()))
+            .await
+            .unwrap_err()
+            .to_string();
+        mock.assert_async().await;
+        assert!(!error.contains("secret-key"));
+    }
+
+    /// Same rule as `direct.rs`: the request that carries the login's key does
+    /// not take its destination from the environment.
+    #[test]
+    fn the_reset_destination_is_not_environment_controlled() {
+        let source = include_str!("resets.rs");
+        assert!(
+            !crate::guard::production_code(source).contains("env::var"),
+            "the credential-bearing request must not take its host from the environment"
+        );
+    }
+}

--- a/src/supergrok/resets.rs
+++ b/src/supergrok/resets.rs
@@ -28,6 +28,11 @@ use crate::vendor::{MAX_BODY_BYTES, read_body_capped, same_origin_redirect_polic
 /// reach the seam through [`fetch_with`].
 const RESET_URL: &str = "https://grok.com/prod_mc_billing.ConsumerUiSvc/GetRemainingResets";
 
+/// Upper bound on the per-credit rows kept for display. Nobody banks this many
+/// resets; the bound exists so a malformed or hostile response cannot turn a
+/// tooltip into a six-figure list.
+const MAX_LISTED_CREDITS: usize = 64;
+
 pub async fn fetch(auth_path: &Path) -> Result<ResetCredits> {
     fetch_with(auth_path, RESET_URL).await
 }
@@ -115,10 +120,16 @@ fn parse_response(bytes: &[u8], credits: &mut ResetCredits) -> Result<()> {
         if key == (10 << 3 | 2) {
             let token = read_delimited(bytes, &mut offset)?;
             credits.available = credits.available.checked_add(1).ok_or_else(schema_error)?;
-            credits.credits.push(ResetCredit {
-                title: None,
-                expires_at: parse_token(token)?,
-            });
+            // Each token becomes a rendered row. The 2 MiB body cap alone
+            // still allows a six-figure row count from ~2-byte tokens, so the
+            // count keeps rising while the *inventory* stops — the number
+            // stays truthful and the tooltip stays a tooltip.
+            if credits.credits.len() < MAX_LISTED_CREDITS {
+                credits.credits.push(ResetCredit {
+                    title: None,
+                    expires_at: parse_token(token)?,
+                });
+            }
         } else {
             skip_field(bytes, &mut offset, key & 7)?;
         }
@@ -390,14 +401,29 @@ mod tests {
         assert!(!error.contains("secret-key"));
     }
 
-    /// Same rule as `direct.rs`: the request that carries the login's key does
-    /// not take its destination from the environment.
+    /// The body cap alone permits a six-figure row count from minimal tokens,
+    /// and every row is rendered. The count must stay truthful while the
+    /// listed inventory stops.
     #[test]
-    fn the_reset_destination_is_not_environment_controlled() {
-        let source = include_str!("resets.rs");
-        assert!(
-            !crate::guard::production_code(source).contains("env::var"),
-            "the credential-bearing request must not take its host from the environment"
+    fn a_flood_of_tokens_is_counted_but_not_all_listed() {
+        let flood = MAX_LISTED_CREDITS + 25;
+        let mut body = Vec::new();
+        for _ in 0..flood {
+            body.extend(delimited(
+                10,
+                &token("restok", 1_786_560_540, 1_789_238_940),
+            ));
+        }
+        let parsed = parse_grpc_web(&data_frame(&body)).expect("a long but valid response parses");
+
+        assert_eq!(
+            parsed.available as usize, flood,
+            "every token still counts toward the total"
+        );
+        assert_eq!(
+            parsed.credits.len(),
+            MAX_LISTED_CREDITS,
+            "the per-credit inventory stops at the cap"
         );
     }
 }

--- a/src/supergrok/types.rs
+++ b/src/supergrok/types.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::error::{AppError, Result};
-use crate::usage::{SuperGrokPeriod, SuperGrokSnapshot};
+use crate::usage::{ResetCredits, SuperGrokPeriod, SuperGrokSnapshot};
 
 const MAX_PLAN_CHARS: usize = 128;
 const MAX_BENIGN_PERCENT: f64 = 100.5;
@@ -18,6 +18,8 @@ pub struct BillingResponse {
     /// compatibility with older/direct extension bridges.
     #[serde(alias = "subscriptionTier")]
     pub subscription_tier: Option<String>,
+    #[serde(skip)]
+    pub reset_credits: ResetCredits,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -93,6 +95,7 @@ pub fn to_snapshot(resp: BillingResponse, account_scope: &str) -> Result<SuperGr
         period,
         reset_at,
         prepaid_balance,
+        reset_credits: resp.reset_credits,
     })
 }
 

--- a/src/supergrok/vendor.rs
+++ b/src/supergrok/vendor.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 
 use crate::countdown;
-use crate::format::{placeholders, substitute, updated_at_hm, usd};
+use crate::format::{
+    placeholders, reset_credit_lines, reset_credits, substitute, updated_at_hm, usd,
+};
 use crate::pacing::PaceSeverity;
 use crate::pango::{self, color_span, escape, severity_color, severity_for};
 use crate::theme::Theme;
@@ -43,6 +45,11 @@ pub fn build_placeholders(
         ("sgk_reset", reset),
         ("sgk_period", snap.period.label().to_string()),
         ("sgk_prepaid", prepaid),
+        (
+            "sgk_resets_available",
+            snap.reset_credits.available.to_string(),
+        ),
+        ("sgk_resets", reset_credits(&snap.reset_credits, now)),
     ])
 }
 
@@ -130,6 +137,7 @@ fn render_tooltip(
 ) -> String {
     let blue = &theme.blue;
     let dim = &theme.dim;
+    let fg = &theme.fg;
 
     let mut lines: Vec<TooltipLine> = Vec::new();
     lines.push(TooltipLine::Center(format!(
@@ -156,6 +164,19 @@ fn render_tooltip(
             " <span foreground='{dim}'>  󰢗  Prepaid API  {}</span>",
             escape(&bal_s)
         )));
+    }
+
+    if snap.reset_credits.available > 0 {
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{fg}'>  󰁯  Reset credits</span>"
+        )));
+        for line in reset_credit_lines(&snap.reset_credits, now) {
+            lines.push(TooltipLine::Body(format!(
+                " <span foreground='{dim}'>     {}</span>",
+                escape(&line)
+            )));
+        }
     }
 
     if let Some((code, msg)) = outcome.last_error.as_ref() {
@@ -214,6 +235,7 @@ mod tests {
             period: SuperGrokPeriod::Weekly,
             reset_at: Some(now() + chrono::Duration::hours(20)),
             prepaid_balance: Some(0.0),
+            reset_credits: Default::default(),
         }
     }
 
@@ -254,6 +276,44 @@ mod tests {
             out.tooltip
         );
         assert!(out.tooltip.contains("Resets in"));
+    }
+
+    #[test]
+    fn tooltip_reports_banked_resets_and_stays_silent_without_them() {
+        let snap = sample_snap();
+        let quiet = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert!(!quiet.tooltip.contains("available"), "{}", quiet.tooltip);
+
+        let mut snap = snap;
+        snap.reset_credits = crate::usage::ResetCredits {
+            available: 1,
+            credits: vec![crate::usage::ResetCredit {
+                title: None,
+                expires_at: Some(now() + chrono::Duration::days(7)),
+            }],
+        };
+        let out = render(
+            &sample_outcome(snap.clone()),
+            &snap,
+            &Theme::default(),
+            &opts(),
+            now(),
+        );
+        assert!(out.tooltip.contains("Reset credits"), "{}", out.tooltip);
+        assert!(out.tooltip.contains("Expires"), "{}", out.tooltip);
+
+        let ph = build_placeholders(&snap, now());
+        assert_eq!(
+            ph.get("sgk_resets_available").map(String::as_str),
+            Some("1")
+        );
+        assert!(ph["sgk_resets"].starts_with("1 reset available"));
     }
 
     #[test]

--- a/src/supergrok/vendor.rs
+++ b/src/supergrok/vendor.rs
@@ -49,7 +49,7 @@ pub fn build_placeholders(
             "sgk_resets_available",
             snap.reset_credits.available.to_string(),
         ),
-        ("sgk_resets", reset_credits(&snap.reset_credits, now)),
+        ("sgk_resets", reset_credits(&snap.reset_credits)),
     ])
 }
 

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -19,7 +19,7 @@ use ratatui_bubbletea_components::{Progress, Spinner, SpinnerFrames};
 use ratatui_bubbletea_theme::BubbleTheme;
 
 use crate::countdown;
-use crate::format::{local_time_hms, money, usd};
+use crate::format::{local_time_hms, money, reset_credit_lines, usd};
 use crate::pacing::{self, PaceSeverity};
 use crate::pango::severity_for;
 use crate::theme::Theme;
@@ -600,6 +600,7 @@ fn openai_sections(
             body,
         });
     }
+    push_reset_credits(&mut v, &s.reset_credits, now);
     v
 }
 
@@ -1096,11 +1097,6 @@ fn supergrok_sections(s: &crate::usage::SuperGrokSnapshot, now: DateTime<Utc>) -
         },
         s.reset_at,
     );
-    v.push(Section::Spacer);
-    v.push(Section::Text {
-        label: "Resets".into(),
-        value: countdown::format(s.reset_at, now),
-    });
     if let Some(bal) = s.prepaid_balance {
         v.push(Section::Spacer);
         v.push(Section::Text {
@@ -1108,7 +1104,23 @@ fn supergrok_sections(s: &crate::usage::SuperGrokSnapshot, now: DateTime<Utc>) -
             value: usd(bal),
         });
     }
+    push_reset_credits(&mut v, &s.reset_credits, now);
     v
+}
+
+fn push_reset_credits(
+    v: &mut SectionBuilder,
+    credits: &crate::usage::ResetCredits,
+    now: DateTime<Utc>,
+) {
+    if credits.is_empty() {
+        return;
+    }
+    v.push(Section::Spacer);
+    v.push(Section::Block {
+        label: "Reset credits".into(),
+        body: reset_credit_lines(credits, now),
+    });
 }
 
 fn deepseek_sections(s: &crate::usage::DeepseekSnapshot) -> SectionBuilder {
@@ -1418,7 +1430,7 @@ mod tests {
     use super::*;
     use crate::usage::{
         AnthropicSnapshot, Cents, ExtraUsage, KimiSnapshot, OpenAiCredits, OpenAiSnapshot,
-        OpenAiSource, OpenRouterSnapshot, UsageWindow, ZaiSnapshot,
+        OpenAiSource, OpenRouterSnapshot, ResetCredit, ResetCredits, UsageWindow, ZaiSnapshot,
     };
     use chrono::TimeZone;
 
@@ -1716,6 +1728,7 @@ mod tests {
             weekly: None,
             code_review: None,
             credits: None,
+            reset_credits: ResetCredits::default(),
             source: OpenAiSource::CodexOauth,
         };
         let sections = sections_for(&ready(VendorSnapshot::Openai(snap)), now(), 5);
@@ -1769,6 +1782,7 @@ mod tests {
                 approx_local_messages: Some((100, 200)),
                 approx_cloud_messages: Some((30, 50)),
             }),
+            reset_credits: ResetCredits::default(),
             source: OpenAiSource::CodexOauth,
         };
         let sections = sections_for(&ready(VendorSnapshot::Openai(snap)), now(), 5);
@@ -1791,6 +1805,7 @@ mod tests {
             }),
             code_review: None,
             credits: None,
+            reset_credits: ResetCredits::default(),
             source: OpenAiSource::CodexOauth,
         };
         let sections = sections_for(&ready(VendorSnapshot::Openai(snap)), now(), 5);
@@ -1801,6 +1816,106 @@ mod tests {
         assert!(!sections.iter().any(|section| matches!(
             section,
             Section::Metric { label, .. } if label == "Codex 5h"
+        )));
+    }
+
+    /// Both vendors reach every frontend through these sections — the TUI
+    /// panel, `usage --json`, and from there the Omarchy, GNOME and KDE
+    /// surfaces. One row, one wording, whichever provider banked the reset.
+    #[test]
+    fn banked_resets_reach_the_panel_for_both_providers() {
+        let now = now();
+        let credits = ResetCredits {
+            available: 2,
+            credits: vec![
+                ResetCredit {
+                    title: Some("Full reset (Weekly + 5 hr)".into()),
+                    expires_at: Some(now + chrono::Duration::days(13)),
+                },
+                ResetCredit {
+                    title: Some("Full reset (Weekly + 5 hr)".into()),
+                    expires_at: Some(now + chrono::Duration::days(13) + chrono::Duration::hours(6)),
+                },
+            ],
+        };
+        let codex = OpenAiSnapshot {
+            plan: "ChatGPT Plus".into(),
+            session: None,
+            weekly: None,
+            code_review: None,
+            credits: None,
+            reset_credits: credits.clone(),
+            source: OpenAiSource::CodexOauth,
+        };
+        let supergrok = crate::usage::SuperGrokSnapshot {
+            plan: "SuperGrok".into(),
+            account: "scope".into(),
+            weekly_pct: 30,
+            period: crate::usage::SuperGrokPeriod::Weekly,
+            reset_at: Some(now + chrono::Duration::days(3)),
+            prepaid_balance: None,
+            reset_credits: credits,
+        };
+
+        for snapshot in [
+            VendorSnapshot::Openai(codex),
+            VendorSnapshot::SuperGrok(supergrok),
+        ] {
+            let sections = sections_for(&ready(snapshot), now, 5);
+            let body = sections.iter().find_map(|section| match section {
+                Section::Block { label, body } if label == "Reset credits" => Some(body.clone()),
+                _ => None,
+            });
+            let body = body.expect("reset credits block");
+            assert_eq!(body.len(), 2, "{body:?}");
+            assert!(
+                body.iter()
+                    .all(|line| line.contains("Full reset (Weekly + 5 hr)")),
+                "{body:?}"
+            );
+        }
+    }
+
+    /// The row is absent, not zeroed: an account that has never earned a reset
+    /// should not carry a permanent "0 resets available" line.
+    #[test]
+    fn a_provider_with_no_banked_resets_shows_no_reset_row() {
+        let snap = OpenAiSnapshot {
+            plan: "ChatGPT Plus".into(),
+            session: None,
+            weekly: None,
+            code_review: None,
+            credits: None,
+            reset_credits: ResetCredits::default(),
+            source: OpenAiSource::CodexOauth,
+        };
+        let sections = sections_for(&ready(VendorSnapshot::Openai(snap)), now(), 5);
+        assert!(!sections.iter().any(|section| matches!(
+            section,
+            Section::Block { label, .. } if label == "Reset credits"
+        )));
+    }
+
+    #[test]
+    fn supergrok_does_not_repeat_the_window_reset_as_its_own_section() {
+        let now = now();
+        let snap = crate::usage::SuperGrokSnapshot {
+            plan: "SuperGrok".into(),
+            account: "scope".into(),
+            weekly_pct: 0,
+            period: crate::usage::SuperGrokPeriod::Weekly,
+            reset_at: Some(now + chrono::Duration::days(6)),
+            prepaid_balance: Some(0.0),
+            reset_credits: ResetCredits::default(),
+        };
+        let sections = sections_for(&ready(VendorSnapshot::SuperGrok(snap)), now, 5);
+        assert!(!sections.iter().any(|section| matches!(
+            section,
+            Section::Text { label, .. } if label == "Resets"
+        )));
+        assert!(sections.iter().any(|section| matches!(
+            section,
+            Section::Text { label, .. } if label == "Prepaid API"
         )));
     }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -13,6 +13,7 @@
 //! sharing the pacing math, color thresholds, and Pango primitives.
 
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, Result};
 
@@ -472,9 +473,9 @@ pub struct GrokSnapshot {
 
 impl Eq for GrokSnapshot {}
 
-/// SuperGrok subscription usage returned by the official Grok Build CLI's
-/// credential-owning `x.ai/billing` ACP extension. Distinct from
-/// [`GrokSnapshot`] (Management API prepaid balance).
+/// SuperGrok subscription usage from Grok Build's billing endpoint (ACP as
+/// fallback) plus banked remaining-resets. Distinct from [`GrokSnapshot`]
+/// (Management API prepaid balance).
 #[derive(Debug, Clone, PartialEq)]
 pub struct SuperGrokSnapshot {
     /// Subscription tier label when the billing response supplies one
@@ -492,6 +493,7 @@ pub struct SuperGrokSnapshot {
     pub reset_at: Option<DateTime<Utc>>,
     /// Remaining prepaid (purchased) API credit in USD, when present.
     pub prepaid_balance: Option<f64>,
+    pub reset_credits: ResetCredits,
 }
 
 impl Eq for SuperGrokSnapshot {}
@@ -533,10 +535,54 @@ pub struct OpenAiSnapshot {
     pub code_review: Option<UsageWindow>,
     /// Optional credit balance + approximate message-count ranges.
     pub credits: Option<OpenAiCredits>,
+    pub reset_credits: ResetCredits,
     /// Source of the snapshot — Codex OAuth vs admin-key fallback. Drives
     /// the placeholder set and the "OpenAI does not expose this for Plus"
     /// tooltip when the OAuth path isn't available.
     pub source: OpenAiSource,
+}
+
+/// Banked, user-redeemable quota resets — Codex's "rate limit reset credits"
+/// and SuperGrok's "remaining resets" are the same idea under two names: a
+/// count you have earned, each with its own expiry, redeemed by hand rather
+/// than arriving on the window's own schedule. Distinct from a
+/// [`UsageWindow::resets_at`], which needs no action and cannot be banked.
+///
+/// The redemption identifier each provider returns alongside these
+/// (`credits[].id`, `tokens[].token_id`) is deliberately *not* carried here:
+/// it is the handle that spends the credit, and nothing that renders a status
+/// bar needs it.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResetCredits {
+    pub available: u32,
+    /// One row per credit the provider described. May be shorter than
+    /// `available` — Codex's usage endpoint gives the count without the
+    /// per-credit detail, and the detail call is allowed to fail on its own.
+    #[serde(default)]
+    pub credits: Vec<ResetCredit>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResetCredit {
+    /// Provider label when one exists ("Full reset (Weekly + 5 hr)"). SuperGrok
+    /// tokens have no title.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
+impl ResetCredits {
+    pub fn is_empty(&self) -> bool {
+        self.available == 0
+    }
+
+    pub fn next_expiry(&self) -> Option<DateTime<Utc>> {
+        self.credits
+            .iter()
+            .filter_map(|credit| credit.expires_at)
+            .min()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## What this changes

Hello!

Codex and Grok (maybe other ai providers, but not sure because I don't have them) often give you full manual resets that expire after a certain amount of time. It would be super helpful to expose this via the window so I decided to add it.

Thanks!

## Checklist

- [x] `make test`, `cargo clippy --all-targets -- -D warnings` and
      `cargo fmt --all -- --check` pass
- [x] `CHANGELOG.md` entry under `## [Unreleased]` in the right category
      (not inside an already-released section)
- [ ] A test that fails on `main` and passes here, for a bug fix
- [x] Docs updated where they mention what changed (`README.md`,
      `config.example.toml`, `docs/`)
- [x] No helper left behind without callers

## Testing

Tested on Omarchy Linux:

<img width="507" height="427" alt="image" src="https://github.com/user-attachments/assets/ebf2bf26-ba80-4226-8f66-9da8884c3b9c" />

<img width="507" height="603" alt="image" src="https://github.com/user-attachments/assets/5e9d8f9c-6df7-4063-9f60-fb04e8089a60" />
