### PR TITLE
fix: run released changelog and version checks in PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Published changelog sections and versions are intact
+        shell: bash
+        run: |
+          if [ "$(git rev-parse --is-shallow-repository)" != "false" ]; then
+            echo "::error::Changelog validation requires a full-history checkout."
+            exit 1
+          fi
+          if [ -z "$(git tag --list 'v*')" ]; then
+            echo "::error::Changelog validation requires v* release tags."
+            exit 1
+          fi
+          make changelog-check
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:


### PR DESCRIPTION
## What this changes

In the existing `linux` job, retain the pinned checkout action and configure its checkout with `fetch-depth: 0` and `fetch-tags: true`, keeping the default PR merge checkout so the check examines the proposed merged content. Immediately after checkout, add an unconditional Bash step named `Published changelog sections and versions are intact` that first rejects a shallow repository and an empty `git tag --list 'v*'` result with clear GitHub error annotations, then runs `make changelog-check`. Let all failures propagate normally, with no `continue-on-error`, path filtering, or PR-only condition; the existing `pull_request`, main push, and manual triggers already cover the intended execution paths.

Clean merges from branches predating a release have rewritten published changelog sections, removed a released heading, and rolled version files back to a previous release. The issue owner's September 10 update says commit `b5f03ee` already supplied `scripts/check-changelog-immutable.sh`, exposed through `make changelog-check`, and explicitly leaves this issue open for CI wiring. The local clone confirms that target exists but `.github/workflows/ci.yml` never invokes it and uses shallow checkouts. Completing the existing Linux PR job closes the remaining gap for both changelog immutability and version rollback prevention.

Fixes #168

## Checklist

- [ ] `make test`, `cargo clippy --all-targets -- -D warnings` and
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
      `cargo fmt --all -- --check` pass
- [ ] `CHANGELOG.md` entry under `## [Unreleased]` in the right category
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
      (not inside an already-released section)
- [ ] A test that fails on `main` and passes here, for a bug fix
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [ ] Docs updated where they mention what changed (`README.md`,
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
      `config.example.toml`, `docs/`)
- [ ] No helper left behind without callers

## Testing

Parse the edited workflow and run `actionlint` if installed; confirm the existing PR trigger, pinned checkout, read-only permissions, and Linux job remain valid. Inspect the diff to ensure the new full-history configuration belongs to the same checkout that feeds the check.
In a disposable full-history checkout on Linux with GNU sed/coreutils, run the exact new step commands against an intact release tree: they must compare real tags and exit zero. The checkout supplied to this planner is shallow and contains no v* tags, so a successful behavior run cannot be claimed from it.
In separate disposable copies with release tags preserved, insert or reword a bullet in a checked released section and delete a released heading entirely; each exact CI command sequence must exit nonzero. These are existing script behavior checks exercised through the newly wired command, not new Cargo tests or test-only abstractions.
Independently roll back the version in each of `Cargo.toml`, `manifest.json`, `packaging/aur/PKGBUILD`, and `packaging/aur/PKGBUILD-bin`; each must fail. Matching current released versions and a legitimate forward bump must pass, as must a change confined to `[Unreleased]`.
In a shallow copy and in a full-history copy without v* tags, the new preflight must fail before the script's existing no-tags success path. Also inspect a PR execution downstream to confirm it checks the merge result and actually lists release tags rather than only checking the base branch.
Follow the repository's ordinary contribution checks downstream (`make test`, clippy, formatting, and cargo machete) and fill its PR template with actual results. No tests or builds were run by this planning lane; local verification was limited to source inspection and `make -n changelog-check`.
