### PR TITLE
feat(catalog): one place that knows which providers exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **`ai-usagebar vendors --json`** — the provider catalog: one row per
+  provider with how it authenticates (`oauth` / `apikey` / `local`), whether
+  config has it `enabled`, whether this machine holds the credential it needs
+  (`configured`), the environment variable it reads (honoring an `api_key_env`
+  override), and the `login` command that fixes it. It contacts nothing.
+  `usage --json` reports only *enabled* providers, so the switched-off and the
+  never-credentialed were exactly the rows a "is anything broken?" list could
+  not describe; this is the answer for them. `needs_credential` is `false` only
+  for Antigravity, which has no credential to be missing, so a frontend never
+  offers to fix one that cannot be.
+
+### Changed
+
+- `KEY_VENDORS` no longer stores each provider's environment variable name: it
+  comes from `VendorId::api_key_env`, and `Config::api_key_env_for` /
+  `Config::inline_api_key` replaced two private helpers that matched on a
+  section *string* with a `_ =>` fallback arm — where a new key vendor nobody
+  added would silently read the wrong default and report as unconfigured for
+  ever. Both match on `VendorId`, so that case now fails to compile.
+
 ## [1.12.0] — 2026-09-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -442,6 +442,11 @@ ai-usagebar --json
 ai-usagebar usage
 ai-usagebar usage --json | jq '.entries[] | {id, metrics, sections}'
 
+# Every provider that exists — the switched-off and the never-configured
+# included — with how each authenticates and whether it is usable here.
+ai-usagebar vendors
+ai-usagebar vendors --json | jq '.vendors[] | select(.enabled and (.configured|not))'
+
 # Live preview while iterating on --format / --tooltip-format.
 ai-usagebar --vendor openrouter --watch 5
 
@@ -454,6 +459,16 @@ The JSON report has two views of each provider:
 - `metrics` contains percentage gauges only.
 - `sections` preserves the complete ordered display, including balances,
   grouped rows, and spacers. Rows without a percentage do not invent one.
+
+`usage` reports only the providers that are **enabled**, which makes the
+switched-off and the never-credentialed exactly the rows it cannot describe.
+`vendors --json` is the catalog that covers them: one row per provider with its
+`kind` (`oauth` / `apikey` / `local`), whether config has it `enabled`, whether
+this machine has the credential it needs (`configured`), the environment
+variable it reads (honoring an `api_key_env` override), and the `login` command
+that fixes it. It contacts nothing. A frontend drawing a per-provider health
+list reads both and needs no provider table of its own — `needs_credential` is
+`false` only for Antigravity, which has no credential to be missing.
 
 The report also includes the configured `primary` id. Each entry has
 `display_name`, `short_name`, `status`, `stale`, and `fetched_at`; metric rows

