### PR TITLE
fix(openai): treat null collections as empty instead of schema drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI (Codex) usage parsing treats explicit `null` for `additional_rate_limits`,
+  `model_usage`, and `rate_limit_reset_credits.credits` as empty rather than schema
+  drift. OpenAI returns `"additional_rate_limits": null` for accounts with no extra
+  limits, which previously surfaced as `⚠ API schema drift ... expected a sequence`.
+
 ## [1.11.0] — 2026-09-05
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ Each release is also published at
 
 ### Fixed
 
-- OpenAI (Codex) usage parsing treats explicit `null` for `additional_rate_limits`,
-  `model_usage`, and `rate_limit_reset_credits.credits` as empty rather than schema
-  drift. OpenAI returns `"additional_rate_limits": null` for accounts with no extra
-  limits, which previously surfaced as `⚠ API schema drift ... expected a sequence`.
+- **Codex works again on accounts with no extra limits.** 1.11.0 added
+  `additional_rate_limits` and `model_usage` as plain collections, and OpenAI
+  sends `null` — not `[]`/`{}` — when an account has none. `#[serde(default)]`
+  covers a *missing* field but not a present-but-null one, so the whole usage
+  response failed and Waybar showed `⚠ API schema drift … expected a sequence`.
+  Explicit `null` is now read as empty for those two and for
+  `rate_limit_reset_credits.credits`. A wrong *type* is still drift: a string or
+  a number where a collection belongs is refused rather than read as empty.
+  Reported within a day by three people independently — thank you.
 
 ## [1.11.0] — 2026-09-05
 

--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -41,10 +41,14 @@ pub struct UsageResponse {
     /// model-specific allowance. Each carries its own windows and can be the
     /// binding constraint while `rate_limit` still reads low, which is
     /// precisely when a user needs to see it.
+    /// Null from the API means "none" (observed 2026-09-05: OpenAI returns
+    /// `"additional_rate_limits": null` for accounts with no extra limits).
+    #[serde(default, deserialize_with = "de_vec_null_as_default")]
     pub additional_rate_limits: Vec<AdditionalRateLimit>,
     /// Per-model availability. `available: false` is what "Selected model is
     /// at capacity" looks like in the data — a dispatch-time refusal, not a
     /// quota, so no percentage anywhere else reflects it.
+    #[serde(default, deserialize_with = "de_map_null_as_default")]
     pub model_usage: BTreeMap<String, ModelUsage>,
 }
 
@@ -106,6 +110,7 @@ pub struct CreditsBlock {
 #[serde(default)]
 pub struct ResetCreditsBlock {
     pub available_count: u32,
+    #[serde(default, deserialize_with = "de_vec_null_as_default")]
     pub credits: Vec<ResetCredit>,
 }
 
@@ -232,6 +237,28 @@ where
             "expected credit balance string, number, or null; got {other:?}"
         ))),
     }
+}
+
+/// OpenAI omits empty collections as `null` instead of `[]`/`{}` (observed
+/// 2026-09-05 for `additional_rate_limits`). With `#[serde(default)]` alone,
+/// a missing field gets the default but an explicit `null` still fails with
+/// "invalid type: null, expected a sequence/map". These helpers treat `null`
+/// as empty while keeping every other malformed shape an error.
+fn de_vec_null_as_default<'de, D, T>(d: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(d)?.unwrap_or_default())
+}
+
+fn de_map_null_as_default<'de, D, K, V>(d: D) -> Result<BTreeMap<K, V>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    K: serde::Deserialize<'de> + Ord,
+    V: serde::Deserialize<'de>,
+{
+    Ok(Option::<BTreeMap<K, V>>::deserialize(d)?.unwrap_or_default())
 }
 
 const MAX_RESET_TITLE_CHARS: usize = 80;
@@ -935,5 +962,37 @@ mod tests {
                 .unavailable_models
                 .is_empty()
         );
