### PR TITLE
fix(tray): use correct wt syntax for Open TUI launch

### DIFF
--- a/src/tray/tui_launch.rs
+++ b/src/tray/tui_launch.rs
@@ -7,7 +7,14 @@ pub fn open() {
     let Some(tui) = resolve_tui() else {
         return;
     };
-    if Command::new("wt.exe").args(["-e", &tui]).spawn().is_ok() {
+    // `wt -e` is not a real Windows Terminal flag (it belongs to wezterm);
+    // wt rejects it, prints its Usage page, and exits — the TUI never starts.
+    // The correct syntax is `wt new-tab -- <command>`.
+    if Command::new("wt.exe")
+        .args(["new-tab", "--", &tui])
+        .spawn()
+        .is_ok()
+    {
         return;
     }
     let _ = Command::new("conhost.exe").arg(&tui).spawn();


### PR DESCRIPTION
## Summary

The tray icon's "Open TUI" menu item was launching `wt.exe` with the `-e` flag:
```rust
Command::new("wt.exe").args(["-e", &tui]).spawn()
```

**`-e` is not a Windows Terminal flag** — it belongs to wezterm. Windows Terminal
rejects it, prints its Usage/help page, and exits immediately. The TUI never
starts; the user sees a brief flash of the `wt` help text and nothing else.

## Fix

Use the correct Windows Terminal syntax: `wt new-tab -- <command>`.

```rust
Command::new("wt.exe")
    .args(["new-tab", "--", &tui])
    .spawn()
```

The `conhost.exe` fallback is kept unchanged as the last resort.

## Verification

- `cargo check --all-targets` — clean
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo build --bin ai-usagebar-tray` — clean
- Manual test: clicking "Open TUI" in the tray now opens a Windows Terminal tab
  running the TUI correctly.