### PR TITLE
fix(openai): tolerate null optional usage collections

### DIFF
--- a/src/openai/types.rs
+++ b/src/openai/types.rs
@@ -41,10 +41,12 @@ pub struct UsageResponse {
     /// model-specific allowance. Each carries its own windows and can be the
     /// binding constraint while `rate_limit` still reads low, which is
     /// precisely when a user needs to see it.
+    #[serde(deserialize_with = "de_null_default")]
     pub additional_rate_limits: Vec<AdditionalRateLimit>,
     /// Per-model availability. `available: false` is what "Selected model is
     /// at capacity" looks like in the data — a dispatch-time refusal, not a
     /// quota, so no percentage anywhere else reflects it.
+    #[serde(deserialize_with = "de_null_default")]
     pub model_usage: BTreeMap<String, ModelUsage>,
 }
 
@@ -120,6 +122,19 @@ pub struct ResetCredit {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     pub expires_at: Option<DateTime<Utc>>,
+}
+
+/// Optional collections in the usage response are represented inconsistently:
+/// accounts with no named limits may receive either an omitted field or JSON
+/// `null`, while accounts with limits receive the collection itself. Treat the
+/// two empty representations alike without weakening validation of populated
+/// arrays/maps.
+fn de_null_default<'de, D, T>(d: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(d)?.unwrap_or_default())
 }
 
 /// Accept a JSON number or numeric string without turning malformed, non-finite
@@ -894,6 +909,21 @@ mod tests {
         .unwrap();
         let snap = response.into_snapshot(None).unwrap();
 
+        assert!(snap.additional_limits.is_empty());
+        assert!(snap.unavailable_models.is_empty());
+    }
+
+    /// The live endpoint uses JSON null, rather than omission or an empty
+    /// array, when this account has no named rate limits. Serde's field-level
+    /// `default` only covers omission, so this exact shape used to fail before
+    /// a snapshot could be produced.
+    #[test]
+    fn null_optional_collections_are_treated_as_empty() {
+        let response: UsageResponse =
+            serde_json::from_str(r#"{"additional_rate_limits": null, "model_usage": null}"#)
+                .expect("null optional collections should parse");
+
+        let snap = response.into_snapshot(None).unwrap();
         assert!(snap.additional_limits.is_empty());
         assert!(snap.unavailable_models.is_empty());
     }


### PR DESCRIPTION
## Summary

- Accept both JSON `null` and omitted values for Codex's optional `additional_rate_limits` and `model_usage` collections.
- Preserve strict deserialization for populated arrays and maps.
- Add a regression test for the live response shape.

## Problem

The Codex usage endpoint can return this when an account has no named limits:

```json
{
  "additional_rate_limits": null
}
```

`UsageResponse` modeled `additional_rate_limits` as `Vec<AdditionalRateLimit>` with struct-level `#[serde(default)]`. That default handles an omitted field, but it does not handle an explicitly present `null`. Deserialization therefore failed before a snapshot could be produced:

```text
openai usage response: invalid type: null, expected a sequence
```

This surfaced as an error in the Omarchy AI Usage panel for otherwise valid Codex usage responses.

## Fix

Add a small generic `de_null_default` deserializer and apply it to the two optional collection fields introduced for named limits and per-model availability. It deserializes populated values normally, but maps `null` to each collection's empty default. This keeps malformed populated data visible as schema drift instead of silently accepting it.

## Validation

- `cargo fmt --check`
- `cargo test openai::types --lib` — 29 passed
- `cargo test --lib` — 1,311 passed
- Verified against the captured live response shape that previously failed; the OpenAI entry now reaches `ready` and renders its usage window.
