### PR TITLE
fix(omarchy): wrap provider tabs onto additional rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- **Omarchy Quattro panel:** the provider tab strip is a wrapping `Flow` again
+  instead of a fixed-width horizontal `ListView`. With five or more providers
+  enabled the list overflowed the panel's edge and the extra entries were
+  simply unreachable — no scrollbar, no way to click them. They now wrap onto
+  additional rows.
+
 ## [1.14.0] — 2026-09-08
 
 ### Added

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -126,7 +126,7 @@ Panel {
     var wrapped = ((index % visibleEntries.length) + visibleEntries.length) % visibleEntries.length
     selectedEntryId = visibleEntries[wrapped].id
     persistSelection(selectedEntryId)
-    if (providerList.visible) providerList.positionViewAtIndex(wrapped, ListView.Contain)
+    if (providerList.visible) providerList.forceLayout()
     if (panelFlick) panelFlick.contentY = 0
   }
 
@@ -423,36 +423,41 @@ Panel {
             onCloseRequested: root.closeSettings()
           }
 
-          ListView {
+          // Providers wrap into additional rows instead of being clipped by
+          // the panel edge once there are more configured entries than fit
+          // on one line — a fixed-width ListView silently hid entries past
+          // the visible edge, with no way to reach them (see #173).
+          Flow {
             id: providerList
             visible: !root.settingsOpen && root.visibleEntries.length > 1
             width: parent.width
-            height: visible ? Style.spacing.controlHeight : 0
-            orientation: ListView.Horizontal
+            height: visible ? childrenRect.height : 0
+            flow: Flow.LeftToRight
             spacing: Style.spacing.md
-            clip: true
-            boundsBehavior: Flickable.StopAtBounds
-            model: root.visibleEntries
-            currentIndex: root.entryIndex
 
-            delegate: Button {
-              required property var modelData
-              required property int index
+            Repeater {
+              model: root.visibleEntries
 
-              height: providerList.height
-              text: Model.providerName(modelData)
-              selected: index === root.entryIndex
-              hasCursor: root.cursorActive && index === root.entryIndex
-              bordered: true
-              foreground: root.foreground
-              fontFamily: root.fontFamily
-              fontSize: Style.font.bodySmall
-              verticalPadding: Style.spacing.controlPaddingY
-              onClicked: {
-                root.cursorActive = true
-                root.selectEntry(index)
+              delegate: Button {
+                required property var modelData
+                required property int index
+
+                height: Style.spacing.controlHeight
+                width: implicitWidth
+                text: Model.providerName(modelData)
+                selected: index === root.entryIndex
+                hasCursor: root.cursorActive && index === root.entryIndex
+                bordered: true
+                foreground: root.foreground
+                fontFamily: root.fontFamily
+                fontSize: Style.font.bodySmall
+                verticalPadding: Style.spacing.controlPaddingY
+                onClicked: {
+                  root.cursorActive = true
+                  root.selectEntry(index)
+                }
+                onHovered: function(isHovered) { if (isHovered) root.cursorActive = true }
               }
-              onHovered: function(isHovered) { if (isHovered) root.cursorActive = true }
             }
           }
 

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -53,6 +53,15 @@ assert.match(panelSource, /Model\.barStrip\(/);
 assert.match(panelSource, /Model\.providerIcon\(entry\)/);
 assert.match(panelSource, /BrandMark\s*\{/);
 assert.match(panelSource, /Model\.brandIconFile\(root\.entry\)/);
+
+// Provider tabs must wrap into additional rows instead of being clipped by
+// the panel edge when more providers are configured than fit on one line.
+assert.match(panelSource, /Flow\s*\{[\s\S]*?id:\s*providerList/);
+assert.match(panelSource, /flow:\s*Flow\.LeftToRight/);
+assert.match(panelSource, /height:\s*visible\s*\?\s*childrenRect\.height\s*:\s*0/);
+assert.match(panelSource, /width:\s*implicitWidth/);
+assert.doesNotMatch(panelSource, /orientation:\s*ListView\.Horizontal/);
+assert.match(panelSource, /providerList\.forceLayout\(\)/);
 assert.match(panelSource, /foreground:\s*root\.entryAlarming\s*\?\s*root\.urgent/);
 assert.doesNotMatch(panelSource, /BrandMark[\s\S]*foreground:\s*root\.alarming\s*\?/m);
 const brandMarkSource = fs.readFileSync(new URL('./BrandMark.qml', import.meta.url), 'utf8');


### PR DESCRIPTION
Fixes #173.

## What

The Omarchy Quattro panel's provider tab strip was a fixed-width
horizontal `ListView`. With five or more providers enabled, the row
overflowed the panel's right edge and the extra entries were silently
clipped — no scrollbar, no way to reach them by mouse or keyboard.

## Fix

Swap the `ListView` for a wrapping `Flow`, keeping the exact same
`Button` delegate, styling, and selection behavior. Providers now wrap
onto additional rows once they no longer fit on one line.

`selectEntry()` no longer needs `positionViewAtIndex` — there's nothing
to scroll into view in a wrapping layout — so it calls
`providerList.forceLayout()` instead, to keep row heights correct
right after a selection change.

## Testing

- `node omarchy/model.test.mjs` — pass (added assertions for the `Flow`
  layout, the `ListView` removal, and the delegate's `width: implicitWidth`)
- Manually verified on Omarchy: with 5 configured providers (Claude,
  Codex, Copilot, Z.AI, commandcode), all five now render across two
  rows and are individually clickable; previously two of them were cut
  off past the panel edge.