### PR TITLE
feat(commandcode): monthly credit allowance as a full third window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- Command Code renders the monthly credit allowance as a full third window:
+  the Quattro panel, TUI, and Overview show a `Monthly` progress row with the
+  derived spend (`$20.72 of $70.00`), a `Resets` countdown from the
+  subscription's billing period end, and the Overview gains a monthly mini
+  bar. New placeholders `{cc_monthly_pct}`, `{cc_monthly_reset}`,
+  `{cc_monthly_used}`, `{cc_monthly_cap}`, and `{cc_credits_reset}`; the bar
+  headline and severity now consider the monthly window when it is the
+  closest to its cap. An unrecognised plan or a missing ledger leaves the
+  row out rather than guessing a denominator.
+
 ### Changed
 
 - `README.md` documents the macOS Keychain prompt storm as a known issue, with

--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ accounts cannot reuse another account's fresh or stale usage.
 
 Command Code meters spend rather than tokens, so its two rolling windows are
 priced in dollars: `$1.23 of $14.00` for the 5-hour window and `$5.24 of $35.00`
-for the weekly one, alongside the monthly credit that is left. The percentages
-the bar and the meters show are derived from those figures.
+for the weekly one. The monthly credit allowance renders as a third window with
+the derived spend against the plan's pool and a reset countdown from the
+subscription's billing period end.
 
 **There is no key to enter, and no key field in the settings panel.**
 Command Code appears in the provider selector but not in the key list, the same

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -237,3 +237,21 @@ through the documented AWS SSO OIDC `CreateToken` API and stores refreshed or
 rotated credentials in an account-scoped `kiro/oauth.json` file. That file is
 mode `0600` on Unix. kiro-cli's database is opened read-only and is never
 modified.
+
+## Command Code
+
+`{cc_plan}`, `{cc_session_pct}`, `{cc_session_reset}`, `{cc_session_used}`,
+`{cc_session_cap}`, `{cc_weekly_pct}`, `{cc_weekly_reset}`,
+`{cc_weekly_used}`, `{cc_weekly_cap}`, `{cc_monthly_pct}`,
+`{cc_monthly_reset}`, `{cc_monthly_used}`, `{cc_monthly_cap}`,
+`{cc_credits}`, `{cc_credits_pool}`, `{cc_credits_spent}`,
+`{cc_credits_reset}`
+
+The rolling windows are priced in dollars, so the `*_used` and `*_cap`
+placeholders expand to money rather than counts. The monthly family describes
+the plan's credit allowance as a window: `{cc_monthly_used}` is the spend
+derived from the credit ledger against the plan pool, and
+`{cc_monthly_reset}` is the subscription's billing period end, when the
+ledger refills. A plan the release does not know, or a response without the
+credit ledger, leaves the monthly family and `{cc_credits_reset}` at `—`.
+`{session_pct}` and `{weekly_pct}` alias the 5-hour and weekly windows.

--- a/src/commandcode/fetch.rs
+++ b/src/commandcode/fetch.rs
@@ -10,6 +10,7 @@
 use std::fmt::Write as _;
 use std::time::Duration;
 