--- a/src/bin/ai-usagebar.rs
+++ b/src/bin/ai-usagebar.rs
@@ -13,6 +13,12 @@ fn main() {
     if let Some(Command::Settings { action }) = &cli.command {
         std::process::exit(ai_usagebar::tui::settings::run_cli(action));
     }
+    // Static catalog: it reads config and the filesystem, never the network,
+    // so it needs no tokio runtime and must not go through the always-exit-0
+    // Waybar contract.
+    if let Some(Command::Vendors { json }) = &cli.command {
+        std::process::exit(ai_usagebar::catalog::run(*json));
+    }
     if let Some(Command::Auth { provider }) = &cli.command {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -1,0 +1,429 @@
+//! The one answer to "which providers exist, how does each authenticate, and
+//! is this one switched on and credentialed on this machine".
+//!
+//! `usage --json` reports only the providers that are *enabled*, which makes
+//! the switched-off and the never-credentialed exactly the rows it cannot
+//! describe — and those are the rows a "is anything broken?" list exists to
+//! show. Filling that gap used to mean a frontend keeping its own provider
+//! table, and two of them did: the GNOME extension carried sixteen of the
+//! twenty-one providers plus a hand-written TOML reader mirroring
+//! `Config::default`, and the macOS menu bar re-derived Claude's, Codex's,
+//! Cursor's and Antigravity's credential locations in Swift. Both drifted the
+//! moment a provider was added in Rust — Antigravity, Cursor, Kiro, Nous
+//! Research and SuperGrok were invisible to the GNOME section for that reason.
+//!
+//! `ai-usagebar vendors --json` emits this, so a frontend can list every
+//! provider, and say what an unusable one is missing, while knowing none of
+//! them. It is the `CLAUDE.md` rule that frontend adapters stay thin, applied
+//! to the one table that had escaped it.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::Config;
+use crate::vendor::{AuthKind, VendorId};
+
+/// Injected IO, so [`statuses_with`] is a pure function of config plus these
+/// answers. Tests pass closures over a fixture and never touch a real `$HOME`,
+/// environment variable, or Keychain.
+pub struct Probes<'a> {
+    /// Whether an environment variable is set to a non-empty value.
+    pub env_set: &'a dyn Fn(&str) -> bool,
+    /// Whether a path exists.
+    pub exists: &'a dyn Fn(&Path) -> bool,
+    /// Whether the macOS login Keychain holds Claude Code's OAuth blob. Always
+    /// `false` off macOS; a subprocess (`security(1)`) when it is consulted,
+    /// which is why it is injected and asked only once Claude's credential
+    /// file has already been ruled out.
+    pub keychain_has_claude: &'a dyn Fn() -> bool,
+}
+
+/// One provider's row in the catalog.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct VendorStatus {
+    /// Machine id, the same string `usage --json` keys its entries by.
+    pub id: &'static str,
+    /// Canonical product name, from [`VendorId::display_name`].
+    pub name: &'static str,
+    pub short_name: &'static str,
+    pub kind: AuthKind,
+    /// Whether config has this provider switched on.
+    pub enabled: bool,
+    /// Whether this provider has everything it needs to be fetched. Always
+    /// `true` when `needs_credential` is `false`.
+    pub configured: bool,
+    /// Whether the provider has a credential to be missing at all. Antigravity
+    /// has none: there is no file, no key and no login — the binary probes
+    /// whichever local product is running — so "not configured" is not a state
+    /// it can be in, and a frontend must not offer to fix one.
+    pub needs_credential: bool,
+    /// Effective environment variable holding this provider's key, honoring an
+    /// `api_key_env` override; empty when the provider takes no key.
+    pub env: String,
+    /// Command that signs this provider in; empty when signing in happens in a
+    /// desktop app's own window.
+    pub login: &'static str,
+}
+
+/// The catalog against the real environment.
+pub fn statuses(cfg: &Config) -> Vec<VendorStatus> {
+    let probes = Probes {
+        env_set: &|name| std::env::var_os(name).is_some_and(|value| !value.is_empty()),
+        exists: &|path| path.exists(),
+        keychain_has_claude: &keychain_has_claude,
+    };
+    statuses_with(cfg, &probes)
+}
+
+/// One row per [`VendorId::all`], in that canonical order — so a provider
+/// added to the enum appears in every frontend with no frontend change, which
+/// is the whole point.
+pub fn statuses_with(cfg: &Config, probes: &Probes) -> Vec<VendorStatus> {
+    VendorId::all()
+        .iter()
+        .copied()
+        .map(|id| {
+            // Antigravity is the only provider with nothing to configure.
+            let needs_credential = id != VendorId::Antigravity;
+            VendorStatus {
+                id: id.slug(),
+                name: id.display_name(),
+                short_name: id.short_name(),
+                kind: id.auth_kind(),
+                enabled: cfg.is_enabled(id),
+                configured: !needs_credential || credential_present(cfg, id, probes),
+                needs_credential,
+                env: cfg.api_key_env_for(id).to_string(),
+                login: id.login_command(),
+            }
+        })
+        .collect()
+}
+
+/// Whether this provider's credential is present. Every provider that
+/// documents an environment variable is satisfied by it — the OAuth ones
+/// included, where it is the headless override — and then by an inline
+/// `api_key`, and only then by its own login artifact.
+fn credential_present(cfg: &Config, id: VendorId, probes: &Probes) -> bool {
+    let env = cfg.api_key_env_for(id);
+    if !env.is_empty() && (probes.env_set)(env) {
+        return true;
+    }
+    if cfg.inline_api_key(id).is_some() {
+        return true;
+    }
+    match id {
+        // A Keychain-only login is what Claude Code leaves on macOS when no
+        // `.credentials.json` was written, so the file alone would report a
+        // signed-in user as unconfigured.
+        VendorId::Anthropic => {
+            any_exists(probes, [crate::anthropic::creds::default_path()])
+                || (probes.keychain_has_claude)()
+        }
+        VendorId::Openai => any_exists(probes, [crate::openai::creds::default_path()]),
+        VendorId::Copilot => {
+            any_exists(probes, [crate::copilot::credentials::default_hosts_path()])
+        }
+        VendorId::CommandCode => match crate::commandcode::creds::default_paths() {
+            Ok(paths) => paths.iter().any(|path| (probes.exists)(path)),
+            Err(_) => false,
+        },
+        VendorId::NousResearch => {
+            (probes.exists)(&crate::nous::credentials::default_credentials_path())
+        }
+        // Kimi takes a key or the Kimi Code CLI's own OAuth login.
+        VendorId::Kimi => any_exists(probes, [kimi_credentials_path(cfg)]),
+        // Cursor reads the IDE's state database, falling back to the headless
+        // `cursor-agent` CLI's login file — either one means signed in.
+        VendorId::Cursor => any_exists(
+            probes,
+            [
+                cfg.cursor
+                    .db_path
+                    .clone()
+                    .map_or_else(crate::cursor::db::default_db_path, Ok),
+                cfg.cursor
+                    .agent_auth_path
+                    .clone()
+                    .map_or_else(crate::cursor::db::default_agent_auth_path, Ok),
+            ],
+        ),
+        VendorId::Kiro => any_exists(
+            probes,
+            [cfg.kiro
+                .db_path
+                .clone()
+                .map_or_else(crate::kiro::db::default_db_path, Ok)],
+        ),
+        // SuperGrok rides the Grok Build CLI's own login; its executable is the
+        // only local artifact, and config pins the trusted path.
+        VendorId::Supergrok => (probes.exists)(&cfg.supergrok.grok_binary),
+        // Nothing to check: handled by `needs_credential`, never reached.
+        VendorId::Antigravity => true,
+        // Key-only providers: the environment and inline checks above are the
+        // whole answer.
+        VendorId::AnthropicApi
+        | VendorId::Zai
+        | VendorId::Openrouter
+        | VendorId::Deepseek
+        | VendorId::Kilo
+        | VendorId::Novita
+        | VendorId::Moonshot
+        | VendorId::Grok
+        | VendorId::Minimax
+        | VendorId::OpenCodeGo => false,
+    }
+}
+
+fn kimi_credentials_path(cfg: &Config) -> crate::error::Result<PathBuf> {
+    match &cfg.kimi.credentials_path {
+        Some(path) => Ok(path.clone()),
+        None => Ok(crate::kimi::oauth::credentials_path_in(
+            &crate::cache::home_dir()?,
+        )),
+    }
+}
+
+/// True when any resolvable path exists. A path that cannot be resolved at all
+/// (no `$HOME`) counts as absent rather than as an error: the row still has to
+/// render, and "not configured" is the honest thing to draw.
+fn any_exists<const N: usize>(probes: &Probes, paths: [crate::error::Result<PathBuf>; N]) -> bool {
+    paths
+        .iter()
+        .filter_map(|path| path.as_ref().ok())
+        .any(|path| (probes.exists)(path))
+}
+
+#[cfg(target_os = "macos")]
+fn keychain_has_claude() -> bool {
+    matches!(crate::anthropic::keychain::read_raw(), Ok(Some(_)))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn keychain_has_claude() -> bool {
+    false
+}
+
+/// `vendors --json`: the catalog as one JSON document.
+pub fn run(json: bool) -> i32 {
+    let cfg = match Config::load() {
+        Ok(cfg) => cfg,
+        Err(error) => {
+            eprintln!("vendors: {error}");
+            return 1;
+        }
+    };
+    let rows = statuses(&cfg);
+    if json {
+        match serde_json::to_string(&serde_json::json!({"vendors": rows})) {
+            Ok(text) => println!("{text}"),
+            Err(error) => {
+                eprintln!("vendors: {error}");
+                return 1;
+            }
+        }
+        return 0;
+    }
+    for row in rows {
+        let state = if !row.enabled {
+            "off"
+        } else if row.configured {
+            "ready"
+        } else {
+            "needs credential"
+        };
+        println!("{:<14} {:<10} {}", row.id, row.kind.as_str(), state);
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::settings::KEY_VENDORS;
+
+    /// Every probe answers "no", so a row is configured only because config
+    /// says so. Nothing here reads a real `$HOME`, variable or Keychain.
+    fn probes<'a>(env: &'a dyn Fn(&str) -> bool, exists: &'a dyn Fn(&Path) -> bool) -> Probes<'a> {
+        Probes {
+            env_set: env,
+            exists,
+            keychain_has_claude: &|| false,
+        }
+    }
+
+    fn bare<'a>() -> Probes<'a> {
+        probes(&|_| false, &|_| false)
+    }
+
+    fn row(rows: &[VendorStatus], id: &str) -> VendorStatus {
+        rows.iter()
+            .find(|row| row.id == id)
+            .unwrap_or_else(|| panic!("{id} is missing from the catalog"))
+            .clone()
+    }
+
+    /// The guard this module exists for. A provider added to `VendorId` shows
+    /// up here for free; the two frontends that kept their own tables had
+    /// silently dropped five of them (Antigravity, Cursor, Kiro, Nous
+    /// Research, SuperGrok), in a list whose whole job is to be complete.
+    #[test]
+    fn every_provider_has_exactly_one_row_in_canonical_order() {
+        let rows = statuses_with(&Config::default(), &bare());
+        let ids: Vec<&str> = rows.iter().map(|row| row.id).collect();
+        let expected: Vec<&str> = VendorId::all().iter().map(|id| id.slug()).collect();
+        assert_eq!(ids, expected);
+    }
+
+    #[test]
+    fn a_key_vendor_is_configured_by_its_environment_variable() {
+        let cfg = Config::default();
+        let set = |name: &str| name == "ZAI_API_KEY";
+        let rows = statuses_with(&cfg, &probes(&set, &|_| false));
+        assert!(row(&rows, "zai").configured);
+        assert!(!row(&rows, "deepseek").configured);
+    }
+
+    #[test]
+    fn an_api_key_env_override_is_the_variable_both_reported_and_read() {
+        let mut cfg = Config::default();
+        cfg.zai.api_key_env = "WORK_ZAI_KEY".to_string();
+        let set = |name: &str| name == "WORK_ZAI_KEY";
+        let rows = statuses_with(&cfg, &probes(&set, &|_| false));
+        let zai = row(&rows, "zai");
+        assert_eq!(
+            zai.env, "WORK_ZAI_KEY",
+            "the row names the effective variable"
+        );
+        assert!(zai.configured, "and is satisfied by it, not by the default");
+
+        // The default name must no longer count once overridden.
+        let stale = |name: &str| name == "ZAI_API_KEY";
+        let rows = statuses_with(&cfg, &probes(&stale, &|_| false));
+        assert!(!row(&rows, "zai").configured);
+    }
+
+    #[test]
+    fn an_inline_key_configures_without_the_environment() {
+        let mut cfg = Config::default();
+        cfg.zai.api_key = Some("sk-inline".to_string());
+        let rows = statuses_with(&cfg, &bare());
+        assert!(row(&rows, "zai").configured);
+    }
+
+    #[test]
+    fn an_empty_inline_key_is_not_a_credential() {
+        let mut cfg = Config::default();
+        cfg.zai.api_key = Some(String::new());
+        let rows = statuses_with(&cfg, &bare());
+        assert!(!row(&rows, "zai").configured);
+    }
+
+    /// Antigravity has no credential of any kind — the binary probes whichever
+    /// local product is running — so a frontend must not draw it as missing
+    /// one, and must not offer to fix it.
+    #[test]
+    fn antigravity_has_nothing_to_configure() {
+        let rows = statuses_with(&Config::default(), &bare());
+        let agy = row(&rows, "antigravity");
+        assert!(!agy.needs_credential);
+        assert!(agy.configured);
+        assert_eq!(agy.env, "");
+        assert_eq!(agy.login, "");
+    }
+
+    /// Claude Code on macOS may leave the OAuth blob only in the login
+    /// Keychain, so the credential file alone would report a signed-in user as
+    /// unconfigured.
+    #[test]
+    fn a_keychain_only_claude_login_counts_as_configured() {
+        let cfg = Config::default();
+        let with_keychain = Probes {
+            env_set: &|_| false,
+            exists: &|_| false,
+            keychain_has_claude: &|| true,
+        };
+        assert!(row(&statuses_with(&cfg, &with_keychain), "anthropic").configured);
+        assert!(!row(&statuses_with(&cfg, &bare()), "anthropic").configured);
+    }
+
+    #[test]
+    fn an_oauth_provider_with_no_artifact_names_the_command_that_fixes_it() {
+        let rows = statuses_with(&Config::default(), &bare());
+        let codex = row(&rows, "openai");
+        assert_eq!(codex.kind, AuthKind::Oauth);
+        assert!(!codex.configured);
+        assert_eq!(codex.login, "codex login");
+    }
+
+    /// A provider is only ever fetched when config has it on, and `enabled` is
+    /// the one fact `usage --json` cannot report for the rows it omits.
+    #[test]
+    fn enabled_follows_config_not_the_credential() {
+        let mut cfg = Config::default();
+        cfg.zai.enabled = false;
+        let set = |name: &str| name == "ZAI_API_KEY";
+        let zai = row(&statuses_with(&cfg, &probes(&set, &|_| false)), "zai");
+        assert!(!zai.enabled, "switched off in config");
+        assert!(zai.configured, "but its key is still there");
+    }
+
+    /// Auth metadata has to be usable, not merely present: a key provider that
+    /// names no variable leaves a frontend with nothing to tell the user.
+    #[test]
+    fn every_key_provider_names_a_variable_and_every_oauth_one_a_login() {
+        let cfg = Config::default();
+        for row in statuses_with(&cfg, &bare()) {
+            match row.kind {
+                AuthKind::ApiKey => assert!(
+                    !row.env.is_empty(),
+                    "{} authenticates by key but names no variable",
+                    row.id
+                ),
+                AuthKind::Oauth => assert!(
+                    !row.login.is_empty(),
+                    "{} authenticates by login but names no command",
+                    row.id
+                ),
+                AuthKind::Local => {}
+            }
+        }
+    }
+
+    /// The settings form's credential fields are a *view* over the catalog, so
+    /// each one must be a provider the catalog agrees takes a key. This is what
+    /// keeps the two from drifting now that the variable name lives in one
+    /// place.
+    #[test]
+    fn the_settings_key_form_covers_only_catalog_key_providers() {
+        for kv in KEY_VENDORS {
+            assert_eq!(
+                kv.id.auth_kind(),
+                AuthKind::ApiKey,
+                "{} has a key field in Settings but is not a key provider",
+                kv.id.slug()
+            );
+            assert!(
+                !kv.id.api_key_env().is_empty(),
+                "{} has a key field in Settings but names no variable",
+                kv.id.slug()
+            );
+        }
+    }
+
+    #[test]
+    fn the_json_document_is_keyed_by_vendors_and_uses_wire_names() {
+        let rows = statuses_with(&Config::default(), &bare());
+        let text = serde_json::to_string(&serde_json::json!({"vendors": rows})).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let vendors = parsed["vendors"].as_array().unwrap();
+        assert_eq!(vendors.len(), VendorId::all().len());
+        assert_eq!(vendors[0]["id"], "anthropic");
+        assert_eq!(vendors[0]["kind"], "oauth");
+        let agy = vendors
+            .iter()
+            .find(|v| v["id"] == "antigravity")
+            .expect("antigravity is in the report");
+        assert_eq!(agy["kind"], "local");
+        assert_eq!(agy["needs_credential"], false);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1168,6 +1168,68 @@ impl Config {
         }
     }
 
+    /// The environment variable this provider's API key is read from, honoring
+    /// a per-vendor `api_key_env` override; `""` for a provider that takes no
+    /// key. Matching on [`VendorId`] rather than on a section name is
+    /// deliberate: a new key vendor that nobody adds here fails to compile,
+    /// where a `_ =>` arm over `&str` sections would silently hand back the
+    /// wrong default and report the provider as unconfigured for ever.
+    pub fn api_key_env_for(&self, id: VendorId) -> &str {
+        match id {
+            VendorId::AnthropicApi => &self.anthropic_api.api_key_env,
+            VendorId::Zai => &self.zai.api_key_env,
+            VendorId::Openrouter => &self.openrouter.api_key_env,
+            VendorId::Deepseek => &self.deepseek.api_key_env,
+            VendorId::Kimi => &self.kimi.api_key_env,
+            VendorId::Kilo => &self.kilo.api_key_env,
+            VendorId::Novita => &self.novita.api_key_env,
+            VendorId::Moonshot => &self.moonshot.api_key_env,
+            VendorId::Grok => &self.grok.api_key_env,
+            VendorId::Minimax => &self.minimax.api_key_env,
+            VendorId::OpenCodeGo => &self.opencode_go.api_key_env,
+            // Fixed names: OAuth-first providers whose environment override is
+            // not user-renameable, and the providers with no key at all.
+            VendorId::Anthropic
+            | VendorId::Openai
+            | VendorId::Copilot
+            | VendorId::Supergrok
+            | VendorId::Antigravity
+            | VendorId::Cursor
+            | VendorId::Kiro
+            | VendorId::NousResearch
+            | VendorId::CommandCode => id.api_key_env(),
+        }
+    }
+
+    /// A non-empty inline `api_key` from this provider's config section. An
+    /// empty string counts as unset, the same way the vendors' own
+    /// `resolve_api_key` treats it.
+    pub fn inline_api_key(&self, id: VendorId) -> Option<&str> {
+        let raw = match id {
+            VendorId::AnthropicApi => self.anthropic_api.api_key.as_deref(),
+            VendorId::Zai => self.zai.api_key.as_deref(),
+            VendorId::Openrouter => self.openrouter.api_key.as_deref(),
+            VendorId::Deepseek => self.deepseek.api_key.as_deref(),
+            VendorId::Kimi => self.kimi.api_key.as_deref(),
+            VendorId::Kilo => self.kilo.api_key.as_deref(),
+            VendorId::Novita => self.novita.api_key.as_deref(),
+            VendorId::Moonshot => self.moonshot.api_key.as_deref(),
+            VendorId::Grok => self.grok.api_key.as_deref(),
+            VendorId::Minimax => self.minimax.api_key.as_deref(),
+            VendorId::OpenCodeGo => self.opencode_go.api_key.as_deref(),
+            VendorId::Anthropic
+            | VendorId::Openai
+            | VendorId::Copilot
+            | VendorId::Supergrok
+            | VendorId::Antigravity
+            | VendorId::Cursor
+            | VendorId::Kiro
+            | VendorId::NousResearch
+            | VendorId::CommandCode => None,
+        };
+        raw.filter(|key| !key.is_empty())
+    }
+
     pub fn enabled_vendors(&self) -> Vec<VendorId> {
         VendorId::all()
             .iter()

--- a/src/copilot/credentials.rs
+++ b/src/copilot/credentials.rs
@@ -7,6 +7,21 @@ use std::process::{Command, Stdio};
 use crate::error::{AppError, Result};
 use crate::vendor::vendor_secret_env_vars_to_remove;
 
+/// Where the GitHub CLI records a completed login. Its existence is the
+/// cheapest honest answer to "is Copilot signed in": the token itself only
+/// comes back from `gh auth token`, and a status list that runs a subprocess
+/// per provider is not a status list. `GH_CONFIG_DIR` wins, as it does for
+/// `gh` itself.
+pub fn default_hosts_path() -> Result<std::path::PathBuf> {
+    if let Some(dir) = std::env::var_os("GH_CONFIG_DIR").filter(|v| !v.is_empty()) {
+        return Ok(std::path::PathBuf::from(dir).join("hosts.yml"));
+    }
+    Ok(crate::cache::home_dir()?
+        .join(".config")
+        .join("gh")
+        .join("hosts.yml"))
+}
+
 /// The deliberately narrow process description used to obtain the current
 /// GitHub CLI OAuth token. Keeping it data makes the subprocess boundary
 /// inspectable in tests and prevents a shell from entering this path.

--- a/src/copilot/credentials.rs
+++ b/src/copilot/credentials.rs
@@ -10,16 +10,39 @@ use crate::vendor::vendor_secret_env_vars_to_remove;
 /// Where the GitHub CLI records a completed login. Its existence is the
 /// cheapest honest answer to "is Copilot signed in": the token itself only
 /// comes back from `gh auth token`, and a status list that runs a subprocess
-/// per provider is not a status list. `GH_CONFIG_DIR` wins, as it does for
-/// `gh` itself.
+/// per provider is not a status list.
+///
+/// This follows `gh`'s own documented precedence exactly, because a path we
+/// invent is a wrong answer on somebody's machine: `GH_CONFIG_DIR`, then
+/// `$XDG_CONFIG_HOME/gh`, then `%AppData%\GitHub CLI` on Windows, then
+/// `~/.config/gh`.
 pub fn default_hosts_path() -> Result<std::path::PathBuf> {
-    if let Some(dir) = std::env::var_os("GH_CONFIG_DIR").filter(|v| !v.is_empty()) {
+    hosts_path_with(
+        |name| std::env::var_os(name).filter(|value| !value.is_empty()),
+        crate::cache::home_dir()?,
+    )
+}
+
+/// Test seam for [`default_hosts_path`]: the environment and the home
+/// directory are the production inputs, so they are injected rather than read.
+pub fn hosts_path_with(
+    environment: impl Fn(&str) -> Option<std::ffi::OsString>,
+    home: std::path::PathBuf,
+) -> Result<std::path::PathBuf> {
+    if let Some(dir) = environment("GH_CONFIG_DIR") {
         return Ok(std::path::PathBuf::from(dir).join("hosts.yml"));
     }
-    Ok(crate::cache::home_dir()?
-        .join(".config")
-        .join("gh")
-        .join("hosts.yml"))
+    if let Some(dir) = environment("XDG_CONFIG_HOME") {
+        return Ok(std::path::PathBuf::from(dir).join("gh").join("hosts.yml"));
+    }
+    if cfg!(windows)
+        && let Some(dir) = environment("AppData")
+    {
+        return Ok(std::path::PathBuf::from(dir)
+            .join("GitHub CLI")
+            .join("hosts.yml"));
+    }
+    Ok(home.join(".config").join("gh").join("hosts.yml"))
 }
 
 /// The deliberately narrow process description used to obtain the current
@@ -159,6 +182,58 @@ mod tests {
     /// is still an ambient choice about which binary runs on every refresh.
     /// `[copilot] gh_binary` is how a user pins it, so the setting has to
     /// actually reach the spawned command.
+    /// `gh`'s own precedence, in order. A path we invent instead is a wrong
+    /// answer on somebody's machine: an XDG user's login would read as absent
+    /// and report Copilot as never signed in.
+    #[test]
+    fn hosts_path_follows_the_github_cli_precedence() {
+        use std::ffi::OsString;
+        use std::path::PathBuf;
+        let home = PathBuf::from("/home/u");
+        let only = |wanted: &'static str, value: &'static str| {
+            move |name: &str| (name == wanted).then(|| OsString::from(value))
+        };
+
+        assert_eq!(
+            hosts_path_with(only("GH_CONFIG_DIR", "/cfg/gh"), home.clone()).unwrap(),
+            PathBuf::from("/cfg/gh/hosts.yml"),
+            "GH_CONFIG_DIR is used verbatim, with no `gh` segment appended"
+        );
+        assert_eq!(
+            hosts_path_with(only("XDG_CONFIG_HOME", "/xdg"), home.clone()).unwrap(),
+            PathBuf::from("/xdg/gh/hosts.yml")
+        );
+        assert_eq!(
+            hosts_path_with(|_| None, home.clone()).unwrap(),
+            home.join(".config").join("gh").join("hosts.yml"),
+            "with nothing set, the home convention"
+        );
+
+        // GH_CONFIG_DIR outranks XDG_CONFIG_HOME.
+        let both = |name: &str| match name {
+            "GH_CONFIG_DIR" => Some(OsString::from("/cfg/gh")),
+            "XDG_CONFIG_HOME" => Some(OsString::from("/xdg")),
+            _ => None,
+        };
+        assert_eq!(
+            hosts_path_with(both, home.clone()).unwrap(),
+            PathBuf::from("/cfg/gh/hosts.yml")
+        );
+
+        // `AppData` is Windows-only and ranks below XDG, so it must not
+        // capture a Linux or macOS machine that happens to have it set.
+        let appdata =
+            hosts_path_with(only("AppData", "C:/Users/u/AppData/Roaming"), home.clone()).unwrap();
+        if cfg!(windows) {
+            assert_eq!(
+                appdata,
+                PathBuf::from("C:/Users/u/AppData/Roaming/GitHub CLI/hosts.yml")
+            );
+        } else {
+            assert_eq!(appdata, home.join(".config").join("gh").join("hosts.yml"));
+        }
+    }
+
     #[test]
     fn a_configured_gh_binary_replaces_the_path_lookup() {
         let pinned = std::path::Path::new("/opt/github/bin/gh");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod anthropic;
 pub mod anthropic_api;
 pub mod antigravity;
 pub mod cache;
+pub mod catalog;
 pub mod claude_desktop;
 pub mod commandcode;
 pub mod config;

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -40,7 +40,6 @@ use crate::vendor::VendorId;
 pub struct KeyVendor {
     pub id: VendorId,
     pub label: &'static str,
-    pub env: &'static str,
     pub section: &'static str,
     /// Config field that stores the credential (`api_key` for most vendors).
     pub config_key: &'static str,
@@ -54,7 +53,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::AnthropicApi,
         label: "Anthropic API",
-        env: "ANTHROPIC_ADMIN_KEY",
         section: "anthropic_api",
         config_key: "api_key",
         secret_label: "API key",
@@ -63,7 +61,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Zai,
         label: "Z.AI",
-        env: "ZAI_API_KEY",
         section: "zai",
         config_key: "api_key",
         secret_label: "API key",
@@ -72,7 +69,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Openrouter,
         label: "OpenRouter",
-        env: "OPENROUTER_API_KEY",
         section: "openrouter",
         config_key: "api_key",
         secret_label: "API key",
@@ -81,7 +77,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Deepseek,
         label: "DeepSeek",
-        env: "DEEPSEEK_API_KEY",
         section: "deepseek",
         config_key: "api_key",
         secret_label: "API key",
@@ -90,7 +85,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Kimi,
         label: "Kimi",
-        env: "KIMI_API_KEY",
         section: "kimi",
         config_key: "api_key",
         secret_label: "API key",
@@ -99,7 +93,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Kilo,
         label: "Kilo",
-        env: "KILO_API_KEY",
         section: "kilo",
         config_key: "api_key",
         secret_label: "API key",
@@ -108,7 +101,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Novita,
         label: "Novita",
-        env: "NOVITA_API_KEY",
         section: "novita",
         config_key: "api_key",
         secret_label: "API key",
@@ -117,7 +109,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Moonshot,
         label: "Moonshot",
-        env: "MOONSHOT_API_KEY",
         section: "moonshot",
         config_key: "api_key",
         secret_label: "API key",
@@ -126,7 +117,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Grok,
         label: "Grok",
-        env: "XAI_MANAGEMENT_KEY",
         section: "grok",
         config_key: "api_key",
         secret_label: "API key",
@@ -135,7 +125,6 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::Minimax,
         label: "MiniMax",
-        env: "MINIMAX_API_KEY",
         section: "minimax",
         config_key: "api_key",
         secret_label: "API key",
@@ -144,32 +133,12 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
     KeyVendor {
         id: VendorId::OpenCodeGo,
         label: "OpenCode Go",
-        env: "OPENCODE_GO_API_KEY",
         section: "opencode-go",
         config_key: "api_key",
         secret_label: "API key",
         note: "usage quota",
     },
 ];
-
-/// Read the inline credential currently in config, so the field opens
-/// pre-filled (masked) when one is already set.
-fn config_inline_key<'a>(cfg: &'a Config, vendor: &KeyVendor) -> Option<&'a str> {
-    match vendor.section {
-        "anthropic_api" => cfg.anthropic_api.api_key.as_deref(),
-        "zai" => cfg.zai.api_key.as_deref(),
-        "openrouter" => cfg.openrouter.api_key.as_deref(),
-        "deepseek" => cfg.deepseek.api_key.as_deref(),
-        "kimi" => cfg.kimi.api_key.as_deref(),
-        "kilo" => cfg.kilo.api_key.as_deref(),
-        "novita" => cfg.novita.api_key.as_deref(),
-        "moonshot" => cfg.moonshot.api_key.as_deref(),
-        "grok" => cfg.grok.api_key.as_deref(),
-        "minimax" => cfg.minimax.api_key.as_deref(),
-        "opencode-go" => cfg.opencode_go.api_key.as_deref(),
-        _ => None,
-    }
-}
 
 /// Which control has keyboard focus. `Key(i)` indexes into [`KEY_VENDORS`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,7 +279,7 @@ impl SettingsState {
     pub fn from_config(cfg: &Config) -> Self {
         let keys = KEY_VENDORS
             .iter()
-            .map(|kv| KeyInput::from_config(config_inline_key(cfg, kv)))
+            .map(|kv| KeyInput::from_config(cfg.inline_api_key(kv.id)))
             .collect();
         let mut primary_choices = cfg.enabled_vendors();
         // Copilot credentials belong to GitHub CLI, so a login cannot write a
@@ -677,23 +646,6 @@ const SETTINGS_SCHEMA_VERSION: u8 = 1;
 const MAX_SETTINGS_REQUEST_BYTES: u64 = 64 * 1024;
 const MAX_API_KEY_BYTES: usize = 16 * 1024;
 
-fn configured_key_env<'a>(cfg: &'a Config, section: &str, fallback: &'a str) -> &'a str {
-    match section {
-        "anthropic_api" => &cfg.anthropic_api.api_key_env,
-        "zai" => &cfg.zai.api_key_env,
-        "openrouter" => &cfg.openrouter.api_key_env,
-        "deepseek" => &cfg.deepseek.api_key_env,
-        "kimi" => &cfg.kimi.api_key_env,
-        "kilo" => &cfg.kilo.api_key_env,
-        "novita" => &cfg.novita.api_key_env,
-        "moonshot" => &cfg.moonshot.api_key_env,
-        "grok" => &cfg.grok.api_key_env,
-        "minimax" => &cfg.minimax.api_key_env,
-        "opencode-go" => &cfg.opencode_go.api_key_env,
-        _ => fallback,
-    }
-}
-
 fn snapshot_from_config_with(
     cfg: &Config,
     environment_configured: impl Fn(&str) -> bool,
@@ -710,8 +662,8 @@ fn snapshot_from_config_with(
     let keys = KEY_VENDORS
         .iter()
         .map(|vendor| {
-            let environment = configured_key_env(cfg, vendor.section, vendor.env);
-            let inline_configured = config_inline_key(cfg, vendor).is_some_and(|v| !v.is_empty());
+            let environment = cfg.api_key_env_for(vendor.id);
+            let inline_configured = cfg.inline_api_key(vendor.id).is_some();
             let environment_configured = environment_configured(environment);
             KeyStatus {
                 id: vendor.id.slug().to_string(),
@@ -972,10 +924,11 @@ fn key_row(kv: &KeyVendor, input: &KeyInput, focused: bool, theme: &BubbleTheme)
     let value = value_text(input, focused);
 
     // Env / status suffix: env-var name, whether an env override is set, note.
-    let env_set = std::env::var(kv.env)
+    let env_name = kv.id.api_key_env();
+    let env_set = std::env::var(env_name)
         .map(|v| !v.is_empty())
         .unwrap_or(false);
-    let mut suffix = format!("   {}", kv.env);
+    let mut suffix = format!("   {env_name}");
     if env_set {
         suffix.push_str(" · env set (overrides)");
     }

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -137,6 +137,31 @@ pub enum VendorId {
     CommandCode,
 }
 
+/// How a provider authenticates. Drives what a frontend offers a provider that
+/// is not usable yet: a command to run, a variable to set, or an app to sign
+/// in to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthKind {
+    /// An interactive login writes a credential file. `login_command` runs it.
+    Oauth,
+    /// An API key, from the environment or an inline `api_key` in config.
+    ApiKey,
+    /// No credential of its own — a local product's session or state file is
+    /// the login, and there is nothing for the user to paste.
+    Local,
+}
+
+impl AuthKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            AuthKind::Oauth => "oauth",
+            AuthKind::ApiKey => "apikey",
+            AuthKind::Local => "local",
+        }
+    }
+}
+
 impl VendorId {
     pub fn slug(self) -> &'static str {
         match self {
@@ -217,6 +242,103 @@ impl VendorId {
             VendorId::NousResearch => "nrs",
             VendorId::OpenCodeGo => "ocg",
             VendorId::CommandCode => "cmc",
+        }
+    }
+
+    /// How a provider proves who you are. This is the fact a frontend needs to
+    /// say what an unconfigured provider is still missing, and it is the one
+    /// thing neither `usage --json` nor the config file carries: the report
+    /// lists only *enabled* providers, so the switched-off and the
+    /// never-credentialed are exactly the rows it cannot describe.
+    pub const fn auth_kind(self) -> AuthKind {
+        match self {
+            VendorId::Anthropic
+            | VendorId::Openai
+            | VendorId::Copilot
+            | VendorId::NousResearch
+            | VendorId::CommandCode => AuthKind::Oauth,
+            VendorId::AnthropicApi
+            | VendorId::Zai
+            | VendorId::Openrouter
+            | VendorId::Deepseek
+            | VendorId::Kimi
+            | VendorId::Kilo
+            | VendorId::Novita
+            | VendorId::Moonshot
+            | VendorId::Grok
+            | VendorId::Minimax
+            | VendorId::OpenCodeGo => AuthKind::ApiKey,
+            // No credential of their own: another local product's session is
+            // the login. Antigravity has no credential file at all (the binary
+            // probes whichever local server answers), Cursor and Kiro read the
+            // IDE's and kiro-cli's own state, and SuperGrok uses the Grok Build
+            // CLI's login.
+            VendorId::Supergrok | VendorId::Antigravity | VendorId::Cursor | VendorId::Kiro => {
+                AuthKind::Local
+            }
+        }
+    }
+
+    /// Default environment variable holding this provider's key, or `""` for a
+    /// provider that has none. This is only the *default*: most key vendors
+    /// accept an `api_key_env` override in config, so a frontend showing the
+    /// variable a user must set wants [`Config::api_key_env_for`], not this.
+    pub const fn api_key_env(self) -> &'static str {
+        match self {
+            VendorId::AnthropicApi => "ANTHROPIC_ADMIN_KEY",
+            VendorId::Zai => "ZAI_API_KEY",
+            VendorId::Openrouter => "OPENROUTER_API_KEY",
+            VendorId::Deepseek => "DEEPSEEK_API_KEY",
+            VendorId::Kimi => "KIMI_API_KEY",
+            VendorId::Kilo => "KILO_API_KEY",
+            VendorId::Novita => "NOVITA_API_KEY",
+            VendorId::Moonshot => "MOONSHOT_API_KEY",
+            VendorId::Grok => "XAI_MANAGEMENT_KEY",
+            VendorId::Minimax => "MINIMAX_API_KEY",
+            VendorId::OpenCodeGo => "OPENCODE_GO_API_KEY",
+            // OAuth-first, with an environment override for CI and headless
+            // use. Neither name is configurable, so neither has an
+            // `api_key_env` field in its config section.
+            VendorId::Copilot => "GITHUB_COPILOT_TOKEN",
+            VendorId::CommandCode => "COMMANDCODE_API_KEY",
+            VendorId::Anthropic
+            | VendorId::Openai
+            | VendorId::Supergrok
+            | VendorId::Antigravity
+            | VendorId::Cursor
+            | VendorId::Kiro
+            | VendorId::NousResearch => "",
+        }
+    }
+
+    /// Command that signs this provider in, or `""` when signing in happens
+    /// somewhere this cannot name — a desktop app's own window. The strings
+    /// are the ones the vendor modules' own credential errors already print,
+    /// so a status row and a failed fetch tell the user to run the same thing.
+    pub const fn login_command(self) -> &'static str {
+        match self {
+            VendorId::Anthropic => "claude",
+            VendorId::Openai => "codex login",
+            VendorId::Copilot => "gh auth login",
+            VendorId::CommandCode => "commandcode",
+            VendorId::NousResearch => "ai-usagebar auth nous login",
+            VendorId::Kiro => "kiro-cli login",
+            // Kimi takes a key *or* the Kimi Code CLI's own OAuth login, which
+            // is what a subscriber already has locally.
+            VendorId::Kimi => "kimi",
+            VendorId::AnthropicApi
+            | VendorId::Zai
+            | VendorId::Openrouter
+            | VendorId::Deepseek
+            | VendorId::Kilo
+            | VendorId::Novita
+            | VendorId::Moonshot
+            | VendorId::Grok
+            | VendorId::Supergrok
+            | VendorId::Antigravity
+            | VendorId::Cursor
+            | VendorId::Minimax
+            | VendorId::OpenCodeGo => "",
         }
     }
 

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -150,6 +150,16 @@ pub enum Command {
         json: bool,
     },
 
+    /// Every provider ai-usagebar knows: how each authenticates, whether it is
+    /// switched on, and whether this machine has the credential it needs.
+    /// Unlike `usage`, this lists the switched-off and the never-configured —
+    /// it contacts nothing and is the catalog a frontend lists providers from.
+    Vendors {
+        /// Machine-readable output.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Read or update settings for native desktop frontends.
     Settings {
         #[command(subcommand)]


### PR DESCRIPTION
## The gap

`usage --json` reports the providers that are **enabled**. That makes the
switched-off and the never-credentialed exactly the rows it cannot describe —
and those are the rows a "is anything broken?" list exists to show. There is
currently no way to ask the binary "which providers exist, and is this one
usable here?", so anything that wants to draw a per-provider list has to keep
its own table.

Two already do, and both are behind `VendorId`:

- `macos/ai-usagebar-menubar.swift`'s `VENDOR_AUTH` lists **13** of the
  **20** providers in `VendorId::all()`. Absent: `commandcode`, `copilot`,
  `kiro`, `minimax`, `nous`, `opencode-go`, `supergrok`.
- `gnome-extension/prefs.js`'s vendor list carries **6**.

`vendorConfigured` also re-derives Claude's, Codex's, Cursor's and
Antigravity's credential locations in Swift, including a hard-coded Cursor
default path that `cursor::db::default_db_path` already resolves.

`CLAUDE.md` already calls this out — "provider fetching, credentials,
canonical product names … belong in Rust; do not add a complete provider-name
table to a frontend" — so this PR adds the thing that makes the rule
followable.

## What this adds

`ai-usagebar vendors --json`: one row per `VendorId::all()`, in canonical
order.

```json
{"vendors":[
  {"id":"anthropic","name":"Claude","short_name":"cld","kind":"oauth",
   "enabled":true,"configured":false,"needs_credential":true,
   "env":"","login":"claude"}
]}
```

- `kind` — `oauth` / `apikey` / `local`, so a caller knows whether to offer a
  command, a variable, or "sign in to the app".
- `enabled` — `Config::is_enabled`.
- `configured` — whether this machine holds the credential.
- `env` — the effective variable, honoring an `api_key_env` override.
- `login` — the command that fixes it, and it is the string the vendor's own
  credential error already prints, so a status row and a failed fetch tell the
  user to run the same thing.

It contacts nothing — config and the filesystem only — so it needs no tokio
runtime and does not go through the Waybar always-exit-0 contract.

`configured` lives here because every resolver already does: Claude's file
plus the macOS Keychain fallback, Codex's `auth.json`, the Kimi Code CLI's
login, Cursor's state db with the `cursor-agent` fallback, kiro-cli's db,
Command Code's search paths, Nous's own store, and the Grok Build binary
SuperGrok rides. An environment key satisfies any provider that documents one,
the OAuth ones included, since that is the headless override.

Antigravity is the one provider with nothing to configure — no file, no key, no
login, because the binary probes whichever local product is running — so it
reports `needs_credential: false` rather than a `configured` flag that would
have to lie whichever way it pointed.

## Incidental fix

`tui::settings` had two private helpers matching on a section **string** with a
`_ =>` fallback arm:

```rust
fn configured_key_env<'a>(cfg: &'a Config, section: &str, fallback: &'a str) -> &'a str {
    match section {
        "zai" => &cfg.zai.api_key_env,
        // …
        _ => fallback,
    }
}
```

A key vendor nobody added there silently read the wrong default and reported as
unconfigured for ever. They are now `Config::api_key_env_for` /
`Config::inline_api_key`, matching on `VendorId` — that case fails to compile
instead. `KEY_VENDORS` drops its `env` field for the same reason: one copy of a
variable name, in `VendorId::api_key_env`.

`copilot::credentials::default_hosts_path` is new. The token itself only comes
back from `gh auth token`, and a status list that runs a subprocess per
provider is not a status list, so gh's own `hosts.yml` (honoring
`GH_CONFIG_DIR`) is the cheapest honest answer to "is Copilot signed in".

## Scope

Rust only. This PR does **not** migrate the Swift or JS tables — it adds the
source they can be derived from. I have that follow-up working against this
branch and will open it separately if you want it, so this one stays reviewable
on its own.

## Tests

12 tests in `src/catalog.rs`. The IO is injected (`Probes`: `env_set`,
`exists`, `keychain_has_claude`), so they never read a real `$HOME`,
environment variable or Keychain — I verified the whole suite still passes
under `HOME=/nonexistent GH_CONFIG_DIR=/nonexistent`, which is what the AUR
`check()` needs.

The one worth naming is `every_provider_has_exactly_one_row_in_canonical_order`:
it asserts the catalog is exactly `VendorId::all()`, so a provider added to the
enum cannot go missing from it the way it can from a hand-written table.

## Gate

```
make test                                   # 1328 passed
cargo clippy --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                  # clean
```

`cargo machete` I could not run (not installed here), but this adds no
dependency.

`CHANGELOG.md` entry is under `## [Unreleased]`, and I compared the published
`[1.12.0]` section against its tag byte for byte to be sure the branch did not
disturb it.
