### PR TITLE
feat(plasmoid): add the vendor cards view as an alternative popup layout

### DIFF
--- a/kde-plasmoid/README.md
+++ b/kde-plasmoid/README.md
@@ -76,8 +76,9 @@ never appears in the chooser.
 
 Right-click the widget → *Configure*. One page: which vendors are in the scroll
 ring (each listed with its plan or its error, straight from the report), the
-current vendor, refresh interval, command timeout, left-click action, compact
-percentage and bar toggles, bar width, and the five severity colours.
+current vendor, the popup layout, refresh interval, command timeout, left-click
+action, compact percentage and bar toggles, bar width, and the five severity
+colours.
 
 The GNOME prefs window has a second "Vendors" page listing per-vendor login
 status. There is no equivalent page here because the report already carries
@@ -123,6 +124,30 @@ human-readable `detail` string, and parsing prose to place a marker is not a
 contract worth depending on; the pace text itself is rendered under each row, so
 the information is kept. Restoring the marker properly means adding an
 `elapsed_pct` field to the report.
+
+### The cards layout
+
+*Popup layout* offers an alternative view, ported from the closed #142 card
+design after its review: **One card per vendor** lays every entry the report
+returned out as a card, each window (session, weekly, …) rendered as its own
+gauge row with the report's own severity colouring. Per-card properties are all
+sourced from the same single aggregate report as the tab layout — labels,
+windows, percentages, severities, staleness and error text come from the report,
+never from a hardcoded provider table, so a newly added vendor gets a card with
+no widget change:
+
+- a window a vendor does not report shows *— not reported*, never a fabricated
+  0% bar (a metric arriving with `percent: null` stays null — see
+  `finitePercent()` in the shared logic)
+- an errored vendor replaces its gauges with the failure message instead of
+  showing empty bars, which would read as "0% used"
+- a stale card is flagged *cached* next to the label, keeping the severity of
+  its last good numbers rather than flipping red
+- clicking a card selects that vendor, so the compact panel tracks it just like
+  the tab strip does; the per-window pace details live in the hover tooltip
+
+Both layouts are projections of one report, so switching the layout never
+refetches.
 
 ## Shared logic
 

--- a/kde-plasmoid/package/contents/code/plasmoid-logic.mjs
+++ b/kde-plasmoid/package/contents/code/plasmoid-logic.mjs
@@ -100,6 +100,12 @@ export function safeText(value, maxLength = 400) {
 }
 
 function finitePercent(value) {
+    // Number(null) === 0 in JS: without this guard a metric the Rust core
+    // reports with percent null (a balance-style row, or a window the vendor
+    // does not report) would normalize into a fabricated 0% bar instead of
+    // keeping the null that means "not reported".
+    if (value === null || value === undefined)
+        return null;
     const n = Number(value);
     return Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : null;
 }
@@ -331,6 +337,69 @@ export function panelCells(entry, options) {
         });
     }
     return cells;
+}
+
+// The card view (viewMode "VendorCards") projects one card per entry the
+// aggregate report already returned — never a hardcoded vendor table. The
+// Rust core owns names, metric projection and severity bands; this only
+// restates what `usage --json` handed over in a shape the QML can lay out.
+function severityRank(severity) {
+    return SEVERITIES.indexOf(severityOf(null, severity));
+}
+
+export function cardState(entry) {
+    if (!entry)
+        return 'ok';
+    if (entry.status === 'error' || entry.error)
+        return 'error';
+    if (entry.stale === true)
+        return 'stale';
+    return 'ok';
+}
+
+// One card's view model. Windows are the entry's metric sections; a window
+// with percent === null renders as "not reported" rather than as a fabricated
+// 0% bar. Block sections (balances, free-form notes) ride along untouched so
+// the card shows everything the tab view would.
+export function cardFor(entry) {
+    if (!entry)
+        return null;
+    let worst = -1;
+    let accent = 'low';
+    for (const s of entry.sections) {
+        if (s.type !== 'metric')
+            continue;
+        const rank = severityRank(s.severity);
+        if (rank > worst) {
+            worst = rank;
+            accent = SEVERITIES[worst];
+        }
+    }
+    const state = cardState(entry);
+    return {
+        id: entry.id,
+        label: entry.label,
+        plan: entry.plan,
+        state: state,
+        // An errored vendor outranks whatever its last good numbers said.
+        accent: state === 'error' ? 'critical' : accent,
+        error: state === 'error' ? errorMessage(entry.error) : '',
+        windows: entry.sections.filter(s => s.type === 'metric').map(s => ({
+            label: s.label,
+            window: shortLabel(s.label),
+            percent: s.percent,
+            value: s.percent === null ? s.value : `${s.percent}%`,
+            severity: s.severity,
+            resetAt: s.resetAt,
+            detail: metricDetail(s),
+        })),
+        blocks: entry.sections.filter(s => s.type === 'block'),
+    };
+}
+
+export function cardModel(report) {
+    const entries = (report && report.entries) || [];
+    return entries.map(cardFor);
 }
 
 // "Session (5h)" -> "5h", "Weekly (7d)" -> "7d". The panel is width