+    }
+
+    /// Live shape observed 2026-09-05: OpenAI returns explicit `null` for
+    /// empty collections instead of omitting them. `#[serde(default)]` alone
+    /// covers a missing field but still rejects `null` with "invalid type:
+    /// null, expected a sequence" — which surfaced as `⚠ API schema drift`
+    /// in Waybar. Null must mean "none", not drift.
+    #[test]
+    fn null_collections_parse_as_empty_rather_than_schema_drift() {
+        let response: UsageResponse = serde_json::from_str(
+            r#"{
+                "plan_type": "plus",
+                "rate_limit": {
+                    "primary_window": {"used_percent": 0, "limit_window_seconds": 18000,
+                                       "reset_after_seconds": 18000, "reset_at": 1788646037},
+                    "secondary_window": {"used_percent": 64, "limit_window_seconds": 604800,
+                                         "reset_after_seconds": 152957, "reset_at": 1788780993}
+                },
+                "code_review_rate_limit": null,
+                "additional_rate_limits": null,
+                "model_usage": null,
+                "rate_limit_reset_credits": {"available_count": 3, "credits": null}
+            }"#,
+        )
+        .expect("null collections must parse");
+        let snap = response.into_snapshot(None).unwrap();
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 0);
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 64);
+        assert!(snap.additional_limits.is_empty());
+        assert!(snap.unavailable_models.is_empty());
+        assert_eq!(snap.reset_credits.available, 3);
+        assert!(snap.reset_credits.credits.is_empty());
     }
 }

--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -43,12 +43,12 @@ pub struct UsageResponse {
     /// precisely when a user needs to see it.
     /// Null from the API means "none" (observed 2026-09-05: OpenAI returns
     /// `"additional_rate_limits": null` for accounts with no extra limits).
-    #[serde(default, deserialize_with = "de_vec_null_as_default")]
+    #[serde(default, deserialize_with = "de_null_as_default")]
     pub additional_rate_limits: Vec<AdditionalRateLimit>,
     /// Per-model availability. `available: false` is what "Selected model is
     /// at capacity" looks like in the data — a dispatch-time refusal, not a
     /// quota, so no percentage anywhere else reflects it.
-    #[serde(default, deserialize_with = "de_map_null_as_default")]
+    #[serde(default, deserialize_with = "de_null_as_default")]
     pub model_usage: BTreeMap<String, ModelUsage>,
 }
 
@@ -110,7 +110,7 @@ pub struct CreditsBlock {
 #[serde(default)]
 pub struct ResetCreditsBlock {
     pub available_count: u32,
-    #[serde(default, deserialize_with = "de_vec_null_as_default")]
+    #[serde(default, deserialize_with = "de_null_as_default")]
     pub credits: Vec<ResetCredit>,
 }
 
@@ -239,26 +239,23 @@ where
     }
 }
 
-/// OpenAI omits empty collections as `null` instead of `[]`/`{}` (observed
-/// 2026-09-05 for `additional_rate_limits`). With `#[serde(default)]` alone,
-/// a missing field gets the default but an explicit `null` still fails with
-/// "invalid type: null, expected a sequence/map". These helpers treat `null`
-/// as empty while keeping every other malformed shape an error.
-fn de_vec_null_as_default<'de, D, T>(d: D) -> Result<Vec<T>, D::Error>
+/// OpenAI sends `null` for an empty collection rather than `[]`/`{}` (observed
+/// 2026-09-05 for `additional_rate_limits`). `#[serde(default)]` alone covers a
+/// *missing* field but not a present-but-null one, which fails with "invalid
+/// type: null, expected a sequence" and takes the whole response with it.
+///
+/// This is deliberately not applied to every collection in the codebase. It is
+/// right here because an absent named limit genuinely means "none" and renders
+/// nothing. For a balance or usage array — DeepSeek's `balance_infos`, the
+/// Anthropic API's `data` — an empty list is not the same as a null one, and
+/// silently reading it as empty would render a confident zero for a figure we
+/// never received.
+fn de_null_as_default<'de, D, T>(d: D) -> Result<T, D::Error>
 where
     D: serde::Deserializer<'de>,
