### PR TITLE
feat(macos): show reset as a wall-clock time instead of a countdown

### DIFF
--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1451,7 +1451,7 @@ struct SettingsView: View {
                         Toggle("Mostrar porcentagem/valor", isOn: $showPercent)
                         Toggle("Mostrar barras (off = só números)", isOn: $showBars)
                         Toggle("Mostrar referência da meta (linha de ritmo)", isOn: $showMeta)
-                        Toggle("Mostrar horário do reset (em vez da contagem regressiva)", isOn: $showResetClock)
+                        Toggle("Show reset time instead of a countdown", isOn: $showResetClock)
                         Picker("Estilo do indicador", selection: $barStyle) {
                             Text("Barras (░█)").tag("block")
                             Text("Anel (○)").tag("ring")

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -32,6 +32,7 @@ let SETTINGS_DEFAULTS: [String: Any] = [
     "showPercent": true,
     "showBars": true,
     "showMeta": true,
+    "showResetClock": false,
     "barStyle": "block",
     "colorLow": "#98c379",
     "colorMid": "#e5c07b",
@@ -66,6 +67,11 @@ var COLOR_EMPTY: String { DEF.string(forKey: "colorEmpty") ?? "#3e4451" }
 // Meta reference: draw a pace marker at the elapsed-time position and flag the
 // over-meta segment of the fill. Off = plain absolute-usage bars, no marker.
 var SHOW_META: Bool { DEF.bool(forKey: "showMeta") }
+// Off (default) = countdown ("1d 1h", "14h 32m"); on = the wall-clock time the
+// window resets at ("14:32", or "9/7/26, 2:32 PM" beyond today), computed
+// client-side from the countdown the binary already reports — see
+// `resetSeconds`/`resetDate` below.
+var SHOW_RESET_CLOCK: Bool { DEF.bool(forKey: "showResetClock") }
 // The meta marker is a fixed blue, matching the binary's default theme `marker`
 // color and distinct from the over-pace warning fill.
 let COLOR_MARKER = "#61afef"
@@ -162,6 +168,66 @@ func shortReset(_ r: String) -> String? {
         return m == "m" ? "0m" : String(m)
     }
     return String(first)
+}
+
+/// Parse the binary's countdown text ("4d 1h", "23h 59m", "now", "—") back
+/// into seconds remaining. `nil` for "—"/empty/unparseable, matching
+/// `isReported`. The binary's own `countdown::format` drops minutes once a
+/// day is present, so a `>=1d` result only carries hour precision — the same
+/// precision loss the countdown display already has.
+func resetSeconds(_ r: String) -> Int? {
+    guard isReported(r) else { return nil }
+    if r == "now" { return 0 }
+    let parts = r.split(separator: " ")
+    var seconds = 0
+    var matchedAny = false
+    for part in parts {
+        if let h = part.hasSuffix("h") ? Int(part.dropLast()) : nil {
+            seconds += h * 3600
+            matchedAny = true
+        } else if let d = part.hasSuffix("d") ? Int(part.dropLast()) : nil {
+            seconds += d * 86_400
+            matchedAny = true
+        } else if let m = part.hasSuffix("m") ? Int(part.dropLast()) : nil {
+            seconds += m * 60
+            matchedAny = true
+        }
+    }
+    return matchedAny ? seconds : nil
+}
+
+/// The absolute instant a countdown string resolves to, or `nil` when the
+/// countdown itself carries no value.
+func resetDate(_ r: String, now: Date = Date()) -> Date? {
+    resetSeconds(r).map { now.addingTimeInterval(TimeInterval($0)) }
+}
+
+private let resetTimeOnlyFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateStyle = .none
+    f.timeStyle = .short
+    return f
+}()
+
+private let resetDateTimeFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateStyle = .short
+    f.timeStyle = .short
+    return f
+}()
+
+/// Wall-clock label for a countdown, honoring `SHOW_RESET_CLOCK`: off returns
+/// the countdown unchanged (`fallback`), on renders the resolved instant —
+/// just the time when it falls today, date + time otherwise. `nil` when the
+/// countdown itself is unreported, same as the value it replaces.
+func resetClockLabel(_ r: String, fallback: String?, showClock: Bool = SHOW_RESET_CLOCK,
+                     now: Date = Date()) -> String? {
+    guard showClock else { return fallback }
+    guard let date = resetDate(r, now: now) else { return nil }
+    let formatter = Calendar.current.isDate(date, inSameDayAs: now)
+        ? resetTimeOnlyFormatter
+        : resetDateTimeFormatter
+    return formatter.string(from: date)
 }
 
 let barFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
