### PR TITLE
fix(macos): default Ollama Cloud to disabled, matching Rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS menu bar knew the wrong default for Ollama Cloud.**
+  `defaultEnabled("ollama")` fell through to `true` while Rust ships
+  `[ollama] enabled = false` (opt-in), so the menu bar could treat Ollama
+  as enabled when the config omits the flag. It now returns `false`,
+  matching `src/config.rs`, and the Swift contract test pins it alongside
+  the other opt-in vendors. Ollama's Session/Weekly bars already rendered
+  through the generic `parse()` path — no format change.
+
 ## [1.15.0] — 2026-09-10
 
 ### Added

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -1365,13 +1365,13 @@ func addAccountScript(binary: String, label: String, desktop: Bool) -> String {
 }
 
 /// Rust defaults (`src/config.rs`): the OAuth/api-key vendors that ship enabled,
-/// versus the opt-in balance vendors that default to disabled. An omitted
+/// versus the opt-in vendors that default to disabled. An omitted
 /// `[vendor].enabled` must reproduce these, not silently enable everything.
 func defaultEnabled(_ id: String) -> Bool {
     switch id {
     case "anthropic", "openai", "zai", "openrouter": return true
     case "deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor", "antigravity",
-         "copilot", "supergrok", "minimax", "kiro", "nous", "opencode-go", "commandcode": return false
+         "copilot", "supergrok", "minimax", "kiro", "nous", "opencode-go", "commandcode", "ollama": return false
     default: return true
     }
 }
@@ -1584,9 +1584,9 @@ struct SettingsView: View {
     @State private var launchAtLogin = launchAgentIsInstalled()
     @State private var launchAtLoginError: String?
 
-    // Only enabled vendors appear in the selector: Rust treats opt-in vendors
-    // (deepseek/kimi/kilo/novita/moonshot/grok/anthropic_api) as disabled when
-    // their `[vendor].enabled` is omitted, and so must this picker. Claude
+    // Only vendors marked enabled by the Rust catalog appear in the selector.
+    // Currently, anthropic/openai/zai/openrouter default to enabled; the remaining
+    // built-in vendors are opt-in. Claude
     // accounts appear as their `vendor@<label>` pseudo-ids, same as the
     // "Switch provider" submenu.
     private var vendors: [String] {

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -199,7 +199,7 @@ func testDefaultEnabled() {
         assertEqual(defaultEnabled(id), true, "\(id) defaults enabled")
     }
     for id in ["deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor", "antigravity",
-               "copilot", "supergrok", "minimax", "kiro", "nous", "opencode-go", "commandcode"] {
+               "copilot", "supergrok", "minimax", "kiro", "nous", "opencode-go", "commandcode", "ollama"] {
         assertEqual(defaultEnabled(id), false, "\(id) defaults disabled (opt-in)")
     }
 }
@@ -465,6 +465,20 @@ func testParserBalances() {
     assertEqual(cmd?.weeklyLabel, "Weekly", "commandcode weekly label")
     assertEqual(cmd?.sonnet?.pct, 65, "commandcode monthly pct")
     assertEqual(cmd?.sonnetLabel, "Monthly", "commandcode monthly label")
+
+    let ollama = snapshot(FORMAT, vendor: "ollama",
+                          fields: fields(through: 16, set: [
+                             0: "pro", 1: "82", 2: "4h 59m", 3: "23", 4: "6d 0h",
+                             13: "10", 14: "45", 16: "oll"
+                          ]))
+    assertEqual(ollama?.hasUsageWindows, true, "ollama shows windows")
+    assertEqual(ollama?.session?.pct, 82, "ollama session pct")
+    assertEqual(ollama?.sessionLabel, "Session", "ollama session label")
+    assertEqual(ollama?.sessionTag, "5h", "ollama session tag")
+    assertEqual(ollama?.session?.elapsed, 10, "ollama session elapsed")
+    assertEqual(ollama?.weekly?.pct, 23, "ollama weekly pct")
+    assertEqual(ollama?.weeklyLabel, "Weekly", "ollama weekly label")
+    assertEqual(ollama?.weekly?.elapsed, 45, "ollama weekly elapsed")
 
     let sgk = snapshot(FORMAT, vendor: "supergrok",
                        fields: fields(through: 40, set: [


### PR DESCRIPTION
## What this changes

Follow-up to #176: Ollama Cloud shipped in v1.15.0 with full Rust wiring, but the macOS menu bar's `defaultEnabled("ollama")` fell through to `true` while Rust ships `[ollama] enabled = false` (opt-in, `src/config.rs`). Now returns `false`, matching Rust.

- `macos/ai-usagebar-menubar.swift`: `ollama` added to the opt-in list; two comments reworded to not overstate their rules ("balance vendors" → "vendors"; picker comment now describes the catalog filter instead of asserting the default rule).
- `macos/ai-usagebar-tests.swift`: `ollama` pinned in `testDefaultEnabled` + new parse test proving Session/Weekly (with pace `elapsed`) render through the generic `parse()` path — no vendor-specific case or FORMAT change needed.
- `CHANGELOG.md`: entry under `[Unreleased]` → `Fixed`.

## Checklist

- [x] `make test`, `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] `CHANGELOG.md` entry under `## [Unreleased]` in the right category (not inside an already-released section)
- [x] A test that fails on `main` and passes here, for a bug fix
- [x] Docs updated where they mention what changed (`README.md`, `config.example.toml`, `docs/`)
- [x] No helper left behind without callers

Docs note: no doc enumerates the macOS `defaultEnabled` list, so nothing else mentions what changed; `docs/configuration.md` already documents `[ollama]` as opt-in.

## Testing

- `macos/run-tests.sh` on macOS: all tests passed, including the 9 new Ollama asserts.
- Old source (`main:macos/ai-usagebar-menubar.swift`) + new tests: `ollama defaults disabled (opt-in)` fails with `got true, expected false` — 1 test FAILED, as expected.
- `make test`: 1564 passed, 0 failed (+ GNOME/KDE/Windows/Omarchy contract suites green).
- `cargo clippy --all-targets -- -D warnings`: clean. `cargo fmt --all -- --check`: clean. `cargo machete`: no unused deps.
- Tested on macOS (Swift harness runs natively here).
