### PR TITLE
refactor(macos): drop the hand-maintained enabled-defaults copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ Each release is also published at
 
 ### Changed
 
+- **macOS menu bar keeps no second copy of Rust's enabled defaults.**
+  The `defaultEnabled` slug list is deleted, together with the helpers the
+  catalog migration had orphaned (`vendorEnabled`, `configEnabledTOML`,
+  `configHasApiKeyTOML`, `vendorConfigured`). Every enabled decision in the
+  menu bar had already read the catalog's `enabled` field from
+  `vendors --json` since the #170 migration — which is why the slug list's
+  disagreement about Ollama Cloud (#185) was latent, never user-visible —
+  and now nothing else exists to drift: the Rust wire test pins the
+  `enabled` field name, and the Swift contract test pins that the field
+  decides. A provider added in Rust reaches the menu bar with its own
+  default, no Swift change needed.
+
 - **Omarchy install is one paste, and the marketplace card says what it needs.**
   The plugin is the display frontend; it reads the `ai-usagebar` binary, which
   installs through a different manager (the binary is a system package, the
@@ -24,10 +36,11 @@ Each release is also published at
 
 - **macOS menu bar knew the wrong default for Ollama Cloud.**
   `defaultEnabled("ollama")` fell through to `true` while Rust ships
-  `[ollama] enabled = false` (opt-in), so the menu bar could treat Ollama
-  as enabled when the config omits the flag. It now returns `false`,
-  matching `src/config.rs`, and the Swift contract test pins it alongside
-  the other opt-in vendors. Ollama's Session/Weekly bars already rendered
+  `[ollama] enabled = false` (opt-in) — a latent disagreement only, since
+  the catalog migration had already moved the menu bar's live decisions to
+  `vendors --json`. The slug list is now deleted outright (see the Changed
+  entry above); the catalog's `enabled` field decides, and the Rust wire
+  test pins the field name. Ollama's Session/Weekly bars already rendered
   through the generic `parse()` path — no format change.
 
 ## [1.15.0] — 2026-09-10

--- a/macos/ai-usagebar-menubar.swift
+++ b/macos/ai-usagebar-menubar.swift
@@ -827,23 +827,9 @@ func configPathTOML() -> String {
     return "\(NSHomeDirectory())/.config/ai-usagebar/config.toml"
 }
 
-func configHasApiKeyTOML(_ section: String) -> Bool {
-    guard let value = configValueTOML(section, "api_key") else { return false }
-    return !value.isEmpty
-}
-
-func configEnabledTOML(_ section: String) -> Bool? {
-    guard let value = configValueTOML(section, "enabled") else { return nil }
-    switch value.lowercased() {
-    case "true": return true
-    case "false": return false
-    default: return nil
-    }
-}
-
 /// Read a single `key` under `[section]` from TOML text. Pure (no filesystem)
-/// so the enabled-flag and api_key_env parsing is testable. Handles quoted
-/// strings, bare booleans (`enabled = false`), inline comments, and `api_key_env`.
+/// so key parsing is testable. Handles quoted strings, bare booleans
+/// (`show_default_account = true`), inline comments, and `api_key_env`.
 func tomlValueInText(_ text: String, section: String, key: String) -> String? {
     var inSection = false
     for raw in text.split(separator: "\n", omittingEmptySubsequences: false) {
@@ -864,8 +850,9 @@ func tomlValueInText(_ text: String, section: String, key: String) -> String? {
             guard let end = content.firstIndex(of: quote) else { continue }
             return String(content[..<end])
         }
-        // Unquoted value: strip a trailing inline comment — `enabled = false
-        // # opt-in` is a bare boolean, not a string starting with '#'.
+        // Unquoted value: strip a trailing inline comment —
+        // `show_default_account = true # per-account` is a bare boolean,
+        // not a string starting with '#'.
         var bare = value
         if let hash = bare.firstIndex(of: "#") {
             bare = String(bare[..<hash]).trimmingCharacters(in: .whitespaces)
@@ -1364,27 +1351,6 @@ func addAccountScript(binary: String, label: String, desktop: Bool) -> String {
         + "echo; read -n 1 -s -r -p 'Press any key to close…'\n"
 }
 
-/// Rust defaults (`src/config.rs`): the OAuth/api-key vendors that ship enabled,
-/// versus the opt-in vendors that default to disabled. An omitted
-/// `[vendor].enabled` must reproduce these, not silently enable everything.
-func defaultEnabled(_ id: String) -> Bool {
-    switch id {
-    case "anthropic", "openai", "zai", "openrouter": return true
-    case "deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor", "antigravity",
-         "copilot", "supergrok", "minimax", "kiro", "nous", "opencode-go", "commandcode", "ollama": return false
-    default: return true
-    }
-}
-
-func vendorEnabled(_ v: VendorAuth) -> Bool {
-    if let explicit = configEnabledTOML(v.id) { return explicit }
-    return defaultEnabled(v.id)
-}
-
-func vendorConfigured(_ v: VendorCatalogEntry) -> Bool {
-    v.configured
-}
-
 func cliInstalled(_ cli: String) -> Bool {
     let home = NSHomeDirectory()
     let fm = FileManager.default
@@ -1584,9 +1550,9 @@ struct SettingsView: View {
     @State private var launchAtLogin = launchAgentIsInstalled()
     @State private var launchAtLoginError: String?
 
-    // Only vendors marked enabled by the Rust catalog appear in the selector.
-    // Currently, anthropic/openai/zai/openrouter default to enabled; the remaining
-    // built-in vendors are opt-in. Claude
+    // Only vendors the Rust catalog marks enabled appear in the selector —
+    // whatever `vendors --json` reports, so a provider added in Rust (and its
+    // opt-in or enabled default) reaches here with no menubar change. Claude
     // accounts appear as their `vendor@<label>` pseudo-ids, same as the
     // "Switch provider" submenu.
     private var vendors: [String] {

--- a/macos/ai-usagebar-tests.swift
+++ b/macos/ai-usagebar-tests.swift
@@ -4,7 +4,7 @@
 // bundle. Instead, the app's `@main` entry point is guarded by
 // `#if !SWIFT_TEST_HARNESS`, and this file — compiled together with the app in
 // one module — supplies its own `@main TestRunner`, calling the app's helpers
-// (arcAngles, tomlValueInText, defaultEnabled, parse) directly.
+// (arcAngles, tomlValueInText, parse) directly.
 //
 // Run:  ./macos/run-tests.sh
 // Gate: pure-logic regression coverage for the review fixes.
@@ -81,31 +81,31 @@ func testRingArc() {
     assertEqual(zero.startDeg, zero.endDeg, "zero-length segment is degenerate")
 }
 
-// ─── TOML enabled / api_key_env parsing ──────────────────────────────────
+// ─── TOML parsing: booleans, api_key, arrays ─────────────────────────────
 func testTomlParsing() {
-    print("TOML enabled + api_key_env")
+    print("TOML booleans, keys and arrays")
     // Bare false.
     let bareFalse = """
-    [deepseek]
-    enabled = false
+    [anthropic]
+    show_default_account = false
     """
-    assertEqual(tomlValueInText(bareFalse, section: "deepseek", key: "enabled"), "false",
-                "bare enabled = false")
+    assertEqual(tomlValueInText(bareFalse, section: "anthropic", key: "show_default_account"), "false",
+                "bare show_default_account = false")
 
     // Bare true.
     let bareTrue = """
-    [kimi]
-    enabled = true
+    [openrouter]
+    show_default_account = true
     """
-    assertEqual(tomlValueInText(bareTrue, section: "kimi", key: "enabled"), "true",
-                "bare enabled = true")
+    assertEqual(tomlValueInText(bareTrue, section: "openrouter", key: "show_default_account"), "true",
+                "bare show_default_account = true")
 
     // Inline comment on a bare boolean.
     let commented = """
-    [kilo]
-    enabled = false  # opt-in balance vendor
+    [anthropic]
+    show_default_account = true  # per-account usage row
     """
-    assertEqual(tomlValueInText(commented, section: "kilo", key: "enabled"), "false",
+    assertEqual(tomlValueInText(commented, section: "anthropic", key: "show_default_account"), "true",
                 "bare bool with inline comment")
 
     // Quoted string still works (api_key).
@@ -145,19 +145,19 @@ func testTomlParsing() {
     [anthropic]
     credentials_path = "/tmp/creds.json"
     """
-    assertNil(tomlValueInText(omitted, section: "anthropic", key: "enabled"),
-              "omitted enabled is nil")
+    assertNil(tomlValueInText(omitted, section: "anthropic", key: "show_default_account"),
+              "omitted key is nil")
 
     // Section scoping: a key under another section must not leak.
     let scoped = """
     [openrouter]
-    enabled = true
+    show_default_account = true
 
     [deepseek]
     api_key = "ds-key"
     """
-    assertNil(tomlValueInText(scoped, section: "deepseek", key: "enabled"),
-              "enabled does not leak across sections")
+    assertNil(tomlValueInText(scoped, section: "deepseek", key: "show_default_account"),
+              "key does not leak across sections")
     assertEqual(tomlValueInText(scoped, section: "deepseek", key: "api_key"), "ds-key",
                 "api_key read from the right section")
 
@@ -190,18 +190,6 @@ func testTomlParsing() {
     """
     assertNil(tomlStringArrayInText(malformedOverview, section: "ui", key: "overview_vendors"),
               "malformed string array rejected")
-}
-
-// ─── Rust enabled defaults (src/config.rs) ───────────────────────────────
-func testDefaultEnabled() {
-    print("Rust enabled defaults")
-    for id in ["anthropic", "openai", "zai", "openrouter"] {
-        assertEqual(defaultEnabled(id), true, "\(id) defaults enabled")
-    }
-    for id in ["deepseek", "kimi", "kilo", "novita", "moonshot", "grok", "anthropic_api", "cursor", "antigravity",
-               "copilot", "supergrok", "minimax", "kiro", "nous", "opencode-go", "commandcode", "ollama"] {
-        assertEqual(defaultEnabled(id), false, "\(id) defaults disabled (opt-in)")
-    }
 }
 
 // ─── Parser: balances per vendor, no fake 0% rows ────────────────────────
@@ -932,6 +920,10 @@ func testSubprocessEnvironment() {
 
 func testVendorCatalogContract() {
     print("vendor catalog contract (ai-usagebar vendors --json)")
+    // `enabled` is the menubar's only source of a vendor's default state —
+    // the app keeps no slug list of its own (a hand copy once disagreed with
+    // Rust about Ollama Cloud), so the opt-in-or-enabled default a vendor
+    // ships with must ride this field.
     let fixtureJson = """
     {"vendors":[{"configured":true,"enabled":true,"env":"GITHUB_COPILOT_TOKEN","id":"copilot","kind":"oauth","login":"gh auth login","name":"GitHub Copilot","needs_credential":true,"short_name":"ghc"},{"configured":false,"enabled":false,"env":"","id":"supergrok","kind":"local","login":"","name":"SuperGrok","needs_credential":true,"short_name":"sgk"},{"configured":true,"enabled":true,"env":"","id":"antigravity","kind":"local","login":"","name":"Antigravity","needs_credential":false,"short_name":"agy"}]}
     """
@@ -947,11 +939,13 @@ func testVendorCatalogContract() {
     assertEqual(copilot?.cli, "gh", "copilot cli is gh")
     assertEqual(copilot?.login, "gh auth login", "copilot login command")
     assertEqual(copilot?.env, "GITHUB_COPILOT_TOKEN", "copilot env var")
+    assertEqual(copilot?.enabled, true, "copilot enabled via catalog")
 
     let supergrok = catalog.first { $0.id == "supergrok" }
     assertEqual(supergrok?.kind, "local", "supergrok kind is local")
     assertEqual(supergrok?.shortName, "sgk", "supergrok short name is sgk")
     assertEqual(supergrok?.configured, false, "supergrok configured via catalog")
+    assertEqual(supergrok?.enabled, false, "supergrok opt-in default via catalog")
 
     let antigravity = catalog.first { $0.id == "antigravity" }
     assertEqual(antigravity?.needsCredential, false, "antigravity needs no credential")
@@ -1030,7 +1024,6 @@ struct TestRunner {
     static func main() {
         testRingArc()
         testTomlParsing()
-        testDefaultEnabled()
         testParserBalances()
         testOverviewHeadline()
         testVendorCycle()

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -420,6 +420,12 @@ mod tests {
         assert_eq!(vendors.len(), VendorId::all().len());
         assert_eq!(vendors[0]["id"], "anthropic");
         assert_eq!(vendors[0]["kind"], "oauth");
+        // The macOS menu bar decides a vendor's default state solely by
+        // `enabled`, so the wire name is frontend contract: a serde rename
+        // here would silently empty its selector, failing no Swift test.
+        assert_eq!(vendors[0]["enabled"], true);
+        assert_eq!(vendors[0]["configured"], false);
+        assert_eq!(vendors[0]["short_name"], "cld");
         let agy = vendors
             .iter()
             .find(|v| v["id"] == "antigravity")


### PR DESCRIPTION
## What this changes

Follow-up to the suggestion in #185's review: `vendors --json` already carries `enabled` per provider, so the menu bar should not keep its own list of which slugs default on.

What the sweep found: #170 had already moved **every live enabled decision** to the catalog field (`vendorEntries`, `SettingsView.vendors`) — orphaning `defaultEnabled` and its helpers. The copy #185 fixed was consulted by nothing; its Ollama disagreement was latent (the catalog migration landed before the Ollama vendor existed), never user-visible. So the suggestion lands as a deletion, not a repoint:

- Deletes the orphaned family: `defaultEnabled`, `vendorEnabled`, `configEnabledTOML`, `configHasApiKeyTOML`, `vendorConfigured` — zero callers in either Swift file (grep-verified; the harness compiles both files as one module, so a missed caller would fail the build).
- Repoints the contract: `testDefaultEnabled` (which pinned the hand copy against itself) is gone; `testVendorCatalogContract` now asserts the `enabled` field decides (copilot enabled / supergrok opt-in).
- Pins the other side of the boundary: the Rust wire test in `src/catalog.rs` now asserts `enabled`/`configured`/`short_name`. Before this, a serde-level rename of `enabled` would pass every gate and silently empty the menu bar's selector (`parseVendorCatalog`'s `try?` → nil, stderr discarded).
- Comments that re-enumerated the defaults (the `SettingsView.vendors` prose, the `tomlValueInText` bare-boolean example) now name no vendor and use a key a live caller actually reads (`show_default_account`).
- Rewords the two `[Unreleased]` entries (this change and #185's) so the shipped story is accurate about the drift being latent.

Net: a provider added in Rust reaches the menu bar with its own default, no Swift change — the #185 bug class becomes unrepresentable in Swift.

**Not here, but found while sweeping:** the GNOME extension never migrated to the catalog — `prefs.js` still keeps `VENDOR_AUTH` (6 of 21 providers) plus a hand-written TOML reader, and the module comment in `src/catalog.rs` reads as if both frontends had migrated. That is the natural next PR of this same shape.

## Checklist

- [x] `make test`, `cargo clippy --all-targets -- -D warnings` and
      `cargo fmt --all -- --check` pass
- [x] `CHANGELOG.md` entry under `## [Unreleased]` in the right category
      (not inside an already-released section)
- [ ] A test that fails on `main` and passes here, for a bug fix — N/A:
      behavior-preserving removal of dead code, so no test distinguishes
      `main` from this branch by design; the safety argument is the caller
      inventory plus the macOS CI job
- [x] Docs updated where they mention what changed (`README.md`,
      `config.example.toml`, `docs/`) — nothing mentions the deleted
      symbols (grep-checked); no behavior changed for docs to describe
- [x] No helper left behind without callers

## Testing

- `./macos/run-tests.sh` (exit 0) and the CI's exact app-build command
  (`swiftc -O -parse-as-library -o /tmp/ai-usagebar-menubar`) on a real
  macOS host — Apple Swift 6.3.3, arm64, via ssh
- Linux: `make test` (1565 Rust tests + the GNOME/KDE/Omarchy/Windows Node
  suites), `cargo clippy --all-targets -- -D warnings`, `fmt --check`,
  `machete`, `make changelog-check`