@@ -1338,6 +1404,7 @@ struct SettingsView: View {
     @AppStorage("showPercent") private var showPercent = true
     @AppStorage("showBars") private var showBars = true
     @AppStorage("showMeta") private var showMeta = true
+    @AppStorage("showResetClock") private var showResetClock = false
     @AppStorage("barStyle") private var barStyle = "block"
     @AppStorage("swapShortcutEnabled") private var swapShortcutEnabled = true
     @AppStorage("compactShortcutEnabled") private var compactShortcutEnabled = true
@@ -1384,6 +1451,7 @@ struct SettingsView: View {
                         Toggle("Mostrar porcentagem/valor", isOn: $showPercent)
                         Toggle("Mostrar barras (off = só números)", isOn: $showBars)
                         Toggle("Mostrar referência da meta (linha de ritmo)", isOn: $showMeta)
+                        Toggle("Mostrar horário do reset (em vez da contagem regressiva)", isOn: $showResetClock)
                         Picker("Estilo do indicador", selection: $barStyle) {
                             Text("Barras (░█)").tag("block")
                             Text("Anel (○)").tag("ring")
@@ -2294,7 +2362,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
                 guard visible.contains($0.id), let s = $0.snap else { return nil }
                 if let cb = s.creditBalance { return ($0.name, -1, nil, "cr \(cb)", nil) }
                 let h = overviewHeadline(s)
-                return ($0.name, h.pct, h.elapsed, "\(h.pct)%", h.reset.flatMap(shortReset))
+                let shortValue = h.reset.flatMap(shortReset)
+                let reset = h.reset.flatMap { resetClockLabel($0, fallback: shortValue) }
+                return ($0.name, h.pct, h.elapsed, "\(h.pct)%", reset)
             }
         guard !heads.isEmpty else { return run("ovr", secondary) }
 
@@ -2482,7 +2552,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             a.append(run(label, .labelColor))
             a.append(progressAttr(pct: pct, width: MENU_BAR_W, elapsed: elapsed, menu: true, appearance: appearance))
             a.append(run("  \(value)", colorForPct(pct)))
-            if let r = reset, !r.isEmpty { a.append(run("   ↺ \(r)", .secondaryLabelColor)) }
+            if let r = reset, !r.isEmpty, let display = resetClockLabel(r, fallback: r) {
+                a.append(run("   ↺ \(display)", .secondaryLabelColor))
+            }
             item.attributedTitle = a
         }
         if let creditBalance = s.creditBalance {

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -554,6 +554,32 @@ func testShortReset() {
     assertEqual(shortReset(""), nil, "empty → nil")
 }
 
+func testResetSeconds() {
+    assertEqual(resetSeconds("4d 1h"), 4 * 86_400 + 3_600, "days+hours")
+    assertEqual(resetSeconds("23h 59m"), 23 * 3_600 + 59 * 60, "hours+minutes")
+    assertEqual(resetSeconds("0h 05m"), 5 * 60, "leading-zero minutes parse")
+    assertEqual(resetSeconds("now"), 0, "already reset → zero seconds")
+    assertEqual(resetSeconds("—"), nil, "em-dash → nil")
+    assertEqual(resetSeconds(""), nil, "empty → nil")
+}
+
+func testResetClockLabel() {
+    let now = Date(timeIntervalSince1970: 1_700_000_000) // fixed instant
+    // Preference off: the countdown passes through unchanged.
+    assertEqual(resetClockLabel("4h 59m", fallback: "4h 59m", showClock: false, now: now),
+                "4h 59m", "preference off returns the fallback untouched")
+    // Preference on, same calendar day: renders a time only.
+    let sameDay = resetClockLabel("1h 00m", fallback: "1h 00m", showClock: true, now: now)
+    assertNotNil(sameDay, "same-day reset renders a clock label")
+    assertEqual(sameDay?.contains("—"), false, "same-day label is not the em-dash")
+    // Preference on, several days out: still renders something (date + time).
+    let daysOut = resetClockLabel("6d 0h", fallback: "6d 0h", showClock: true, now: now)
+    assertNotNil(daysOut, "far-out reset still renders a clock label")
+    // Unreported countdown stays unreported regardless of the preference.
+    assertEqual(resetClockLabel("—", fallback: nil, showClock: true, now: now), nil,
+                "em-dash countdown has no clock label to show")
+}
+
 func testOverviewProviderToggle() {
     // The top-bar summary keeps only providers not toggled off, in order.
     let ids = ["anthropic@struct", "anthropic@gmail", "cursor"]
@@ -734,6 +760,8 @@ struct TestRunner {
         testDesktopAccounts()
         testCompactToggle()
         testShortReset()
+        testResetSeconds()
+        testResetClockLabel()
         testOverviewProviderToggle()
         testAccountStatus()
         testSystemIntegrations()


### PR DESCRIPTION
## Summary

The macOS menu bar app only shows *how long* until a window resets ("1d",
"14h", "4h 59m"). This adds a Preferences toggle to show *when* it resets
instead, as a wall-clock time (e.g. "14:32", or a date + time once the
reset falls beyond today).

## Changes

- New Preferences toggle under **Exibição**: "Mostrar horário do reset (em
  vez da contagem regressiva)" (`showResetClock`, default off — no behavior
  change unless enabled).
- `resetSeconds(_:)` parses the binary's existing countdown string ("4d 1h",
  "23h 59m", "now", "—") back into seconds remaining.
- `resetDate(_:now:)` adds that to the current instant.
- `resetClockLabel(_:fallback:showClock:now:)` picks the countdown or the
  clock label depending on the toggle, formatting via `DateFormatter` so it
  follows the system locale's 12h/24h convention automatically.
- Applied at both places a reset currently renders: the compact overview
  status-bar title and each vendor's dropdown row.

No Rust/backend change — the binary already reports a countdown per window,
so this is computed entirely client-side from that string, kept as pure
functions (`showClock`/`now` are explicit parameters, not read from
`UserDefaults`/`Date()` directly) so the test harness can exercise both
states deterministically.

## Tests

Added `testResetSeconds` and `testResetClockLabel` to
`macos/ai-usagebar-tests.swift`. `./run-tests.sh` passes (all tests,
including the two new ones).

Manually verified: built with `./build.sh`, ran the app, confirmed the
toggle flips the overview title and dropdown rows between countdown and
clock-time display.

## Verified on macOS

Screenshot below is the overview status-bar title with the toggle **on**,
on a real Apple Silicon Mac against live Claude and Codex accounts:

- `Claude 21% 🕐 07/09/26, 23:52` — Claude's 5h window, 21% used, resets
  07/09/26 at 23:52.
- `Codex 100% ⭕ 07/09/26, 09:14` — Codex's weekly window, 100% used, resets
  07/09/26 at 09:14.

<img width="563" height="71" alt="Screenshot 2026-09-06 at 18 53 00" src="https://github.com/user-attachments/assets/dff292c9-bb36-4b3e-bf6f-c5cc6705fa82" />




Both resets fall beyond today, so the date+time formatter kicked in rather
than the time-only one — exactly the `isDate(_:inSameDayAs:)` branch in
`resetClockLabel`.

<!-- paste the screenshot here -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxrAHcBFDcrMFmWXrBPnN9