--- a/kde-plasmoid/package/contents/config/main.xml
+++ b/kde-plasmoid/package/contents/config/main.xml
@@ -60,6 +60,18 @@
       <default>ExpandPopup</default>
     </entry>
 
+    <!-- Popup layout. ProviderTabs is the report shaped view with one selected
+         entry; VendorCards lays every entry the report returned out as a card
+         with one gauge row per window. Both are projections of the same single
+         aggregate usage report, so switching never refetches. -->
+    <entry name="viewMode" type="Enum">
+      <choices>
+        <choice name="ProviderTabs"/>
+        <choice name="VendorCards"/>
+      </choices>
+      <default>ProviderTabs</default>
+    </entry>
+
     <entry name="terminalCommand" type="String">
       <default></default>
     </entry>

--- a/kde-plasmoid/package/contents/ui/FullRepresentation.qml
+++ b/kde-plasmoid/package/contents/ui/FullRepresentation.qml
@@ -115,11 +115,12 @@ Item {
         // --- provider tabs -------------------------------------------------
         // Every configured vendor, including the ones currently failing. Hiding
         // a broken vendor is what made "not configured" indistinguishable from
-        // "configured and erroring".
+        // "configured and erroring". Only in the tab layout; the cards layout
+        // shows every entry side by side instead.
         Flow {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.smallSpacing
-            visible: full.applet.tabs.length > 1
+            visible: full.applet.viewMode === 0 && full.applet.tabs.length > 1
             spacing: Kirigami.Units.smallSpacing
 
             Repeater {
@@ -161,16 +162,16 @@ Item {
             }
         }
 
-        // --- usage rows -----------------------------------------------------
+        // --- usage rows (tab layout) ----------------------------------------
         Kirigami.Separator {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.smallSpacing
-            visible: full.rows.length > 0
+            visible: full.applet.viewMode === 0 && full.rows.length > 0
         }
 
         PlasmaComponents.Label {
             Layout.fillWidth: true
-            visible: full.rows.length > 0
+            visible: full.applet.viewMode === 0 && full.rows.length > 0
             font: Kirigami.Theme.smallFont
             opacity: 0.6
             text: i18n("USAGE & BALANCE")
@@ -178,7 +179,7 @@ Item {
         }
 
         Repeater {
-            model: full.rows
+            model: full.applet.viewMode === 0 ? full.rows : []
 
             UsageRow {
                 required property var modelData
@@ -194,12 +195,23 @@ Item {
         PlasmaComponents.Label {
             Layout.fillWidth: true
             Layout.topMargin: Kirigami.Units.smallSpacing
-            visible: !full.entry && full.status === ""
+            visible: !full.entry && full.status === "" && full.applet.viewMode === 0
             horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.WordWrap
             opacity: 0.6
             text: i18n("No configured provider reported usage.")
             textFormat: Text.PlainText
+        }
+
+        // --- cards (alternative layout) -------------------------------------
+        // The #142 card design, reworked: one card per entry the report
+        // returned, gauges per window, failures and staleness inline. Sourced
+        // from the same aggregate report as the tab view, so switching the
+        // layout never refetches.
+        VendorCards {
+            Layout.fillWidth: true
+            visible: full.applet.viewMode === 1
+            applet: full.applet
         }
 
         // --- footer ---------------------------------------------------------

--- a/kde-plasmoid/package/contents/ui/VendorCards.qml
+++ b/kde-plasmoid/package/contents/ui/VendorCards.qml
@@ -1,0 +1,242 @@
+// The alternative popup layout (config "viewMode": VendorCards): one card per
+// entry the aggregate `usage --json` report returned, every window rendered as
+// its own gauge row.
+//
+// Ported from the closed #142 card design, reworked the way the maintainer
+// asked: no second plasmoid, no per-vendor subprocess plumbing, and above all
+// no hardcoded provider table — every label, window, percentage, severity and
+// error text comes from the same report the tab view consumes, projected by
+// Logic.cardModel (table-tested in plasmoid-logic.test.mjs). Colours follow
+// the applet's severity palette, so this view tracks the same theme tokens as
+// everything else instead of carrying its own hexes.
+//
+// A window the vendor does not report (percent === null) renders as a dash
+// with "not reported", never as a fabricated 0% bar — an absent 5h window must
+// not look like an empty one.
+import QtQuick
+import QtQuick.Layouts
+import org.kde.kirigami as Kirigami
+import org.kde.plasma.components as PlasmaComponents
+import "../code/plasmoid-logic.mjs" as Logic
+
+ColumnLayout {
+    id: cards
+
+    required property var applet
+
+    spacing: Kirigami.Units.smallSpacing
+
+    Repeater {
+        model: cards.applet.cards
+
+        delegate: Rectangle {
+            id: card
+
+            required property var modelData
+
+            readonly property bool isError: modelData.state === "error"
+            readonly property color accent: Logic.severityColor(
+                modelData.accent, cards.applet.colors) ?? Kirigami.Theme.textColor
+
+            Layout.fillWidth: true
+            implicitHeight: content.implicitHeight + Kirigami.Units.largeSpacing
+            radius: Kirigami.Units.cornerRadius
+            color: Qt.alpha(card.accent, 0.07)
+            border.width: 1
+            border.color: Qt.alpha(card.accent, card.isError ? 0.55 : 0.30)
+
+            TapHandler {
+                onTapped: cards.applet.selectVendor(card.modelData.id)
+            }
+
+            // The detail lines (pace, resets) live in the hover tooltip rather
+            // than inline, which is what keeps a five-provider report from
+            // becoming an unscrollable wall.
+            PlasmaComponents.ToolTip {
+                visible: cardHover.hovered && tooltipText !== ""
+                delay: Kirigami.Units.toolTipDelay
+                timeout: 5000
+                text: card.tooltipText
+            }
+
+            readonly property string tooltipText: {
+                const lines = [];
+                for (const w of card.modelData.windows)
+                    if (w.detail !== "")
+                        lines.push(w.label + " · " + w.detail);
+                return lines.join("\n");
+            }
+
+            HoverHandler {
+                id: cardHover
+                cursorShape: Qt.PointingHandCursor
+            }
+
+            ColumnLayout {
+                id: content
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.margins: Kirigami.Units.smallSpacing
+                spacing: Kirigami.Units.smallSpacing / 2
+
+                // --- header -------------------------------------------------
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Kirigami.Units.smallSpacing
+
+                    PlasmaComponents.Label {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        font.bold: true
+                        text: card.modelData.label
+                        textFormat: Text.PlainText
+                    }
+
+                    // Same "cached" wording the tab view puts after the plan.
+                    PlasmaComponents.Label {
+                        visible: card.modelData.state === "stale"
+                        font: Kirigami.Theme.smallFont
+                        opacity: 0.7
+                        text: i18n("cached")
+                        textFormat: Text.PlainText
+                    }
+
+                    // The selected card is the entry the compact panel and the
+                    // tooltip show, matching the tab view's checked button.
+                    Kirigami.Icon {
+                        source: "emblem-ok-symbolic"
+                        isMask: true
+                        visible: cards.applet.vendor === card.modelData.id && !card.isError
+                        implicitWidth: Kirigami.Units.iconSizes.small
+                        implicitHeight: Kirigami.Units.iconSizes.small
+                        color: Kirigami.Theme.positiveTextColor
+                    }
+
+                    Kirigami.Icon {
+                        source: "dialog-warning"
+                        visible: card.isError
+                        implicitWidth: Kirigami.Units.iconSizes.small
+                        implicitHeight: Kirigami.Units.iconSizes.small
+                    }
+                }
+
+                PlasmaComponents.Label {
+                    Layout.fillWidth: true
+                    visible: text !== ""
+                    elide: Text.ElideRight
+                    font: Kirigami.Theme.smallFont
+                    opacity: 0.7
+                    text: card.modelData.plan
+                    textFormat: Text.PlainText
+                }
+
+                // --- gauges, or the failure that replaces them ---------------
+                // Credential and fetch failures replace the gauges entirely:
+                // an empty bar would read as "0% used", which is exactly the
+                // silently-failing fetch the cards view exists to expose.
+                Repeater {
+                    model: card.isError ? [] : card.modelData.windows
+
+                    ColumnLayout {
+                        id: gauge
+
+                        required property var modelData
+
+                        Layout.fillWidth: true
+                        spacing: Math.round(Kirigami.Units.smallSpacing / 2)
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: Kirigami.Units.smallSpacing
+
+                            PlasmaComponents.Label {
+                                Layout.fillWidth: true
+                                elide: Text.ElideRight
+                                text: gauge.modelData.label
+                                textFormat: Text.PlainText
+                            }
+
+                            // A window the vendor does not report shows a dash
+                            // and the words, never a bar and never a bare 0%.
+                            PlasmaComponents.Label {
+                                visible: gauge.modelData.percent === null
+                                font: Kirigami.Theme.smallFont
+                                opacity: 0.6
+                                text: i18n("— not reported")
+                                textFormat: Text.PlainText
+                            }
+
+                            PlasmaComponents.Label {
+                                visible: gauge.modelData.percent !== null
+                                font.bold: gauge.modelData.severity === "critical"
+                                color: gauge.modelData.severity === "critical"
+                                    ? Kirigami.Theme.negativeTextColor
+                                    : Kirigami.Theme.textColor
+                                text: gauge.modelData.value
+                                textFormat: Text.PlainText
+                            }
+                        }
+
+                        UsageBar {
+                            Layout.fillWidth: true
+                            visible: gauge.modelData.percent !== null
+                            pct: gauge.modelData.percent ?? 0
+                            severity: gauge.modelData.severity
+                            colors: cards.applet.colors
+                        }
+                    }
+                }
+
+                PlasmaComponents.Label {
+                    Layout.fillWidth: true
+                    visible: card.isError
+                    wrapMode: Text.WordWrap
+                    font: Kirigami.Theme.smallFont
+                    color: Kirigami.Theme.negativeTextColor
+                    text: card.isError ? card.modelData.error : ""
+                    textFormat: Text.PlainText
+                }
+
+                // --- block sections (balances and notes) ---------------------
+                Repeater {
+                    model: card.isError ? [] : card.modelData.blocks
+
+                    ColumnLayout {
+                        required property var modelData
+
+                        Layout.fillWidth: true
+                        spacing: 0
+
+                        PlasmaComponents.Label {
+                            Layout.fillWidth: true
+                            visible: text !== ""
+                            elide: Text.ElideRight
+                            font: Kirigami.Theme.smallFont
+                            opacity: 0.7
+                            text: modelData.label || ""
+                            textFormat: Text.PlainText
+                        }
+
+                        Repeater {
+                            model: modelData.body || []
+
+                            PlasmaComponents.Label {
+                                required property string modelData
+
+                                Layout.fillWidth: true
+                                visible: text !== ""
+                                wrapMode: Text.WordWrap
+                                font: Kirigami.Theme.smallFont
+                                opacity: 0.7
+                                text: modelData
+                                textFormat: Text.PlainText
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kde-plasmoid/package/contents/ui/configGeneral.qml
+++ b/kde-plasmoid/package/contents/ui/configGeneral.qml
@@ -28,6 +28,7 @@ KCM.SimpleKCM {
     // A ComboBox cannot use `property alias` to currentIndex: the alias would be
     // write-only from Plasma's side at load time, so the saved value never shows.
     property int cfg_leftClickAction: 0
+    property int cfg_viewMode: 0
     property string cfg_vendor: ""
     property var cfg_vendorRing: []
 
@@ -171,6 +172,14 @@ KCM.SimpleKCM {
             model: [i18n("Open the panel popup"), i18n("Open the TUI")]
             currentIndex: page.cfg_leftClickAction
             onActivated: page.cfg_leftClickAction = currentIndex
+        }
+
+        QQC2.ComboBox {
+            id: viewCombo
+            Kirigami.FormData.label: i18n("Popup layout:")
+            model: [i18n("Provider tabs"), i18n("One card per vendor")]
+            currentIndex: page.cfg_viewMode
+            onActivated: page.cfg_viewMode = currentIndex
         }
 
         QQC2.TextField {

--- a/kde-plasmoid/package/contents/ui/main.qml
+++ b/kde-plasmoid/package/contents/ui/main.qml
@@ -41,6 +41,12 @@ PlasmoidItem {
     readonly property var compactCells: Logic.panelCells(root.entry, {max: 2})
     readonly property bool showBars: Plasmoid.configuration.showBars
 
+    // Read back as the integer index of the Enum choice (0 = tabs, 1 = cards).
+    readonly property int viewMode: Plasmoid.configuration.viewMode
+    // The cards view projects every entry the report returned; it needs no
+    // per-vendor selection and never refetches when toggled.
+    readonly property var cards: Logic.cardModel(root.report)
+
     // The user's own five colours, defaulting to One Dark exactly as in
     // src/theme.rs, the GNOME extension and the macOS app.
     readonly property var fixedColors: ({

--- a/kde-plasmoid/package/metadata.json
+++ b/kde-plasmoid/package/metadata.json
@@ -7,7 +7,7 @@
         "Icon": "utilities-system-monitor",
         "Category": "System Information",
         "License": "MIT",
-        "Version": "0.1.0",
+        "Version": "0.2.0",
         "Authors": [
             {
                 "Name": "AkitaOnRails"

--- a/kde-plasmoid/plasmoid-logic.test.mjs
+++ b/kde-plasmoid/plasmoid-logic.test.mjs
@@ -5,7 +5,8 @@ import assert from 'node:assert/strict';
 import {readFileSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import {
-    buildArgv, buildCommand, buildTuiCommand, DEFAULT_BINARY, DEFAULT_TIMEOUT_SECS,
+    buildArgv, buildCommand, buildTuiCommand, cardFor, cardModel, cardState,
+    DEFAULT_BINARY, DEFAULT_TIMEOUT_SECS,
     detailRows, entryFor, errorMessage, EXIT_KILLED, EXIT_TIMED_OUT, formatDuration,
     headline, isAlarming, MAX_TIMEOUT_SECS, MIN_TIMEOUT_SECS,
     metricDetail, nextVendor, paletteFromTheme, panelCells, parseReport,
@@ -86,6 +87,7 @@ for (const rel of [
     './package/contents/ui/FullRepresentation.qml',
     './package/contents/ui/UsageRow.qml',
     './package/contents/ui/UsageRows.qml',
+    './package/contents/ui/VendorCards.qml',
     './package/contents/ui/configGeneral.qml',
 ]) {
     const src = readFileSync(at(rel), 'utf8');
@@ -159,6 +161,15 @@ assert.equal(parseReport('not json').raw, 'not json', 'the original output is ke
 // An entry with no id cannot be selected or tabbed to, so it is dropped rather
 // than rendered as a nameless row.
 assert.equal(parseReport(JSON.stringify({entries: [{plan: 'x'}]})).entries.length, 0);
+
+// Number(null) === 0 in JS. A metric the report sends with percent null (a
+// balance-style row, or a window the vendor does not report) must normalize to
+// null so the views can show "not reported" — not to a fabricated 0% bar.
+const nullPercent = parseReport(JSON.stringify({entries: [{id: 'v', sections: [
+    {type: 'metric', label: 'Balance', value: '$4.10', percent: null},
+]}]})).entries[0].sections[0];
+assert.equal(nullPercent.percent, null);
+assert.equal(nullPercent.severity, 'low');
 
 // Provider-controlled strings cannot turn into QML rich text, preserve terminal
 // controls, or use bidi overrides to disguise what the panel displays.
@@ -269,6 +280,56 @@ assert.deepEqual(panelCells(zai).map(c => c.text), ['⚠']);
 assert.deepEqual(panelCells(null), []);
 // A vendor whose only section is a block has no percentage to plot.
 assert.deepEqual(panelCells(openai), []);
+
+// ---------------------------------------------------------------------------
+// cards (viewMode "VendorCards")
+// ---------------------------------------------------------------------------
+const claudeCard = cardFor(anthropic);
+const codexCard = cardFor(openai);
+const zaiCard = cardFor(zai);
+
+// One card per entry the aggregate report returned, in report order — the
+// card view never restates a provider list of its own.
+assert.deepEqual(cardModel(report).map(c => c.label), ['Claude', 'Codex', 'Z.AI']);
+assert.equal(cardModel(null).length, 0);
+assert.equal(cardFor(null), null);
+assert.equal(cardState(null), 'ok');
+
+// Windows are the metric sections, in report order; block sections ride along.
+assert.deepEqual(claudeCard.windows.map(w => w.window), ['5h', '7d']);
+assert.deepEqual(claudeCard.windows.map(w => w.value), ['62%', '91%']);
+assert.deepEqual(claudeCard.windows.map(w => w.severity), ['mid', 'critical']);
+assert.equal(claudeCard.windows[0].detail, '40% elapsed · 22pts over');
+assert.equal(claudeCard.blocks.length, 0);
+assert.equal(codexCard.blocks.length, 1);
+
+// The accent is the WORST window — the same rule headline() applies.
+assert.equal(claudeCard.accent, 'critical');
+
+// Staleness is the report's own verdict (the Rust core owns it), and a stale
+// card keeps the severity of its last good numbers instead of flipping red.
+assert.equal(claudeCard.state, 'ok');
+assert.equal(codexCard.state, 'stale');
+assert.equal(codexCard.accent, 'low');
+assert.deepEqual(codexCard.windows, []);
+
+// An errored vendor outranks whatever its last good numbers said, replaces the
+// gauges with the message, and never renders as a 0% bar.
+assert.equal(zaiCard.state, 'error');
+assert.equal(zaiCard.accent, 'critical');
+assert.equal(zaiCard.error, 'no API key');
+assert.deepEqual(zaiCard.windows, []);
+
+// A window a vendor does not report carries percent null and its value text —
+// the QML renders that as "not reported", never as a fabricated 0%.
+const partial = cardFor(parseReport(JSON.stringify({entries: [{
+    id: 'openrouter', display_name: 'OpenRouter', name: 'openrouter', plan: '',
+    status: 'ready', stale: false, error: null,
+    sections: [{type: 'metric', label: 'Session (5h)', value: '$1.20',
+        percent: null, severity: 'low'}],
+}]})).entries[0]);
+assert.deepEqual(partial.windows.map(w => [w.percent, w.value]), [[null, '$1.20']]);
+assert.equal(partial.accent, 'low');
 
 assert.equal(shortLabel('Session (5h)'), '5h');
 assert.equal(shortLabel('Weekly (7d)'), '7d');


### PR DESCRIPTION
## What

Takes the rework route from the #142 review: the card layout lands **inside the existing `kde-plasmoid/`** as an alternative popup view — no second applet, no separate plugin id, no packaging question.

- New **Popup layout** setting: `Provider tabs` (default, unchanged behaviour) or `One card per vendor`.
- The cards are driven entirely by the entries the aggregate `usage --json` report returns. There is **no provider table** anywhere: labels, windows, percentages, severities, staleness and error text all come from the report, so a newly added vendor gets a card with no widget change. Adding a vendor is still zero QML.
- The projection lives in the existing `plasmoid-logic.mjs` adapter (`cardModel` / `cardFor` / `cardState`) and is table-tested in `plasmoid-logic.test.mjs`, wired into `make test` like the rest.
- No per-vendor subprocess plumbing: one report covers every card, both layouts are projections of the same data, and switching the layout never refetches.

## The cards

Each card renders one report entry with a gauge row per window:

- a window the vendor does not report (percent `null`) shows *— not reported*, never a fabricated 0% bar
- an errored vendor replaces its gauges with the failure message — empty bars would read as "0% used"
- a stale card is flagged *cached* and keeps the severity of its last good numbers instead of flipping red
- clicking a card selects that vendor, so the compact panel tracks it exactly like the tab strip does; per-window pace details live in the hover tooltip
- colours come from the applet's existing severity palette (`severityColor` + the Kirigami theme roles), so the cards follow the same theme tokens as everything else

## Root-cause fix the port exposed

`finitePercent(null)` coerced a report metric with `percent: null` (balance-style rows, unreported windows) into **0** via `Number(null) === 0`, so the views would have painted a fabricated 0% bar for exactly the "not reported" case the cards exist to show honestly. It now keeps `null`; a regression test asserts the normalizer on its own. `panelCells`' existing `percent === null` branch is now actually reachable for null-percentage metrics, not only for missing percent fields.

## Validation

- `make test` — cargo suite (1310 passed) plus the GNOME, KDE and Omarchy frontend contract suites, exit 0
- `make qml-lint` — clean (Qt 6 qmllint, the repo's own flag set)
- `make qml-test` — qmltestrunner 9/9 passed, offscreen
- `node kde-plasmoid/plasmoid-logic.test.mjs` — includes the new card table tests and the config-schema guards (the `cfg_viewMode` alias check caught a first draft missing it; the double-hyphen XML guard caught `--json` inside a comment)

`KPlugin.Version` bumped 0.1.0 → 0.2.0 per the release rules. No Rust changes.