### PR TITLE
fix(macos): retain the AppDelegate so ARC can't drop the status item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- The macOS menu bar icon no longer disappears mid-session. `AppMain` held its
+  `AppDelegate` in a `main()` local, and `NSApplication.delegate` is a *weak*
+  reference — so in optimised builds ARC was free to release it after the
+  assignment, since nothing later in the function mentions it, taking the
+  status item with it. The delegate is now held for the program's lifetime.
+
 ### Changed
 
 - The macOS menu bar and the GNOME extension are in English. Both shipped with

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -2816,10 +2816,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 #if !SWIFT_TEST_HARNESS
 @main
 struct AppMain {
+    // NSApplication.delegate is `weak`; in optimized (-O) builds ARC can free a
+    // main()-local delegate before app.run() returns since it sees no later
+    // textual use, taking the status item down with it — the menu bar icon
+    // vanishes, intermittently, mid-session. Retain it here instead.
+    static var delegate: AppDelegate!
+
     static func main() {
         DEF.register(defaults: SETTINGS_DEFAULTS)
         let app = NSApplication.shared
-        let delegate = AppDelegate()
+        delegate = AppDelegate()
         app.delegate = delegate
         app.setActivationPolicy(.accessory)   // menu-bar agent, no Dock icon
         app.run()


### PR DESCRIPTION
## Summary
- The menu-bar icon could vanish mid-session, especially right when clicked.
- `NSApplication.delegate` is `weak`, and `main()` only held the `AppDelegate` in a local `let`. In optimized (`-O`) builds, ARC can free a local once it sees no further textual use — even while `app.run()` is still executing — taking the `NSStatusItem` down with it.
- Fix: store the delegate in a `static var` on `AppMain` so it outlives `app.run()`.

## Test plan
- [x] `macos/build.sh` (swiftc -O -parse-as-library) builds clean
- [x] `macos/run-tests.sh` — all tests pass
- [x] Manually reproduced (icon disappearing on click in a release build) and confirmed it no longer happens after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AecGGzBVoUNfr3MCV344YG