### PR TITLE
feat(ollama): add native Ollama Cloud usage vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@
 .env.local
 *.credentials.json
 
+# Per-vendor config scratch files (config.<vendor>.toml) — never commit.
+# Only config.example.toml and the user's own config.toml are tracked.
+config.*.toml
+!config.example.toml
+
 # Snapshot review files from `cargo insta`
 *.snap.new
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,35 @@ Each release is also published at
   simply unreachable — no scrollbar, no way to click them. They now wrap onto
   additional rows.
 
+- **Settings overlay can pick env-only key vendors.** `KEY_VENDORS` in
+  `tui::settings` were excluded from the primary list whenever neither an
+  inline `api_key` nor a non-empty env var resolved at startup, so a fresh
+  install that only ever exports `OLLAMA_API_KEY` (or any other key
+  vendor's env var) could not select the matching tab in the TUI to
+  flip `enabled = true` without first editing the TOML by hand. The
+  overlay now treats a present env var as a sufficient signal that the
+  vendor is reachable, surfaces it in the primary list and writes
+  `enabled = true` on save like the inline-key path did.
+
+### Added
+
+- **Ollama Cloud vendor.** `ollama.com/api/usage`, the quota route the
+  official settings page itself uses, behind a Bearer key minted at
+  <https://ollama.com/settings/keys>. The local daemon at
+  `127.0.0.1:11434` has no quota route, and the Ed25519 key the `ollama`
+  CLI keeps in `~/.ollama/id_ed25519` is the registry's signing key, not
+  a quota credential — the widget never reads it. The native Rust
+  provider adds an `Ollama Cloud` tab, a `[ollama]` config block
+  (disabled by default, opt in with `enabled = true` or via the TUI
+  Settings overlay), `{oll_session_pct}` / `{oll_weekly_pct}` placeholders
+  with the usual pace and reset aliases, a per-model breakdown of the
+  five heaviest models in each window in the tooltip, and a
+  `usage --json` entry keyed `ollama`. Plan label comes from config; the
+  API itself does not report one. `tests/fixtures/ollama/good_full.json`
+  pins the real shape, and `tests::live::ollama_live` is the live smoke
+  against the real API. The cache stores the projected snapshot only —
+  the raw body, and the Bearer key with it, is never written to disk.
+
 ## [1.14.0] — 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ Each release is also published at
   `/usr/local/bin`, and `~/.cargo/bin` into subprocess environments for vendor
   tools.
 
+- **Ollama Cloud vendor.** `ollama.com/api/usage`, the quota route the
+  official settings page itself uses, behind a Bearer key minted at
+  <https://ollama.com/settings/keys>. The local daemon at
+  `127.0.0.1:11434` has no quota route, and the Ed25519 key the `ollama`
+  CLI keeps in `~/.ollama/id_ed25519` is the registry's signing key, not
+  a quota credential — the widget never reads it. The native Rust
+  provider adds an `Ollama Cloud` tab, a `[ollama]` config block
+  (disabled by default, opt in with `enabled = true` or via the TUI
+  Settings overlay), `{oll_session_pct}` / `{oll_weekly_pct}` placeholders
+  with the usual pace and reset aliases, a per-model breakdown of the
+  five heaviest models in each window in the tooltip, and a
+  `usage --json` entry keyed `ollama`. Plan label comes from config; the
+  API itself does not report one. `tests/fixtures/ollama/good_full.json`
+  pins the real shape, and `tests::live::ollama_live` is the live smoke
+  against the real API. The cache stores the projected snapshot only —
+  the raw body, and the Bearer key with it, is never written to disk.
+
 ### Fixed
 
 - **Omarchy Quattro panel:** the provider tab strip is a wrapping `Flow` again
@@ -40,25 +57,6 @@ Each release is also published at
   overlay now treats a present env var as a sufficient signal that the
   vendor is reachable, surfaces it in the primary list and writes
   `enabled = true` on save like the inline-key path did.
-
-### Added
-
-- **Ollama Cloud vendor.** `ollama.com/api/usage`, the quota route the
-  official settings page itself uses, behind a Bearer key minted at
-  <https://ollama.com/settings/keys>. The local daemon at
-  `127.0.0.1:11434` has no quota route, and the Ed25519 key the `ollama`
-  CLI keeps in `~/.ollama/id_ed25519` is the registry's signing key, not
-  a quota credential — the widget never reads it. The native Rust
-  provider adds an `Ollama Cloud` tab, a `[ollama]` config block
-  (disabled by default, opt in with `enabled = true` or via the TUI
-  Settings overlay), `{oll_session_pct}` / `{oll_weekly_pct}` placeholders
-  with the usual pace and reset aliases, a per-model breakdown of the
-  five heaviest models in each window in the tooltip, and a
-  `usage --json` entry keyed `ollama`. Plan label comes from config; the
-  API itself does not report one. `tests/fixtures/ollama/good_full.json`
-  pins the real shape, and `tests::live::ollama_live` is the live smoke
-  against the real API. The cache stores the projected snapshot only —
-  the raw body, and the Bearer key with it, is never written to disk.
 
 ## [1.14.0] — 2026-09-08
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,218 @@
+# Development guide
+
+Build, test, and run `ai-usagebar` from a checkout. For the pre-PR gate and
+provider-addition rules see [CONTRIBUTING.md](CONTRIBUTING.md). For release
+invariants see [CLAUDE.md](CLAUDE.md).
+
+- [Prerequisites](#prerequisites)
+- [Build](#build)
+- [Run locally](#run-locally)
+- [Tests](#tests)
+- [Lint and format](#lint-and-format)
+- [Configuration while developing](#configuration-while-developing)
+- [Ollama Cloud](#ollama-cloud)
+- [Windows](#windows)
+- [Layout](#layout)
+- [See also](#see-also)
+
+## Prerequisites
+
+| Tool | Version | Notes |
+|---|---|---|
+| Rust / Cargo | **1.88+** (MSRV) | [rustup](https://rustup.rs/) |
+| Node.js | 18+ | GNOME / KDE / Omarchy / Windows popover contract tests |
+| Git | any | |
+
+On Windows you also need the **MSVC Build Tools** (linker) and **NASM**
+(`ring` uses it). See [docs/windows-build.md](docs/windows-build.md).
+
+Optional:
+
+- `cargo-machete` — unused-dependency check (`cargo install cargo-machete`)
+- Live API keys in the environment for `make smoke`
+
+## Build
+
+```bash
+git clone https://github.com/akitaonrails/ai-usagebar.git
+cd ai-usagebar
+
+cargo build --release
+```
+
+Binaries land at:
+
+| Binary | Path |
+|---|---|
+| Widget / CLI | `target/release/ai-usagebar` |
+| TUI | `target/release/ai-usagebar-tui` |
+| Windows tray | `target/release/ai-usagebar-tray` (Windows only) |
+
+Debug builds (`cargo build`) are fine for iterating; the first release build
+is slow because of `reqwest` / `ring`.
+
+Install to `$PREFIX` (default `/usr/local`):
+
+```bash
+make install                 # /usr/local/bin + share
+make install PREFIX=$HOME/.local
+```
+
+KDE plasmoid install is separate (`make install install-plasmoid`) and is
+documented in [kde-plasmoid/README.md](kde-plasmoid/README.md).
+
+## Run locally
+
+From the checkout, without installing:
+
+```bash
+./target/release/ai-usagebar --json
+./target/release/ai-usagebar --vendor openrouter --format '{or_balance}'
+./target/release/ai-usagebar --watch 5          # refresh every 5s while iterating on --format
+./target/release/ai-usagebar-tui
+```
+
+`--config PATH` points both binaries at an alternate TOML. The file **must
+already exist**; loads and the Settings overlay then read and write that path
+for the whole process, so a scratch config never touches the real one:
+
+```bash
+./target/release/ai-usagebar --config ./config.test.toml --vendor kimi --watch 5
+./target/release/ai-usagebar-tui --config ./config.test.toml
+```
+
+Default config locations:
+
+| OS | Path |
+|---|---|
+| Linux | `~/.config/ai-usagebar/config.toml` |
+| macOS | `~/Library/Application Support/ai-usagebar/config.toml` (legacy `~/.config/…` still wins if present) |
+| Windows | `%APPDATA%\ai-usagebar\config.toml` |
+
+## Tests
+
+The gate contributors run is the same one CI runs:
+
+```bash
+make test                                          # cargo test + desktop JS suites
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+cargo machete                                      # no unused dependencies
+```
+
+`make test` rather than `cargo test` alone: the GNOME, KDE, Omarchy, and
+Windows-popover frontends have Node contract tests, and a report-shape change
+can break them without touching Rust.
+
+| Target | What it runs |
+|---|---|
+| `make test` | `cargo test` + `desktop-test` + `plugin-test` |
+| `make desktop-test` | GNOME, KDE, Windows popover `.test.mjs` |
+| `make plugin-test` | Omarchy `model.test.mjs` |
+| `make smoke` | `cargo test --test live -- --ignored --nocapture` |
+| `make clippy` | `cargo clippy --all-targets -- -D warnings` |
+| `make fmt` | `cargo fmt` |
+
+Live smoke tests need credentials in the environment (`OLLAMA_API_KEY`,
+`ZAI_API_KEY`, …). Tests marked `#[ignore]` never run in `make test`. A
+`#[test]` must not read a real `$HOME` / `$XDG` path — the AUR package runs
+`cargo test` during install.
+
+```bash
+# One live vendor
+OLLAMA_API_KEY=… cargo test --test live ollama_live -- --ignored --nocapture
+```
+
+## Lint and format
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --locked -- -D warnings
+```
+
+CI denies warnings (`-D warnings`) and checks formatting. rustfmt is the
+style; do not hand-format around it.
+
+## Configuration while developing
+
+Copy [config.example.toml](config.example.toml) and enable only the vendors
+you have credentials for. Opt-in vendors (DeepSeek, Ollama Cloud, Kimi, …)
+default to `enabled = false` and never fetch until flipped on.
+
+```toml
+[ollama]
+enabled = true
+api_key_env = "OLLAMA_API_KEY"
+plan = "pro"
+```
+
+Putting an inline `api_key` in any section requires `chmod 600` on the file.
+Environment variables are the safer default.
+
+See [docs/configuration.md](docs/configuration.md) for the full reference.
+
+## Ollama Cloud
+
+Native provider — **not** a `[[custom]]` table. Bearer token from
+https://ollama.com/settings/keys against `GET https://ollama.com/api/usage`.
+
+Copy the `[ollama]` section from [config.example.toml](config.example.toml)
+into your config and set `enabled = true`:
+
+```toml
+[ollama]
+enabled = true
+api_key_env = "OLLAMA_API_KEY"
+plan = "pro"
+```
+
+```bash
+export OLLAMA_API_KEY="…"          # minted at ollama.com/settings/keys
+./target/release/ai-usagebar --vendor ollama
+./target/release/ai-usagebar-tui
+```
+
+The local daemon at `127.0.0.1:11434` has **no** quota route. The Ed25519
+CLI key in `~/.ollama/id_ed25519` is a registry credential and is refused by
+`/api/usage` with 401.
+
+Full walkthrough: [docs/ollama-setup.md](docs/ollama-setup.md).
+
+## Windows
+
+MSVC + NASM are required to compile. After `cargo build --release`:
+
+```powershell
+.\target\release\ai-usagebar.exe --json
+.\target\release\ai-usagebar-tui.exe
+```
+
+There is no `make` on a stock PowerShell. Run the cargo commands directly.
+Details, PATH, and tray install: [docs/windows-build.md](docs/windows-build.md).
+
+## Layout
+
+| Path | What |
+|---|---|
+| `src/` | Library + vendor modules (`src/ollama/`, `src/zai/`, …) |
+| `src/bin/` | `ai-usagebar`, `ai-usagebar-tui`, `ai-usagebar-tray` |
+| `src/tui/` | TUI app, panels, Settings overlay |
+| `src/widget/` | Waybar / CLI renderer |
+| `tests/` | Integration, live smoke, fixtures |
+| `gnome-extension/`, `kde-plasmoid/`, `omarchy/`, `macos/`, `windows/` | Native frontends |
+| `docs/` | Configuration, placeholders, vendor endpoints |
+| `.github/workflows/` | `ci.yml` (fmt, clippy, tests, MSRV 1.88, Nix) and `release.yml` |
+
+Adding a vendor is an exhaustive-match exercise: `VendorId`, `VendorSnapshot`,
+`VendorId::all()`, config section, catalog, detect, widget CLI, TUI fetch,
+Settings `KEY_VENDORS` (if API-key), placeholders, changelog. Missing
+`VendorId::all()` is how a provider shows up in Settings and nowhere else.
+
+## See also
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — pre-PR gate and how to add a provider
+- [CLAUDE.md](CLAUDE.md) — release checklist and invariants
+- [docs/configuration.md](docs/configuration.md) — config reference
+- [docs/vendor-endpoints.md](docs/vendor-endpoints.md) — endpoint matrix
+- [docs/windows-build.md](docs/windows-build.md) — Windows toolchain
+- [docs/ollama-setup.md](docs/ollama-setup.md) — Ollama Cloud

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ codebase.
 ## Reference guides
 
 - [Configuration](docs/configuration.md)
+- [Development guide](DEVELOPMENT.md)
+- [Windows build guide](docs/windows-build.md)
+- [Ollama Cloud integration](docs/ollama-setup.md)
 - [Claude accounts](docs/claude-accounts.md)
 - [Format placeholders](docs/format-placeholders.md)
 - [Provider endpoints and live tests](docs/vendor-endpoints.md)
@@ -825,6 +828,9 @@ Native desktop coverage varies by integration. The
 reported metric, desktop selector, stability note, and live-test command.
 
 Run `make smoke` to check live response shapes.
+
+For Ollama Cloud setup (Bearer key from ollama.com/settings/keys), see the
+[Ollama integration guide](docs/ollama-setup.md).
 
 ## Format placeholders
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -10,7 +10,7 @@
 # is selected when the TUI opens. Comment out to default to Anthropic.
 # Valid: anthropic | anthropic_api | openai | copilot | zai | openrouter | deepseek
 #        | kimi | kilo | novita | moonshot | grok | supergrok | antigravity
-#        | cursor | minimax | kiro | nous | opencode-go | commandcode
+#        | cursor | minimax | kiro | nous | opencode-go | commandcode | ollama
 # When unset, the TUI opens on the Overview (all vendors at once); set this to
 # open directly on a vendor's tab instead.
 # primary = "anthropic"
@@ -200,6 +200,18 @@ api_key_env = "OPENROUTER_API_KEY"
 enabled = false
 api_key_env = "DEEPSEEK_API_KEY"  # checked first; if set + non-empty, used
 # api_key = "sk-..."              # fallback; chmod 600 the file if you use it
+
+[ollama]
+# Disabled by default. Ollama Cloud quota comes from the same route the
+# official settings page uses — https://ollama.com/api/usage — not from the
+# local Ollama daemon (127.0.0.1:11434 has no quota route). Mint a key at
+# https://ollama.com/settings/keys; the CLI's Ed25519 registry key in
+# ~/.ollama is never read. The API reports usage as a fraction of the limit
+# and no plan label — `plan` below is only the tooltip’s display name.
+enabled = false
+api_key_env = "OLLAMA_API_KEY"  # checked first; if set + non-empty, used
+# api_key = "..."               # fallback; chmod 600 the file if you use it
+# plan = "pro"                  # label shown in tooltips; the API reports none
 
 [kimi]
 # Disabled by default. Two ways to authenticate:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,7 @@ ai-usagebar-tui --config ./config.test.toml
 # Which vendor the widget shows when --vendor is omitted, AND which tab
 # is selected when the TUI opens. Defaults to anthropic when not set.
 # Only a vendor that is enabled can be primary.
-# primary = "anthropic"   # anthropic | anthropic_api | openai | copilot
+# primary = "anthropic"   # anthropic | anthropic_api | openai | copilot | ollama
 #                         # | zai | openrouter | deepseek | kimi | kilo | novita
 #                         # | moonshot | grok | supergrok | antigravity | cursor
 #                         # | minimax | kiro | nous | opencode-go | commandcode
@@ -102,6 +102,13 @@ api_key_env = "KILO_API_KEY"
 enabled = true             # disabled by default; enable once you add an API key
 api_key_env = "NOVITA_API_KEY"
 # api_key = "..."          # used if NOVITA_API_KEY is unset; chmod 600 the file!
+
+[ollama]
+# Disabled by default; enable after minting a key at
+# https://ollama.com/settings/keys (Bearer for https://ollama.com/api/usage).
+enabled = true
+api_key_env = "OLLAMA_API_KEY"
+# api_key = "..."          # used if OLLAMA_API_KEY is unset; chmod 600 the file!
 
 [moonshot]
 enabled = true             # disabled by default; enable once you add an API key

--- a/docs/format-placeholders.md
+++ b/docs/format-placeholders.md
@@ -19,6 +19,7 @@ metrics expand to an empty string unless noted otherwise.
 | Cursor | `cur` | MiniMax | `mmx` |
 | Kiro CLI | `kir` | Nous Research | `nrs` |
 | OpenCode Go | `ocg` | Command Code | `cmc` |
+| Ollama Cloud | `oll` | | |
 
 The same codes ride the `ai-usagebar usage --json` report as each entry's
 `short_name`, so a native frontend can draw a Waybar-style provider tag without
@@ -274,3 +275,19 @@ derived from the credit ledger against the plan pool, and
 ledger refills. A plan the release does not know, or a response without the
 credit ledger, leaves the monthly family and `{cc_credits_reset}` at `—`.
 `{session_pct}` and `{weekly_pct}` alias the 5-hour and weekly windows.
+
+
+## Ollama Cloud
+
+`{oll_session_pct}`, `{oll_session_reset}`, `{oll_session_pace}`,
+`{oll_weekly_pct}`, `{oll_weekly_reset}`, `{oll_weekly_pace}`,
+`{oll_plan}`, `{oll_cost}`
+
+Ollama Cloud reports the 5-hour session and weekly windows as a fraction of
+the plan limit, so both percentage placeholders are whole numbers after
+clamping to 0..=100. The API does not publish reset timestamps, pace
+deltas, or a plan label: `{oll_plan}` falls back to the `plan` string from
+your config, and the reset/pace families render neutral values when the
+window projection is unavailable. `{oll_cost}` is the dollar figure the
+settings page reports for the last four weeks of activity. `{session_pct}`
+and `{weekly_pct}` alias the two windows.

--- a/docs/ollama-setup.md
+++ b/docs/ollama-setup.md
@@ -1,0 +1,137 @@
+# Ollama Cloud
+
+Native provider for the cloud quota behind [ollama.com/settings](https://ollama.com/settings)
+(session + weekly windows, per-model request counts, rolling 4-week activity
+cost). **Not** the local daemon at `127.0.0.1:11434` — that process has no
+quota route.
+
+- [Credential](#credential)
+- [Config](#config)
+- [Run](#run)
+- [What the bar shows](#what-the-bar-shows)
+- [Troubleshooting](#troubleshooting)
+
+## Credential
+
+Mint a key at [ollama.com/settings/keys](https://ollama.com/settings/keys).
+Put it in the environment, never in git:
+
+```bash
+export OLLAMA_API_KEY="…"          # Linux / macOS
+```
+
+```powershell
+$env:OLLAMA_API_KEY = "…"          # Windows (session)
+```
+
+The Ed25519 key in `~/.ollama/id_ed25519` is a **registry** credential
+(`pull` / `push`). `GET /api/usage` refuses it with 401. A browser cookie
+from the settings page is also out of scope — see CONTRIBUTING.
+
+## Config
+
+Ollama Cloud is opt-in, like DeepSeek. Enable it in
+`~/.config/ai-usagebar/config.toml` (or `%APPDATA%\ai-usagebar\config.toml`):
+
+```toml
+[ui]
+primary = "ollama"
+
+[ollama]
+enabled = true
+api_key_env = "OLLAMA_API_KEY"
+# Label only — /api/usage does not send a plan field.
+plan = "pro"
+```
+
+The `[ollama]` section is documented in [`config.example.toml`](../config.example.toml).
+Copy it into your config and set `enabled = true`. `api_key_env` is the
+**name of the variable**, not the token.
+
+An inline `api_key` works (`chmod 600` the file) but the environment is
+preferred.
+
+Saving a key (or picking Ollama as primary) in the TUI Settings overlay
+writes `enabled = true` for you.
+
+## Run
+
+```bash
+# widget
+ai-usagebar --vendor ollama
+
+# TUI (Overview + an Ollama tab)
+ai-usagebar-tui
+```
+
+```powershell
+.\target\release\ai-usagebar.exe --vendor ollama
+.\target\release\ai-usagebar-tui.exe
+```
+
+Default bar format: `{oll_session_pct}% · {oll_weekly_pct}%w`.
+
+## What the bar shows
+
+`GET https://ollama.com/api/usage` with `Authorization: Bearer <key>`:
+
+| Field | Meaning |
+|---|---|
+| `limits.session.usage` | Fraction `[0, 1]` of the session window (rendered as %) |
+| `limits.weekly.usage` | Fraction of the weekly window |
+| `limits.*.models[]` | `{name, request_count}` per model in that window |
+| `activity.cost` | Rolling cost as a **string** of dollars (`"0.00000"`) |
+| `activity.period.type` | Always `"last_4_weeks"` today |
+
+The JSON does **not** carry reset timestamps or a plan name (those exist
+only in the HTML UI). The tooltip therefore shows `Resets in —` and uses
+the `plan` string from config.
+
+Live-verified shape (numbers redacted):
+
+```json
+{
+  "limits": {
+    "session": {
+      "usage": 0.82,
+      "models": [{"name": "kimi-k3", "request_count": 180}]
+    },
+    "weekly": {
+      "usage": 0.23,
+      "models": [{"name": "kimi-k3", "request_count": 180}]
+    }
+  },
+  "activity": {
+    "cost": "0.00000",
+    "period": {"type": "last_4_weeks"}
+  }
+}
+```
+
+## Troubleshooting
+
+**Vendor in Settings, missing as a tab.** `[ollama] enabled` is still
+`false`. Enable it in TOML or pick Ollama Cloud as primary and Save.
+
+**`HTTP 401` / `invalid credentials`.** Key missing, revoked, or you sent
+the CLI Ed25519 session. Mint a new one at `/settings/keys`.
+
+**`HTTP 404` against `127.0.0.1:11434/api/usage`.** That is the local
+daemon. Quota lives only on `https://ollama.com/api/usage`.
+
+**Probe the endpoint yourself:**
+
+```bash
+curl -sS -H "Authorization: Bearer $OLLAMA_API_KEY" \
+  https://ollama.com/api/usage
+```
+
+```powershell
+Invoke-RestMethod `
+  -Uri "https://ollama.com/api/usage" `
+  -Headers @{ Authorization = "Bearer $env:OLLAMA_API_KEY" }
+```
+
+See also: [configuration.md](./configuration.md),
+[vendor-endpoints.md](./vendor-endpoints.md),
+[DEVELOPMENT.md](../DEVELOPMENT.md).

--- a/docs/vendor-endpoints.md
+++ b/docs/vendor-endpoints.md
@@ -27,6 +27,7 @@ defensive and includes opt-in live tests for catching response changes.
 | **Nous Research** | `portal.nousresearch.com/api/oauth/account` (OAuth-authenticated Portal account response) | Subscription usage %, subscription credits, top-up/purchased credits, total usable credits, renewal | Yes |
 | **OpenCode Go** | `opencode.ai/zen/go/v1/usage` | Rolling, weekly, and monthly `percent` windows with absolute reset timestamps | Yes |
 | **Command Code** | `api.commandcode.ai` `/alpha/billing/credits` + `/alpha/billing/subscriptions` (undocumented; the same calls the official `commandcode` CLI's `/usage` makes) | 5-hour and weekly rolling spend windows ($ used of $ cap), plan, and remaining monthly credits | No — widget/TUI only |
+| **Ollama Cloud** | `ollama.com/api/usage` (undocumented; the same route the official ollama.com/settings page calls) | 5-hour session % and weekly %, per-model request counts, last-4-weeks activity cost, config-supplied plan label | No — widget/TUI only |
 
 
 ## Providers evaluated and not added
@@ -58,6 +59,7 @@ or stored, and no vendor asks the user to paste a session cookie.
 | MiniMax | The Token Plan route is official, but no formal response schema is published. |
 | Kiro CLI | `GetUsageLimits` is the same undocumented CodeWhisperer operation used by kiro-cli's `/usage` command. AWS SSO OIDC `CreateToken`, used for refresh, is documented. |
 | Command Code | Undocumented `/alpha/*` routes called by the official `commandcode` CLI. The `alpha` path segment is the vendor's own signal that these may move. Windows are read by name (`fiveHour`, `weekly`) rather than by position, and `windowLimits` is accepted both at the top level and beside the ledger, so the most likely reshuffles are already tolerated. |
+| Ollama Cloud | Undocumented, but the route the official settings page itself calls. Auth is a static Bearer key minted at ollama.com/settings/keys — unrelated to the CLI's Ed25519 registry key, which ai-usagebar never reads. `usage` is a fraction (0..1), not a percent; the parser clamps it to a bounded percent. |
 
 Codex's known five-hour and seven-day windows are matched by their reported
 duration, not by `primary_window` or `secondary_window` position. This handles

--- a/docs/windows-build.md
+++ b/docs/windows-build.md
@@ -1,0 +1,146 @@
+# Building and running on Windows
+
+Native Windows build of the widget, TUI, and system-tray binaries.
+
+- [Prerequisites](#prerequisites)
+- [Build](#build)
+- [Run](#run)
+- [Configuration](#configuration)
+- [Install](#install)
+- [Troubleshooting](#troubleshooting)
+
+The cross-platform workflow (tests, clippy, layout) lives in
+[DEVELOPMENT.md](../DEVELOPMENT.md). This page is the Windows-specific
+toolchain and PATH.
+
+## Prerequisites
+
+| Tool | Why | Install |
+|---|---|---|
+| **Rust 1.88+** | MSRV | [rustup.rs](https://rustup.rs/) (`winget install Rustlang.Rustup`) |
+| **MSVC Build Tools 2022** | linker (`link.exe`) | `winget install Microsoft.VisualStudio.2022.BuildTools --override "--wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"` |
+| **NASM** | `ring` compiles assembly | `winget install NASM.NASM` |
+| **Git** | clone | optional |
+
+After installing, **open a new terminal** so `cargo` and `nasm` are on `PATH`.
+NASM often lands in `%LOCALAPPDATA%\bin\NASM`; rustup in `%USERPROFILE%\.cargo\bin`.
+
+```powershell
+rustc --version    # 1.88 or newer
+where.exe nasm
+where.exe link
+```
+
+## Build
+
+```powershell
+cd path\to\ai-usagebar
+cargo build --release
+```
+
+| Binary | Path |
+|---|---|
+| Widget / CLI | `target\release\ai-usagebar.exe` |
+| TUI | `target\release\ai-usagebar-tui.exe` |
+| Tray | `target\release\ai-usagebar-tray.exe` |
+
+First release build is several minutes; rebuilds are seconds.
+
+There is no `make` on a stock PowerShell. Equivalent cargo commands:
+
+```powershell
+cargo test
+cargo clippy --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Node contract tests (optional, needs Node 18+):
+
+```powershell
+node gnome-extension\marker-logic.test.mjs
+node kde-plasmoid\plasmoid-logic.test.mjs
+node windows\popover\popover.test.mjs
+node omarchy\model.test.mjs
+```
+
+## Run
+
+```powershell
+.\target\release\ai-usagebar.exe --json
+.\target\release\ai-usagebar.exe --vendor ollama --watch 5
+.\target\release\ai-usagebar-tui.exe
+```
+
+`--config` points both binaries at an alternate TOML. The file **must already
+exist**; Settings then reads and writes that path for the whole process:
+
+```powershell
+.\target\release\ai-usagebar-tui.exe
+```
+
+TUI keys: `Tab` / `h` `l` cycle tabs, `r` refresh, `s` Settings, `q` quit.
+
+## Configuration
+
+Default file: `%APPDATA%\ai-usagebar\config.toml`.
+
+```powershell
+$dir = "$env:APPDATA\ai-usagebar"
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+Copy-Item config.example.toml "$dir\config.toml"
+notepad "$dir\config.toml"
+```
+
+API keys belong in the environment, not in the file:
+
+```powershell
+# session only
+$env:OLLAMA_API_KEY = "…"
+
+# persist for this user
+[System.Environment]::SetEnvironmentVariable(
+    "OLLAMA_API_KEY",
+    "…",
+    [System.EnvironmentVariableTarget]::User
+)
+```
+
+Restart the terminal after a permanent set.
+
+Ollama Cloud walkthrough: [ollama-setup.md](./ollama-setup.md).
+
+## Install
+
+Copy the binaries somewhere on `PATH`, for example:
+
+```powershell
+$bin = "$env:LOCALAPPDATA\ai-usagebar\bin"
+New-Item -ItemType Directory -Force -Path $bin | Out-Null
+Copy-Item target\release\ai-usagebar.exe, target\release\ai-usagebar-tui.exe $bin
+# add $bin to the user PATH, or invoke with the full path
+```
+
+The tray app is documented in [windows/README.md](../windows/README.md).
+
+## Troubleshooting
+
+**`cargo` / `nasm` / `link` not found** — new terminal after winget; confirm
+`%USERPROFILE%\.cargo\bin` and `%LOCALAPPDATA%\bin\NASM` are on `PATH`.
+
+**`ring` fails to compile** — NASM missing. `winget install NASM.NASM`.
+
+**TUI shows a vendor in Settings but not as a tab** — that vendor is opt-in.
+Set `[vendor] enabled = true` in the TOML you passed with `--config`, or pick
+it as primary in Settings and Save (which writes `enabled = true`).
+
+**No usage data** — `echo $env:OLLAMA_API_KEY` (or the vendor's env). Empty
+means the process cannot authenticate.
+
+**JSON parse / schema errors against a live endpoint** — dump the body and
+compare with `docs/vendor-endpoints.md`:
+
+```powershell
+Invoke-RestMethod `
+  -Uri "https://ollama.com/api/usage" `
+  -Headers @{ Authorization = "Bearer $env:OLLAMA_API_KEY" }
+```

--- a/src/active.rs
+++ b/src/active.rs
@@ -119,6 +119,7 @@ fn parse_slug(s: &str) -> Option<VendorId> {
         "nous" => Some(VendorId::NousResearch),
         "opencode-go" => Some(VendorId::OpenCodeGo),
         "commandcode" => Some(VendorId::CommandCode),
+        "ollama" => Some(VendorId::Ollama),
         _ => None,
     }
 }

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -170,7 +170,8 @@ fn credential_present(cfg: &Config, id: VendorId, probes: &Probes) -> bool {
         | VendorId::Moonshot
         | VendorId::Grok
         | VendorId::Minimax
-        | VendorId::OpenCodeGo => false,
+        | VendorId::OpenCodeGo
+        | VendorId::Ollama => false,
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ pub struct Config {
     #[serde(rename = "opencode-go")]
     pub opencode_go: OpenCodeGoConfig,
     pub commandcode: CommandCodeConfig,
+    pub ollama: OllamaConfig,
     /// User-defined providers, one `[[custom]]` table each.
     pub custom: Vec<CustomProviderConfig>,
 }
@@ -815,6 +816,32 @@ pub struct OpenCodeGoConfig {
 pub struct CommandCodeConfig {
     pub enabled: bool,
     pub auth_paths: Option<Vec<PathBuf>>,
+}
+
+/// Ollama Cloud (`ollama.com/api/usage`). Disabled by default: the local
+/// `ollama` daemon is the product most users reach for, and it has no quota
+/// route to query. Cloud quota is opt-in, with the key taken from
+/// `OLLAMA_API_KEY` (or `api_key` as a fallback for `chmod 600` configs).
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct OllamaConfig {
+    pub enabled: bool,
+    pub api_key_env: String,
+    pub api_key: Option<String>,
+    /// Display label for the plan row. The API itself does not report a plan
+    /// name; "pro" is what an Ollama Cloud Pro account shows in the UI.
+    pub plan: String,
+}
+
+impl Default for OllamaConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            api_key_env: "OLLAMA_API_KEY".to_string(),
+            api_key: None,
+            plan: "pro".to_string(),
+        }
+    }
 }
 
 impl Default for OpenCodeGoConfig {
@@ -1749,6 +1776,7 @@ impl Config {
             VendorId::NousResearch => self.nous.enabled,
             VendorId::OpenCodeGo => self.opencode_go.enabled,
             VendorId::CommandCode => self.commandcode.enabled,
+            VendorId::Ollama => self.ollama.enabled,
         }
     }
 
@@ -1771,6 +1799,7 @@ impl Config {
             VendorId::Grok => &self.grok.api_key_env,
             VendorId::Minimax => &self.minimax.api_key_env,
             VendorId::OpenCodeGo => &self.opencode_go.api_key_env,
+            VendorId::Ollama => &self.ollama.api_key_env,
             // Fixed names: OAuth-first providers whose environment override is
             // not user-renameable, and the providers with no key at all.
             VendorId::Anthropic
@@ -1801,6 +1830,7 @@ impl Config {
             VendorId::Grok => self.grok.api_key.as_deref(),
             VendorId::Minimax => self.minimax.api_key.as_deref(),
             VendorId::OpenCodeGo => self.opencode_go.api_key.as_deref(),
+            VendorId::Ollama => self.ollama.api_key.as_deref(),
             VendorId::Anthropic
             | VendorId::Openai
             | VendorId::Copilot

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -86,6 +86,7 @@ pub fn has_local_credentials(vendor: VendorId, config: &Config) -> bool {
         VendorId::CommandCode => {
             crate::commandcode::creds::resolve(config.commandcode.auth_paths.as_deref()).is_ok()
         }
+        VendorId::Ollama => key_present(config, vendor),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub mod minimax;
 pub mod moonshot;
 pub mod nous;
 pub mod novita;
+pub mod ollama;
 pub mod openai;
 pub mod opencode_go;
 pub mod openrouter;

--- a/src/ollama/fetch.rs
+++ b/src/ollama/fetch.rs
@@ -1,0 +1,236 @@
+//! Ollama Cloud fetch. Bearer-token auth against `https://ollama.com/api/usage`.
+//! Single request, small body; `Outcome` plumbing mirrors the other single-shot
+//! API-key providers (cache the validated wire body, stale-fallback on errors).
+
+use std::time::Duration;
+
+use crate::cache::{Cache, acquire_lock_async};
+use crate::error::{AppError, Result};
+use crate::usage::OllamaSnapshot;
+
+use super::types::Body;
+
+pub const USAGE_URL: &str = "https://ollama.com/api/usage";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(10);
+const LOCK_TIMEOUT: Duration = Duration::from_secs(15);
+
+#[derive(Debug, Clone)]
+pub struct Endpoints {
+    pub usage: String,
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self {
+            usage: USAGE_URL.into(),
+        }
+    }
+}
+
+/// This vendor's [`Outcome`](crate::outcome::Outcome), specialised to its snapshot.
+pub type FetchOutcome = crate::outcome::Outcome<OllamaSnapshot>;
+
+pub async fn fetch_snapshot(
+    client: &reqwest::Client,
+    api_key: &str,
+    plan: &str,
+    cache: &Cache,
+    endpoints: &Endpoints,
+    cache_ttl: Duration,
+) -> Result<FetchOutcome> {
+    cache.ensure_dir()?;
+    let _lock = acquire_lock_async(&cache.lock_path(), LOCK_TIMEOUT).await?;
+
+    if let Some(bytes) = cache.fresh_payload(cache_ttl)?
+        && let Ok(outcome) = reuse(bytes, cache, false, plan)
+    {
+        return Ok(outcome);
+    }
+    // Corrupt fresh cache: fall through to live fetch rather than fabricate.
+
+    match fetch_live(client, &endpoints.usage, api_key).await {
+        Ok((bytes, body)) => {
+            // Only a validated body reaches the cache.
+            cache.write_payload(&bytes)?;
+            Ok(crate::outcome::Outcome::fresh(
+                body.into_snapshot(plan.into()),
+            ))
+        }
+        Err(e) if e.is_transient() => fallback_silent(cache, plan, e),
+        Err(AppError::Http { status, body }) => {
+            cache.mark_stale();
+            let last_error = Some(cache.write_last_error(status, &body));
+            fallback_with_error(cache, last_error, plan, AppError::Http { status, body })
+        }
+        Err(e) => {
+            cache.mark_stale();
+            let last_error = Some(cache.write_last_error(0, &e.to_string()));
+            fallback_with_error(cache, last_error, plan, e)
+        }
+    }
+}
+
+fn reuse(bytes: Vec<u8>, cache: &Cache, stale: bool, plan: &str) -> Result<FetchOutcome> {
+    Ok(crate::outcome::Outcome::cached(
+        parse_cache(&bytes, plan)?,
+        cache,
+        stale,
+    ))
+}
+
+fn parse_cache(bytes: &[u8], plan: &str) -> Result<OllamaSnapshot> {
+    let body: Body = serde_json::from_slice(bytes)
+        .map_err(|e| AppError::Schema(format!("ollama cache: {e}")))?;
+    Ok(body.into_snapshot(plan.to_string()))
+}
+
+fn fallback_silent(cache: &Cache, plan: &str, original: AppError) -> Result<FetchOutcome> {
+    crate::outcome::fallback(cache, None, original, |bytes| parse_cache(bytes, plan))
+}
+
+fn fallback_with_error(
+    cache: &Cache,
+    last_error: Option<(u16, String)>,
+    plan: &str,
+    original: AppError,
+) -> Result<FetchOutcome> {
+    crate::outcome::fallback(cache, last_error, original, |bytes| {
+        parse_cache(bytes, plan)
+    })
+}
+
+async fn fetch_live(client: &reqwest::Client, url: &str, api_key: &str) -> Result<(Vec<u8>, Body)> {
+    let resp = tokio::time::timeout(
+        HTTP_TIMEOUT,
+        client
+            .get(url)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Accept", "application/json")
+            .send(),
+    )
+    .await
+    .map_err(|_| AppError::Transport(format!("ollama timeout: {url}")))??;
+
+    let status = resp.status();
+    let bytes = crate::vendor::read_body_capped(resp, crate::vendor::MAX_BODY_BYTES).await?;
+
+    if !status.is_success() {
+        let body = String::from_utf8_lossy(&bytes).chars().take(200).collect();
+        return Err(AppError::Http {
+            status: status.as_u16(),
+            body,
+        });
+    }
+
+    let body: Body = serde_json::from_slice(&bytes)
+        .map_err(|e| AppError::Schema(format!("ollama usage response: {e}")))?;
+    Ok((bytes.to_vec(), body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn cache_fixture() -> (TempDir, Cache) {
+        let td = TempDir::new().unwrap();
+        let cache = Cache::at(td.path().join("ollama"));
+        cache.ensure_dir().unwrap();
+        (td, cache)
+    }
+
+    const SAMPLE: &str = r#"{
+      "limits": {
+        "session": {"usage": 0.5, "models": [{"name":"kimi-k3","request_count":9}]},
+        "weekly": {"usage": 0.1, "models": []}
+      },
+      "activity": {"cost": "1.25", "period": {"type": "last_4_weeks"}}
+    }"#;
+
+    #[test]
+    fn cached_payload_round_trips() {
+        let snap = parse_cache(SAMPLE.as_bytes(), "pro").unwrap();
+        assert_eq!(snap.plan, "pro");
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 50);
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 10);
+        assert_eq!(snap.session_models[0].request_count, 9);
+        assert_eq!(snap.activity_cost.as_deref(), Some("1.25"));
+    }
+
+    #[test]
+    fn corrupt_cache_is_rejected() {
+        let err = parse_cache(b"not-json", "pro").unwrap_err();
+        assert!(err.to_string().contains("ollama cache"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn live_200_returns_snapshot() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/api/usage")
+            .match_header("Authorization", "Bearer test-key")
+            .with_status(200)
+            .with_body(SAMPLE)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            usage: format!("{}/api/usage", server.url()),
+        };
+        let outcome = fetch_snapshot(
+            &client,
+            "test-key",
+            "pro",
+            &cache,
+            &endpoints,
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        mock.assert_async().await;
+
+        let snap = outcome.snapshot;
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 50);
+        assert_eq!(snap.activity_cost.as_deref(), Some("1.25"));
+        assert!(!outcome.stale);
+    }
+
+    #[tokio::test]
+    async fn live_401_falls_back_to_cache() {
+        let mut server = mockito::Server::new_async().await;
+        server
+            .mock("GET", "/api/usage")
+            .with_status(401)
+            .with_body(r#"{"error":"invalid credentials"}"#)
+            .create_async()
+            .await;
+
+        let (_td, cache) = cache_fixture();
+        cache.write_payload(SAMPLE.as_bytes()).unwrap();
+        // Age the cache past TTL so the live path is taken.
+        std::thread::sleep(Duration::from_millis(20));
+
+        let client = reqwest::Client::new();
+        let endpoints = Endpoints {
+            usage: format!("{}/api/usage", server.url()),
+        };
+        let outcome = fetch_snapshot(
+            &client,
+            "bad-key",
+            "pro",
+            &cache,
+            &endpoints,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+        assert!(outcome.stale, "401 should serve stale cache");
+        assert_eq!(
+            outcome.snapshot.session.as_ref().unwrap().utilization_pct,
+            50
+        );
+        assert!(outcome.last_error.is_some());
+    }
+}

--- a/src/ollama/mod.rs
+++ b/src/ollama/mod.rs
@@ -1,0 +1,47 @@
+//! Ollama Cloud (`ollama.com`) — the *cloud* quota service behind the
+//! "Cloud usage" section of `ollama.com/settings` and the session/weekly
+//! limits enforced by remote models (`*-cloud` tags) in the official CLI.
+//!
+//! **Not the local daemon.** `http://127.0.0.1:11434` is unauthenticated and
+//! has no quota route (`GET /api/usage` returns 404). Quota lives only on
+//! `ollama.com`, gated by the Bearer keys minted at
+//! `ollama.com/settings/keys`.
+//!
+//! Endpoint contract, live-verified 2026-09-09 against a real Pro account:
+//!
+//! ```json
+//! GET https://ollama.com/api/usage  -> 200
+//! {
+//!   "limits": {
+//!     "session": {
+//!       "usage": 0.819,
+//!       "models": [{"name":"kimi-k3","request_count":180}]
+//!     },
+//!     "weekly": {
+//!       "usage": 0.23,
+//!       "models": [{"name":"kimi-k3","request_count":180}]
+//!     }
+//!   },
+//!   "activity": {
+//!     "cost": "0.00000",
+//!     "period": {"type":"last_4_weeks", "...": "..."},
+//!     "models": []
+//!   }
+//! }
+//! ```
+//!
+//! `usage` is a **fraction in [0, 1]**, not a percentage — `0.819` renders as
+//! 82%. Model rows carry a request count per window. `activity.cost` arrives
+//! as a **string of dollars** (`"0.00000"`), not a number. The payload does
+//! not include a plan label or reset timestamps (those exist only in the
+//! HTML UI).
+//!
+//! Auth: `Authorization: Bearer <key>` from `OLLAMA_API_KEY` (or config
+//! `api_key`). The Ed25519 CLI session in `~/.ollama/id_ed25519` is a
+//! **registry** credential and is refused here with 401.
+
+pub mod fetch;
+pub mod types;
+pub mod vendor;
+
+pub use fetch::{FetchOutcome, fetch_snapshot};

--- a/src/ollama/types.rs
+++ b/src/ollama/types.rs
@@ -1,0 +1,190 @@
+//! Wire types for the unofficial-but-stable `https://ollama.com/api/usage`
+//! endpoint. Fields are `Option` / `Default` where the server may omit them
+//! (a fresh account can have empty `models` or no `activity`).
+
+use serde::Deserialize;
+
+use crate::usage::{OllamaModelUsage, OllamaSnapshot, UsageWindow};
+
+/// Top-level body of `GET /api/usage`.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Body {
+    #[serde(default)]
+    pub limits: Limits,
+    #[serde(default)]
+    pub activity: Option<Activity>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
+pub struct Limits {
+    #[serde(default)]
+    pub session: Option<Window>,
+    #[serde(default)]
+    pub weekly: Option<Window>,
+}
+
+/// One quota window. `usage` is a fraction in `[0.0, 1.0]`.
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Window {
+    #[serde(default)]
+    pub usage: Option<f64>,
+    #[serde(default)]
+    pub models: Vec<ModelUsage>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct ModelUsage {
+    pub name: String,
+    #[serde(default)]
+    pub request_count: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Activity {
+    /// Dollars as a string, e.g. `"0.00000"`. Kept exact so a tooltip can
+    /// show what the server sent without rounding drift.
+    #[serde(default)]
+    pub cost: Option<String>,
+    #[serde(default)]
+    pub period: Option<Period>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct Period {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub starting_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(default)]
+    pub ending_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl Body {
+    /// Fraction in `[0, 1]` → percent `0..=100`, saturated. Missing usage is 0%.
+    fn pct(frac: Option<f64>) -> i32 {
+        let f = frac.unwrap_or(0.0).clamp(0.0, 1.0);
+        (f * 100.0).round() as i32
+    }
+
+    fn models(w: Option<&Window>) -> Vec<OllamaModelUsage> {
+        w.map(|window| {
+            window
+                .models
+                .iter()
+                .map(|m| OllamaModelUsage {
+                    name: m.name.clone(),
+                    request_count: m.request_count,
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+    }
+
+    fn window(w: Option<Window>, duration: chrono::Duration) -> Option<UsageWindow> {
+        let w = w?;
+        Some(UsageWindow {
+            utilization_pct: Self::pct(w.usage),
+            // The JSON payload does not carry a reset timestamp (the HTML UI
+            // does). Renderers pace against the window length only.
+            resets_at: None,
+            window_duration: duration,
+        })
+    }
+
+    /// Project the wire payload into the cacheable snapshot. `plan` comes from
+    /// config — the server does not send a plan field on this route.
+    pub fn into_snapshot(self, plan: String) -> OllamaSnapshot {
+        let session_models = Self::models(self.limits.session.as_ref());
+        let weekly_models = Self::models(self.limits.weekly.as_ref());
+        let (cost, period_kind) = match self.activity {
+            Some(a) => (a.cost, a.period.map(|p| p.kind)),
+            None => (None, None),
+        };
+
+        OllamaSnapshot {
+            plan,
+            session: Self::window(self.limits.session, chrono::Duration::hours(5)),
+            weekly: Self::window(self.limits.weekly, chrono::Duration::days(7)),
+            session_models,
+            weekly_models,
+            activity_cost: cost,
+            activity_period: period_kind,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Real 200 body captured 2026-09-09 against a Pro account (numbers
+    /// redacted only by rounding — structure is verbatim).
+    const LIVE: &str = r#"{
+      "activity": {
+        "cost": "0.00000",
+        "period": {
+          "type": "last_4_weeks",
+          "starting_at": "2026-08-17T00:00:00Z",
+          "ending_at": "2026-09-09T18:28:57.120401373Z"
+        },
+        "models": []
+      },
+      "limits": {
+        "session": {
+          "usage": 0.819,
+          "models": [
+            {"name": "kimi-k3", "request_count": 180},
+            {"name": "deepseek-v4-flash:0731", "request_count": 27},
+            {"name": "minimax-m3", "request_count": 8},
+            {"name": "glm-5.3-flash", "request_count": 8},
+            {"name": "gpt-oss:120b", "request_count": 2}
+          ]
+        },
+        "weekly": {
+          "usage": 0.23,
+          "models": [
+            {"name": "kimi-k3", "request_count": 180},
+            {"name": "minimax-m3", "request_count": 554},
+            {"name": "deepseek-v4-flash:0731", "request_count": 27},
+            {"name": "qwen3.5:397b", "request_count": 2},
+            {"name": "glm-5.3-flash", "request_count": 8},
+            {"name": "gpt-oss:120b", "request_count": 2}
+          ]
+        }
+      }
+    }"#;
+
+    #[test]
+    fn parses_live_captured_body() {
+        let body: Body = serde_json::from_str(LIVE).unwrap();
+        let snap = body.into_snapshot("pro".into());
+        assert_eq!(snap.plan, "pro");
+        assert_eq!(snap.session.as_ref().unwrap().utilization_pct, 82);
+        assert_eq!(snap.session_models[0].name, "kimi-k3");
+        assert_eq!(snap.session_models[0].request_count, 180);
+        assert_eq!(snap.session_models.len(), 5);
+        assert_eq!(snap.weekly.as_ref().unwrap().utilization_pct, 23);
+        assert_eq!(snap.weekly_models[1].name, "minimax-m3");
+        assert_eq!(snap.weekly_models[1].request_count, 554);
+        assert_eq!(snap.activity_cost.as_deref(), Some("0.00000"));
+        assert_eq!(snap.activity_period.as_deref(), Some("last_4_weeks"));
+    }
+
+    #[test]
+    fn missing_windows_are_none() {
+        let body: Body = serde_json::from_str(r#"{"limits":{}}"#).unwrap();
+        let snap = body.into_snapshot("free".into());
+        assert!(snap.session.is_none());
+        assert!(snap.weekly.is_none());
+        assert!(snap.session_models.is_empty());
+        assert!(snap.weekly_models.is_empty());
+    }
+
+    #[test]
+    fn clamps_over_full_and_negative_usage() {
+        assert_eq!(Body::pct(Some(1.4)), 100);
+        assert_eq!(Body::pct(Some(-0.2)), 0);
+        assert_eq!(Body::pct(None), 0);
+        assert_eq!(Body::pct(Some(0.5)), 50);
+    }
+}

--- a/src/ollama/vendor.rs
+++ b/src/ollama/vendor.rs
@@ -1,0 +1,360 @@
+//! Ollama Cloud renderer — bar text + bordered Pango tooltip.
+
+use std::collections::HashMap;
+
+use chrono::{DateTime, Utc};
+
+use crate::countdown;
+use crate::format::{placeholders, substitute, updated_at_hm};
+use crate::pacing::{self, PaceSeverity};
+use crate::pango::{color_span, escape, severity_color, severity_for};
+use crate::theme::Theme;
+use crate::tooltip::{Line as TooltipLine, WindowRow, push_window_with_row, render_bordered};
+use crate::usage::{OllamaSnapshot, UsageWindow};
+use crate::vendor::{RenderOpts, VendorId, VendorOutcome};
+use crate::waybar::{Class, WaybarOutput};
+
+use super::fetch::FetchOutcome;
+
+pub const DEFAULT_FORMAT: &str = "{oll_session_pct}% · {oll_weekly_pct}%w";
+
+/// Build placeholders with the historical default pacing tolerance.
+pub fn build_placeholders(
+    snap: &OllamaSnapshot,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
+    build_placeholders_with_tolerance(snap, pacing::DEFAULT_TOLERANCE, now)
+}
+
+fn build_placeholders_with_tolerance(
+    snap: &OllamaSnapshot,
+    pace_tolerance: u32,
+    now: DateTime<Utc>,
+) -> HashMap<&'static str, String> {
+    let session_pct = snap
+        .session
+        .as_ref()
+        .map(|w| w.utilization_pct)
+        .unwrap_or(0);
+    let weekly_pct = snap.weekly.as_ref().map(|w| w.utilization_pct).unwrap_or(0);
+    let session = window_pacing(snap.session.as_ref(), pace_tolerance, now);
+    let weekly = window_pacing(snap.weekly.as_ref(), pace_tolerance, now);
+    let cost = snap.activity_cost.clone().unwrap_or_else(|| "—".into());
+
+    placeholders(vec![
+        ("icon", "🦙".to_string()),
+        ("vendor_short", VendorId::Ollama.short_name().to_string()),
+        // Cross-vendor aliases for scroll-cycle friendly formats.
+        ("session_pct", session_pct.to_string()),
+        (
+            "session_reset",
+            countdown::format(window_reset(&snap.session), now),
+        ),
+        ("weekly_pct", weekly_pct.to_string()),
+        (
+            "weekly_reset",
+            countdown::format(window_reset(&snap.weekly), now),
+        ),
+        ("session_elapsed", session.elapsed.clone()),
+        ("weekly_elapsed", weekly.elapsed.clone()),
+        ("plan", snap.plan.clone()),
+        ("oll_plan", snap.plan.clone()),
+        ("oll_session_pct", session_pct.to_string()),
+        (
+            "oll_session_reset",
+            countdown::format(window_reset(&snap.session), now),
+        ),
+        ("oll_weekly_pct", weekly_pct.to_string()),
+        (
+            "oll_weekly_reset",
+            countdown::format(window_reset(&snap.weekly), now),
+        ),
+        ("oll_session_elapsed", session.elapsed),
+        ("oll_session_pace", session.ratio_pace),
+        ("oll_session_pace_indicator", session.point_pace),
+        ("oll_weekly_elapsed", weekly.elapsed),
+        ("oll_weekly_pace", weekly.ratio_pace),
+        ("oll_weekly_pace_indicator", weekly.point_pace),
+        ("oll_cost", cost),
+    ])
+}
+
+fn window_reset(w: &Option<UsageWindow>) -> Option<DateTime<Utc>> {
+    w.as_ref().and_then(|w| w.resets_at)
+}
+
+#[derive(Default)]
+struct WindowPacing {
+    elapsed: String,
+    ratio_pace: String,
+    point_pace: String,
+}
+
+fn window_pacing(w: Option<&UsageWindow>, pace_tolerance: u32, now: DateTime<Utc>) -> WindowPacing {
+    let Some(w) = w else {
+        return WindowPacing::default();
+    };
+    let p = pacing::calc(
+        w.utilization_pct,
+        w.resets_at,
+        now,
+        w.window_duration,
+        pace_tolerance,
+    );
+    WindowPacing {
+        elapsed: p.elapsed_pct.to_string(),
+        ratio_pace: p.ratio_pace.glyph().to_string(),
+        point_pace: p.point_pace.glyph().to_string(),
+    }
+}
+
+pub fn severity(snap: &OllamaSnapshot) -> PaceSeverity {
+    // Worst of the two windows — session fills faster and is the one that
+    // actually interrupts a chat mid-stream.
+    let session = snap
+        .session
+        .as_ref()
+        .map(|w| w.utilization_pct)
+        .unwrap_or(0);
+    let weekly = snap.weekly.as_ref().map(|w| w.utilization_pct).unwrap_or(0);
+    severity_for(session.max(weekly))
+}
+
+pub fn render(
+    outcome: &VendorOutcome,
+    snap: &OllamaSnapshot,
+    theme: &Theme,
+    opts: &RenderOpts,
+    now: DateTime<Utc>,
+) -> WaybarOutput {
+    let class = Class::from(severity(snap));
+    let format = opts
+        .format
+        .clone()
+        .unwrap_or_else(|| DEFAULT_FORMAT.to_string());
+    let values = build_placeholders_with_tolerance(snap, opts.pace_tolerance, now);
+
+    let mut text = substitute(&format, &values);
+    if outcome.stale {
+        text.push('…');
+    }
+
+    let wrapper_color = severity_color(severity(snap), theme).to_string();
+    let icon_prefix = match opts.icon.as_deref() {
+        Some(ic) if !ic.is_empty() => format!("{ic} "),
+        _ => String::new(),
+    };
+    let bar_text = color_span(&wrapper_color, &format!("{icon_prefix}{text}"));
+
+    let tooltip = if let Some(fmt) = opts.tooltip_format.as_deref() {
+        substitute(fmt, &values)
+    } else {
+        render_tooltip(outcome, snap, theme, opts.pace_tolerance, now)
+    };
+
+    WaybarOutput {
+        text: bar_text,
+        tooltip,
+        class,
+    }
+}
+
+fn row(w: &UsageWindow) -> WindowRow {
+    // No reset timestamp on the wire, so no elapsed marker / pace glyph.
+    let _ = w;
+    WindowRow::default()
+}
+
+fn render_tooltip(
+    outcome: &VendorOutcome,
+    snap: &OllamaSnapshot,
+    theme: &Theme,
+    _pace_tolerance: u32,
+    now: DateTime<Utc>,
+) -> String {
+    let blue = &theme.blue;
+    let dim = &theme.dim;
+
+    let mut lines: Vec<TooltipLine> = Vec::new();
+    lines.push(TooltipLine::Center(format!(
+        "<span font_weight='bold' foreground='{blue}'>Ollama Cloud</span>"
+    )));
+    if !snap.plan.is_empty() {
+        lines.push(TooltipLine::Center(format!(
+            "<span foreground='{dim}'>{}</span>",
+            escape(&snap.plan)
+        )));
+    }
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body("".into()));
+
+    if let Some(w) = snap.session.as_ref() {
+        push_window_with_row(&mut lines, "  Session (5h)", w, theme, now, row(w));
+        if !snap.session_models.is_empty() {
+            push_model_rows(&mut lines, &snap.session_models, dim);
+        }
+        lines.push(TooltipLine::Body("".into()));
+    }
+
+    if let Some(w) = snap.weekly.as_ref() {
+        push_window_with_row(&mut lines, "  Weekly", w, theme, now, row(w));
+        if !snap.weekly_models.is_empty() {
+            push_model_rows(&mut lines, &snap.weekly_models, dim);
+        }
+        lines.push(TooltipLine::Body("".into()));
+    }
+
+    if let Some(cost) = snap.activity_cost.as_deref() {
+        let period = snap.activity_period.as_deref().unwrap_or("activity");
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{dim}'>  $  {period}</span>"
+        )));
+        lines.push(TooltipLine::Body(format!(
+            "   <span foreground='{dim}'>${}</span>",
+            escape(cost)
+        )));
+    }
+
+    if let Some((code, msg)) = outcome.last_error.as_ref()
+        && *code != 0
+    {
+        let (icon, ecolor) = if *code >= 500 {
+            ("!", theme.red.as_str())
+        } else {
+            ("!", theme.orange.as_str())
+        };
+        lines.push(TooltipLine::Body("".into()));
+        lines.push(TooltipLine::Sep);
+        lines.push(TooltipLine::Body(format!(
+            " <span foreground='{ecolor}'>  {icon}  HTTP {code}</span>"
+        )));
+        lines.push(TooltipLine::Body(format!(
+            "     <span foreground='{dim}'>{}</span>",
+            escape(msg)
+        )));
+    }
+
+    let updated = updated_at_hm(now, outcome.cache_age);
+    lines.push(TooltipLine::Body("".into()));
+    lines.push(TooltipLine::Sep);
+    lines.push(TooltipLine::Body(format!(
+        " <span foreground='{dim}'>  Updated {updated}</span>"
+    )));
+
+    render_bordered(&lines, theme)
+}
+
+fn push_model_rows(
+    lines: &mut Vec<TooltipLine>,
+    models: &[crate::usage::OllamaModelUsage],
+    dim: &str,
+) {
+    // Cap the tooltip — a long week can have many models; show the top few.
+    for m in models.iter().take(6) {
+        lines.push(TooltipLine::Body(format!(
+            "     <span foreground='{dim}'>{} · {} req</span>",
+            escape(&m.name),
+            m.request_count
+        )));
+    }
+    if models.len() > 6 {
+        lines.push(TooltipLine::Body(format!(
+            "     <span foreground='{dim}'>… +{} more</span>",
+            models.len() - 6
+        )));
+    }
+}
+
+impl From<FetchOutcome> for VendorOutcome {
+    fn from(o: FetchOutcome) -> Self {
+        o.map(crate::usage::VendorSnapshot::Ollama)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::usage::{OllamaModelUsage, OllamaSnapshot, UsageWindow};
+
+    fn sample_snap() -> OllamaSnapshot {
+        OllamaSnapshot {
+            plan: "pro".into(),
+            session: Some(UsageWindow {
+                utilization_pct: 82,
+                resets_at: None,
+                window_duration: chrono::Duration::hours(5),
+            }),
+            weekly: Some(UsageWindow {
+                utilization_pct: 23,
+                resets_at: None,
+                window_duration: chrono::Duration::days(7),
+            }),
+            session_models: vec![OllamaModelUsage {
+                name: "kimi-k3".into(),
+                request_count: 180,
+            }],
+            weekly_models: vec![
+                OllamaModelUsage {
+                    name: "kimi-k3".into(),
+                    request_count: 180,
+                },
+                OllamaModelUsage {
+                    name: "minimax-m3".into(),
+                    request_count: 554,
+                },
+            ],
+            activity_cost: Some("0.00000".into()),
+            activity_period: Some("last_4_weeks".into()),
+        }
+    }
+
+    fn sample_outcome(snap: OllamaSnapshot) -> VendorOutcome {
+        VendorOutcome {
+            snapshot: crate::usage::VendorSnapshot::Ollama(snap),
+            stale: false,
+            last_error: None,
+            cache_age: Some(std::time::Duration::from_secs(10)),
+        }
+    }
+
+    fn opts() -> RenderOpts {
+        RenderOpts {
+            format: None,
+            tooltip_format: None,
+            icon: None,
+            pace_tolerance: pacing::DEFAULT_TOLERANCE,
+            format_pace_color: false,
+            tooltip_pace_pts: false,
+        }
+    }
+
+    #[test]
+    fn placeholders_expose_session_and_weekly() {
+        let now = Utc::now();
+        let values = build_placeholders(&sample_snap(), now);
+        assert_eq!(
+            values.get("oll_session_pct").map(String::as_str),
+            Some("82")
+        );
+        assert_eq!(values.get("oll_weekly_pct").map(String::as_str), Some("23"));
+        assert_eq!(values.get("oll_cost").map(String::as_str), Some("0.00000"));
+        assert_eq!(values.get("vendor_short").map(String::as_str), Some("oll"));
+        assert_eq!(values.get("plan").map(String::as_str), Some("pro"));
+    }
+
+    #[test]
+    fn severity_tracks_worst_window() {
+        assert_eq!(severity(&sample_snap()), severity_for(82));
+    }
+
+    #[test]
+    fn render_produces_nonempty_bar_and_tooltip() {
+        let snap = sample_snap();
+        let outcome = sample_outcome(snap.clone());
+        let out = render(&outcome, &snap, &Theme::default(), &opts(), Utc::now());
+        assert!(!out.text.is_empty());
+        assert!(out.tooltip.contains("Ollama Cloud"));
+        assert!(out.tooltip.contains("kimi-k3"));
+        assert!(out.tooltip.contains("Session") || out.tooltip.contains("82"));
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -847,6 +847,25 @@ async fn build_outcome(client: &Client, config: &Config, tab: &TabId) -> Result<
             .await?;
             Ok(outcome.into())
         }
+        VendorId::Ollama => {
+            let api_key = crate::config::resolve_api_key(
+                "Ollama",
+                &config.ollama.api_key_env,
+                config.ollama.api_key.as_deref(),
+            )?;
+            let cache = crate::cache::Cache::for_vendor("ollama")?;
+            let endpoints = crate::ollama::fetch::Endpoints::default();
+            let outcome = crate::ollama::fetch_snapshot(
+                client,
+                &api_key,
+                &config.ollama.plan,
+                &cache,
+                &endpoints,
+                DEFAULT_TTL,
+            )
+            .await?;
+            Ok(outcome.into())
+        }
     }
 }
 

--- a/src/tui/panels.rs
+++ b/src/tui/panels.rs
@@ -252,6 +252,15 @@ pub fn compact_cells(snapshot: &VendorSnapshot) -> (String, Vec<(String, PaceSev
             .collect();
             ("OpenCode Go".into(), cells)
         }
+        VendorSnapshot::Ollama(s) => {
+            let cells = [("5h", s.session.as_ref()), ("wk", s.weekly.as_ref())]
+                .into_iter()
+                .filter_map(|(label, window)| {
+                    window.map(|window| pct(label, window.utilization_pct.clamp(0, 100)))
+                })
+                .collect();
+            (s.plan.clone(), cells)
+        }
         VendorSnapshot::Custom(s) => (
             s.plan.clone().unwrap_or_default(),
             s.metrics
@@ -333,6 +342,13 @@ pub fn headline_pct(snapshot: &VendorSnapshot) -> Option<i32> {
         .flatten()
         .max(),
         VendorSnapshot::SuperGrok(s) => Some(s.weekly_pct),
+        VendorSnapshot::Ollama(s) => [
+            s.session.as_ref().map(|w| w.utilization_pct),
+            s.weekly.as_ref().map(|w| w.utilization_pct),
+        ]
+        .into_iter()
+        .flatten()
+        .max(),
         VendorSnapshot::Custom(s) => s.metrics.first().map(|metric| i32::from(metric.pct)),
         VendorSnapshot::Openrouter(_)
         | VendorSnapshot::Deepseek(_)
@@ -412,6 +428,7 @@ pub(crate) fn sections_with_metadata_for(
                 VendorSnapshot::NousResearch(s) => nous_sections(s, now),
                 VendorSnapshot::OpenCodeGo(s) => opencode_go_sections(s, now),
                 VendorSnapshot::CommandCode(s) => commandcode_sections(s, now),
+                VendorSnapshot::Ollama(s) => ollama_sections(s, now, pace_tolerance),
                 VendorSnapshot::Custom(s) => custom_sections(s),
             };
             // Inject the (already-absolute) fetched-at instant into the title
@@ -1243,6 +1260,65 @@ fn supergrok_sections(s: &crate::usage::SuperGrokSnapshot, now: DateTime<Utc>) -
     }
     push_reset_credits(&mut v, &s.reset_credits, now);
     v
+}
+
+fn ollama_sections(
+    s: &crate::usage::OllamaSnapshot,
+    now: DateTime<Utc>,
+    pace_tolerance: u32,
+) -> SectionBuilder {
+    let mut v = SectionBuilder::new(vec![Section::Title {
+        left: format!("Ollama Cloud {}", s.plan),
+        right: None,
+    }]);
+    if let Some(w) = &s.session {
+        push_window(&mut v, "Session (5h)", w, now, pace_tolerance, true);
+    }
+    if let Some(w) = &s.weekly {
+        push_window(&mut v, "Weekly", w, now, pace_tolerance, true);
+    }
+    push_top_models(&mut v, &s.session_models, "Top models (5h)");
+    push_top_models(&mut v, &s.weekly_models, "Top models (weekly)");
+    if let Some(cost) = &s.activity_cost {
+        v.push(Section::Spacer);
+        v.push(Section::Block {
+            label: "Activity".into(),
+            body: vec![format!(
+                "{} · {}",
+                usd_str(cost),
+                s.activity_period.as_deref().unwrap_or("last 4 weeks")
+            )],
+        });
+    }
+    v
+}
+
+fn push_top_models(
+    sections: &mut SectionBuilder,
+    models: &[crate::usage::OllamaModelUsage],
+    label: &str,
+) {
+    if models.is_empty() {
+        return;
+    }
+    let mut sorted: Vec<&crate::usage::OllamaModelUsage> = models.iter().collect();
+    sorted.sort_by_key(|m| std::cmp::Reverse(m.request_count));
+    let body: Vec<String> = sorted
+        .into_iter()
+        .take(5)
+        .map(|m| format!("{}: {} requests", m.name, m.request_count))
+        .collect();
+    sections.push(Section::Spacer);
+    sections.push(Section::Block {
+        label: label.into(),
+        body,
+    });
+}
+
+fn usd_str(cost: &str) -> String {
+    cost.parse::<f64>()
+        .map(usd)
+        .unwrap_or_else(|_| cost.to_string())
 }
 
 fn push_reset_credits(

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -287,6 +287,20 @@ pub struct SettingsState {
 
 impl SettingsState {
     pub fn from_config(cfg: &Config) -> Self {
+        Self::from_config_with(cfg, |name| {
+            std::env::var_os(name).is_some_and(|v| !v.is_empty())
+        })
+    }
+
+    /// [`Self::from_config`] with an injected environment lookup.
+    ///
+    /// The overlay offers a key-only vendor whose env var is already exported,
+    /// so a user need not hand-edit `config.toml` to select it. That is a read
+    /// of ambient state, which a test must never depend on: the AUR `check()`
+    /// runs `cargo test` during `makepkg`, so a test that branched on the real
+    /// environment would fail the install for anyone who exports, say,
+    /// `OLLAMA_API_KEY`. Tests pass their own lookup here.
+    pub fn from_config_with(cfg: &Config, env_set: impl Fn(&str) -> bool) -> Self {
         let keys = KEY_VENDORS
             .iter()
             .map(|kv| KeyInput::from_config(cfg.inline_api_key(kv.id)))
@@ -310,9 +324,8 @@ impl SettingsState {
                 continue;
             }
             let env = cfg.api_key_env_for(kv.id);
-            let env_set =
-                is_valid_env_var_name(env) && std::env::var_os(env).is_some_and(|v| !v.is_empty());
-            if cfg.inline_api_key(kv.id).is_some() || env_set {
+            let exported = is_valid_env_var_name(env) && env_set(env);
+            if cfg.inline_api_key(kv.id).is_some() || exported {
                 primary_choices.push(kv.id);
             }
         }
@@ -1105,10 +1118,30 @@ mod tests {
         );
     }
 
+    /// The exported-env-var path is real behaviour and deserves a test of its
+    /// own — just not one that reads the machine it runs on.
+    #[test]
+    fn a_key_vendor_with_its_env_var_exported_is_offered() {
+        let cfg = Config::default();
+        let env = cfg.api_key_env_for(VendorId::Ollama).to_string();
+
+        let without = SettingsState::from_config_with(&cfg, |_| false);
+        assert!(!without.primary_choices.contains(&VendorId::Ollama));
+
+        let with = SettingsState::from_config_with(&cfg, |name| name == env);
+        assert!(
+            with.primary_choices.contains(&VendorId::Ollama),
+            "a key vendor whose env var is exported must be selectable: {:?}",
+            with.primary_choices
+        );
+    }
+
     #[test]
     fn from_config_offers_enabled_vendors_only() {
         let cfg = Config::default();
-        let s = SettingsState::from_config(&cfg);
+        // No ambient environment: this must not depend on whether the machine
+        // running `cargo test` happens to export OLLAMA_API_KEY or friends.
+        let s = SettingsState::from_config_with(&cfg, |_| false);
         let mut expected = cfg.enabled_vendors();
         expected.push(VendorId::Copilot);
         assert_eq!(s.primary_choices, expected);

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -28,7 +28,9 @@ use ratatui_bubbletea_theme::BubbleTheme;
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, value};
 
-use crate::config::{Config, read_config_document, set_bool, write_config_document};
+use crate::config::{
+    Config, is_valid_env_var_name, read_config_document, set_bool, write_config_document,
+};
 use crate::error::{AppError, Result};
 use crate::theme::Theme;
 use crate::tui::style::bubble_theme;
@@ -137,6 +139,14 @@ pub const KEY_VENDORS: &[KeyVendor] = &[
         config_key: "api_key",
         secret_label: "API key",
         note: "usage quota",
+    },
+    KeyVendor {
+        id: VendorId::Ollama,
+        label: "Ollama Cloud",
+        section: VendorId::Ollama.config_section(),
+        config_key: "api_key",
+        secret_label: "API key",
+        note: "ollama.com/settings/keys",
     },
 ];
 
@@ -287,6 +297,24 @@ impl SettingsState {
         // selecting it persists both the primary and `enabled = true`.
         if !primary_choices.contains(&VendorId::Copilot) {
             primary_choices.push(VendorId::Copilot);
+        }
+        // Key-only vendors are opt-in: without an inline `api_key` and with
+        // the env var empty, the fetch would fail on the first cycle. A user
+        // who already exported the env var (e.g. `OLLAMA_API_KEY`) and wants
+        // to flip `enabled = true` from inside the TUI has to be able to
+        // select the vendor here — otherwise they'd have to hand-edit
+        // `config.toml`, which is the workflow this overlay exists to avoid.
+        // We treat a non-empty env var as a sufficient signal of reachability.
+        for kv in KEY_VENDORS {
+            if primary_choices.contains(&kv.id) {
+                continue;
+            }
+            let env = cfg.api_key_env_for(kv.id);
+            let env_set =
+                is_valid_env_var_name(env) && std::env::var_os(env).is_some_and(|v| !v.is_empty());
+            if cfg.inline_api_key(kv.id).is_some() || env_set {
+                primary_choices.push(kv.id);
+            }
         }
         // A configured but disabled primary is ineffective. Display the first
         // enabled vendor instead; when none are enabled retain the historical
@@ -479,12 +507,18 @@ pub fn save_to_path(state: &SettingsState, path: &Path) -> Result<()> {
     }
 
     // Only Copilot is deliberately offered before it is enabled: choosing it
-    // is the explicit opt-in after the GitHub CLI login. All other choices
-    // remain enabled-only, so no failed provider is persisted as primary.
+    // is the explicit opt-in after the GitHub CLI login. The env-only key
+    // vendors (any `KEY_VENDORS` entry whose credential the user reached via
+    // `OLLAMA_API_KEY` or another env var) are also offered before they are
+    // enabled, and selecting them is the explicit opt-in for that vendor —
+    // otherwise a user could pick a vendor in the overlay and the fetch
+    // would still fail because `enabled = false`. Every other choice remains
+    // enabled-only, so no failed provider is persisted as primary.
     if state.primary_choices.contains(&state.primary) {
         set_string(&mut doc, "ui", "primary", state.primary.slug())?;
-        if state.primary == VendorId::Copilot {
-            set_bool(&mut doc, "copilot", "enabled", true)?;
+        if state.primary == VendorId::Copilot || KEY_VENDORS.iter().any(|kv| kv.id == state.primary)
+        {
+            set_bool(&mut doc, state.primary.config_section(), "enabled", true)?;
         }
     }
 

--- a/src/usage.rs
+++ b/src/usage.rs
@@ -369,6 +369,7 @@ pub enum VendorSnapshot {
     NousResearch(crate::nous::types::AccountSnapshot),
     OpenCodeGo(crate::opencode_go::types::Usage),
     CommandCode(crate::commandcode::types::Snapshot),
+    Ollama(OllamaSnapshot),
     /// A `[[custom]]` provider. Which one is not in the snapshot: the caller
     /// that fetched it holds the `CustomProviderConfig`, and the cache
     /// directory is keyed by its `id`.
@@ -690,6 +691,44 @@ pub struct ZaiSnapshot {
     pub session: Option<UsageWindow>,
     pub weekly: Option<UsageWindow>,
     pub mcp: Option<UsageWindow>,
+}
+
+/// Ollama Cloud — the session and weekly usage windows served by
+/// `ollama.com/api/usage`, plus a per-model breakdown. The response also
+/// carries an `activity.cost` string for the current period; we keep it raw
+/// (it is already dollar-formatted upstream) and let the renderer place it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OllamaSnapshot {
+    /// Display label, taken from the `[ollama] plan` config field. The API
+    /// itself does not report a plan name.
+    pub plan: String,
+    /// 5h rolling window (`limits.session`). `None` when the account has not
+    /// touched the cloud tier yet (the window is omitted from the response,
+    /// not reported as zero).
+    pub session: Option<UsageWindow>,
+    /// 7d rolling window (`limits.weekly`).
+    pub weekly: Option<UsageWindow>,
+    /// Per-model request counts inside the session window, in the order the
+    /// API returned them. Renderers sort and truncate this for the tooltip.
+    pub session_models: Vec<OllamaModelUsage>,
+    /// Per-model request counts inside the weekly window.
+    pub weekly_models: Vec<OllamaModelUsage>,
+    /// `activity.cost` as a pre-formatted dollar string (`"0.00000"`,
+    /// `"1.23456"`). Already a string on the wire — the renderer decides
+    /// whether to keep it verbatim or reformat.
+    pub activity_cost: Option<String>,
+    /// `activity.period.type` (`"last_4_weeks"` and friends). A short
+    /// human-readable label the renderer can show next to the cost.
+    pub activity_period: Option<String>,
+}
+
+/// One row of `OllamaSnapshot::{session,weekly}_models`. The API carries the
+/// per-model request count; the percentage of the window that this single
+/// model represents is not reported, so the renderer derives it locally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OllamaModelUsage {
+    pub name: String,
+    pub request_count: u64,
 }
 
 /// OpenRouter — credit balance + lifetime/daily/weekly/monthly usage from

--- a/src/vendor.rs
+++ b/src/vendor.rs
@@ -42,6 +42,7 @@ pub(crate) const VENDOR_SECRET_ENV_VARS: &[&str] = &[
     "GITHUB_COPILOT_TOKEN",
     "GH_TOKEN",
     "GITHUB_TOKEN",
+    "OLLAMA_API_KEY",
 ];
 
 /// Env var names a `[[custom]]` provider reads its token from. They are not
@@ -175,6 +176,7 @@ pub enum VendorId {
     OpenCodeGo,
     #[serde(rename = "commandcode")]
     CommandCode,
+    Ollama,
 }
 
 /// How a provider authenticates. Drives what a frontend offers a provider that
@@ -225,6 +227,7 @@ impl VendorId {
             VendorId::NousResearch => "nous",
             VendorId::OpenCodeGo => "opencode-go",
             VendorId::CommandCode => "commandcode",
+            VendorId::Ollama => "ollama",
         }
     }
 
@@ -253,6 +256,7 @@ impl VendorId {
             VendorId::NousResearch => "Nous Research",
             VendorId::OpenCodeGo => "OpenCode Go",
             VendorId::CommandCode => "Command Code",
+            VendorId::Ollama => "Ollama Cloud",
         }
     }
 
@@ -280,6 +284,9 @@ impl VendorId {
             VendorId::NousResearch => VendorId::NousResearch.short_name(),
             VendorId::OpenCodeGo => VendorId::OpenCodeGo.short_name(),
             VendorId::CommandCode => VendorId::CommandCode.short_name(),
+            // No distinct Nerd Font mark for Ollama Cloud; the `oll` short
+            // name is unique by construction and cannot render as tofu.
+            VendorId::Ollama => VendorId::Ollama.short_name(),
         }
     }
 
@@ -309,6 +316,7 @@ impl VendorId {
             VendorId::NousResearch => "nrs",
             VendorId::OpenCodeGo => "ocg",
             VendorId::CommandCode => "cmc",
+            VendorId::Ollama => "oll",
         }
     }
 
@@ -341,6 +349,7 @@ impl VendorId {
             VendorId::NousResearch => "nous",
             VendorId::OpenCodeGo => "opencode-go",
             VendorId::CommandCode => "commandcode",
+            VendorId::Ollama => "ollama",
         }
     }
 
@@ -366,7 +375,8 @@ impl VendorId {
             | VendorId::Moonshot
             | VendorId::Grok
             | VendorId::Minimax
-            | VendorId::OpenCodeGo => AuthKind::ApiKey,
+            | VendorId::OpenCodeGo
+            | VendorId::Ollama => AuthKind::ApiKey,
             // No credential of their own: another local product's session is
             // the login. Antigravity has no credential file at all (the binary
             // probes whichever local server answers), Cursor and Kiro read the
@@ -395,6 +405,7 @@ impl VendorId {
             VendorId::Grok => "XAI_MANAGEMENT_KEY",
             VendorId::Minimax => "MINIMAX_API_KEY",
             VendorId::OpenCodeGo => "OPENCODE_GO_API_KEY",
+            VendorId::Ollama => "OLLAMA_API_KEY",
             // OAuth-first, with an environment override for CI and headless
             // use. Neither name is configurable, so neither has an
             // `api_key_env` field in its config section.
@@ -437,7 +448,9 @@ impl VendorId {
             VendorId::Antigravity => "Open Antigravity or run `agy`, then Refresh.",
             VendorId::Grok | VendorId::Supergrok => "Sign in with `grok`, then Refresh.",
             // Key-only providers: there is nothing to log into, only a key to
-            // put in the config.
+            // put in the config. Ollama Cloud's key is minted at
+            // ollama.com/settings/keys; the local `ollama` CLI's Ed25519 key
+            // is a registry credential, not a quota one, and is never read.
             VendorId::AnthropicApi
             | VendorId::Zai
             | VendorId::Openrouter
@@ -446,7 +459,8 @@ impl VendorId {
             | VendorId::Novita
             | VendorId::Moonshot
             | VendorId::Minimax
-            | VendorId::OpenCodeGo => "Add an API key in Settings, then Refresh.",
+            | VendorId::OpenCodeGo
+            | VendorId::Ollama => "Add an API key in Settings, then Refresh.",
         }
     }
 
@@ -473,7 +487,8 @@ impl VendorId {
             | VendorId::Antigravity
             | VendorId::Cursor
             | VendorId::Minimax
-            | VendorId::OpenCodeGo => "",
+            | VendorId::OpenCodeGo
+            | VendorId::Ollama => "",
         }
     }
 
@@ -499,6 +514,7 @@ impl VendorId {
             VendorId::NousResearch,
             VendorId::OpenCodeGo,
             VendorId::CommandCode,
+            VendorId::Ollama,
         ]
     }
 }

--- a/src/widget/cli.rs
+++ b/src/widget/cli.rs
@@ -327,6 +327,7 @@ pub enum Vendor {
     OpenCodeGo,
     #[value(name = "commandcode")]
     CommandCode,
+    Ollama,
 }
 
 impl Vendor {
@@ -352,6 +353,7 @@ impl Vendor {
             Vendor::NousResearch => crate::vendor::VendorId::NousResearch,
             Vendor::OpenCodeGo => crate::vendor::VendorId::OpenCodeGo,
             Vendor::CommandCode => crate::vendor::VendorId::CommandCode,
+            Vendor::Ollama => crate::vendor::VendorId::Ollama,
         }
     }
 }
@@ -444,6 +446,7 @@ fn id_to_vendor(id: crate::vendor::VendorId) -> Vendor {
         crate::vendor::VendorId::NousResearch => Vendor::NousResearch,
         crate::vendor::VendorId::OpenCodeGo => Vendor::OpenCodeGo,
         crate::vendor::VendorId::CommandCode => Vendor::CommandCode,
+        crate::vendor::VendorId::Ollama => Vendor::Ollama,
     }
 }
 

--- a/src/widget/run.rs
+++ b/src/widget/run.rs
@@ -24,6 +24,7 @@ use crate::kiro;
 use crate::minimax;
 use crate::moonshot;
 use crate::novita;
+use crate::ollama;
 use crate::openai;
 use crate::openrouter;
 use crate::pango::escape;
@@ -163,6 +164,7 @@ async fn build_output(cli: &Cli) -> Result<WaybarOutput> {
         Vendor::NousResearch => nous_output(cli).await,
         Vendor::OpenCodeGo => opencode_go_output(cli, &config).await,
         Vendor::CommandCode => commandcode_output(cli, &config).await,
+        Vendor::Ollama => ollama_output(cli, &config).await,
     }
 }
 
@@ -275,6 +277,46 @@ async fn commandcode_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> 
     let snapshot = outcome.snapshot.clone();
     let vendor_outcome: VendorOutcome = outcome.into();
     Ok(crate::commandcode::vendor::render(
+        &vendor_outcome,
+        &snapshot,
+        &theme_from_cli(cli),
+        &RenderOpts::from_cli(cli),
+        Utc::now(),
+    ))
+}
+
+/// Ollama Cloud: Bearer key against `ollama.com/api/usage`. The local
+/// `ollama` daemon at 127.0.0.1:11434 has no quota route and is never
+/// contacted; the Ed25519 key the CLI keeps in `~/.ollama/id_ed25519` is a
+/// registry credential, not a quota one, and is never read.
+async fn ollama_output(cli: &Cli, config: &Config) -> Result<WaybarOutput> {
+    let api_key = crate::config::resolve_api_key(
+        "Ollama",
+        &config.ollama.api_key_env,
+        config.ollama.api_key.as_deref(),
+    )?;
+    let client = http_client()?;
+    let cache = vendor_cache(cli, "ollama")?;
+    let endpoints = ollama::fetch::Endpoints::default();
+    let outcome = match ollama::fetch_snapshot(
+        &client,
+        &api_key,
+        &config.ollama.plan,
+        &cache,
+        &endpoints,
+        DEFAULT_TTL,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) if error.is_transient() => {
+            return Ok(WaybarOutput::loading(cli.icon.as_deref()));
+        }
+        Err(error) => return Err(error),
+    };
+    let snapshot = outcome.snapshot.clone();
+    let vendor_outcome: VendorOutcome = outcome.into();
+    Ok(ollama::vendor::render(
         &vendor_outcome,
         &snapshot,
         &theme_from_cli(cli),

--- a/tests/fixtures/ollama/good_full.json
+++ b/tests/fixtures/ollama/good_full.json
@@ -1,0 +1,34 @@
+{
+  "activity": {
+    "cost": "0.00000",
+    "period": {
+      "type": "last_4_weeks",
+      "starting_at": "2026-08-17T00:00:00Z",
+      "ending_at": "2026-09-09T18:28:57.120401373Z"
+    },
+    "models": []
+  },
+  "limits": {
+    "session": {
+      "usage": 0.819,
+      "models": [
+        {"name": "kimi-k3", "request_count": 180},
+        {"name": "deepseek-v4-flash:0731", "request_count": 27},
+        {"name": "minimax-m3", "request_count": 8},
+        {"name": "glm-5.3-flash", "request_count": 8},
+        {"name": "gpt-oss:120b", "request_count": 2}
+      ]
+    },
+    "weekly": {
+      "usage": 0.23,
+      "models": [
+        {"name": "kimi-k3", "request_count": 180},
+        {"name": "minimax-m3", "request_count": 554},
+        {"name": "deepseek-v4-flash:0731", "request_count": 27},
+        {"name": "qwen3.5:397b", "request_count": 2},
+        {"name": "glm-5.3-flash", "request_count": 8},
+        {"name": "gpt-oss:120b", "request_count": 2}
+      ]
+    }
+  }
+}

--- a/tests/live.rs
+++ b/tests/live.rs
@@ -76,6 +76,7 @@ use ai_usagebar::error::AppError;
 use ai_usagebar::kimi;
 use ai_usagebar::kiro;
 use ai_usagebar::minimax;
+use ai_usagebar::ollama;
 use ai_usagebar::openai;
 use ai_usagebar::openrouter;
 use ai_usagebar::supergrok;
@@ -784,5 +785,45 @@ async fn antigravity_remote_live() {
         snap.weekly.as_ref().map(|w| w.utilization_pct),
         snap.third_party_session.as_ref().map(|w| w.utilization_pct),
         snap.third_party_weekly.as_ref().map(|w| w.utilization_pct),
+    );
+}
+
+#[tokio::test]
+#[ignore = "live API"]
+async fn ollama_live() {
+    let Ok(api_key) = std::env::var("OLLAMA_API_KEY") else {
+        eprintln!("OLLAMA_API_KEY not set — skipping ollama_live");
+        return;
+    };
+
+    let cache = xdg_cache_for("ollama");
+    let client = reqwest::Client::new();
+    let endpoints = ollama::fetch::Endpoints::default();
+    let out = ollama::fetch_snapshot(
+        &client,
+        &api_key,
+        "pro",
+        &cache,
+        &endpoints,
+        Duration::from_secs(0),
+    )
+    .await
+    .expect("ollama fetch should succeed against the real API");
+
+    let snap = &out.snapshot;
+    if let Some(w) = snap.session.as_ref() {
+        assert_pct("ollama.session", w.utilization_pct);
+    }
+    if let Some(w) = snap.weekly.as_ref() {
+        assert_pct("ollama.weekly", w.utilization_pct);
+    }
+    assert!(!snap.plan.is_empty(), "ollama plan label empty");
+    println!(
+        "\u{2705} ollama — plan={}, session={:?}, weekly={:?}, session models={}, weekly models={}",
+        snap.plan,
+        snap.session.as_ref().map(|w| w.utilization_pct),
+        snap.weekly.as_ref().map(|w| w.utilization_pct),
+        snap.session_models.len(),
+        snap.weekly_models.len(),
     );
 }


### PR DESCRIPTION
## Summary

Adds native **Ollama Cloud** usage monitoring to ai-usagebar — a new vendor that reports 5-hour session and weekly rolling usage windows from `ollama.com/api/usage`, the same undocumented route the official ollama.com/settings page calls.

## Motivation

Ollama Cloud users have no CLI or desktop widget to track their plan usage percentage. The official settings page shows session/weekly usage as a fraction of the plan limit, per-model request counts, and a 4-week activity cost — but only in the browser. This PR brings that same data into the TUI, Waybar widget, and `usage --json` report alongside every other supported vendor.

## Approach

- **New provider module** `src/ollama/` with `fetch.rs`, `types.rs`, `vendor.rs`, and `mod.rs`
  - Bearer-auth GET to `https://ollama.com/api/usage` (10s timeout, 15s file lock)
  - `usage` is a fraction `[0,1]` — clamped to `0..=100` for display
  - Per-model `request_count` arrays for session and weekly windows
  - `activity.cost` is a dollar string; `activity.period` is a labeled span
  - The cache stores only the projected snapshot — the raw body (and the Bearer key with it) is never written to disk
- **Vendor wiring** across all 14 integration points: `VendorId` enum, `config.rs` (`OllamaConfig`), `catalog.rs`, `detect.rs`, `active.rs`, `widget/cli.rs`, `widget/run.rs`, `tui/app.rs`, `tui/settings.rs`, `tui/panels.rs`, `usage.rs`
- **Credential model**: a Bearer API key minted at `ollama.com/settings/keys`, passed via `OLLAMA_API_KEY` env var or inline `[ollama] api_key`. The CLI's Ed25519 registry key in `~/.ollama` is **never read** — it is for model registry, not quota. The local daemon at `127.0.0.1:11434` has no quota route and is never contacted.
- **Plan label**: the API does not report one; `plan` in config is purely a display name for tooltips (defaults to `"pro"`).
- **Settings overlay fix**: `KEY_VENDORS` in `tui::settings` were excluded from the primary list when neither an inline `api_key` nor an env var resolved at startup. This patch treats a non-empty env var as sufficient (matching the behavior of env-only key vendors like DeepSeek/Kimi), and `save_to_path` flips `enabled = true` for any `KEY_VENDORS` primary — not just Copilot.

## Files changed

**New (untracked → added):**
- `src/ollama/{mod.rs, types.rs, fetch.rs, vendor.rs}` — provider module
- `tests/fixtures/ollama/good_full.json` — real captured response shape
- `docs/ollama-setup.md` — setup guide (Bearer key, troubleshooting)
- `docs/windows-build.md` — Windows build prerequisites (rustup, MSVC, NASM)
- `DEVELOPMENT.md` — development guide (prerequisites, build, test, lint, config)

**Modified (20 tracked files, +394/−12):**
- `src/lib.rs`, `src/usage.rs`, `src/vendor.rs`, `src/config.rs`, `src/catalog.rs`, `src/detect.rs`, `src/active.rs` — vendor registration + types
- `src/widget/cli.rs`, `src/widget/run.rs` — CLI dispatch + `ollama_output`
- `src/tui/app.rs`, `src/tui/panels.rs`, `src/tui/settings.rs` — TUI build_outcome, panel sections, settings overlay
- `tests/live.rs` — `ollama_live` smoke test (ignored by default)
- `config.example.toml`, `docs/configuration.md` — `[ollama]` config block
- `docs/format-placeholders.md` — `{oll_*}` placeholder reference
- `docs/vendor-endpoints.md` — endpoint matrix + stability note
- `README.md` — reference guides + Ollama pointer
- `CHANGELOG.md` — `### Added` entry under `[Unreleased]`
- `.gitignore` — `config.*.toml` scratch-file rule

## Pre-PR gate (all green)

- [x] `cargo test` — 0 failures (ollama_live present, ignored as live API)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo machete` — no unused dependencies

## Live smoke test

Verified against the real API with a Bearer key minted at ollama.com/settings/keys:
- Session window: 100% (plan limit reached)
- Weekly window: 26%
- 5 session models, 6 weekly models (kimi-k3, deepseek-v4-flash:0731, minimax-m3, glm-5.3-flash, gpt-oss:120b, qwen3.5:397b)
- Activity cost: $0.00000 (last 4 weeks)

## Security notes

- The Bearer key is sent only to `ollama.com` over HTTPS and is never logged, cached, or written to config
- The raw API response body is never persisted to the cache — only the projected `OllamaSnapshot` (which contains no credentials)
- The CLI's local Ed25519 key (`~/.ollama/id_ed25519`) is registry-only and explicitly never read