-    T: serde::Deserialize<'de>,
+    T: Default + Deserialize<'de>,
 {
-    Ok(Option::<Vec<T>>::deserialize(d)?.unwrap_or_default())
-}
-
-fn de_map_null_as_default<'de, D, K, V>(d: D) -> Result<BTreeMap<K, V>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-    K: serde::Deserialize<'de> + Ord,
-    V: serde::Deserialize<'de>,
-{
-    Ok(Option::<BTreeMap<K, V>>::deserialize(d)?.unwrap_or_default())
+    Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
 }
 
 const MAX_RESET_TITLE_CHARS: usize = 80;
@@ -969,6 +966,47 @@ mod tests {
     /// covers a missing field but still rejects `null` with "invalid type:
     /// null, expected a sequence" — which surfaced as `⚠ API schema drift`
     /// in Waybar. Null must mean "none", not drift.
+    /// The exact payload from the reports: every optional collection null at
+    /// once, including the nested `rate_limit_reset_credits.credits`. Three
+    /// people hit this within a day of 1.11.0, so the shape earns a test of
+    /// its own rather than only the per-field one below.
+    #[test]
+    fn the_reported_all_null_payload_parses() {
+        let response: UsageResponse = serde_json::from_str(
+            r#"{"plan_type":"plus",
+                "rate_limit":{"primary_window":{"used_percent":5,
+                              "limit_window_seconds":604800}},
+                "code_review_rate_limit":null,
+                "additional_rate_limits":null,
+                "model_usage":null,
+                "rate_limit_reset_credits":{"available_count":0,"credits":null}}"#,
+        )
+        .expect("the reported shape must parse");
+
+        let snap = response.into_snapshot(None).unwrap();
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 5);
+        assert!(snap.additional_limits.is_empty());
+        assert!(snap.unavailable_models.is_empty());
+    }
+
+    /// Null means "none", but a wrong *type* is still drift. Reading a string
+    /// or a number as an empty collection would hide a real schema change
+    /// behind a plausible-looking empty panel.
+    #[test]
+    fn a_mistyped_collection_is_still_schema_drift() {
+        for bad in [
+            r#"{"additional_rate_limits": "none"}"#,
+            r#"{"additional_rate_limits": 0}"#,
+            r#"{"model_usage": []}"#,
+            r#"{"model_usage": "none"}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<UsageResponse>(bad).is_err(),
+                "{bad} should not be read as empty"
+            );
+        }
+    }
+
     #[test]
     fn null_collections_parse_as_empty_rather_than_schema_drift() {
         let response: UsageResponse = serde_json::from_str(


### PR DESCRIPTION
OpenAI started returning explicit `null` for empty collections on accounts with no extra limits. Live Plus payload 2026-09-05:

```json
"code_review_rate_limit": null,
"additional_rate_limits": null,
```

On v1.11.0 this fails parsing with:

`openai usage response: invalid type: null, expected a sequence at line 23 column 32`

surfacing in Waybar as `⚠ API schema drift`. `#[serde(default)]` alone covers a missing field but not explicit `null`.

This change adds `de_vec_null_as_default` / `de_map_null_as_default` and applies them to:
- `UsageResponse.additional_rate_limits`
- `UsageResponse.model_usage`
- `ResetCreditsBlock.credits`

Other malformed shapes still error — only `null` becomes empty.

Checklist:
- [x] CHANGELOG.md entry under [Unreleased] / Fixed
- [x] Test `null_collections_parse_as_empty_rather_than_schema_drift` uses the live shape (redacted numbers preserved); verified old binary fails on the same cached payload while the patched binary renders `gpt 0% · 4h 59m`
- [x] `cargo test`: 1311 passed; `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt --check` clean; `make desktop-test` + `plugin-test` pass
- [x] No new deps, no docs with old behaviour to update (wire shape is undocumented by OpenAI)

Fixes Waybar `custom/aibar-openai` showing schema mismatch while zai / opencode-go stay ready.