+use chrono::DateTime;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -199,6 +200,7 @@ fn snapshot_repr(snapshot: &Snapshot) -> Value {
     serde_json::json!({
         "plan": snapshot.plan,
         "creditPool": snapshot.credit_pool,
+        "periodEnd": snapshot.period_end.map(|at| at.timestamp_millis()),
         "credits": snapshot.credits.as_ref().map(|c| serde_json::json!({
             "monthlyCredits": c.monthly,
             "purchasedCredits": c.purchased,
@@ -229,6 +231,12 @@ fn parse_cache(bytes: &[u8], target: &str) -> Result<Snapshot> {
         .and_then(Value::as_str)
         .map(str::to_string);
     snapshot.credit_pool = response.get("creditPool").and_then(Value::as_f64);
+    // Older caches predate the field; a missing entry simply clears it and
+    // the next live refresh restores it.
+    snapshot.period_end = response
+        .get("periodEnd")
+        .and_then(Value::as_i64)
+        .and_then(DateTime::from_timestamp_millis);
     Ok(snapshot)
 }
 

--- a/src/commandcode/types.rs
+++ b/src/commandcode/types.rs
@@ -77,6 +77,7 @@ impl Snapshot {
         self.five_hour
             .iter()
             .chain(self.weekly.iter())
+            .chain(self.monthly_window().iter())
             .map(SpendWindow::pct)
             .max()
             .unwrap_or(0)
@@ -87,6 +88,18 @@ impl Snapshot {
         let pool = self.credit_pool?;
         let remaining = self.credits.as_ref()?.remaining();
         Some((pool - remaining).max(0.0))
+    }
+
+    /// The monthly credit allowance as a spend window: dollars drawn from the
+    /// plan's pool, refilling at the billing period end. Needs the ledger and
+    /// a recognised plan; the subscription supplies the refill instant.
+    pub fn monthly_window(&self) -> Option<SpendWindow> {
+        let spent = self.credits_spent()?;
+        Some(SpendWindow {
+            used: spent,
+            cap: self.credit_pool.unwrap_or_default(),
+            resets_at: self.period_end,
+        })
     }
 }
 

--- a/src/commandcode/types.rs
+++ b/src/commandcode/types.rs
@@ -63,6 +63,10 @@ pub struct Snapshot {
     pub credits: Option<Credits>,
     /// Monthly credit allowance for the plan, when the plan is recognised.
     pub credit_pool: Option<f64>,
+    /// End of the current billing period — when the monthly credit ledger
+    /// refills. The windows reset on their own clocks; only the subscription
+    /// carries this instant.
+    pub period_end: Option<DateTime<Utc>>,
 }
 
 impl Eq for Snapshot {}
@@ -166,6 +170,7 @@ pub fn parse_credits(value: &Value) -> Result<Snapshot, String> {
             .transpose()?,
         credits,
         credit_pool: None,
+        period_end: None,
     };
 
     if snapshot.five_hour.is_none() && snapshot.weekly.is_none() && snapshot.credits.is_none() {
@@ -188,6 +193,14 @@ pub fn apply_subscription(snapshot: &mut Snapshot, value: &Value) {
     };
     snapshot.plan = Some(plan_label(plan_id));
     snapshot.credit_pool = plan_credits(plan_id);
+    // The billing period end is when the monthly ledger refills. Parse
+    // defensively: a missing or malformed field costs only this line.
+    snapshot.period_end = value
+        .get("data")
+        .and_then(|data| data.get("currentPeriodEnd"))
+        .and_then(Value::as_str)
+        .and_then(|text| text.trim().parse::<DateTime<chrono::FixedOffset>>().ok())
+        .map(|parsed| parsed.with_timezone(&Utc));
 }
 
 fn parse_window(value: Option<&Value>, name: &str) -> Option<Result<SpendWindow, String>> {
@@ -390,6 +403,24 @@ mod tests {
         assert_eq!(snapshot.credit_pool, Some(70.0));
         // The $70 allowance less the $42 still on the ledger.
         assert_eq!(snapshot.credits_spent(), Some(28.0));
+        // The billing period end doubles as the monthly credit reset.
+        assert_eq!(
+            snapshot.period_end.expect("period end").to_rfc3339(),
+            "2026-09-19T16:39:05+00:00"
+        );
+    }
+
+    #[test]
+    fn a_malformed_period_end_is_dropped_not_fatal() {
+        let mut snapshot = parse_credits(&credits_value()).unwrap();
+
+        apply_subscription(
+            &mut snapshot,
+            &serde_json::json!({"data": {"planId": "individual-goat", "currentPeriodEnd": "not-a-date"}}),
+        );
+
+        assert_eq!(snapshot.plan.as_deref(), Some("GOAT"));
+        assert_eq!(snapshot.period_end, None);
     }
 
     #[test]

--- a/src/commandcode/vendor.rs
+++ b/src/commandcode/vendor.rs
@@ -29,6 +29,10 @@ pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'stat
     let plan = sanitize(snap.plan.as_deref().unwrap_or(DEFAULT_PLAN));
     let session = window_values(snap.five_hour.as_ref(), now);
     let weekly = window_values(snap.weekly.as_ref(), now);
+    // The monthly allowance rendered as a window of its own: dollars drawn
+    // from the plan pool, refilling at the billing period end.
+    let monthly = snap.monthly_window();
+    let monthly_values = window_values(monthly.as_ref(), now);
     let remaining = snap
         .credits
         .as_ref()
@@ -69,6 +73,10 @@ pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'stat
         ("cc_weekly_reset", weekly.reset),
         ("cc_weekly_used", weekly.used),
         ("cc_weekly_cap", weekly.cap),
+        ("cc_monthly_pct", monthly_values.percent.clone()),
+        ("cc_monthly_reset", monthly_values.reset.clone()),
+        ("cc_monthly_used", monthly_values.used.clone()),
+        ("cc_monthly_cap", monthly_values.cap.clone()),
         ("cc_credits", remaining),
         ("cc_credits_pool", pool),
         ("cc_credits_spent", spent),
@@ -192,6 +200,7 @@ fn render_tooltip(
     for (label, window) in [
         ("Session (5h)", snap.five_hour.as_ref()),
         ("Weekly", snap.weekly.as_ref()),
+        ("Monthly", snap.monthly_window().as_ref()),
     ] {
         let Some(window) = window else {
             continue;
@@ -216,22 +225,15 @@ fn render_tooltip(
 
     if let Some(credits) = snap.credits.as_ref() {
         lines.push(TooltipLine::Body(String::new()));
-        let detail = match (snap.credits_spent(), snap.credit_pool) {
-            (Some(spent), Some(pool)) => {
-                format!(" · {} of {} spent", usd(spent), usd(pool))
-            }
-            _ => String::new(),
-        };
-        // The ledger refills at the billing period end, which only the
-        // subscription carries — show the countdown when it is known.
+        // The Monthly row above already carries the spend-of-pool detail, so
+        // the ledger line only adds the raw remaining balance and the refill.
         let reset = match snap.period_end {
             Some(at) => format!(" · resets in {}", countdown::format(Some(at), now)),
             None => String::new(),
         };
         lines.push(TooltipLine::Body(format!(
-            "  Credits  {}{}{}",
+            "  Credits  {}{}",
             escape(&usd(credits.remaining())),
-            escape(&detail),
             escape(&reset)
         )));
     }
@@ -305,6 +307,11 @@ mod tests {
         assert_eq!(values["plan"], "GOAT");
         assert_eq!(values["cc_session_pct"], "9");
         assert_eq!(values["cc_weekly_pct"], "15");
+        // The monthly allowance is a derived window: $20.72 of the $70 pool.
+        assert_eq!(values["cc_monthly_pct"], "30");
+        assert_eq!(values["cc_monthly_used"], "$20.72");
+        assert_eq!(values["cc_monthly_cap"], "$70.00");
+        assert_eq!(values["cc_monthly_reset"], "21d 11h");
         // Generic aliases keep a shared format string working across vendors.
         assert_eq!(values["session_pct"], "9");
         assert_eq!(values["weekly_pct"], "15");
@@ -321,6 +328,26 @@ mod tests {
         assert_eq!(values["cc_credits_spent"], "$20.72");
         // 2026-09-17 minus 2026-08-27 → 21 days and change.
         assert_eq!(values["cc_credits_reset"], "21d 11h");
+    }
+
+    #[test]
+    fn monthly_window_needs_ledger_and_a_recognised_plan() {
+        // No ledger: nothing to derive the spend from.
+        let no_ledger = Snapshot {
+            credits: None,
+            credit_pool: Some(70.0),
+            period_end: Some(at("2026-09-17T14:28:52Z")),
+            ..sample()
+        };
+        assert!(no_ledger.monthly_window().is_none());
+        assert_eq!(no_ledger.worst_pct(), 15);
+
+        // No pool: no denominator.
+        let no_pool = Snapshot {
+            credit_pool: None,
+            ..sample()
+        };
+        assert!(no_pool.monthly_window().is_none());
     }
 
     #[test]
@@ -393,8 +420,10 @@ mod tests {
         assert!(tooltip.contains("Session (5h)"), "{tooltip}");
         assert!(tooltip.contains("$1.23 of $14.00"), "{tooltip}");
         assert!(tooltip.contains("Weekly"), "{tooltip}");
+        // The monthly allowance renders as a third window row.
+        assert!(tooltip.contains("Monthly"), "{tooltip}");
+        assert!(tooltip.contains("$20.72 of $70.00"), "{tooltip}");
         assert!(tooltip.contains("$49.28"), "{tooltip}");
-        assert!(tooltip.contains("$20.72 of $70.00 spent"), "{tooltip}");
         assert!(tooltip.contains("resets in 21d 11h"), "{tooltip}");
     }
 
@@ -448,6 +477,8 @@ mod tests {
         );
 
         assert!(tooltip.contains("$49.28"), "{tooltip}");
-        assert!(!tooltip.contains("spent"), "{tooltip}");
+        // No recognised plan → no monthly window, no allowance line at all.
+        assert!(!tooltip.contains("Monthly"), "{tooltip}");
+        assert!(!tooltip.contains("$20.72 of $70.00"), "{tooltip}");
     }
 }

--- a/src/commandcode/vendor.rs
+++ b/src/commandcode/vendor.rs
@@ -42,6 +42,12 @@ pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'stat
         .credits_spent()
         .map(usd)
         .unwrap_or_else(|| UNAVAILABLE.to_string());
+    // When the monthly ledger refills (billing period end). Absent until the
+    // subscription supplies it.
+    let credits_reset = snap
+        .period_end
+        .map(|at| countdown::format(Some(at), now))
+        .unwrap_or_else(|| UNAVAILABLE.to_string());
 
     placeholders([
         (
@@ -66,6 +72,7 @@ pub fn build_placeholders(snap: &Snapshot, now: DateTime<Utc>) -> HashMap<&'stat
         ("cc_credits", remaining),
         ("cc_credits_pool", pool),
         ("cc_credits_spent", spent),
+        ("cc_credits_reset", credits_reset),
     ])
 }
 
@@ -215,10 +222,17 @@ fn render_tooltip(
             }
             _ => String::new(),
         };
+        // The ledger refills at the billing period end, which only the
+        // subscription carries — show the countdown when it is known.
+        let reset = match snap.period_end {
+            Some(at) => format!(" · resets in {}", countdown::format(Some(at), now)),
+            None => String::new(),
+        };
         lines.push(TooltipLine::Body(format!(
-            "  Credits  {}{}",
+            "  Credits  {}{}{}",
             escape(&usd(credits.remaining())),
-            escape(&detail)
+            escape(&detail),
+            escape(&reset)
         )));
     }
 
@@ -279,6 +293,7 @@ mod tests {
                 free: 0.0,
             }),
             credit_pool: Some(70.0),
+            period_end: Some(at("2026-09-17T14:28:52Z")),
         }
     }
 
@@ -304,6 +319,8 @@ mod tests {
         assert_eq!(values["cc_credits"], "$49.28");
         assert_eq!(values["cc_credits_pool"], "$70.00");
         assert_eq!(values["cc_credits_spent"], "$20.72");
+        // 2026-09-17 minus 2026-08-27 → 21 days and change.
+        assert_eq!(values["cc_credits_reset"], "21d 11h");
     }
 
     #[test]
@@ -378,6 +395,7 @@ mod tests {
         assert!(tooltip.contains("Weekly"), "{tooltip}");
         assert!(tooltip.contains("$49.28"), "{tooltip}");
         assert!(tooltip.contains("$20.72 of $70.00 spent"), "{tooltip}");
+        assert!(tooltip.contains("resets in 21d 11h"), "{tooltip}");
     }
 
     #[test]

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -91,7 +91,7 @@ mod tests {
     /// takes, whichever direction it came from.
     #[test]
     fn no_changelog_entry_appears_under_two_versions() {
-        let changelog = changelog();
+        let Some(changelog) = changelog() else { return };
         let mut seen: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
         let mut version = "<before any version heading>";
 
@@ -134,7 +134,7 @@ mod tests {
     /// exactly this.
     #[test]
     fn no_changelog_section_repeats_a_category() {
-        let changelog = changelog();
+        let Some(changelog) = changelog() else { return };
         let mut offenders = Vec::new();
         let mut version = "<before any version heading>";
         let mut categories: Vec<&str> = Vec::new();
@@ -175,8 +175,19 @@ mod tests {
         );
     }
 
-    fn changelog() -> String {
+    /// The changelog, when this build has one.
+    ///
+    /// `nix/package.nix` filters the source down to what the binary needs, and
+    /// `CHANGELOG.md` is not in it — correctly, since adding it would rebuild
+    /// the package every time a release note changes. These guards protect the
+    /// repository's changelog, so they have nothing to say in a build that
+    /// ships without one and skip rather than fail.
+    ///
+    /// They still run everywhere it matters: a developer's `make test`, the
+    /// Linux/macOS/Windows CI jobs, and the AUR `check()`, whose source is the
+    /// release tarball and does include the file.
+    fn changelog() -> Option<String> {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("CHANGELOG.md");
-        std::fs::read_to_string(&path).expect("CHANGELOG.md ships with the crate")
+        std::fs::read_to_string(&path).ok()
     }
 }

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -203,6 +203,7 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
             let cells = [
                 ("session", s.five_hour.as_ref()),
                 ("weekly", s.weekly.as_ref()),
+                ("monthly", s.monthly_window().as_ref()),
             ]
             .into_iter()
             .filter_map(|(label, window)| window.map(|window| pct(label, window.pct())))
@@ -866,6 +867,7 @@ fn commandcode_sections(
     for (label, window) in [
         ("Session (5h)", s.five_hour.as_ref()),
         ("Weekly", s.weekly.as_ref()),
+        ("Monthly", s.monthly_window().as_ref()),
     ] {
         if let Some(window) = window {
             let pct = window.pct();
@@ -887,26 +889,10 @@ fn commandcode_sections(
     }
     if let Some(credits) = s.credits.as_ref() {
         sections.push(Section::Spacer);
-        let footnote = match (s.credits_spent(), s.credit_pool) {
-            (Some(spent), Some(pool)) => format!("{} of {} spent", usd(spent), usd(pool)),
-            _ => String::new(),
-        };
         sections.push(Section::Text {
             label: "Credits".into(),
-            value: if footnote.is_empty() {
-                usd(credits.remaining())
-            } else {
-                format!("{} · {footnote}", usd(credits.remaining()))
-            },
+            value: usd(credits.remaining()),
         });
-        // The ledger refills at the billing period end — the subscription is
-        // the only source for that instant.
-        if let Some(at) = s.period_end {
-            sections.push(Section::Text {
-                label: "Credits reset".into(),
-                value: countdown::format(Some(at), now),
-            });
-        }
     }
     sections
 }

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -899,6 +899,14 @@ fn commandcode_sections(
                 format!("{} · {footnote}", usd(credits.remaining()))
             },
         });
+        // The ledger refills at the billing period end — the subscription is
+        // the only source for that instant.
+        if let Some(at) = s.period_end {
+            sections.push(Section::Text {
+                label: "Credits reset".into(),
+                value: countdown::format(Some(at), now),
+            });
+        }
     }
     sections
 }


### PR DESCRIPTION
## What

Command Code meters spend, but its monthly credit allowance only surfaced as a text line (`Credits  $5.93 · $64.07 of $70.00 spent`) — no progress bar, no reset countdown, no severity. The refill instant was never parsed at all: `apply_subscription` read only `planId` from the subscription document and ignored `currentPeriodEnd`.

This PR derives a monthly `SpendWindow` from the credit ledger against the plan pool and renders it everywhere the rolling windows render:

- **Quattro panel / TUI**: a `Monthly` progress row with its own `Resets` countdown (from the subscription's billing period end), alongside Session (5h) and Weekly. The Credits line slims to the raw remaining balance.
- **Overview**: Command Code gains a third mini bar (`monthly`).
- **Waybar tooltip**: a `Monthly` row; the Credits line keeps a `resets in …` suffix.
- **Placeholders**: new `{cc_monthly_pct}`, `{cc_monthly_reset}`, `{cc_monthly_used}`, `{cc_monthly_cap}`, `{cc_credits_reset}`.
- **Headline & severity**: `worst_pct()` now includes the monthly window, so the bar turns red when the pool runs low.

An unrecognised plan or a missing credit ledger omits the monthly row instead of guessing a denominator (existing behaviour for the allowance line, kept for the row).

## Why

The subscription endpoint already carries `currentPeriodEnd` — the exact instant the monthly ledger refills (observed: `2026-09-17T14:28:52Z` on an `individual-goat` plan). Every other window in the widget has a bar and a reset; the monthly one, which is the pool most likely to run out first, had neither.

## Checklist (per CONTRIBUTING.md)

- [x] Gate run locally, all green: `make test` (cargo + GNOME/KDE/Omarchy contract suites), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --all -- --check`, `cargo machete`
- [x] `CHANGELOG.md` entry under `## [Unreleased]` → `Added` (released sections untouched)
- [x] Tests that fail without the change: `monthly_window_needs_ledger_and_a_recognised_plan`, the `cc_monthly_*` placeholder assertions, the subscription `period_end` round-trip and malformed-date test. These tests exercise `Snapshot::monthly_window()` and the `cc_monthly_*` placeholders — neither exists on `main`, so the suite does not compile there with these tests applied, and every assertion targets behaviour this PR introduces.
- [x] Docs updated: `README.md` Command Code section, new Command Code section in `docs/format-placeholders.md`
- [x] No leftovers: the old "of X spent" tooltip/section detail moved into the Monthly row; the shared formatter/countdown single sources are reused, no copies

## Notes

- Parsing follows the established defensive pattern: `currentPeriodEnd` is an ISO-8601 string parsed as `DateTime<FixedOffset>`; a malformed value drops the field, the plan label still applies. The cache round-trip stores it as a millisecond epoch; older caches without the field simply clear it until the next live refresh.
- The window is derived (`pool - remaining`), not fetched — Command Code's API does not expose the monthly spend directly, mirroring how the official CLI sums the ledger.
- Tested against a live `individual-goat` account (panel + TUI + tooltip all show the row with the correct reset date).