### PR TITLE
feat(omarchy): top bar usage-window picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Each release is also published at
 
 ## [Unreleased]
 
+### Added
+
+- **Omarchy top bar usage-window picker.** The Quattro settings page gains a
+  **Top bar usage window** dropdown (`auto` / `session` / `weekly` /
+  `monthly`), also settable with
+  `omarchy bar set akitaonrails.ai-usagebar barWindow session` that pins the
+  bar label to one quota window instead of always showing the highest percent;
+  the tooltip and panel hero echo the pinned value. `session` pins the 5-hour
+  window, `weekly` the 7-day window, and `monthly` the monthly pool where one
+  exists; `auto` keeps the historical highest-percent behavior and is the
+  default, so existing installs are unchanged. A pinned window a vendor does
+  not offer falls back to the highest percent rather than blanking the bar.
+  Panel rows and alert state still follow the highest percent regardless.
+
 ## [1.15.0] — 2026-09-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -155,7 +155,10 @@ wheel to switch providers. In QML settings, turn off **Show usage value in the
 top bar** for an icon-only widget; the panel and tooltip keep the full details.
 Turn on **Show provider name in the top bar** to prefix the entry with the same
 three-letter code Waybar's `{vendor_short}` prints, so a bar cycling several
-providers says which one it is showing.
+providers says which one it is showing. Use **Top bar usage window** to pin the
+bar to one quota window — auto (highest), 5-hour, weekly, or monthly — instead
+of always showing the highest percent; the tooltip and panel hero echo the
+pinned value while panel rows and alert state still follow the highest quota.
 
 The source-built `ai-usagebar` AUR package can replace `ai-usagebar-bin` in
 the first command.
@@ -621,6 +624,10 @@ The widget reads the providers and accounts already enabled in
   widget; this applies immediately and preserves the full panel and tooltip.
 - QML settings can also show the provider's `{vendor_short}` code before that
   value (`cld 29%`). It is off by default and applies immediately.
+- QML settings can pin the bar to one quota window — auto (highest),
+  5-hour, weekly, or monthly — instead of always showing the highest
+  percent. The tooltip and panel hero echo the pinned value; panel rows
+  and alert state still follow the highest quota.
 - Right-click launches the TUI.
 - Middle-click or the mouse wheel switches providers.
 - The selected provider or named account is remembered across shell reloads

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,8 @@
       "refreshIntervalSec": 300,
       "showValue": true,
       "showProvider": false,
-      "showAll": false
+      "showAll": false,
+      "barWindow": "auto"
     },
     "schema": [
       {
@@ -68,6 +69,14 @@
         "label": "Show all providers",
         "description": "Show every configured provider's icon and usage in the top bar at once, instead of cycling one at a time. Off by default.",
         "defaultValue": false
+      },
+      {
+        "key": "barWindow",
+        "type": "enum",
+        "label": "Top bar usage window",
+        "description": "Which quota window the top bar shows. Auto keeps the highest percent; 5-hour pins the session/rolling window; weekly pins the 7-day window; monthly pins the monthly pool where one exists. Falls back to highest when a vendor lacks the pinned window.",
+        "options": ["auto", "session", "weekly", "monthly"],
+        "defaultValue": "auto"
       }
     ]
   }

--- a/omarchy/Model.js
+++ b/omarchy/Model.js
@@ -44,6 +44,8 @@ function normalizeSection(raw) {
     var severity = String(raw.severity || "")
     if (["low", "mid", "high", "critical"].indexOf(severity) < 0)
       severity = percent >= 90 ? "critical" : percent >= 75 ? "high" : percent >= 50 ? "mid" : "low"
+    var windowSecs = Math.floor(Number(raw.window_secs))
+    if (!isFinite(windowSecs) || windowSecs <= 0) windowSecs = null
     return {
       type: "metric",
       label: cleanText(raw.label, 160),
@@ -51,7 +53,8 @@ function normalizeSection(raw) {
       value: cleanText(raw.value, 240),
       detail: cleanText(raw.detail, 1000),
       severity: severity,
-      reset_at: cleanText(raw.reset_at, 80)
+      reset_at: cleanText(raw.reset_at, 80),
+      window_secs: windowSecs
     }
   }
   if (type === "text") {
@@ -226,14 +229,14 @@ function barLabel(alarming, vertical, showValue, loading, hasEntry, summaryText,
     : icon + "  " + provider + " " + summary
 }
 
-function barChip(entry, showValue, showProvider) {
+function barChip(entry, showValue, showProvider, barWindow) {
   if (!entry) return ""
   var icon = providerIcon(entry)
   var provider = showProvider ? providerShort(entry) : ""
   var summary = ""
   if (showValue) {
     if (entry.error) summary = "!"
-    else summary = autoTextSafe(headline(entry).text).trim()
+    else summary = autoTextSafe(headline(entry, barWindow).text).trim()
   }
   if (provider === "") return summary === "" ? icon : icon + "  " + summary
   return summary === "" ? icon + "  " + provider : icon + "  " + provider + " " + summary
@@ -241,14 +244,14 @@ function barChip(entry, showValue, showProvider) {
 
 // Every visible entry as its own icon+value chip. A vertical bar has no
 // width for the strip and keeps a single glyph, same as `barLabel`.
-function barStrip(entries, alarming, vertical, showValue, showProvider, loading) {
+function barStrip(entries, alarming, vertical, showValue, showProvider, loading, barWindow) {
   var list = Array.isArray(entries) ? entries : []
   if (vertical) return alarming ? "󰅙" : "󰚩"
   if (loading && list.length === 0) return "󰚩  …"
   if (list.length === 0) return alarming ? "󰅙" : "󰚩"
   var chips = []
   for (var i = 0; i < list.length; i++) {
-    var chip = barChip(list[i], showValue, showProvider)
+    var chip = barChip(list[i], showValue, showProvider, barWindow)
     if (chip !== "") chips.push(chip)
   }
   return chips.length === 0 ? "󰚩" : chips.join("  ")
@@ -309,7 +312,7 @@ function brandIconFile(entry) {
   }
 }
 
-function barChips(entries, selected, showAll, showValue, showProvider, loading, alarming, vertical) {
+function barChips(entries, selected, showAll, showValue, showProvider, loading, alarming, vertical, barWindow) {
   var list = Array.isArray(entries) ? entries : []
   if (vertical) {
     return [{ brand: "", icon: alarming ? "󰅙" : "󰚩", label: "", alarming: alarming === true }]
@@ -328,7 +331,7 @@ function barChips(entries, selected, showAll, showValue, showProvider, loading, 
     var label = ""
     if (showProvider) label = providerShort(entry)
     if (showValue) {
-      var summary = entry.error ? "!" : autoTextSafe(headline(entry).text).trim()
+      var summary = entry.error ? "!" : autoTextSafe(headline(entry, barWindow).text).trim()
       label = label === "" ? summary : (summary === "" ? label : label + " " + summary)
     }
     var brand = brandIconFile(entry)
@@ -336,20 +339,98 @@ function barChips(entries, selected, showAll, showValue, showProvider, loading, 
       brand: brand,
       icon: brand !== "" ? providerIcon(entry) : providerShort(entry),
       label: label,
+      // Alert state always follows the highest-percent window, never the
+      // pinned one: barWindow changes only the displayed value.
       alarming: isAlarming(entry)
     })
   }
   return chips
 }
 
-function headline(entry) {
-  if (!entry) return { text: "", percent: null, severity: "low", label: "" }
+// Which usage window the top bar shows. "auto" keeps the historical
+// highest-percent metric; the rest pin one window class across vendors.
+// Unknown, empty, and legacy values fall back to "auto" so an existing
+// shell.json never goes blank after an update.
+function normalizeBarWindow(value) {
+  var text = cleanText(value, 24).trim().toLowerCase()
+  if (text === "" || text === "auto" || text === "highest" || text === "max") return "auto"
+  if (text === "session" || text === "5h" || text === "5-hour" || text === "5hour"
+      || text === "5hr" || text === "five-hour" || text === "rolling"
+      || text === "shortest" || text === "session-5h") return "session"
+  if (text === "weekly" || text === "week" || text === "7d" || text === "7-day"
+      || text === "weekly-7d") return "weekly"
+  if (text === "monthly" || text === "month" || text === "30d" || text === "monthly-cycle") return "monthly"
+  return "auto"
+}
+
+// The two window lengths the report states exactly. Same values as the Rust
+// constants that publish them: openai/types.rs SESSION_WINDOW_SECS /
+// WEEKLY_WINDOW_SECS, opencode_go/vendor.rs and kimi/vendor.rs ROLLING_WINDOW /
+// WEEKLY_WINDOW, anthropic/types.rs SESSION / WEEKLY. A vendor that states any
+// other length falls through to label matching instead of being forced into
+// one of these classes.
+var SESSION_WINDOW_SECS = 18000
+var WEEKLY_WINDOW_SECS = 604800
+
+function metricMatchesWindow(section, want) {
+  if (!section || section.type !== "metric") return false
+  var label = String(section.label || "")
+  var secs = Math.floor(Number(section.window_secs))
+  var hasSecs = isFinite(secs) && secs > 0
+  var knownSize = hasSecs && (secs === SESSION_WINDOW_SECS || secs === WEEKLY_WINDOW_SECS)
+  // A known size is authoritative; an unknown positive size is treated as
+  // missing so labels decide. Labels only cover older reports that predate
+  // window_secs.
+  if (want === "session") {
+    if (knownSize) return secs === SESSION_WINDOW_SECS
+    return /(\b5\s*-?\s*h(?:ours?|rs?)?\b|\bsessions?\b|\brolling\b)/i.test(label)
+  }
+  if (want === "weekly") {
+    if (knownSize) return secs === WEEKLY_WINDOW_SECS
+    return /(\bweek(?:ly|s)?\b|\b7\s*-?\s*d(?:ays?)?\b)/i.test(label)
+  }
+  if (want === "monthly") {
+    // Monthly pools have no single fixed length (opencode-go publishes
+    // none; Z.AI uses 30d; Cursor/custom vary), so no secs value is
+    // authoritative here — except known 5h/7d sizes, which exclude.
+    if (knownSize) return false
+    return /(\bmonthly\b|\bmonth(?:ly|s)?\b|\bspend\s*\(mo\)|\b30\s*-?\s*d(?:ays?)?\b)/i.test(label)
+  }
+  return false
+}
+
+function maxPercent(sections) {
   var best = null
-  var sections = entry.sections || []
   for (var i = 0; i < sections.length; i++) {
     var section = sections[i]
     if (section.type === "metric" && (!best || section.percent > best.percent)) best = section
   }
+  return best
+}
+
+function selectMetric(entry, barWindow) {
+  var sections = entry && Array.isArray(entry.sections) ? entry.sections : []
+  var metrics = []
+  for (var i = 0; i < sections.length; i++) {
+    if (sections[i] && sections[i].type === "metric") metrics.push(sections[i])
+  }
+  if (metrics.length === 0) return null
+  var want = normalizeBarWindow(barWindow)
+  if (want === "auto") return maxPercent(metrics)
+  var candidates = []
+  for (var j = 0; j < metrics.length; j++) {
+    if (metricMatchesWindow(metrics[j], want)) candidates.push(metrics[j])
+  }
+  // A pinned window that a vendor does not offer (a balance-only provider,
+  // a weekly-only response, no monthly pool) falls back to the historical
+  // highest-percent value rather than blanking the bar.
+  if (candidates.length === 0) return maxPercent(metrics)
+  return maxPercent(candidates)
+}
+
+function headline(entry, barWindow) {
+  if (!entry) return { text: "", percent: null, severity: "low", label: "" }
+  var best = selectMetric(entry, barWindow)
   if (best) {
     var bestText = /balance/i.test(best.label) && best.value !== ""
       ? best.value : best.percent + "%"
@@ -360,6 +441,7 @@ function headline(entry) {
       label: best.label
     }
   }
+  var sections = entry.sections || []
   for (var j = 0; j < sections.length; j++) {
     var row = sections[j]
     if (row.type === "text" && /(balance|available|spend|prepaid)/i.test(row.label) && row.value !== "")

--- a/omarchy/Panel.qml
+++ b/omarchy/Panel.qml
@@ -45,6 +45,7 @@ Panel {
   readonly property bool showValue: Model.booleanSetting(setting("showValue", true), true)
   readonly property bool showProvider: Model.booleanSetting(setting("showProvider", false), false)
   readonly property bool showAll: Model.booleanSetting(setting("showAll", false), false)
+  readonly property string barWindow: Model.normalizeBarWindow(setting("barWindow", "auto"))
   readonly property var visibleEntries: Model.filteredEntries(entries, configuredProvider)
   readonly property int entryIndex: Model.selectedIndex(visibleEntries, selectedEntryId)
   readonly property var entry: entryIndex >= 0 ? visibleEntries[entryIndex] : null
@@ -52,7 +53,10 @@ Panel {
     if (!entry) return ""
     return String(entry.fetched_at || "")
   }
-  readonly property var summary: Model.headline(entry)
+  readonly property var summary: Model.headline(entry, barWindow)
+  // barWindow pins the bar value and its echoes (hero detail, tooltip).
+  // Panel rows and alert state keep the historical highest-percent headline,
+  // matching every other frontend (Waybar class, KDE isAlarming, TUI).
   readonly property var entrySections: entry ? entry.sections : []
   readonly property bool filterMiss: configuredProvider !== "" && entries.length > 0 && visibleEntries.length === 0
   readonly property bool entryAlarming: Model.isAlarming(entry)
@@ -119,6 +123,12 @@ Panel {
     var next = enabled === true
     if (next === showAll) return
     persistWidgetSettings({ showAll: next })
+  }
+
+  function setBarWindow(value) {
+    var next = Model.normalizeBarWindow(value)
+    if (next === barWindow) return
+    persistWidgetSettings({ barWindow: next })
   }
 
   function selectEntry(index) {
@@ -221,11 +231,11 @@ Panel {
   }
 
   readonly property var barChips: Model.barChips(
-    visibleEntries, entry, showAll, showValue, showProvider, loading, alarming, vertical)
+    visibleEntries, entry, showAll, showValue, showProvider, loading, alarming, vertical, barWindow)
 
   function barText() {
     if (showAll)
-      return Model.barStrip(visibleEntries, alarming, vertical, showValue, showProvider, loading)
+      return Model.barStrip(visibleEntries, alarming, vertical, showValue, showProvider, loading, barWindow)
     return Model.barLabel(alarming, vertical, showValue, loading,
       entry !== null, summary.text, showProvider ? Model.providerShort(entry) : "",
       Model.providerIcon(entry))
@@ -237,7 +247,7 @@ Panel {
       for (var i = 0; i < visibleEntries.length; i++) {
         var item = visibleEntries[i]
         var bit = Model.providerName(item)
-        var value = Model.autoTextSafe(Model.headline(item).text).trim()
+        var value = Model.autoTextSafe(Model.headline(item, barWindow).text).trim()
         if (value !== "") bit += " · " + value
         if (item.stale) bit += " · cached"
         chips.push(bit)
@@ -413,10 +423,12 @@ Panel {
             showValue: root.showValue
             showProvider: root.showProvider
             showAll: root.showAll
+            barWindow: root.barWindow
             onSaved: root.startRefresh()
             onShowValueRequested: function(enabled) { root.setShowValue(enabled) }
             onShowProviderRequested: function(enabled) { root.setShowProvider(enabled) }
             onShowAllRequested: function(enabled) { root.setShowAll(enabled) }
+            onBarWindowRequested: function(value) { root.setBarWindow(value) }
             onFallbackRequested: root.openTerminalSettings()
             onNousLoginRequested: root.openNousLogin()
             onCopilotLoginRequested: root.openCopilotLogin()

--- a/omarchy/README.md
+++ b/omarchy/README.md
@@ -48,7 +48,10 @@ omarchy plugin remove akitaonrails.ai-usagebar
   icon-and-value label and a compact icon-only label without hiding panel or
   tooltip details. Its **Show provider name in the top bar** toggle adds the
   provider's three-letter code in front of that value — the same code Waybar's
-  `{vendor_short}` prints — and is off by default.
+  `{vendor_short}` prints — and is off by default. Its **Top bar usage window**
+  dropdown pins the bar to auto (highest), 5-hour, weekly, or monthly; the
+  tooltip and panel hero echo the pinned value while the panel rows keep
+  showing every window and alert state still follows the highest percent.
   `h`/`l` or Left/Right switches provider, `j`/`k` or Up/Down scrolls, `r`,
   Enter, or Space refreshes, Tab moves to the neighboring bar panel, and Esc
   closes.
@@ -110,13 +113,22 @@ omarchy bar set akitaonrails.ai-usagebar showProvider true --json
 
 # Show every configured provider's icon and usage at once. The default is false.
 omarchy bar set akitaonrails.ai-usagebar showAll true --json
+
+# Which quota window the top bar shows: auto (highest, the historical
+# default), session (5-hour), weekly (7-day), or monthly. The default is auto.
+omarchy bar set akitaonrails.ai-usagebar barWindow session
 ```
 
 The refresh interval is clamped to 30–3600 seconds. The `provider` setting
 prefers an exact entry id; if there is no exact match, a base id such as
 `anthropic` selects all accounts for that provider. `showValue`,
-`showProvider`, and `showAll` change only the top-bar label; none hide report
+`showProvider`, and `showAll` change only the top-bar label; `barWindow`
+changes the top-bar value and its tooltip/hero echo; none hide report
 details or change provider fetching.
+Panel rows and alert state still follow the highest percent. `barWindow` falls
+back to the highest percent (balance/text where a vendor has no metric) when
+a vendor lacks the pinned window (a balance-only provider, a weekly-only
+response, or no monthly pool), so the bar never goes blank.
 
 `showProvider` draws the `short_name` the Rust report ships for the selected
 entry, so the codes never fork from Waybar's `{vendor_short}`: `cld 29%`,

--- a/omarchy/SettingsView.qml
+++ b/omarchy/SettingsView.qml
@@ -17,6 +17,7 @@ Column {
   property bool showValue: true
   property bool showProvider: false
   property bool showAll: false
+  property string barWindow: "auto"
   readonly property color dim: Qt.darker(foreground, 1.45)
 
   property var snapshot: ({ primary_choices: [], keys: [] })
@@ -42,6 +43,7 @@ Column {
   signal showValueRequested(bool enabled)
   signal showProviderRequested(bool enabled)
   signal showAllRequested(bool enabled)
+  signal barWindowRequested(string value)
   signal closeRequested()
 
   spacing: Style.space(12)
@@ -248,6 +250,42 @@ Column {
       fontFamily: root.fontFamily
       enabled: !root.saving
       onClicked: root.showAllRequested(!root.showAll)
+    }
+  }
+
+  Column {
+    visible: !root.loading
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "TOP BAR WINDOW"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+    Text {
+      width: parent.width
+      text: "Which quota the bar shows. Providers lacking it fall back to highest. Applies immediately."
+      textFormat: Text.PlainText
+      color: root.dim
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.caption
+      wrapMode: Text.WordWrap
+    }
+    Dropdown {
+      width: parent.width
+      showLabel: false
+      value: Model.normalizeBarWindow(root.barWindow)
+      options: [
+        { value: "auto", label: "Highest (auto)" },
+        { value: "session", label: "5-hour (session)" },
+        { value: "weekly", label: "7-day (weekly)" },
+        { value: "monthly", label: "Monthly (monthly)" }
+      ]
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      enabled: !root.saving
+      onChanged: function(value) { root.barWindowRequested(value) }
     }
   }
 

--- a/omarchy/model.test.mjs
+++ b/omarchy/model.test.mjs
@@ -27,6 +27,17 @@ assert.equal(manifest.barWidget.defaults.showAll, false);
 const showAllSchema = manifest.barWidget.schema.find(row => row.key === 'showAll');
 assert.equal(showAllSchema.type, 'boolean');
 assert.equal(showAllSchema.defaultValue, false);
+// Pinned window is opt-in display-only: existing shell.json entries without
+// the key keep the historical highest-percent label.
+assert.equal(manifest.barWidget.defaults.barWindow, 'auto');
+const barWindowSchema = manifest.barWidget.schema.find(row => row.key === 'barWindow');
+assert.equal(barWindowSchema.type, 'enum');
+assert.deepEqual(barWindowSchema.options, ['auto', 'session', 'weekly', 'monthly']);
+assert.equal(barWindowSchema.defaultValue, 'auto');
+// The normalizer must accept every option the manifest offers, or the
+// dropdown would write a value the panel silently ignores.
+for (const option of barWindowSchema.options)
+  assert.equal(model.normalizeBarWindow(option), option);
 
 const barWidgetSource = fs.readFileSync(new URL('./BarWidget.qml', import.meta.url), 'utf8');
 assert.match(barWidgetSource, /^BarWidget\s*\{/m);
@@ -48,8 +59,20 @@ assert.match(panelSource, /setting\("lastSelectedEntryId",\s*""\)/);
 assert.match(panelSource, /setting\("showValue",\s*true\)/);
 assert.match(panelSource, /setting\("showProvider",\s*false\)/);
 assert.match(panelSource, /setting\("showAll",\s*false\)/);
+assert.match(panelSource, /Model\.normalizeBarWindow\(setting\("barWindow",\s*"auto"\)\)/);
+// The pin covers the bar value and its echoes (hero detail, tooltip):
+// summary (bar label/chips) is pinned, while panel rows and alert state
+// keep the auto headline.
+assert.match(panelSource, /Model\.headline\(entry,\s*barWindow\)/);
+assert.match(panelSource, /Model\.headline\(item,\s*barWindow\)/);
+assert.match(panelSource, /Model\.isAlarming\(entry\)/);
+assert.match(panelSource, /Model\.anyAlarming\(visibleEntries\)/);
+assert.doesNotMatch(panelSource, /autoSummary/);
+assert.match(panelSource, /function\s+setBarWindow\s*\(/);
+assert.match(panelSource, /onBarWindowRequested/);
 assert.match(panelSource, /showProvider\s*\?\s*Model\.providerShort\(entry\)\s*:\s*""/);
-assert.match(panelSource, /Model\.barStrip\(/);
+assert.match(panelSource, /Model\.barStrip\([\s\S]*?barWindow/);
+assert.match(panelSource, /Model\.barChips\([\s\S]*?barWindow/);
 assert.match(panelSource, /Model\.providerIcon\(entry\)/);
 assert.match(panelSource, /BrandMark\s*\{/);
 assert.match(panelSource, /Model\.brandIconFile\(root\.entry\)/);
@@ -91,6 +114,13 @@ assert.match(settingsViewSource, /signal\s+showProviderRequested\(bool\s+enabled
 assert.match(settingsViewSource, /label:\s*"Show provider name in the top bar"/);
 assert.match(settingsViewSource, /signal\s+showAllRequested\(bool\s+enabled\)/);
 assert.match(settingsViewSource, /label:\s*"Show all providers in the top bar"/);
+assert.match(settingsViewSource, /signal\s+barWindowRequested\(string\s+value\)/);
+assert.match(settingsViewSource, /text:\s*"TOP BAR WINDOW"/);
+assert.match(settingsViewSource, /\{\s*value:\s*"auto",\s*label:\s*"Highest \(auto\)"/);
+assert.match(settingsViewSource, /\{\s*value:\s*"session",\s*label:\s*"5-hour \(session\)"/);
+assert.match(settingsViewSource, /\{\s*value:\s*"weekly",\s*label:\s*"7-day \(weekly\)"/);
+assert.match(settingsViewSource, /\{\s*value:\s*"monthly",\s*label:\s*"Monthly \(monthly\)"/);
+assert.match(panelSource, /barWindow:\s*root\.barWindow/);
 assert.match(panelSource, /onShowAllRequested/);
 assert.match(panelSource, /onShowProviderRequested/);
 assert.match(settingsViewSource, /Log in with Nous Research/);
@@ -435,5 +465,241 @@ assert.equal(model.buildSettingsPatch('openai', [{id: 'kimi', action: 'set', val
 assert.equal(model.buildSettingsPatch('openai', [{id: 'kimi', action: 'bogus'}]).ok, false);
 assert.equal(model.parseSettingsApplyResult('{"ok":true}'), true);
 assert.equal(model.parseSettingsApplyResult('{"ok":false}'), false);
+
+// Top bar window pinning: auto keeps history, session/weekly/monthly pin one
+// window class, unknown pins fall back to highest instead of blanking.
+assert.equal(model.normalizeBarWindow('auto'), 'auto');
+assert.equal(model.normalizeBarWindow(''), 'auto');
+assert.equal(model.normalizeBarWindow('  Session '), 'session');
+assert.equal(model.normalizeBarWindow('5h'), 'session');
+assert.equal(model.normalizeBarWindow('rolling'), 'session');
+assert.equal(model.normalizeBarWindow('WEEKLY'), 'weekly');
+assert.equal(model.normalizeBarWindow('7d'), 'weekly');
+assert.equal(model.normalizeBarWindow('Monthly'), 'monthly');
+assert.equal(model.normalizeBarWindow('bogus'), 'auto');
+assert.equal(model.normalizeBarWindow(undefined), 'auto');
+
+const twoWindow = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Codex 5h', percent: 44, value: '44%', detail: '', severity: 'low', window_secs: 18000},
+    {type: 'metric', label: 'Codex weekly', percent: 59, value: '59%', detail: '', severity: 'mid', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(twoWindow.sections[0].window_secs, 18000);
+assert.equal(twoWindow.sections[1].window_secs, 604800);
+assert.equal(model.headline(twoWindow).text, '59%');
+assert.equal(model.headline(twoWindow, 'auto').text, '59%');
+assert.equal(model.headline(twoWindow, 'session').text, '44%');
+assert.equal(model.headline(twoWindow, 'session').label, 'Codex 5h');
+assert.equal(model.headline(twoWindow, 'weekly').text, '59%');
+assert.equal(model.headline(twoWindow, 'bogus').text, '59%');
+// No monthly pool: falls back to highest rather than blanking.
+assert.equal(model.headline(twoWindow, 'monthly').text, '59%');
+
+const threeWindow = model.parseReport(JSON.stringify({entries: [{
+  id: 'opencode-go', error: null,
+  sections: [
+    {type: 'metric', label: 'Rolling (5h)', percent: 0, value: '0%', detail: '', severity: 'low', window_secs: 18000},
+    {type: 'metric', label: 'Weekly (7d)', percent: 18, value: '18%', detail: '', severity: 'low', window_secs: 604800},
+    {type: 'metric', label: 'Monthly', percent: 81, value: '81%', detail: '', severity: 'high'}
+  ]
+}]})).entries[0];
+assert.equal(threeWindow.sections[2].window_secs, null);
+assert.equal(model.headline(threeWindow).text, '81%');
+assert.equal(model.headline(threeWindow, 'session').text, '0%');
+assert.equal(model.headline(threeWindow, 'weekly').text, '18%');
+assert.equal(model.headline(threeWindow, 'monthly').text, '81%');
+// Label-only match when the report predates window_secs.
+const legacyWeekly = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Codex 5h', percent: 10, value: '10%', detail: ''},
+    {type: 'metric', label: 'Codex weekly', percent: 90, value: '90%', detail: ''}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(legacyWeekly, 'session').text, '10%');
+assert.equal(model.headline(legacyWeekly, 'weekly').text, '90%');
+// window_secs wins over labels: neutral labels disambiguate by size alone,
+// and a present-but-different size overrules a misleading label.
+const secsOnly = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Foo', percent: 44, value: '44%', detail: '', severity: 'low', window_secs: 18000},
+    {type: 'metric', label: 'Bar', percent: 59, value: '59%', detail: '', severity: 'mid', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(secsOnly, 'session').text, '44%');
+assert.equal(model.headline(secsOnly, 'weekly').text, '59%');
+const secsMismatch = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Codex weekly', percent: 44, value: '44%', detail: '', severity: 'low', window_secs: 18000},
+    {type: 'metric', label: 'Codex 5h', percent: 59, value: '59%', detail: '', severity: 'mid', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(secsMismatch, 'session').text, '44%');
+assert.equal(model.headline(secsMismatch, 'weekly').text, '59%');
+// Weekly-only response: a session pin falls back to highest.
+const weeklyOnly = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Codex weekly', percent: 77, value: '77%', detail: '', severity: 'high', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(weeklyOnly, 'session').text, '77%');
+// Abbreviated monthly spend label matches the monthly pin.
+const spendMo = model.parseReport(JSON.stringify({entries: [{
+  id: 'anthropic_api', error: null,
+  sections: [
+    {type: 'metric', label: 'Spend (mo)', percent: 12, value: '$1.34 / $1000', detail: '', severity: 'low'}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(spendMo, 'monthly').text, '12%');
+// Balance-only vendors ignore the pin and keep showing the balance.
+assert.equal(model.headline(balance, 'session').text, '$8.42');
+// Alert state always follows the highest-percent window, never the pin;
+// the pin covers the bar value plus its hero/tooltip echoes.
+assert.equal(model.isAlarming(twoWindow), false);
+assert.equal(model.headline(legacyWeekly, 'weekly').severity, 'critical');
+assert.equal(model.isAlarming(legacyWeekly), true);
+const pinnedChips = model.barChips([twoWindow, threeWindow], twoWindow, true, true, false, false, false, false, 'session');
+assert.deepEqual(Array.from(pinnedChips.map(chip => chip.label)), ['44%', '0%']);
+assert.equal(model.barStrip([twoWindow, threeWindow], false, false, true, false, false, 'weekly'), '󰚩  59%  󰚩  18%');
+// Scoped 7-day pools carry window_secs, so the weekly pin selects them
+// (max among weekly candidates, not first).
+const scopedWeekly = model.parseReport(JSON.stringify({entries: [{
+  id: 'anthropic', error: null,
+  sections: [
+    {type: 'metric', label: 'Weekly (7d)', percent: 30, value: '30%', detail: '', severity: 'low', window_secs: 604800},
+    {type: 'metric', label: 'Fable (7d)', percent: 88, value: '88%', detail: '', severity: 'high', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(scopedWeekly, 'weekly').text, '88%');
+// Pools without any window shape (Cursor-style) fall back to highest.
+const cursorLike = model.parseReport(JSON.stringify({entries: [{
+  id: 'cursor', error: null,
+  sections: [
+    {type: 'metric', label: 'Cursor Models', percent: 80, value: '80%', detail: '', severity: 'high'},
+    {type: 'metric', label: 'Other Models', percent: 20, value: '20%', detail: '', severity: 'low'}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(cursorLike, 'weekly').text, '80%');
+assert.equal(model.headline(cursorLike, 'session').text, '80%');
+// Buckets without any window shape (Copilot-style) fall back to highest.
+const copilotLike = model.parseReport(JSON.stringify({entries: [{
+  id: 'copilot', error: null,
+  sections: [
+    {type: 'metric', label: 'Premium requests', percent: 80, value: '80%', detail: '', severity: 'high'},
+    {type: 'metric', label: 'Chat', percent: 20, value: '20%', detail: '', severity: 'low'}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(copilotLike, 'weekly').text, '80%');
+assert.equal(model.headline(copilotLike, 'session').text, '80%');
+// The exact labels and sizes src/tui/panels.rs emits, not synthetic names:
+// Z.AI ships session/weekly plus a 30-day MCP bucket with a monthly label,
+// MiniMax names its pools Text/Video and its video session 24h, and SuperGrok
+// puts the period in the label with no window size at all.
+const zaiReal = model.parseReport(JSON.stringify({entries: [{
+  id: 'zai', error: null,
+  sections: [
+    {type: 'metric', label: 'Session (5h)', percent: 71, value: '71%', detail: '', severity: 'mid', window_secs: 18000},
+    {type: 'metric', label: 'Weekly', percent: 12, value: '12%', detail: '', severity: 'low', window_secs: 604800},
+    {type: 'metric', label: 'MCP tools (monthly)', percent: 40, value: '40%', detail: '', severity: 'low', window_secs: 2592000}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(zaiReal, 'session').text, '71%');
+assert.equal(model.headline(zaiReal, 'weekly').text, '12%');
+assert.equal(model.headline(zaiReal, 'monthly').text, '40%');
+const minimaxReal = model.parseReport(JSON.stringify({entries: [{
+  id: 'minimax', error: null,
+  sections: [
+    {type: 'metric', label: 'Text', percent: 20, value: '20%', detail: '', severity: 'low', window_secs: 18000},
+    {type: 'metric', label: 'Text', percent: 30, value: '30%', detail: '', severity: 'low', window_secs: 604800},
+    {type: 'metric', label: 'Video', percent: 90, value: '90%', detail: '', severity: 'critical', window_secs: 86400},
+    {type: 'metric', label: 'Video', percent: 50, value: '50%', detail: '', severity: 'mid', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(minimaxReal, 'auto').text, '90%');
+assert.equal(model.headline(minimaxReal, 'session').text, '20%');
+assert.equal(model.headline(minimaxReal, 'weekly').text, '50%');
+assert.equal(model.headline(minimaxReal, 'monthly').text, '90%');
+assert.equal(model.isAlarming(minimaxReal), true);
+const supergrokReal = model.parseReport(JSON.stringify({entries: [{
+  id: 'supergrok', error: null,
+  sections: [
+    {type: 'metric', label: 'Monthly Build credits', percent: 42, value: '42%', detail: '', severity: 'low'}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(supergrokReal, 'monthly').text, '42%');
+assert.equal(model.headline(supergrokReal, 'session').text, '42%');
+const divergent = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Codex 5h', percent: 10, value: '10%', detail: '', severity: 'low', window_secs: 18000},
+    {type: 'metric', label: 'Codex weekly', percent: 95, value: '95%', detail: '', severity: 'critical', window_secs: 604800}
+  ]
+}]})).entries[0];
+assert.equal(model.headline(divergent, 'session').text, '10%');
+assert.equal(model.headline(divergent, 'session').severity, 'low');
+assert.equal(model.isAlarming(divergent), true);
+// Chip alert state follows highest, never the pin: pinned low label with a
+// critical hidden window still alarms.
+const divergentChip = model.barChips([divergent], divergent, false, true, false, false, false, false, 'session')[0];
+assert.equal(divergentChip.label, '10%');
+assert.equal(divergentChip.alarming, true);
+assert.equal(model.normalizeBarWindow('highest'), 'auto');
+assert.equal(model.normalizeBarWindow('max'), 'auto');
+assert.equal(model.normalizeBarWindow('shortest'), 'session');
+assert.equal(model.normalizeBarWindow('session-5h'), 'session');
+assert.equal(model.normalizeBarWindow('5-hour'), 'session');
+assert.equal(model.normalizeBarWindow('5hour'), 'session');
+assert.equal(model.normalizeBarWindow('5hr'), 'session');
+assert.equal(model.normalizeBarWindow('five-hour'), 'session');
+assert.equal(model.normalizeBarWindow('week'), 'weekly');
+assert.equal(model.normalizeBarWindow('7-day'), 'weekly');
+assert.equal(model.normalizeBarWindow('weekly-7d'), 'weekly');
+assert.equal(model.normalizeBarWindow('month'), 'monthly');
+assert.equal(model.normalizeBarWindow('30d'), 'monthly');
+assert.equal(model.normalizeBarWindow('monthly-cycle'), 'monthly');
+assert.equal(model.normalizeBarWindow(null), 'auto');
+assert.deepEqual(Array.from(pinnedChips.map(chip => chip.alarming)), [false, false]);
+assert.equal(model.barStrip([twoWindow], false, false, true, false, false, 'monthly'), '󰚩  59%');
+const bogusChips = model.barChips([twoWindow, threeWindow], twoWindow, true, true, false, false, false, false, 'bogus');
+const autoChips = model.barChips([twoWindow, threeWindow], twoWindow, true, true, false, false, false, false);
+assert.deepEqual(Array.from(bogusChips.map(chip => chip.label)), Array.from(autoChips.map(chip => chip.label)));
+const secsEdge = model.parseReport(JSON.stringify({entries: [{
+  id: 'openai', error: null,
+  sections: [
+    {type: 'metric', label: 'Zero', percent: 10, value: '10%', detail: '', severity: 'low', window_secs: 0},
+    {type: 'metric', label: 'Negative', percent: 20, value: '20%', detail: '', severity: 'low', window_secs: -5},
+    {type: 'metric', label: 'String', percent: 30, value: '30%', detail: '', severity: 'low', window_secs: "18000"},
+    {type: 'metric', label: 'Float', percent: 40, value: '40%', detail: '', severity: 'low', window_secs: 18000.9}
+  ]
+}]})).entries[0];
+assert.equal(secsEdge.sections[0].window_secs, null);
+assert.equal(secsEdge.sections[1].window_secs, null);
+assert.equal(secsEdge.sections[2].window_secs, 18000);
+assert.equal(secsEdge.sections[3].window_secs, 18000);
+const monthlyExclude = model.parseReport(JSON.stringify({entries: [{
+id: 'openai', error: null,
+sections: [
+{type: 'metric', label: 'Monthly quota', percent: 90, value: '90%', detail: '', severity: 'low', window_secs: 18000},
+{type: 'metric', label: 'Monthly dues', percent: 10, value: '10%', detail: '', severity: 'low'}
+]
+}]})).entries[0];
+assert.equal(model.headline(monthlyExclude, 'monthly').text, '10%');
+const sessionMax = model.parseReport(JSON.stringify({entries: [{
+id: 'openai', error: null,
+sections: [
+{type: 'metric', label: 'A 5h', percent: 20, value: '20%', detail: '', severity: 'low', window_secs: 18000},
+{type: 'metric', label: 'B 5h', percent: 70, value: '70%', detail: '', severity: 'mid', window_secs: 18000}
+]
+}]})).entries[0];
+assert.equal(model.headline(sessionMax, 'session').text, '70%');
+assert.equal(model.headline(twoWindow, '5h').text, '44%');
+assert.equal(model.headline(twoWindow, 'shortest').text, '44%');
+assert.equal(model.headline(secsEdge, 'session').text, '40%');
+assert.equal(model.barStrip([threeWindow], false, false, true, false, false, 'bogus'), '󰚩  81%');
 
 console.log('Omarchy model tests passed');


### PR DESCRIPTION
## What this changes

Adds a **Top bar usage window** picker to the Omarchy Quattro widget. The
settings page gains a dropdown (`auto` / `session` / `weekly` / `monthly`), and
the same key is settable from the CLI:

```
omarchy bar set akitaonrails.ai-usagebar barWindow session
```

`barWindow` pins the bar label — and the tooltip/hero echo — to one quota
window instead of always showing the highest percent:

- `session` — the 5-hour / rolling window
- `weekly` — the 7-day window
- `monthly` — the monthly pool where one exists
- `auto` (default) — the historical highest-percent behavior; existing
  `shell.json` entries are unchanged

A vendor that does not offer the pinned window falls back to the highest
percent rather than blanking the bar. Panel rows and alert state always follow
the worst window, matching KDE's `isAlarming` and Waybar's class; the pin is
display-only.

Classification consumes the report's existing `window_secs` first; the two
exact sizes are named after the Rust constants that publish them
(`openai/types.rs` `SESSION_WINDOW_SECS`/`WEEKLY_WINDOW_SECS`,
`opencode_go/vendor.rs` and `kimi/vendor.rs` `ROLLING_WINDOW`/`WEEKLY_WINDOW`,
`anthropic/types.rs` `SESSION`/`WEEKLY`). Bounded label matching only covers
older reports that predate `window_secs`. A vendor stating any other length
falls through to labels rather than being forced into one of these classes. If
you would rather this lived in the report as a canonical window tag, I'm happy
to move it.

## Checklist

- [x] `make test`, `cargo clippy --all-targets -- -D warnings` and
      `cargo fmt --all -- --check` pass (also `cargo machete`,
      `make changelog-check`, `omarchy plugin validate .`)
- [x] `CHANGELOG.md` entry under `## [Unreleased]` in the right category
- [x] Docs updated (`README.md`, `omarchy/README.md`)
- [x] No helper left behind without callers

## Testing

Gate on `8a58593`, Linux (Omarchy Quattro):

```
make test                                   # 1583 cargo tests passed, 0 failed, 13 ignored
                                            #   + GNOME, KDE, Windows popover, Omarchy suites
cargo clippy --all-targets -- -D warnings   # clean
cargo fmt --all -- --check                  # clean
cargo machete                               # no unused dependencies
make changelog-check                        # released sections intact
omarchy plugin validate .                   # exit 0
```

- Exercised live in a running Quattro session: selecting each window in the
  dropdown updates the bar label, tooltip and hero immediately; the choice
  persists.
- **Fails on `main`:** copy this branch's `omarchy/model.test.mjs` into a
  `main` worktree and run `node omarchy/model.test.mjs` — it fails at line 32
  (`barWindow` default is `undefined`, expected `'auto'`). The behavioral
  assertions below it call `Model.normalizeBarWindow`/`metricMatchesWindow`,
  which don't exist on `main`.
- **Real-report check:** piped `ai-usagebar usage --json` through
  `omarchy/Model.js` in Node — `openai` (Codex 5h 53 / weekly 60) resolves
  auto 60, session 53, weekly 60; `opencode-go` (Rolling 6 / Weekly 20 /
  Monthly 82) resolves auto 82, session 6, weekly 20, monthly 82; a vendor
  with no monthly pool (openai) falls back to 60% as documented.
- **Fixtures use the exact labels/sizes `src/tui/panels.rs` emits:** Z.AI
  `MCP tools (monthly)` (30d), MiniMax `Text`/`Video` (5h/24h/7d), SuperGrok
  `Monthly Build credits` with no `window_secs`, plus a manifest-options ↔
  normalizer round-trip guard.
